### PR TITLE
docs: add DEVLOG with GitHub project and epic issue setup

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,19 @@
+# Dev Log
+
+## 2026-03-28 — GitHub project setup
+
+- Created `epic` label on DavidCozens/solid-syslog
+- Created epic issues E0–E10 as GitHub Issues (#2–#12):
+  - E0 (#2): Epic: Walking Skeleton
+  - E1 (#3): Epic: Core Syslog Formatting
+  - E2 (#4): Epic: UDP Transport
+  - E3 (#5): Epic: TLS Transport
+  - E4 (#6): Epic: Buffering
+  - E5 (#7): Epic: Store and Forward
+  - E6 (#8): Epic: Optional Header Fields
+  - E7 (#9): Epic: Structured Data
+  - E8 (#10): Epic: RTOS Examples
+  - E9 (#11): Epic: C++ Wrapper
+  - E10 (#12): Epic: Static Analysis and MISRA
+- Created GitHub Project board "SolidSyslog" (project #1); all epics added
+- No open questions


### PR DESCRIPTION
## Summary

- Adds `DEVLOG.md` as a freeform narrative log for project decisions and setup steps not captured in commit history
- Records creation of the `epic` label, issues E0–E10 (#2–#12), and the SolidSyslog project board (#1)

## Test plan

- [ ] No code changes — docs only, no CI impact expected