### PR TITLE
ci: replace EnricoMi with dorny/test-reporter for per-test visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      pull-requests: write
     container:
       image: ghcr.io/davidcozens/cpputest:sha-e7aa8a1
       options: --user root
@@ -33,20 +32,19 @@ jobs:
       - name: Build and test
         run: cmake --build --preset debug --target junit
 
-      - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
-        if: always()
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
         with:
-          check_name: Test Results (GCC)
-          comment_mode: always
-          files: build/debug/cpputest_*.xml
+          name: Test Results (GCC)
+          path: build/debug/cpputest_*.xml
+          reporter: java-junit
 
   clang-build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
-      pull-requests: write
     container:
       image: ghcr.io/davidcozens/cpputest-clang:sha-6ea3f95
       options: --user root
@@ -64,20 +62,19 @@ jobs:
       - name: Build and test
         run: cmake --build --preset clang-debug --target junit
 
-      - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
-        if: always()
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
         with:
-          check_name: Test Results (Clang)
-          comment_mode: always
-          files: build/clang-debug/cpputest_*.xml
+          name: Test Results (Clang)
+          path: build/clang-debug/cpputest_*.xml
+          reporter: java-junit
 
   sanitize:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
-      pull-requests: write
     container:
       image: ghcr.io/davidcozens/cpputest:sha-e7aa8a1
       options: --user root
@@ -95,13 +92,13 @@ jobs:
       - name: Build and test
         run: cmake --build --preset sanitize --target junit
 
-      - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
-        if: always()
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
         with:
-          check_name: Test Results (Sanitize)
-          comment_mode: always
-          files: build/sanitize/cpputest_*.xml
+          name: Test Results (Sanitize)
+          path: build/sanitize/cpputest_*.xml
+          reporter: java-junit
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removes `EnricoMi/publish-unit-test-result-action` from all three test jobs (GCC, Clang, Sanitize)
- Replaces with `dorny/test-reporter@v3` using `reporter: java-junit`
- Drops `pull-requests: write` permission from test jobs — only `checks: write` needed

## Test plan
- [ ] CI runs triggered by this PR
- [ ] "Test Results (GCC/Clang/Sanitize)" Check Runs appear with individual test names
- [ ] Skipped tests (`HappyPathOnly`) visible as skipped, not just counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)