### PR TITLE
ci: show CppUTest summary in default VS Code build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
         {
             "label": "build and test",
             "type": "shell",
-            "command": "cmake --build --preset ${env:BUILD_PRESET} && ctest --preset ${env:BUILD_PRESET}",
+            "command": "cmake --build --preset ${env:BUILD_PRESET} && ctest --preset ${env:BUILD_PRESET} --verbose",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
## Summary
- Adds `--verbose` to the `ctest` invocation in the default VS Code build task so CppUTest's summary line (`OK (39 tests, 37 ran, 45 checks, 2 ignored...)`) is always visible
- Keeps individual test names out of the output (no `-v` flag on the test binary) — dots for progress, summary at the end, clickable `file:line` on failure

## Test plan
- [ ] CI passes
- [ ] Ctrl+Shift+B shows dots + CppUTest summary, not individual test names

🤖 Generated with [Claude Code](https://claude.com/claude-code)