### PR TITLE
chore: clean up code style and split SolidSyslog.h (ISP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ ci/          — CI-specific files (e.g. docker-compose.bdd.yml).
 The separation between `Interface/` and `Source/` is deliberate — it enforces the dependency inversion
 boundary that makes the code testable and portable to embedded targets.
 
+### Public header audiences (Interface Segregation)
+
+Headers in `Interface/` are split by audience — each user includes only what they need:
+
+| Header | Audience | Provides |
+|---|---|---|
+| `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log` |
+| `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy` |
+| `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
+| `SolidSyslogSenderDef.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct |
+| `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSender_Create`, `_Destroy` |
+
+Most application code only needs `SolidSyslog.h` — it never sees allocators, senders, or config structs.
+
 ---
 
 ## Naming Conventions

--- a/Example/SolidSyslogExample.c
+++ b/Example/SolidSyslogExample.c
@@ -1,4 +1,5 @@
 #include "SolidSyslog.h"
+#include "SolidSyslogConfig.h"
 #include "SolidSyslogUdpSender.h"
 
 #include <getopt.h>

--- a/Interface/SolidSyslog.h
+++ b/Interface/SolidSyslog.h
@@ -1,20 +1,12 @@
 #ifndef SOLIDSYSLOG_H
 #define SOLIDSYSLOG_H
 
-#include "SolidSyslogAlloc.h"
+#include "ExternC.h"
 #include "SolidSyslogPrival.h"
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogSender;
     struct SolidSyslog;
-
-    struct SolidSyslogConfig
-    {
-        struct SolidSyslogSender* sender;
-        SolidSyslogAllocFn        alloc;
-        SolidSyslogFreeFn         free;
-    };
 
     struct SolidSyslogMessage
     {
@@ -22,9 +14,7 @@ EXTERN_C_BEGIN
         enum SolidSyslog_Severity severity;
     };
 
-    struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config);
-    void                SolidSyslog_Destroy(struct SolidSyslog * logger);
-    void                SolidSyslog_Log(struct SolidSyslog * logger, const struct SolidSyslogMessage* message);
+    void SolidSyslog_Log(struct SolidSyslog * logger, const struct SolidSyslogMessage* message);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogConfig.h
+++ b/Interface/SolidSyslogConfig.h
@@ -1,0 +1,23 @@
+#ifndef SOLIDSYSLOGCONFIG_H
+#define SOLIDSYSLOGCONFIG_H
+
+#include "SolidSyslog.h"
+#include "SolidSyslogAlloc.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogSender;
+
+    struct SolidSyslogConfig
+    {
+        struct SolidSyslogSender* sender;
+        SolidSyslogAllocFn        alloc;
+        SolidSyslogFreeFn         free;
+    };
+
+    struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config);
+    void                SolidSyslog_Destroy(struct SolidSyslog * logger);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGCONFIG_H */

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ All fields — required and optional — use a uniform field object pattern.
 Optional features are composed at link time via dead code elimination; there are
 no conditional compilation directives in the library source.
 
+Public headers are split by audience (Interface Segregation Principle):
+- **`SolidSyslog.h`** — application code that logs events
+- **`SolidSyslogConfig.h`** — system setup code that creates and destroys loggers
+- **`SolidSyslogSenderDef.h`** — transport implementors adding new sender types
+
 ## CI pipeline
 
 See [CI pipeline](docs/ci.md).

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -1,4 +1,5 @@
 #include "SolidSyslog.h"
+#include "SolidSyslogConfig.h"
 #include "SolidSyslogSender.h"
 
 #include <stdbool.h>

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -1,11 +1,16 @@
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDef.h"
+
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+static struct sockaddr_in BuildAddress(const struct addrinfo* resolved, int port);
+static struct sockaddr_in ResolveAddress(const struct SolidSyslogUdpSenderConfig* config);
+static void               Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
 
 struct SolidSyslogUdpSender
 {
@@ -14,12 +19,6 @@ struct SolidSyslogUdpSender
     struct SolidSyslogUdpSenderConfig config;
     struct sockaddr_in                addr;
 };
-
-static void Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
-{
-    struct SolidSyslogUdpSender* sender = (struct SolidSyslogUdpSender*) self;
-    sendto(sender->fd, buffer, size, 0, (struct sockaddr*) &sender->addr, sizeof(sender->addr));
-}
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
@@ -30,19 +29,8 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     self->base.Send = Send;
     // cppcheck-suppress nullPointerOutOfMemory -- malloc NULL check deferred to error handling phase
     self->fd = socket(AF_INET, SOCK_DGRAM, 0);
-
-    struct addrinfo hints   = {0};
-    hints.ai_family         = AF_INET;
-    hints.ai_socktype       = SOCK_DGRAM;
-    struct addrinfo* result = NULL;
     // cppcheck-suppress nullPointerOutOfMemory -- malloc NULL check deferred to error handling phase
-    // NOLINTNEXTLINE(bugprone-unused-return-value) -- error handling deferred to error handling phase
-    getaddrinfo(config->getHost(), NULL, &hints, &result);
-    // cppcheck-suppress nullPointerOutOfMemory -- malloc NULL check deferred to error handling phase
-    self->addr = *(struct sockaddr_in*) result->ai_addr;
-    // cppcheck-suppress nullPointerOutOfMemory -- malloc NULL check deferred to error handling phase
-    self->addr.sin_port = htons((uint16_t) config->getPort());
-    freeaddrinfo(result);
+    self->addr = ResolveAddress(config);
 
     return &self->base;
 }
@@ -52,4 +40,33 @@ void SolidSyslogUdpSender_Destroy(struct SolidSyslogSender* sender)
     struct SolidSyslogUdpSender* self = (struct SolidSyslogUdpSender*) sender;
     close(self->fd);
     free(self);
+}
+
+static struct sockaddr_in ResolveAddress(const struct SolidSyslogUdpSenderConfig* config)
+{
+    struct addrinfo  hints  = {0};
+    struct addrinfo* result = NULL;
+    hints.ai_family         = AF_INET;
+    hints.ai_socktype       = SOCK_DGRAM;
+
+    // NOLINTNEXTLINE(bugprone-unused-return-value) -- error handling deferred to error handling phase
+    getaddrinfo(config->getHost(), NULL, &hints, &result);
+
+    struct sockaddr_in addr = BuildAddress(result, config->getPort());
+    freeaddrinfo(result);
+
+    return addr;
+}
+
+static struct sockaddr_in BuildAddress(const struct addrinfo* resolved, int port)
+{
+    struct sockaddr_in addr = *(struct sockaddr_in*) resolved->ai_addr;
+    addr.sin_port           = htons((uint16_t) port);
+    return addr;
+}
+
+static void Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
+{
+    struct SolidSyslogUdpSender* sender = (struct SolidSyslogUdpSender*) self;
+    sendto(sender->fd, buffer, size, 0, (struct sockaddr*) &sender->addr, sizeof(sender->addr));
 }

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslog.h"
+#include "SolidSyslogConfig.h"
 #include "SenderSpy.h"
 #include <cstdlib>
 #include <string>
@@ -280,12 +281,4 @@ IGNORE_TEST(SolidSyslog, HappyPathOnly)
     //
     // Optional header fields not yet driven in — see Epic #8
     //   MSG is preceded by UTF-8 BOM
-    //
-    // Multi-logger independence not yet tested
-    //   SolidSyslog_Log called twice results in Send called twice
-    //   Two independently created loggers have different handles
-    //   Each logger sends through its own sender
-    //
-    // End-to-end validated message — see Story S2.4
-    //   A single Log call produces the fully validated RFC 5424 message
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -70,6 +70,11 @@ TEST_GROUP(SolidSyslogUdpSender)
     {
         SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
     }
+
+    void Send(const void* buffer, size_t size) const
+    {
+        SolidSyslogSender_Send(sender, buffer, size);
+    }
 };
 
 // clang-format on
@@ -100,7 +105,7 @@ TEST(SolidSyslogUdpSender, MaxMessageSizeTransmittedWithoutTruncation)
 {
     std::array<char, TEST_MAX_MESSAGE_SIZE> buffer{};
     buffer.fill('A');
-    SolidSyslogSender_Send(sender, buffer.data(), buffer.size());
+    Send(buffer.data(), buffer.size());
     LONGS_EQUAL(TEST_MAX_MESSAGE_SIZE, SocketSpy_LastLen());
     MEMCMP_EQUAL(buffer.data(), SocketSpy_LastBuf(), TEST_MAX_MESSAGE_SIZE);
 }
@@ -236,6 +241,11 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
         config = {getPort, getHost};
         sender = SolidSyslogUdpSender_Create(&config);
     }
+
+    void Send() const
+    {
+        SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    }
 };
 
 // clang-format on
@@ -244,14 +254,14 @@ TEST(SolidSyslogUdpSenderConfig, GetPortCalledOnCreate)
 {
     CreateSender(SpyGetPort, GetDefaultHost);
     LONGS_EQUAL(1, getPortCallCount);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     LONGS_EQUAL(1, getPortCallCount);
 }
 
 TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithConfiguredPort)
 {
     CreateSender(GetAlternatePort, GetDefaultHost);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketSpy_LastPort());
 }
 
@@ -259,7 +269,7 @@ TEST(SolidSyslogUdpSenderConfig, GetHostCalledOnCreate)
 {
     CreateSender(GetDefaultPort, SpyGetHost);
     LONGS_EQUAL(1, getHostCallCount);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     LONGS_EQUAL(1, getHostCallCount);
 }
 
@@ -273,6 +283,6 @@ TEST(SolidSyslogUdpSenderConfig, GetAddrInfoCalledWithHostnameFromGetHost)
 TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithResolvedAddress)
 {
     CreateSender(GetDefaultPort, GetDefaultHost);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     STRCMP_EQUAL(TEST_DEFAULT_HOST, SocketSpy_LastAddrAsString());
 }


### PR DESCRIPTION
## Summary
- Split `SolidSyslog.h` into `SolidSyslog.h` (logging API) and `SolidSyslogConfig.h` (lifecycle) per Interface Segregation Principle
- Clean up `SolidSyslogUdpSender.c`: function ordering, extracted `ResolveAddress`/`BuildAddress` helpers
- Clean up `SolidSyslogUdpSenderTest.cpp`: added `Send` overloads to test groups
- Pruned implemented items from `IGNORE_TEST` todo comments
- Updated CLAUDE.md and README.md with interface audience guidance

## Test plan
- [x] 49 unit tests pass across debug, clang-debug, sanitize presets
- [x] 100% line and function coverage
- [x] clang-tidy, cppcheck, clang-format all clean
- [x] No behavioural changes — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)