### PR TITLE
ci: promote BDD to required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,6 @@ jobs:
   bdd:
     needs: build-and-test
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
       checks: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ All changes to `main` must go via a pull request — direct pushes are blocked b
 becomes the single commit message — so the PR title must follow Conventional Commits format (see below).
 
 **Before raising a PR:**
-- All CI checks must pass: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format
+- All CI checks must pass: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd
 - Commits on the branch can be informal (work-in-progress messages are fine)
 - The PR title is what matters — it becomes the permanent commit message on `main`
 
 **Branch protection rules (configured on GitHub):**
 - Direct pushes to `main` are blocked
-- PRs require all status checks to pass before merging: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format
+- PRs require all status checks to pass before merging: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd
 - Squash merge only — other merge strategies are disabled
 - Branches are deleted automatically after merge
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,12 +13,11 @@ GitHub Actions runs all jobs in parallel on every push and pull request to `main
 | `tidy` | `tidy` | clang-tidy — pass/fail with errors in job log |
 | `cppcheck` | `cppcheck` | cppcheck static analysis |
 | `format` | — | clang-format dry-run; fails if any file needs reformatting |
-| `bdd` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave). Advisory — not a required check |
+| `bdd` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave) |
 
 ## Branch protection
 
-All jobs except `bdd` are required status checks. A PR cannot be merged unless the required checks pass.
-The `bdd` job runs and reports pass/fail but does not block merge (`continue-on-error: true`).
+All jobs are required status checks. A PR cannot be merged unless all checks pass.
 Direct pushes to `main` are blocked. Squash merge only.
 
 ## Release automation


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from BDD job — failures now block merge
- Update CLAUDE.md and docs/ci.md to reflect BDD as required

BDD scenarios are stable and passing. Red BDD on `main` should be treated
as a regression, same as any other CI failure.

**Note:** Branch protection rules on GitHub also need updating to add `bdd`
as a required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)