### PR TITLE
feat: S4.2 SolidSyslog_Service API and Buffer Read

### DIFF
--- a/Interface/SolidSyslog.h
+++ b/Interface/SolidSyslog.h
@@ -4,6 +4,8 @@
 #include "ExternC.h"
 #include "SolidSyslogPrival.h"
 
+#include <stdbool.h>
+
 EXTERN_C_BEGIN
 
     enum
@@ -22,6 +24,7 @@ EXTERN_C_BEGIN
     };
 
     void SolidSyslog_Log(struct SolidSyslog * logger, const struct SolidSyslogMessage* message);
+    bool SolidSyslog_Service(struct SolidSyslog * logger);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogBuffer.h
+++ b/Interface/SolidSyslogBuffer.h
@@ -2,6 +2,7 @@
 #define SOLIDSYSLOGBUFFER_H
 
 #include "ExternC.h"
+#include <stdbool.h>
 #include <stddef.h>
 
 EXTERN_C_BEGIN
@@ -9,6 +10,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogBuffer;
 
     void SolidSyslogBuffer_Write(struct SolidSyslogBuffer * buffer, const void* data, size_t size);
+    bool SolidSyslogBuffer_Read(struct SolidSyslogBuffer * buffer);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogBufferDef.h
+++ b/Interface/SolidSyslogBufferDef.h
@@ -8,6 +8,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogBuffer
     {
         void (*Write)(struct SolidSyslogBuffer* self, const void* data, size_t size);
+        bool (*Read)(struct SolidSyslogBuffer* self);
     };
 
 EXTERN_C_END

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -77,6 +77,11 @@ void SolidSyslog_Destroy(struct SolidSyslog* logger)
     logger->free(logger);
 }
 
+bool SolidSyslog_Service(struct SolidSyslog* logger)
+{
+    return SolidSyslogBuffer_Read(logger->buffer);
+}
+
 void SolidSyslog_Log(struct SolidSyslog* logger, const struct SolidSyslogMessage* message)
 {
     char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];

--- a/Source/SolidSyslogBuffer.c
+++ b/Source/SolidSyslogBuffer.c
@@ -4,3 +4,8 @@ void SolidSyslogBuffer_Write(struct SolidSyslogBuffer* buffer, const void* data,
 {
     buffer->Write(buffer, data, size);
 }
+
+bool SolidSyslogBuffer_Read(struct SolidSyslogBuffer* buffer)
+{
+    return buffer->Read(buffer);
+}

--- a/Source/SolidSyslogNullBuffer.c
+++ b/Source/SolidSyslogNullBuffer.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 
+static bool Read(struct SolidSyslogBuffer* self);
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
 struct SolidSyslogNullBuffer
@@ -16,6 +17,7 @@ struct SolidSyslogBuffer* SolidSyslogNullBuffer_Create(struct SolidSyslogSender*
 {
     struct SolidSyslogNullBuffer* self = malloc(sizeof(struct SolidSyslogNullBuffer));
     self->base.Write                   = Write;
+    self->base.Read                    = Read;
     self->sender                       = sender;
     return &self->base;
 }
@@ -23,6 +25,12 @@ struct SolidSyslogBuffer* SolidSyslogNullBuffer_Create(struct SolidSyslogSender*
 void SolidSyslogNullBuffer_Destroy(struct SolidSyslogBuffer* buffer)
 {
     free(buffer);
+}
+
+static bool Read(struct SolidSyslogBuffer* self)
+{
+    (void) self;
+    return false;
 }
 
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)

--- a/Tests/SolidSyslogNullBufferTest.cpp
+++ b/Tests/SolidSyslogNullBufferTest.cpp
@@ -64,6 +64,12 @@ TEST(SolidSyslogNullBuffer, NoWritesResultInNoSends)
     LONGS_EQUAL(0, SenderSpy_CallCount());
 }
 
+TEST(SolidSyslogNullBuffer, ReadReturnsNothingToSend)
+{
+    bool sent = SolidSyslogBuffer_Read(buffer);
+    CHECK_FALSE(sent);
+}
+
 IGNORE_TEST(SolidSyslogNullBuffer, HappyPathOnly)
 {
     // Error handling not yet implemented — see Epic #31

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -897,12 +897,25 @@ TEST(SolidSyslog, EmptyProcIdProducesNilvalue)
     CHECK_PROCID("-");
 }
 
+TEST(SolidSyslog, ServiceReturnsNothingToSendWithNullBuffer)
+{
+    bool sent = SolidSyslog_Service(logger);
+    CHECK_FALSE(sent);
+}
+
+TEST(SolidSyslog, MultipleServiceCallsReturnNothingToSend)
+{
+    CHECK_FALSE(SolidSyslog_Service(logger));
+    CHECK_FALSE(SolidSyslog_Service(logger));
+}
+
 IGNORE_TEST(SolidSyslog, HappyPathOnly)
 {
     // Error handling not yet implemented — see Epic #31
     //   SolidSyslog_Create with a NULL config returns NULL
     //   SolidSyslog_Destroy with a NULL handle does not crash
     //   SolidSyslog_Log on NULL handle does nothing, does not crash
+    //   SolidSyslog_Service on NULL handle does nothing, does not crash
     //
     // Optional header fields not yet driven in — see Epic #8
     //   MSG is preceded by UTF-8 BOM


### PR DESCRIPTION
## Summary
- Add `SolidSyslog_Service(logger)` as the public sender-side entry point — returns `bool` indicating whether a message was sent
- Add `Read` to the `SolidSyslogBuffer` vtable — NullBuffer always returns false (nothing to send)
- `SolidSyslog_Service` delegates to `Buffer_Read`
- Document deferred `SolidSyslog_Service` NULL handling in existing `IGNORE_TEST(HappyPathOnly)`

Closes #51

## Test plan
- [x] 166 unit tests passing (163 ran + 3 ignored)
- [x] cppcheck clean
- [x] clang-tidy clean
- [x] clang-format clean
- [x] ASan + UBSan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)