### PR TITLE
ci: add missing quality-summary dependencies and resilient downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
 
   quality-summary:
     if: always() && github.event_name == 'pull_request'
-    needs: [build-and-test, clang-build-and-test, sanitize, tidy, cppcheck, bdd]
+    needs: [build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -371,12 +371,14 @@ jobs:
           path: quality-reports/
 
       - name: Download clang-tidy report
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: clang-tidy-report
           path: quality-reports/
 
       - name: Download cppcheck report
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: cppcheck-report


### PR DESCRIPTION
## Purpose
Fix two issues identified by CodeRabbit review on #70:
- quality-summary job could complete before all CI gates finish
- artifact download failures block the summary job

## Change Description
- Add `coverage` and `format` to quality-summary `needs` array so it waits for all 8 CI gates before aggregating
- Add `continue-on-error: true` to clang-tidy and cppcheck artifact download steps so the summary job still produces results when a producer fails before upload

## Test Evidence
CI workflow change only — no production code affected. Verified by CI run on this PR.

## Areas Affected
`.github/workflows/ci.yml` — quality-summary job only. No impact on other CI jobs or production code.