### PR TITLE
feat: structured data with sequenceId (S7.1)

### DIFF
--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -21,6 +21,13 @@ def line_count(path):
         return sum(1 for _ in f)
 
 
+def read_new_lines(path, skip):
+    """Return all lines after the first 'skip' lines."""
+    with open(path) as f:
+        lines = f.readlines()
+    return [line.strip() for line in lines[skip:] if line.strip()]
+
+
 def read_last_line(path):
     """Return the last non-empty line from a file."""
     with open(path) as f:
@@ -36,6 +43,12 @@ def parse_syslog_line(line):
     fields = {}
     for match in re.finditer(r"(\w+)=(\S+)", line):
         fields[match.group(1)] = match.group(2)
+
+    # STRUCTURED_DATA may contain spaces and special chars — capture between
+    # "STRUCTURED_DATA=" and " MSG="
+    sd_match = re.search(r"STRUCTURED_DATA=(.*?) MSG=", line)
+    if sd_match:
+        fields["STRUCTURED_DATA"] = sd_match.group(1)
 
     # MSG may contain spaces — capture everything after "MSG="
     msg_match = re.search(r"MSG=(.*)", line)
@@ -90,8 +103,9 @@ def run_example(context, extra_args=None, binary=None, expected_messages=1):
             )
         time.sleep(0.1)
 
-    context.fields = parse_syslog_line(read_last_line(RECEIVED_LOG))
-    context.message_count = line_count(RECEIVED_LOG) - context.lines_before
+    context.all_lines = read_new_lines(RECEIVED_LOG, context.lines_before)
+    context.fields = parse_syslog_line(context.all_lines[-1])
+    context.message_count = len(context.all_lines)
 
 
 @when("the example program sends a syslog message")
@@ -205,8 +219,42 @@ def step_check_msg(context, msg):
     )
 
 
+@when("the example program sends {count:d} syslog messages")
+def step_example_sends_multiple(context, count):
+    run_example(context, ["--count", str(count)], expected_messages=count)
+
+
 @then("syslog-ng receives {count:d} messages")
 def step_check_message_count(context, count):
     assert context.message_count == count, (
         f"Expected {count} messages, got {context.message_count}"
     )
+
+
+@then('the structured data contains sequenceId "{value}"')
+def step_check_sequence_id(context, value):
+    sd = context.fields.get("STRUCTURED_DATA", "")
+    match = re.search(r'sequenceId="(\d+)"', sd)
+    assert match, (
+        f"No sequenceId found in structured data: {sd}"
+    )
+    assert match.group(1) == value, (
+        f"Expected sequenceId {value}, got {match.group(1)}"
+    )
+
+
+@then("syslog-ng receives {count:d} messages with sequential sequenceId values")
+def step_check_sequential_ids(context, count):
+    assert context.message_count == count, (
+        f"Expected {count} messages, got {context.message_count}"
+    )
+    for i, line in enumerate(context.all_lines, start=1):
+        fields = parse_syslog_line(line)
+        sd = fields.get("STRUCTURED_DATA", "")
+        match = re.search(r'sequenceId="(\d+)"', sd)
+        assert match, (
+            f"Message {i}: no sequenceId in structured data: {sd}"
+        )
+        assert match.group(1) == str(i), (
+            f"Message {i}: expected sequenceId {i}, got {match.group(1)}"
+        )

--- a/Bdd/features/structured_data.feature
+++ b/Bdd/features/structured_data.feature
@@ -1,0 +1,12 @@
+Feature: Structured data — sequence ID
+  The library includes an auto-incrementing sequence ID in structured data.
+
+  Scenario: First message has sequence ID 1
+    Given syslog-ng is running
+    When the example program sends a syslog message
+    Then the structured data contains sequenceId "1"
+
+  Scenario: Sequence ID increments with each message
+    Given syslog-ng is running
+    When the example program sends 3 syslog messages
+    Then syslog-ng receives 3 messages with sequential sequenceId values

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,10 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogPosixClock.h` | System setup code using POSIX clock | `SolidSyslogPosixClock_GetTimestamp` |
 | `SolidSyslogPosixHostname.h` | System setup code using POSIX hostname | `SolidSyslogPosixHostname_Get` |
 | `SolidSyslogPosixProcId.h` | System setup code using POSIX process ID | `SolidSyslogPosixProcId_Get` |
+| `SolidSyslogStructuredData.h` | Library internals (SD dispatch) | `SolidSyslogStructuredData_Format` |
+| `SolidSyslogStructuredDataDef.h` | SD implementors (extension point) | `SolidSyslogStructuredData` vtable struct |
+| `SolidSyslogMetaSd.h` | System setup code using sequenceId SD | `SolidSyslogMetaSd_Create`, `_Destroy` |
+| `SolidSyslogAtomicCounter.h` | System setup code on platforms with C11 atomics | `SolidSyslogAtomicCounter_Create`, `_Destroy`, `_Increment` |
 
 Most application code only needs `SolidSyslog.h` — it never sees allocators, senders, buffers, or config structs.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ include(CheckSymbolExists)
 check_symbol_exists(sendto "sys/socket.h" HAVE_POSIX_SOCKETS)
 option(SOLIDSYSLOG_POSIX "Include POSIX UDP sender" ${HAVE_POSIX_SOCKETS})
 
+include(CheckIncludeFile)
+check_include_file(stdatomic.h HAVE_STDATOMIC_H)
+
 add_subdirectory(Source)
 
 if(SOLIDSYSLOG_POSIX)

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -3,7 +3,9 @@
 #include "ExampleCommandLine.h"
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
+#include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogMetaSd.h"
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogPosixClock.h"
 #include "SolidSyslogPosixHostname.h"
@@ -26,8 +28,10 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         .getPort = ExampleUdpConfig_GetPort,
         .getHost = ExampleUdpConfig_GetHost,
     };
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&udpConfig);
-    struct SolidSyslogBuffer* buffer = SolidSyslogNullBuffer_Create(sender);
+    struct SolidSyslogSender*         sender  = SolidSyslogUdpSender_Create(&udpConfig);
+    struct SolidSyslogBuffer*         buffer  = SolidSyslogNullBuffer_Create(sender);
+    struct SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create(malloc);
+    struct SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(malloc, counter);
 
     struct SolidSyslogConfig config = {
         .buffer      = buffer,
@@ -38,6 +42,7 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         .getHostname = SolidSyslogPosixHostname_Get,
         .getAppName  = ExampleAppName_Get,
         .getProcId   = SolidSyslogPosixProcId_Get,
+        .sd          = metaSd,
     };
     struct SolidSyslog* logger = SolidSyslog_Create(&config);
 
@@ -53,6 +58,8 @@ int SolidSyslogExample_Run(int argc, char* argv[])
     }
 
     SolidSyslog_Destroy(logger);
+    SolidSyslogMetaSd_Destroy(metaSd, free);
+    SolidSyslogAtomicCounter_Destroy(counter, free);
     SolidSyslogNullBuffer_Destroy(buffer);
     SolidSyslogUdpSender_Destroy(sender);
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -3,7 +3,9 @@
 #include "ExampleServiceThread.h"
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
+#include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogMetaSd.h"
 #include "SolidSyslogPosixClock.h"
 #include "SolidSyslogPosixHostname.h"
 #include "SolidSyslogPosixMqBuffer.h"
@@ -42,8 +44,10 @@ int main(int argc, char* argv[])
         .getPort = ExampleUdpConfig_GetPort,
         .getHost = ExampleUdpConfig_GetHost,
     };
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&udpConfig);
-    struct SolidSyslogBuffer* buffer = SolidSyslogPosixMqBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
+    struct SolidSyslogSender*         sender  = SolidSyslogUdpSender_Create(&udpConfig);
+    struct SolidSyslogBuffer*         buffer  = SolidSyslogPosixMqBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
+    struct SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create(malloc);
+    struct SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(malloc, counter);
 
     struct SolidSyslogConfig config = {
         .buffer      = buffer,
@@ -54,6 +58,7 @@ int main(int argc, char* argv[])
         .getHostname = SolidSyslogPosixHostname_Get,
         .getAppName  = ExampleAppName_Get,
         .getProcId   = SolidSyslogPosixProcId_Get,
+        .sd          = metaSd,
     };
     struct SolidSyslog* logger = SolidSyslog_Create(&config);
 
@@ -78,6 +83,8 @@ int main(int argc, char* argv[])
     pthread_join(serviceThread, NULL);
 
     SolidSyslog_Destroy(logger);
+    SolidSyslogMetaSd_Destroy(metaSd, free);
+    SolidSyslogAtomicCounter_Destroy(counter, free);
     SolidSyslogPosixMqBuffer_Destroy(buffer);
     SolidSyslogUdpSender_Destroy(sender);
 

--- a/Interface/SolidSyslogAtomicCounter.h
+++ b/Interface/SolidSyslogAtomicCounter.h
@@ -1,0 +1,19 @@
+#ifndef SOLIDSYSLOGATOMICCOUNTER_H
+#define SOLIDSYSLOGATOMICCOUNTER_H
+
+#include "ExternC.h"
+#include "SolidSyslogAlloc.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogAtomicCounter;
+
+    struct SolidSyslogAtomicCounter* SolidSyslogAtomicCounter_Create(SolidSyslogAllocFunction alloc);
+    void                             SolidSyslogAtomicCounter_Destroy(struct SolidSyslogAtomicCounter * counter, SolidSyslogFreeFunction dealloc);
+    uint_fast32_t                    SolidSyslogAtomicCounter_Increment(struct SolidSyslogAtomicCounter * counter);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGATOMICCOUNTER_H */

--- a/Interface/SolidSyslogConfig.h
+++ b/Interface/SolidSyslogConfig.h
@@ -9,19 +9,21 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogBuffer;
     struct SolidSyslogSender;
+    struct SolidSyslogStructuredData;
 
     typedef size_t (*SolidSyslogStringFunction)(char* buffer, size_t size);
 
     struct SolidSyslogConfig
     {
-        struct SolidSyslogBuffer* buffer;
-        struct SolidSyslogSender* sender;
-        SolidSyslogAllocFunction  alloc;
-        SolidSyslogFreeFunction   free;
-        SolidSyslogClockFunction  clock;
-        SolidSyslogStringFunction getHostname;
-        SolidSyslogStringFunction getAppName;
-        SolidSyslogStringFunction getProcId;
+        struct SolidSyslogBuffer*         buffer;
+        struct SolidSyslogSender*         sender;
+        SolidSyslogAllocFunction          alloc;
+        SolidSyslogFreeFunction           free;
+        SolidSyslogClockFunction          clock;
+        SolidSyslogStringFunction         getHostname;
+        SolidSyslogStringFunction         getAppName;
+        SolidSyslogStringFunction         getProcId;
+        struct SolidSyslogStructuredData* sd;
     };
 
     struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config);

--- a/Interface/SolidSyslogMetaSd.h
+++ b/Interface/SolidSyslogMetaSd.h
@@ -1,0 +1,17 @@
+#ifndef SOLIDSYSLOGMETASD_H
+#define SOLIDSYSLOGMETASD_H
+
+#include "ExternC.h"
+#include "SolidSyslogAlloc.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogAtomicCounter;
+    struct SolidSyslogStructuredData;
+
+    struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(SolidSyslogAllocFunction alloc, struct SolidSyslogAtomicCounter * counter);
+    void                              SolidSyslogMetaSd_Destroy(struct SolidSyslogStructuredData * sd, SolidSyslogFreeFunction dealloc);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGMETASD_H */

--- a/Interface/SolidSyslogStructuredData.h
+++ b/Interface/SolidSyslogStructuredData.h
@@ -1,0 +1,15 @@
+#ifndef SOLIDSYSLOGSTRUCTUREDDATA_H
+#define SOLIDSYSLOGSTRUCTUREDDATA_H
+
+#include "ExternC.h"
+#include <stddef.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogStructuredData;
+
+    size_t SolidSyslogStructuredData_Format(struct SolidSyslogStructuredData * sd, char* buffer, size_t size);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSTRUCTUREDDATA_H */

--- a/Interface/SolidSyslogStructuredDataDef.h
+++ b/Interface/SolidSyslogStructuredDataDef.h
@@ -1,0 +1,15 @@
+#ifndef SOLIDSYSLOGSTRUCTUREDDATADEF_H
+#define SOLIDSYSLOGSTRUCTUREDDATADEF_H
+
+#include "SolidSyslogStructuredData.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogStructuredData
+    {
+        size_t (*Format)(struct SolidSyslogStructuredData* self, char* buffer, size_t size);
+    };
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSTRUCTUREDDATADEF_H */

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,9 +1,18 @@
 set(SOURCES
     SolidSyslog.c
     SolidSyslogBuffer.c
+    SolidSyslogFormat.c
+    SolidSyslogMetaSd.c
     SolidSyslogNullBuffer.c
     SolidSyslogSender.c
+    SolidSyslogStructuredData.c
 )
+
+if(HAVE_STDATOMIC_H)
+    list(APPEND SOURCES
+        SolidSyslogAtomicCounter.c
+    )
+endif()
 
 if(SOLIDSYSLOG_POSIX)
     list(APPEND SOURCES

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -1,7 +1,9 @@
 #include "SolidSyslog.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogFormat.h"
 #include "SolidSyslogSender.h"
+#include "SolidSyslogStructuredData.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -22,21 +24,18 @@ static inline bool    FacilityIsValid(uint8_t facility);
 static inline size_t  FormatAppName(char* buffer, SolidSyslogStringFunction getAppName);
 static inline size_t  FormatAsHours(char* buffer, int16_t absoluteMinutes);
 static inline size_t  FormatAsMinutes(char* buffer, int16_t absoluteMinutes);
-static inline size_t  FormatBoundedString(char* buffer, const char* source, size_t bufferSize);
 static inline size_t  FormatCapturedTimestamp(char* buffer, const struct SolidSyslogTimestamp* ts);
-static inline size_t  FormatCharacter(char* buffer, char value);
 static inline size_t  FormatHostname(char* buffer, SolidSyslogStringFunction getHostname);
 static inline size_t  FormatMessage(const struct SolidSyslog* self, char* buffer, size_t size, const struct SolidSyslogMessage* message);
 static inline size_t  FormatMicrosecond(char* buffer, uint32_t value);
 static inline size_t  FormatMsg(char* buffer, const char* msg, size_t remaining);
 static inline size_t  FormatMsgId(char* buffer, const char* messageId);
-static inline size_t  FormatNilvalue(char* buffer);
 static inline size_t  FormatNonZeroUtcOffset(char* buffer, int16_t offsetMinutes);
 static inline size_t  FormatPrival(char* buffer, uint8_t prival);
 static inline size_t  FormatProcId(char* buffer, SolidSyslogStringFunction getProcId);
 static inline size_t  FormatSign(char* buffer, int16_t value);
 static inline size_t  FormatSpace(char* buffer);
-static inline size_t  FormatStructuredData(char* buffer);
+static inline size_t  FormatStructuredData(char* buffer, size_t size, struct SolidSyslogStructuredData* sd);
 static inline size_t  FormatTimestamp(char* buffer, size_t size, SolidSyslogClockFunction clock);
 static inline size_t  FormatTwoDigit(char* buffer, uint8_t value);
 static inline size_t  FormatUtcOffset(char* buffer, int16_t offsetMinutes);
@@ -50,13 +49,14 @@ static inline bool    TimestampIsValid(const struct SolidSyslogTimestamp* ts);
 
 struct SolidSyslog
 {
-    struct SolidSyslogBuffer* buffer;
-    struct SolidSyslogSender* sender;
-    SolidSyslogFreeFunction   free;
-    SolidSyslogClockFunction  clock;
-    SolidSyslogStringFunction getHostname;
-    SolidSyslogStringFunction getAppName;
-    SolidSyslogStringFunction getProcId;
+    struct SolidSyslogBuffer*         buffer;
+    struct SolidSyslogSender*         sender;
+    SolidSyslogFreeFunction           free;
+    SolidSyslogClockFunction          clock;
+    SolidSyslogStringFunction         getHostname;
+    SolidSyslogStringFunction         getAppName;
+    SolidSyslogStringFunction         getProcId;
+    struct SolidSyslogStructuredData* sd;
 };
 
 struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config)
@@ -71,6 +71,7 @@ struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config)
         instance->getHostname = config->getHostname;
         instance->getAppName  = config->getAppName;
         instance->getProcId   = config->getProcId;
+        instance->sd          = config->sd;
     }
     return instance;
 }
@@ -118,7 +119,7 @@ static inline size_t FormatMessage(const struct SolidSyslog* self, char* buffer,
     len += FormatSpace(buffer + len);
     len += FormatMsgId(buffer + len, message->messageId);
     len += FormatSpace(buffer + len);
-    len += FormatStructuredData(buffer + len);
+    len += FormatStructuredData(buffer + len, size - len, self->sd);
     len += FormatMsg(buffer + len, message->msg, size - len);
 
     return len;
@@ -128,26 +129,19 @@ static inline size_t FormatPrival(char* buffer, uint8_t prival)
 {
     size_t len = 0;
 
-    len += FormatCharacter(buffer + len, '<');
+    len += SolidSyslogFormat_Character(buffer + len, '<');
     if (prival >= 100U)
     {
-        len += FormatCharacter(buffer + len, (char) ('0' + (prival / 100U)));
+        len += SolidSyslogFormat_Character(buffer + len, SolidSyslogFormat_DigitToChar(prival / 100U));
     }
     if (prival >= 10U)
     {
-        len += FormatCharacter(buffer + len, (char) ('0' + ((prival / 10U) % 10U)));
+        len += SolidSyslogFormat_Character(buffer + len, SolidSyslogFormat_DigitToChar(prival / 10U));
     }
-    len += FormatCharacter(buffer + len, (char) ('0' + (prival % 10U)));
-    len += FormatCharacter(buffer + len, '>');
+    len += SolidSyslogFormat_Character(buffer + len, SolidSyslogFormat_DigitToChar(prival));
+    len += SolidSyslogFormat_Character(buffer + len, '>');
 
     return len;
-}
-
-static inline size_t FormatCharacter(char* buffer, char value)
-{
-    buffer[0] = value;
-    buffer[1] = '\0';
-    return 1;
 }
 
 static inline uint8_t MakePrival(const struct SolidSyslogMessage* message)
@@ -186,12 +180,12 @@ static inline bool SeverityIsValid(uint8_t severity)
 
 static inline size_t FormatVersion(char* buffer)
 {
-    return FormatCharacter(buffer, '1');
+    return SolidSyslogFormat_Character(buffer, '1');
 }
 
 static inline size_t FormatSpace(char* buffer)
 {
-    return FormatCharacter(buffer, ' ');
+    return SolidSyslogFormat_Character(buffer, ' ');
 }
 
 static inline size_t FormatTimestamp(char* buffer, size_t size, SolidSyslogClockFunction clock)
@@ -207,7 +201,7 @@ static inline size_t FormatTimestamp(char* buffer, size_t size, SolidSyslogClock
     }
     else
     {
-        len = FormatNilvalue(buffer);
+        len = SolidSyslogFormat_Nilvalue(buffer);
     }
 
     return len;
@@ -246,17 +240,17 @@ static inline size_t FormatCapturedTimestamp(char* buffer, const struct SolidSys
     size_t len = 0;
 
     len += FormatYear(buffer + len, ts->year);
-    len += FormatCharacter(buffer + len, '-');
+    len += SolidSyslogFormat_Character(buffer + len, '-');
     len += FormatTwoDigit(buffer + len, ts->month);
-    len += FormatCharacter(buffer + len, '-');
+    len += SolidSyslogFormat_Character(buffer + len, '-');
     len += FormatTwoDigit(buffer + len, ts->day);
-    len += FormatCharacter(buffer + len, 'T');
+    len += SolidSyslogFormat_Character(buffer + len, 'T');
     len += FormatTwoDigit(buffer + len, ts->hour);
-    len += FormatCharacter(buffer + len, ':');
+    len += SolidSyslogFormat_Character(buffer + len, ':');
     len += FormatTwoDigit(buffer + len, ts->minute);
-    len += FormatCharacter(buffer + len, ':');
+    len += SolidSyslogFormat_Character(buffer + len, ':');
     len += FormatTwoDigit(buffer + len, ts->second);
-    len += FormatCharacter(buffer + len, '.');
+    len += SolidSyslogFormat_Character(buffer + len, '.');
     len += FormatMicrosecond(buffer + len, ts->microsecond);
     len += FormatUtcOffset(buffer + len, ts->utcOffsetMinutes);
 
@@ -265,30 +259,30 @@ static inline size_t FormatCapturedTimestamp(char* buffer, const struct SolidSys
 
 static inline size_t FormatYear(char* buffer, uint16_t value)
 {
-    buffer[0] = (char) ('0' + ((value / 1000U) % 10U));
-    buffer[1] = (char) ('0' + ((value / 100U) % 10U));
-    buffer[2] = (char) ('0' + ((value / 10U) % 10U));
-    buffer[3] = (char) ('0' + (value % 10U));
+    buffer[0] = SolidSyslogFormat_DigitToChar(value / 1000U);
+    buffer[1] = SolidSyslogFormat_DigitToChar(value / 100U);
+    buffer[2] = SolidSyslogFormat_DigitToChar(value / 10U);
+    buffer[3] = SolidSyslogFormat_DigitToChar(value);
     buffer[4] = '\0';
     return 4;
 }
 
 static inline size_t FormatTwoDigit(char* buffer, uint8_t value)
 {
-    buffer[0] = (char) ('0' + (value / 10U));
-    buffer[1] = (char) ('0' + (value % 10U));
+    buffer[0] = SolidSyslogFormat_DigitToChar(value / 10U);
+    buffer[1] = SolidSyslogFormat_DigitToChar(value);
     buffer[2] = '\0';
     return 2;
 }
 
 static inline size_t FormatMicrosecond(char* buffer, uint32_t value)
 {
-    buffer[0] = (char) ('0' + ((value / 100000U) % 10U));
-    buffer[1] = (char) ('0' + ((value / 10000U) % 10U));
-    buffer[2] = (char) ('0' + ((value / 1000U) % 10U));
-    buffer[3] = (char) ('0' + ((value / 100U) % 10U));
-    buffer[4] = (char) ('0' + ((value / 10U) % 10U));
-    buffer[5] = (char) ('0' + (value % 10U));
+    buffer[0] = SolidSyslogFormat_DigitToChar(value / 100000U);
+    buffer[1] = SolidSyslogFormat_DigitToChar(value / 10000U);
+    buffer[2] = SolidSyslogFormat_DigitToChar(value / 1000U);
+    buffer[3] = SolidSyslogFormat_DigitToChar(value / 100U);
+    buffer[4] = SolidSyslogFormat_DigitToChar(value / 10U);
+    buffer[5] = SolidSyslogFormat_DigitToChar(value);
     buffer[6] = '\0';
     return 6;
 }
@@ -299,7 +293,7 @@ static inline size_t FormatUtcOffset(char* buffer, int16_t offsetMinutes)
 
     if (offsetMinutes == 0)
     {
-        len = FormatCharacter(buffer, 'Z');
+        len = SolidSyslogFormat_Character(buffer, 'Z');
     }
     else
     {
@@ -316,7 +310,7 @@ static inline size_t FormatNonZeroUtcOffset(char* buffer, int16_t offsetMinutes)
 
     len += FormatSign(buffer + len, offsetMinutes);
     len += FormatAsHours(buffer + len, absoluteMinutes);
-    len += FormatCharacter(buffer + len, ':');
+    len += SolidSyslogFormat_Character(buffer + len, ':');
     len += FormatAsMinutes(buffer + len, absoluteMinutes);
 
     return len;
@@ -336,7 +330,7 @@ static inline int16_t AbsoluteInt16(int16_t value)
 
 static inline size_t FormatSign(char* buffer, int16_t value)
 {
-    return FormatCharacter(buffer, (value > 0) ? '+' : '-');
+    return SolidSyslogFormat_Character(buffer, (value > 0) ? '+' : '-');
 }
 
 static inline size_t FormatAsHours(char* buffer, int16_t absoluteMinutes)
@@ -347,11 +341,6 @@ static inline size_t FormatAsHours(char* buffer, int16_t absoluteMinutes)
 static inline size_t FormatAsMinutes(char* buffer, int16_t absoluteMinutes)
 {
     return FormatTwoDigit(buffer, (uint8_t) (absoluteMinutes % 60));
-}
-
-static inline size_t FormatNilvalue(char* buffer)
-{
-    return FormatCharacter(buffer, '-');
 }
 
 static inline size_t FormatHostname(char* buffer, SolidSyslogStringFunction getHostname)
@@ -365,7 +354,7 @@ static inline size_t FormatHostname(char* buffer, SolidSyslogStringFunction getH
 
     if (len == 0)
     {
-        len = FormatNilvalue(buffer);
+        len = SolidSyslogFormat_Nilvalue(buffer);
     }
 
     return len;
@@ -382,7 +371,7 @@ static inline size_t FormatAppName(char* buffer, SolidSyslogStringFunction getAp
 
     if (len == 0)
     {
-        len = FormatNilvalue(buffer);
+        len = SolidSyslogFormat_Nilvalue(buffer);
     }
 
     return len;
@@ -399,7 +388,7 @@ static inline size_t FormatProcId(char* buffer, SolidSyslogStringFunction getPro
 
     if (len == 0)
     {
-        len = FormatNilvalue(buffer);
+        len = SolidSyslogFormat_Nilvalue(buffer);
     }
 
     return len;
@@ -411,12 +400,12 @@ static inline size_t FormatMsgId(char* buffer, const char* messageId)
 
     if (StringIsValid(messageId))
     {
-        len = FormatBoundedString(buffer, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE);
+        len = SolidSyslogFormat_BoundedString(buffer, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE);
     }
 
     if (len == 0)
     {
-        len = FormatNilvalue(buffer);
+        len = SolidSyslogFormat_Nilvalue(buffer);
     }
 
     return len;
@@ -427,22 +416,14 @@ static inline bool StringIsValid(const char* value)
     return (value != NULL) && (value[0] != '\0');
 }
 
-static inline size_t FormatBoundedString(char* buffer, const char* source, size_t bufferSize)
+static inline size_t FormatStructuredData(char* buffer, size_t size, struct SolidSyslogStructuredData* sd)
 {
-    size_t maxLength = (bufferSize > 0) ? bufferSize - 1 : 0;
-    size_t len       = 0;
-    while ((len < maxLength) && (source[len] != '\0'))
+    if (sd != NULL)
     {
-        buffer[len] = source[len];
-        len++;
+        return SolidSyslogStructuredData_Format(sd, buffer, size);
     }
-    buffer[len] = '\0';
-    return len;
-}
 
-static inline size_t FormatStructuredData(char* buffer)
-{
-    return FormatNilvalue(buffer);
+    return SolidSyslogFormat_Nilvalue(buffer);
 }
 
 static inline size_t FormatMsg(char* buffer, const char* msg, size_t remaining)
@@ -452,7 +433,7 @@ static inline size_t FormatMsg(char* buffer, const char* msg, size_t remaining)
     if (StringIsValid(msg))
     {
         len += FormatSpace(buffer + len);
-        len += FormatBoundedString(buffer + len, msg, remaining - len);
+        len += SolidSyslogFormat_BoundedString(buffer + len, msg, remaining - len);
     }
 
     return len;

--- a/Source/SolidSyslogAtomicCounter.c
+++ b/Source/SolidSyslogAtomicCounter.c
@@ -1,0 +1,28 @@
+#include "SolidSyslogAtomicCounter.h"
+
+#include <stdatomic.h>
+
+struct SolidSyslogAtomicCounter
+{
+    atomic_uint_fast32_t value;
+};
+
+struct SolidSyslogAtomicCounter* SolidSyslogAtomicCounter_Create(SolidSyslogAllocFunction alloc)
+{
+    struct SolidSyslogAtomicCounter* counter = alloc(sizeof(struct SolidSyslogAtomicCounter));
+    if (counter != NULL)
+    {
+        atomic_init(&counter->value, 0);
+    }
+    return counter;
+}
+
+void SolidSyslogAtomicCounter_Destroy(struct SolidSyslogAtomicCounter* counter, SolidSyslogFreeFunction dealloc)
+{
+    dealloc(counter);
+}
+
+uint_fast32_t SolidSyslogAtomicCounter_Increment(struct SolidSyslogAtomicCounter* counter)
+{
+    return atomic_fetch_add(&counter->value, 1) + 1;
+}

--- a/Source/SolidSyslogFormat.c
+++ b/Source/SolidSyslogFormat.c
@@ -1,0 +1,48 @@
+#include "SolidSyslogFormat.h"
+
+static size_t CountSignificantDigits(uint32_t value);
+static void   FormatLeastSignificantDigits(char* buffer, uint32_t value, size_t count);
+
+size_t SolidSyslogFormat_BoundedString(char* buffer, const char* source, size_t bufferSize)
+{
+    size_t maxLength = (bufferSize > 0) ? bufferSize - 1 : 0;
+    size_t len       = 0;
+    while ((len < maxLength) && (source[len] != '\0'))
+    {
+        buffer[len] = source[len];
+        len++;
+    }
+    buffer[len] = '\0';
+    return len;
+}
+
+size_t SolidSyslogFormat_Uint32(char* buffer, uint32_t value)
+{
+    size_t digits = CountSignificantDigits(value);
+    FormatLeastSignificantDigits(buffer, value, digits);
+    buffer[digits] = '\0';
+    return digits;
+}
+
+static size_t CountSignificantDigits(uint32_t value)
+{
+    size_t count = 1;
+    while (value >= 10U)
+    {
+        count++;
+        value /= 10U;
+    }
+    return count;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value is the number to format, count is the digit width; distinct semantics
+static void FormatLeastSignificantDigits(char* buffer, uint32_t value, size_t count)
+{
+    size_t i = count;
+    while (i > 0)
+    {
+        i--;
+        buffer[i] = SolidSyslogFormat_DigitToChar(value);
+        value /= 10U;
+    }
+}

--- a/Source/SolidSyslogFormat.h
+++ b/Source/SolidSyslogFormat.h
@@ -1,0 +1,32 @@
+#ifndef SOLIDSYSLOGFORMAT_H
+#define SOLIDSYSLOGFORMAT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+static inline size_t SolidSyslogFormat_MinSize(size_t a, size_t b)
+{
+    return (a < b) ? a : b;
+}
+
+static inline size_t SolidSyslogFormat_Character(char* buffer, char value)
+{
+    buffer[0] = value;
+    buffer[1] = '\0';
+    return 1;
+}
+
+static inline size_t SolidSyslogFormat_Nilvalue(char* buffer)
+{
+    return SolidSyslogFormat_Character(buffer, '-');
+}
+
+static inline char SolidSyslogFormat_DigitToChar(uint32_t value)
+{
+    return (char) ('0' + (value % 10U));
+}
+
+size_t SolidSyslogFormat_BoundedString(char* buffer, const char* source, size_t bufferSize);
+size_t SolidSyslogFormat_Uint32(char* buffer, uint32_t value);
+
+#endif /* SOLIDSYSLOGFORMAT_H */

--- a/Source/SolidSyslogMetaSd.c
+++ b/Source/SolidSyslogMetaSd.c
@@ -1,0 +1,43 @@
+#include "SolidSyslogMetaSd.h"
+#include "SolidSyslogAtomicCounter.h"
+#include "SolidSyslogFormat.h"
+#include "SolidSyslogStructuredDataDef.h"
+
+#include <stdint.h>
+
+struct SolidSyslogMetaSd
+{
+    struct SolidSyslogStructuredData base;
+    struct SolidSyslogAtomicCounter* counter;
+};
+
+static size_t Format(struct SolidSyslogStructuredData* self, char* buffer, size_t size);
+
+struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(SolidSyslogAllocFunction alloc, struct SolidSyslogAtomicCounter* counter)
+{
+    struct SolidSyslogMetaSd* instance = alloc(sizeof(struct SolidSyslogMetaSd));
+    if (instance != NULL)
+    {
+        instance->base.Format = Format;
+        instance->counter     = counter;
+    }
+    return &instance->base;
+}
+
+void SolidSyslogMetaSd_Destroy(struct SolidSyslogStructuredData* sd, SolidSyslogFreeFunction dealloc)
+{
+    dealloc(sd);
+}
+
+static size_t Format(struct SolidSyslogStructuredData* self, char* buffer, size_t size)
+{
+    struct SolidSyslogMetaSd* meta = (struct SolidSyslogMetaSd*) self;
+    uint_fast32_t             id   = SolidSyslogAtomicCounter_Increment(meta->counter);
+    size_t                    len  = 0;
+
+    len += SolidSyslogFormat_BoundedString(buffer + len, "[meta sequenceId=\"", size - len);
+    len += SolidSyslogFormat_Uint32(buffer + len, (uint32_t) id);
+    len += SolidSyslogFormat_BoundedString(buffer + len, "\"]", size - len);
+
+    return len;
+}

--- a/Source/SolidSyslogPosixHostname.c
+++ b/Source/SolidSyslogPosixHostname.c
@@ -5,12 +5,14 @@
 
 size_t SolidSyslogPosixHostname_Get(char* buffer, size_t size)
 {
-    if (gethostname(buffer, size) != 0)
+    size_t len = 0;
+
+    if (gethostname(buffer, size) == 0)
     {
-        buffer[0] = '\0';
-        return 0;
+        buffer[size - 1] = '\0';
+        len              = strlen(buffer);
     }
 
-    buffer[size - 1] = '\0';
-    return strlen(buffer);
+    buffer[len] = '\0';
+    return len;
 }

--- a/Source/SolidSyslogPosixMqBuffer.c
+++ b/Source/SolidSyslogPosixMqBuffer.c
@@ -1,12 +1,11 @@
 #include "SolidSyslogPosixMqBuffer.h"
 #include "SolidSyslogBufferDef.h"
+#include "SolidSyslogFormat.h"
+#include "SolidSyslogPosixProcId.h"
 
 #include <mqueue.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
-#include <unistd.h>
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
@@ -24,8 +23,10 @@ struct SolidSyslogBuffer* SolidSyslogPosixMqBuffer_Create(size_t maxMessageSize,
 {
     struct SolidSyslogPosixMqBuffer* self = calloc(1, sizeof(struct SolidSyslogPosixMqBuffer));
 
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- snprintf with bounded size; snprintf_s is not portable
-    snprintf(self->name, sizeof(self->name), "/solidsyslog_%d", getpid());
+    size_t nameLen = 0;
+    nameLen += SolidSyslogFormat_BoundedString(self->name + nameLen, "/solidsyslog_", sizeof(self->name) - nameLen);
+    nameLen += SolidSyslogPosixProcId_Get(self->name + nameLen, sizeof(self->name) - nameLen);
+    (void) nameLen;
 
     struct mq_attr attr = {0};
     attr.mq_maxmsg      = maxMessages;

--- a/Source/SolidSyslogPosixProcId.c
+++ b/Source/SolidSyslogPosixProcId.c
@@ -1,12 +1,10 @@
 #include "SolidSyslogPosixProcId.h"
+#include "SolidSyslogFormat.h"
 
-#include <stdio.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 size_t SolidSyslogPosixProcId_Get(char* buffer, size_t size)
 {
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- snprintf is bounded; snprintf_s is not portable
-    int written = snprintf(buffer, size, "%d", (int) getpid());
-    return (written > 0) ? (size_t) written : 0;
+    (void) size;
+    return SolidSyslogFormat_Uint32(buffer, (uint32_t) getpid());
 }

--- a/Source/SolidSyslogStructuredData.c
+++ b/Source/SolidSyslogStructuredData.c
@@ -1,0 +1,6 @@
+#include "SolidSyslogStructuredDataDef.h"
+
+size_t SolidSyslogStructuredData_Format(struct SolidSyslogStructuredData* sd, char* buffer, size_t size)
+{
+    return sd->Format(sd, buffer, size);
+}

--- a/Tests/BufferFake.c
+++ b/Tests/BufferFake.c
@@ -1,5 +1,6 @@
 #include "BufferFake.h"
 #include "SolidSyslogBufferDef.h"
+#include "SolidSyslogFormat.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -35,27 +36,26 @@ void BufferFake_Destroy(struct SolidSyslogBuffer* buffer)
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
-    struct BufferFake* fake = (struct BufferFake*) self;
+    struct BufferFake* fake    = (struct BufferFake*) self;
+    bool               success = fake->pending;
 
-    if (!fake->pending)
+    if (success)
     {
-        return false;
+        size_t copySize = SolidSyslogFormat_MinSize(fake->storedSize, maxSize);
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
+        memcpy(data, fake->stored, copySize);
+        *bytesRead    = copySize;
+        fake->pending = false;
     }
 
-    size_t copySize = fake->storedSize < maxSize ? fake->storedSize : maxSize;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
-    memcpy(data, fake->stored, copySize);
-    *bytesRead    = copySize;
-    fake->pending = false;
-
-    return true;
+    return success;
 }
 
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct BufferFake* fake = (struct BufferFake*) self;
 
-    size_t copySize = size < sizeof(fake->stored) ? size : sizeof(fake->stored);
+    size_t copySize = SolidSyslogFormat_MinSize(size, sizeof(fake->stored));
     // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
     memcpy(fake->stored, data, copySize);
     fake->storedSize = copySize;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 
 set(TEST_SOURCES
     SolidSyslogTest.cpp
+    SolidSyslogMetaSdTest.cpp
     SolidSyslogNullBufferTest.cpp
     SolidSyslogPrivalTest.cpp
     BufferFakeTest.cpp
@@ -15,6 +16,12 @@ set(TEST_SOURCES
     StringFake.c
     main.cpp
 )
+
+if(HAVE_STDATOMIC_H)
+    list(APPEND TEST_SOURCES
+        SolidSyslogAtomicCounterTest.cpp
+    )
+endif()
 
 if(SOLIDSYSLOG_POSIX)
     list(APPEND TEST_SOURCES
@@ -28,6 +35,7 @@ endif()
 add_executable(${PROJECT_NAME}Tests ${TEST_SOURCES})
 
 target_link_libraries(${PROJECT_NAME}Tests PRIVATE ${PROJECT_NAME} CppUTest CppUTestExt pthread)
+target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Source)
 
 if(SOLIDSYSLOG_POSIX)
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE PosixFakes)

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -30,7 +30,7 @@ TEST_GROUP(ExampleServiceThread)
         sender = SolidSyslogUdpSender_Create(&udpConfig);
         buffer = SolidSyslogPosixMqBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
 
-        SolidSyslogConfig config = {buffer, sender, malloc, free, nullptr, nullptr, nullptr, nullptr};
+        SolidSyslogConfig config = {buffer, sender, malloc, free, nullptr, nullptr, nullptr, nullptr, nullptr};
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         logger = SolidSyslog_Create(&config);
     }

--- a/Tests/SenderSpy.c
+++ b/Tests/SenderSpy.c
@@ -1,4 +1,5 @@
 #include "SenderSpy.h"
+#include "SolidSyslogFormat.h"
 #include "SolidSyslogSenderDef.h"
 
 #include <string.h>
@@ -16,7 +17,7 @@ static struct SolidSyslogSender sender;
 static void Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     (void) self;
-    size_t copySize = size < sizeof(lastBuffer) - 1 ? size : sizeof(lastBuffer) - 1;
+    size_t copySize = SolidSyslogFormat_MinSize(size, sizeof(lastBuffer) - 1);
     // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
     memcpy(lastBuffer, buffer, copySize);
     lastBuffer[copySize] = '\0';

--- a/Tests/SolidSyslogAtomicCounterTest.cpp
+++ b/Tests/SolidSyslogAtomicCounterTest.cpp
@@ -1,0 +1,47 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogAtomicCounter.h"
+
+#include <cstdlib>
+
+// clang-format off
+TEST_GROUP(SolidSyslogAtomicCounter)
+{
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    SolidSyslogAtomicCounter* counter;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        counter = SolidSyslogAtomicCounter_Create(malloc);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogAtomicCounter_Destroy(counter, free);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogAtomicCounter, CreateReturnsNonNull)
+{
+    CHECK(counter != nullptr);
+}
+
+TEST(SolidSyslogAtomicCounter, FirstIncrementReturns1)
+{
+    LONGS_EQUAL(1, SolidSyslogAtomicCounter_Increment(counter));
+}
+
+TEST(SolidSyslogAtomicCounter, SecondIncrementReturns2)
+{
+    SolidSyslogAtomicCounter_Increment(counter);
+    LONGS_EQUAL(2, SolidSyslogAtomicCounter_Increment(counter));
+}
+
+TEST(SolidSyslogAtomicCounter, ThirdIncrementReturns3)
+{
+    SolidSyslogAtomicCounter_Increment(counter);
+    SolidSyslogAtomicCounter_Increment(counter);
+    LONGS_EQUAL(3, SolidSyslogAtomicCounter_Increment(counter));
+}

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -1,0 +1,72 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogAtomicCounter.h"
+#include "SolidSyslogMetaSd.h"
+#include "SolidSyslogStructuredData.h"
+
+#include <cstdlib>
+
+// clang-format off
+TEST_GROUP(SolidSyslogMetaSd)
+{
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    SolidSyslogAtomicCounter* counter;
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    SolidSyslogStructuredData* sd;
+    char buffer[256];
+
+    void setup() override
+    {
+        counter = SolidSyslogAtomicCounter_Create(malloc);
+        sd = SolidSyslogMetaSd_Create(malloc, counter);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogMetaSd_Destroy(sd, free);
+        SolidSyslogAtomicCounter_Destroy(counter, free);
+    }
+
+    size_t Format()
+    {
+        return SolidSyslogStructuredData_Format(sd, buffer, sizeof(buffer));
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogMetaSd, CreateReturnsNonNull)
+{
+    CHECK(sd != nullptr);
+}
+
+TEST(SolidSyslogMetaSd, FirstFormatProducesSequenceId1)
+{
+    Format();
+    STRCMP_EQUAL("[meta sequenceId=\"1\"]", buffer);
+}
+
+TEST(SolidSyslogMetaSd, SecondFormatProducesSequenceId2)
+{
+    Format();
+    Format();
+    STRCMP_EQUAL("[meta sequenceId=\"2\"]", buffer);
+}
+
+TEST(SolidSyslogMetaSd, ThirdFormatProducesSequenceId3)
+{
+    Format();
+    Format();
+    Format();
+    STRCMP_EQUAL("[meta sequenceId=\"3\"]", buffer);
+}
+
+TEST(SolidSyslogMetaSd, FormatReturnsLengthOfFormattedString)
+{
+    size_t len = Format();
+    LONGS_EQUAL(strlen(buffer), len);
+}
+
+TEST(SolidSyslogMetaSd, DestroyDoesNotCrash)
+{
+    // Covered by teardown — this test documents the intent
+}

--- a/Tests/SolidSyslogPosixMqBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMqBufferTest.cpp
@@ -90,7 +90,7 @@ TEST(SolidSyslogPosixMqBuffer, SecondReadAfterSingleWriteReturnsFalse)
 TEST(SolidSyslogPosixMqBuffer, ServiceSendsMessageWrittenViaLog)
 {
     SenderSpy_Reset();
-    SolidSyslogConfig config = {buffer, SenderSpy_GetSender(), malloc, free, nullptr, nullptr, nullptr, nullptr};
+    SolidSyslogConfig config = {buffer, SenderSpy_GetSender(), malloc, free, nullptr, nullptr, nullptr, nullptr, nullptr};
     SolidSyslog*      logger = SolidSyslog_Create(&config);
 
     SolidSyslogMessage message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1,11 +1,15 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslog.h"
+#include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogMetaSd.h"
 #include "SolidSyslogNullBuffer.h"
+#include "SolidSyslogStructuredDataDef.h"
 #include "BufferFake.h"
 #include "SenderSpy.h"
 #include "StringFake.h"
 #include <cstdlib>
+#include <cstring>
 #include <string>
 
 // clang-format off
@@ -89,34 +93,88 @@ static const int TIMESTAMP_OFFSET_OFFSET       = 26;
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
-static std::string SyslogField(const char* buffer, int n)
+static size_t SdSpyFormat(struct SolidSyslogStructuredData* /* self */, char* buffer, size_t /* size */)
 {
-    std::string            s(buffer);
+    const char* text = "[spy]";
+    size_t      len  = strlen(text);
+    memcpy(buffer, text, len + 1);
+    return len;
+}
+
+static struct SolidSyslogStructuredData sdSpy = {SdSpyFormat};
+
+static std::string::size_type SkipSdata(const std::string& s, std::string::size_type pos)
+{
+    if (pos < s.size() && s[pos] == '[')
+    {
+        while (pos < s.size() && s[pos] == '[')
+        {
+            pos = s.find(']', pos);
+            if (pos == std::string::npos)
+            {
+                return std::string::npos;
+            }
+            pos++;
+        }
+        return pos;
+    }
+    auto end = s.find(' ', pos);
+    return end == std::string::npos ? s.size() : end;
+}
+
+static std::string::size_type FindFieldStart(const std::string& s, int n)
+{
     std::string::size_type pos = 0;
     for (int i = 0; i < n; i++)
     {
-        pos = s.find(' ', pos);
+        if (i == SYSLOG_FIELD_SDATA)
+        {
+            pos = SkipSdata(s, pos);
+        }
+        else
+        {
+            pos = s.find(' ', pos);
+        }
         if (pos == std::string::npos)
         {
-            return {};
+            return std::string::npos;
         }
-        pos++;
+        if (s[pos] == ' ')
+        {
+            pos++;
+        }
     }
-    std::string::size_type end = s.find(' ', pos);
+    return pos;
+}
+
+static std::string SyslogField(const char* buffer, int n)
+{
+    std::string            s(buffer);
+    std::string::size_type pos = FindFieldStart(s, n);
+    if (pos == std::string::npos)
+    {
+        return {};
+    }
+
+    std::string::size_type end = (n == SYSLOG_FIELD_SDATA) ? SkipSdata(s, pos) : s.find(' ', pos);
     return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
 }
 
 static std::string SyslogMsg(const char* buffer)
 {
     std::string            s(buffer);
-    std::string::size_type pos = 0;
-    for (int i = 0; i < SYSLOG_FIELD_SDATA + 1; i++)
+    std::string::size_type pos = FindFieldStart(s, SYSLOG_FIELD_SDATA);
+    if (pos == std::string::npos)
     {
-        pos = s.find(' ', pos);
-        if (pos == std::string::npos)
-        {
-            return {};
-        }
+        return {};
+    }
+    pos = SkipSdata(s, pos);
+    if (pos == std::string::npos || pos >= s.size())
+    {
+        return {};
+    }
+    if (s[pos] == ' ')
+    {
         pos++;
     }
     return s.substr(pos);
@@ -138,7 +196,7 @@ TEST_GROUP(SolidSyslog)
         SenderSpy_Reset();
         StringFake_Reset();
         buffer = SolidSyslogNullBuffer_Create(SenderSpy_GetSender());
-        config = {buffer, nullptr, malloc, free, nullptr, StringFake_GetHostname, StringFake_GetAppName, StringFake_GetProcId};
+        config = {buffer, nullptr, malloc, free, nullptr, StringFake_GetHostname, StringFake_GetAppName, StringFake_GetProcId, nullptr};
         logger = SolidSyslog_Create(&config);
         message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
     }
@@ -187,7 +245,7 @@ TEST(SolidSyslog, TwoCreatesReturnDifferentHandles)
 TEST(SolidSyslog, EachLoggerSendsThroughItsOwnSender)
 {
     SolidSyslogBuffer* secondBuffer = SolidSyslogNullBuffer_Create(SenderSpy_GetSender());
-    SolidSyslogConfig  secondConfig = {secondBuffer, nullptr, malloc, free, nullptr, nullptr, nullptr, nullptr};
+    SolidSyslogConfig  secondConfig = {secondBuffer, nullptr, malloc, free, nullptr, nullptr, nullptr, nullptr, nullptr};
     SolidSyslog*       second       = SolidSyslog_Create(&secondConfig);
 
     SolidSyslog_Log(logger, &message);
@@ -399,6 +457,52 @@ TEST(SolidSyslog, StructuredDataIsNilValue)
     STRCMP_EQUAL(TEST_SDATA, SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
+TEST(SolidSyslog, InjectedSdObjectFormatIsCalledDuringLog)
+{
+    config.sd = &sdSpy;
+    ReplaceLogger();
+    Log();
+    STRCMP_EQUAL("[spy]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+}
+
+TEST(SolidSyslog, MetaSdProducesSequenceIdInStructuredData)
+{
+    SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create(malloc);
+    SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(malloc, counter);
+    config.sd                          = metaSd;
+    ReplaceLogger();
+    Log();
+    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    SolidSyslogMetaSd_Destroy(metaSd, free);
+    SolidSyslogAtomicCounter_Destroy(counter, free);
+}
+
+TEST(SolidSyslog, MetaSdSequenceIdIncrementsAcrossLogCalls)
+{
+    SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create(malloc);
+    SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(malloc, counter);
+    config.sd                          = metaSd;
+    ReplaceLogger();
+    Log();
+    Log();
+    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    SolidSyslogMetaSd_Destroy(metaSd, free);
+    SolidSyslogAtomicCounter_Destroy(counter, free);
+}
+
+TEST(SolidSyslog, MsgFieldPreservedWithMetaSd)
+{
+    SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create(malloc);
+    SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(malloc, counter);
+    config.sd                          = metaSd;
+    ReplaceLogger();
+    message.msg = "hello world";
+    Log();
+    STRCMP_EQUAL("hello world", SyslogMsg(LastMessage()).c_str());
+    SolidSyslogMetaSd_Destroy(metaSd, free);
+    SolidSyslogAtomicCounter_Destroy(counter, free);
+}
+
 TEST(SolidSyslog, NullMessageOmitsMsgField)
 {
     Log();
@@ -471,7 +575,7 @@ static void* AlwaysFailAlloc(size_t size)
 
 TEST(SolidSyslog, CreateReturnsNullWhenAllocFails)
 {
-    SolidSyslogConfig failConfig = {buffer, nullptr, AlwaysFailAlloc, free, nullptr, nullptr, nullptr, nullptr};
+    SolidSyslogConfig failConfig = {buffer, nullptr, AlwaysFailAlloc, free, nullptr, nullptr, nullptr, nullptr, nullptr};
     SolidSyslog*      result     = SolidSyslog_Create(&failConfig);
     POINTERS_EQUAL(nullptr, result);
 }
@@ -913,7 +1017,7 @@ TEST(SolidSyslog, MultipleServiceCallsReturnNothingToSend)
 TEST(SolidSyslog, ServiceSendsMessageReadFromBuffer)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderSpy_GetSender(), malloc, free, nullptr, nullptr, nullptr, nullptr};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderSpy_GetSender(), malloc, free, nullptr, nullptr, nullptr, nullptr, nullptr};
     SolidSyslog*       serviceLogger = SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "test", 4);

--- a/Tests/StringFake.c
+++ b/Tests/StringFake.c
@@ -1,4 +1,5 @@
 #include "StringFake.h"
+#include "SolidSyslogFormat.h"
 
 #include <string.h>
 
@@ -58,6 +59,5 @@ static size_t CopyBounded(char* buffer, size_t size, const char* source)
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- length and bufferSize are semantically distinct
 static size_t ClampToBufferSize(size_t length, size_t bufferSize)
 {
-    size_t maxLength = bufferSize - 1;
-    return (length < maxLength) ? length : maxLength;
+    return SolidSyslogFormat_MinSize(length, bufferSize - 1);
 }


### PR DESCRIPTION
## Purpose
Implement Story S7.1 (#65) — replace the hardcoded structured data NILVALUE `-` with a real
`[meta sequenceId="N"]` SD-ELEMENT. This establishes the SD extension point that S7.2 and S7.3
build on.

## Change Description
- **SD vtable** (`SolidSyslogStructuredData.h`, `Def.h`, `.c`) — follows the Sender/Buffer pattern.
  `FormatStructuredData` dispatches through the vtable when an SD object is injected, falls back to
  NILVALUE when NULL.
- **MetaSd** (`SolidSyslogMetaSd.h`, `.c`) — implements the SD vtable with an auto-incrementing
  sequenceId. Counter is injected via dependency injection rather than owned internally, so platforms
  without C11 atomics can provide their own counter implementation.
- **Atomic counter** (`SolidSyslogAtomicCounter.h`, `.c`) — opaque type in a separate translation
  unit, conditionally compiled when CMake detects `stdatomic.h`. RTOS users link their own
  implementation instead.
- **SolidSyslogFormat** (`SolidSyslogFormat.h`, `.c`) — shared formatting primitives extracted from
  `SolidSyslog.c`. Eliminates `<stdio.h>` from all library sources (PosixProcId, PosixMqBuffer).
  `DigitToChar`, `MinSize` as `static inline`; `BoundedString`, `Uint32` in the `.c` file.
- **Config** — new `sd` field on `SolidSyslogConfig`.
- **Examples** — both SingleTask and Threaded examples create and inject MetaSd.
- **Clean code** — single return points, DRY improvements, consistent digit formatting via
  `DigitToChar` across all formatters.

## Test Evidence
- 196 unit tests (14 new: AtomicCounter 4, MetaSd 6, SolidSyslog integration 3, SD spy 1)
- 100% line and function coverage
- ASan + UBSan clean
- clang-tidy, cppcheck, clang-format clean
- 18 BDD scenarios (2 new: sequenceId "1" on first message, sequential IDs across 3 messages)
- GCC and Clang builds pass

## Areas Affected
- `Interface/` — 4 new public headers (StructuredData, StructuredDataDef, MetaSd, AtomicCounter);
  `SolidSyslogConfig` gains `sd` field
- `Source/` — new SolidSyslogFormat module, MetaSd, AtomicCounter, StructuredData; refactored
  SolidSyslog.c, PosixProcId, PosixMqBuffer, PosixHostname
- `Tests/` — new test files for MetaSd and AtomicCounter; updated SolidSyslogTest with SD-aware
  field parser; BufferFake, SenderSpy, StringFake use shared MinSize
- `Example/` — both examples updated with counter + MetaSd injection
- `Bdd/` — new structured_data.feature and step definitions
- `CLAUDE.md` — header table updated

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for structured data with auto-incrementing sequence IDs in syslog messages
  * Extended message parsing to correctly extract and handle structured data fields

* **Tests**
  * Added BDD test scenarios validating structured data sequence ID generation
  * Expanded test coverage for structured data formatting and atomic counter functionality

* **Build**
  * Enhanced build system to detect and conditionally compile C11 atomic operations support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->