### PR TITLE
refactor: change SolidSyslogClockFunction to pointer parameter

### DIFF
--- a/Interface/SolidSyslogPosixClock.h
+++ b/Interface/SolidSyslogPosixClock.h
@@ -5,7 +5,7 @@
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogTimestamp SolidSyslogPosixClock_GetTimestamp(void);
+    void SolidSyslogPosixClock_GetTimestamp(struct SolidSyslogTimestamp * timestamp);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogTimestamp.h
+++ b/Interface/SolidSyslogTimestamp.h
@@ -19,8 +19,7 @@ EXTERN_C_BEGIN
         int16_t  utcOffsetMinutes;
     };
 
-    typedef struct SolidSyslogTimestamp (*SolidSyslogClockFunction)(
-        void); // NOLINT(modernize-redundant-void-arg) -- C idiom; void is required in C to mean "no parameters"
+    typedef void (*SolidSyslogClockFunction)(struct SolidSyslogTimestamp* timestamp);
 
 EXTERN_C_END
 

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -215,7 +215,7 @@ static inline bool CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslog
 
     if (clock != NULL)
     {
-        *ts      = clock();
+        clock(ts);
         captured = TimestampIsValid(ts);
     }
 

--- a/Source/SolidSyslogPosixClock.c
+++ b/Source/SolidSyslogPosixClock.c
@@ -6,18 +6,17 @@
 static inline bool GetBrokenDownTime(struct timespec* now, struct tm* breakdown);
 static inline void PopulateTimestamp(struct SolidSyslogTimestamp* timestamp, const struct timespec* now, const struct tm* breakdown);
 
-struct SolidSyslogTimestamp SolidSyslogPosixClock_GetTimestamp(void)
+void SolidSyslogPosixClock_GetTimestamp(struct SolidSyslogTimestamp* timestamp)
 {
-    struct SolidSyslogTimestamp timestamp = {0};
-    struct timespec             now;
-    struct tm                   breakdown;
+    struct timespec now;
+    struct tm       breakdown;
+
+    *timestamp = (struct SolidSyslogTimestamp) {0};
 
     if (GetBrokenDownTime(&now, &breakdown))
     {
-        PopulateTimestamp(&timestamp, &now, &breakdown);
+        PopulateTimestamp(timestamp, &now, &breakdown);
     }
-
-    return timestamp;
 }
 
 static inline bool GetBrokenDownTime(struct timespec* now, struct tm* breakdown)

--- a/Tests/SolidSyslogPosixClockTest.cpp
+++ b/Tests/SolidSyslogPosixClockTest.cpp
@@ -7,7 +7,7 @@ static const time_t TEST_EPOCH = 1743552000;
 
 // clang-format off
 // NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
-#define GET_TIMESTAMP()              SolidSyslogPosixClock_GetTimestamp()
+#define GET_TIMESTAMP()              getTimestamp()
 #define CHECK_YEAR(expected)         LONGS_EQUAL(expected, GET_TIMESTAMP().year)
 #define CHECK_MONTH(expected)        LONGS_EQUAL(expected, GET_TIMESTAMP().month)
 #define CHECK_DAY(expected)          LONGS_EQUAL(expected, GET_TIMESTAMP().day)
@@ -27,6 +27,13 @@ TEST_GROUP(SolidSyslogPosixClock)
     {
         ClockFake_Reset();
         ClockFake_SetTime(TEST_EPOCH, 0);
+    }
+
+    static struct SolidSyslogTimestamp getTimestamp()
+    {
+        struct SolidSyslogTimestamp ts = {};
+        SolidSyslogPosixClock_GetTimestamp(&ts);
+        return ts;
     }
 };
 
@@ -163,7 +170,7 @@ TEST(SolidSyslogPosixClock, NoY2038LimitOnThisPlatform)
 
 TEST(SolidSyslogPosixClock, AllFieldsInValidRanges)
 {
-    struct SolidSyslogTimestamp ts = SolidSyslogPosixClock_GetTimestamp();
+    struct SolidSyslogTimestamp ts = getTimestamp();
     CHECK(ts.year > 0);
     CHECK((ts.month >= 1) && (ts.month <= 12));
     CHECK((ts.day >= 1) && (ts.day <= 31));

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -680,10 +680,9 @@ static const int16_t  TEST_UTC_OFFSET  = 0;
 
 static struct SolidSyslogTimestamp stubTimestamp;
 
-// NOLINTNEXTLINE(modernize-redundant-void-arg) -- C linkage function matching SolidSyslogClockFunction signature
-static struct SolidSyslogTimestamp StubClock(void)
+static void StubClock(struct SolidSyslogTimestamp* timestamp)
 {
-    return stubTimestamp;
+    *timestamp = stubTimestamp;
 }
 
 // clang-format off


### PR DESCRIPTION
## Purpose

Post-S7.2 cleanup. Aligns the clock callback signature with the TimeQuality callback pattern established in S7.2 (#66).

## Change Description

Change `SolidSyslogClockFunction` from return-by-value to pointer parameter:

- **Before:** `struct SolidSyslogTimestamp (*)(void)`
- **After:** `void (*)(struct SolidSyslogTimestamp*)`

Clearer ownership, consistent embedded C idiom, and opens the door for error returns in future. All callers updated: `CaptureTimestamp`, `SolidSyslogPosixClock_GetTimestamp`, test stubs, and the PosixClock test helper.

## Test Evidence

- 212 tests, 279 checks, all pass
- All presets green: debug, clang-debug, sanitize, tidy, cppcheck, format
- Coverage: 100% lines, 100% functions
- No new tests needed — this is a pure signature refactor

## Areas Affected

- **Interface** — `SolidSyslogTimestamp.h` (typedef), `SolidSyslogPosixClock.h` (function signature)
- **Source** — `SolidSyslog.c` (`CaptureTimestamp`), `SolidSyslogPosixClock.c` (implementation)
- **Tests** — `SolidSyslogTest.cpp` (stub clock), `SolidSyslogPosixClockTest.cpp` (helper + macros)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified timestamp retrieval function to accept output parameters instead of returning values directly. Callers will need to update their code to use the new calling convention.

* **Tests**
  * Updated test suite to work with the new timestamp API pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->