### PR TITLE
test: prove string callbacks are invoked per Log call

### DIFF
--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -16,9 +16,6 @@
 
 // clang-format off
 static const char * const TEST_PRIVAL    = "<134>";
-static const char * const TEST_HOSTNAME  = "TestHost";
-static const char * const TEST_APP_NAME  = "TestApp";
-static const char * const TEST_PROCID    = "42";
 static const char * const TEST_MSGID     = "54";
 static const char * const TEST_SDATA     = "-";
 static const char * const TEST_MSG       = "hello world";
@@ -350,11 +347,14 @@ TEST(SolidSyslog, HostnameFromGetHostnameAppearsInMessage)
     CHECK_HOSTNAME("MyHost");
 }
 
-TEST(SolidSyslog, HostnameIsNotHardCoded)
+TEST(SolidSyslog, HostnameCallbackIsInvokedPerLogCall)
 {
-    StringFake_SetHostname(TEST_HOSTNAME);
+    StringFake_SetHostname("FirstHost");
     Log();
-    CHECK_HOSTNAME(TEST_HOSTNAME);
+    CHECK_HOSTNAME("FirstHost");
+    StringFake_SetHostname("SecondHost");
+    Log();
+    CHECK_HOSTNAME("SecondHost");
 }
 
 TEST(SolidSyslog, NullGetAppNameProducesNilvalue)
@@ -373,11 +373,14 @@ TEST(SolidSyslog, AppNameFromGetAppNameAppearsInMessage)
     CHECK_APP_NAME("MyApp");
 }
 
-TEST(SolidSyslog, AppNameIsNotHardCoded)
+TEST(SolidSyslog, AppNameCallbackIsInvokedPerLogCall)
 {
-    StringFake_SetAppName(TEST_APP_NAME);
+    StringFake_SetAppName("FirstApp");
     Log();
-    CHECK_APP_NAME(TEST_APP_NAME);
+    CHECK_APP_NAME("FirstApp");
+    StringFake_SetAppName("SecondApp");
+    Log();
+    CHECK_APP_NAME("SecondApp");
 }
 
 TEST(SolidSyslog, NullGetProcessIdProducesNilvalue)
@@ -396,11 +399,14 @@ TEST(SolidSyslog, ProcessIdFromGetProcessIdAppearsInMessage)
     CHECK_PROCID("9999");
 }
 
-TEST(SolidSyslog, ProcessIdIsNotHardCoded)
+TEST(SolidSyslog, ProcessIdCallbackIsInvokedPerLogCall)
 {
-    StringFake_SetProcessId(TEST_PROCID);
+    StringFake_SetProcessId("1111");
     Log();
-    CHECK_PROCID(TEST_PROCID);
+    CHECK_PROCID("1111");
+    StringFake_SetProcessId("2222");
+    Log();
+    CHECK_PROCID("2222");
 }
 
 TEST(SolidSyslog, NullMessageIdProducesNilvalue)


### PR DESCRIPTION
## Purpose

Addresses the config callback test audit identified during S15.1 review.
Closes a gap where tests could pass even if production code cached callback
values instead of invoking them per `Log()` call.

## Change Description

Replace three tests (`HostnameIsNotHardCoded`, `AppNameIsNotHardCoded`,
`ProcessIdIsNotHardCoded`) with `CallbackIsInvokedPerLogCall` variants.
Each new test:
1. Sets a value via StringFake, calls Log, verifies output
2. Changes the value, calls Log again, verifies the new value appears

This proves the callbacks are invoked on every `Log()` call, not cached
at `Create` time or after the first call.

Remove unused `TEST_HOSTNAME`, `TEST_APP_NAME`, `TEST_PROCID` constants.

**Audit results:** All other test files were reviewed. The clock/timestamp
tests already use extensive alternate values. The UdpSender and TcpSender
config groups already have spy and alternate-value tests. No other gaps found.

## Test Evidence

271 tests pass. The three replaced tests each verify two distinct values
across two Log calls, proving per-call callback invocation.

## Areas Affected

- **Tests/SolidSyslogTest.cpp** — three tests replaced, three constants removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for callback invocation behavior to ensure values are correctly captured across multiple log calls rather than relying on fixed test constants.

**Note:** This release contains internal testing improvements with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->