### PR TITLE
feat: S5.4 Power cycle replay BDD scenario

### DIFF
--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -49,5 +49,7 @@ def after_scenario(context, scenario):
         context.syslog_ng_config_changed = False
 
     # Clean up store file to prevent cross-scenario contamination
-    if os.path.exists(STORE_FILE_PATH):
+    try:
         os.remove(STORE_FILE_PATH)
+    except FileNotFoundError:
+        pass

--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("behave.environment")
 SYSLOG_NG_CONF = "Bdd/syslog-ng/syslog-ng.conf"
 SYSLOG_NG_FULL_CONF = "Bdd/syslog-ng/syslog-ng-full.conf"
 SYSLOG_NG_CTL = "/var/lib/syslog-ng/syslog-ng.ctl"
+STORE_FILE_PATH = "/tmp/solidsyslog_store.dat"
 
 
 def before_all(context):
@@ -46,3 +47,7 @@ def after_scenario(context, scenario):
         except Exception as exc:
             logger.warning("Failed to restore syslog-ng config in teardown: %s", exc)
         context.syslog_ng_config_changed = False
+
+    # Clean up store file to prevent cross-scenario contamination
+    if os.path.exists(STORE_FILE_PATH):
+        os.remove(STORE_FILE_PATH)

--- a/Bdd/features/power_cycle_replay.feature
+++ b/Bdd/features/power_cycle_replay.feature
@@ -1,0 +1,21 @@
+Feature: Power cycle replay from file store
+  After a power cycle, unsent messages persisted in the file store
+  are replayed before new messages. The collector sees old-session
+  sequenceIds followed by a jump to 1 (restart signal).
+
+  Scenario: Stored messages replayed after power cycle
+    Given syslog-ng is running
+    And the file store is enabled
+    And the threaded example is running with transport tcp
+    When the client sends a message
+    Then syslog-ng receives 1 message
+    When the syslog server stops accepting TCP connections
+    And the client sends 3 messages
+    And the client is killed
+    And the syslog server resumes accepting TCP connections
+    Given the threaded example is running with transport tcp
+    Then syslog-ng receives 4 messages
+    And the replayed messages have sequenceIds 2, 3, 4
+    When the client sends a message
+    Then syslog-ng receives 5 messages
+    And the last message has sequenceId 1

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime, timezone
 
 from behave import given, when, then
+from environment import STORE_FILE_PATH
 
 RECEIVED_LOG = "Bdd/output/received.log"
 EXAMPLE_BINARY = "build/debug/Example/SolidSyslogExample"
@@ -16,7 +17,6 @@ SYSLOG_NG_CTL = "/var/lib/syslog-ng/syslog-ng.ctl"
 SYSLOG_NG_CONF = "Bdd/syslog-ng/syslog-ng.conf"
 SYSLOG_NG_FULL_CONF = "Bdd/syslog-ng/syslog-ng-full.conf"
 SYSLOG_NG_UDP_ONLY_CONF = "Bdd/syslog-ng/syslog-ng-udp-only.conf"
-STORE_FILE_PATH = "/tmp/solidsyslog_store.dat"
 
 
 def line_count(path):
@@ -447,7 +447,7 @@ def step_client_sends_n_messages(context, count):
 @when("the client is killed")
 def step_client_is_killed(context):
     context.interactive_process.send_signal(signal.SIGKILL)
-    context.interactive_process.wait()
+    context.interactive_process.wait(timeout=5)
     del context.interactive_process
 
 
@@ -472,6 +472,10 @@ def step_check_contiguous_sequence_ids(context):
 @then("the replayed messages have sequenceIds {id_list}")
 def step_check_replayed_sequence_ids(context, id_list):
     expected = [int(x.strip()) for x in id_list.split(",")]
+    assert len(context.all_lines) >= len(expected), (
+        f"Expected at least {len(expected)} messages, "
+        f"got {len(context.all_lines)}"
+    )
     # Replayed messages are the most recent batch excluding the first message
     # from the previous session (already verified)
     replayed = context.all_lines[-len(expected):]

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import signal
 import socket
 import subprocess
 import time
@@ -15,6 +16,7 @@ SYSLOG_NG_CTL = "/var/lib/syslog-ng/syslog-ng.ctl"
 SYSLOG_NG_CONF = "Bdd/syslog-ng/syslog-ng.conf"
 SYSLOG_NG_FULL_CONF = "Bdd/syslog-ng/syslog-ng-full.conf"
 SYSLOG_NG_UDP_ONLY_CONF = "Bdd/syslog-ng/syslog-ng-udp-only.conf"
+STORE_FILE_PATH = "/tmp/solidsyslog_store.dat"
 
 
 def line_count(path):
@@ -204,6 +206,8 @@ def step_threaded_running_with_transport(context, transport):
 @given("the file store is enabled")
 def step_file_store_enabled(context):
     context.store_type = "file"
+    if os.path.exists(STORE_FILE_PATH):
+        os.remove(STORE_FILE_PATH)
 
 
 @when("the client sends a message")
@@ -440,6 +444,13 @@ def step_client_sends_n_messages(context, count):
     time.sleep(0.5)
 
 
+@when("the client is killed")
+def step_client_is_killed(context):
+    context.interactive_process.send_signal(signal.SIGKILL)
+    context.interactive_process.wait()
+    del context.interactive_process
+
+
 @then("the messages have contiguous sequenceIds")
 def step_check_contiguous_sequence_ids(context):
     ids = []
@@ -456,3 +467,37 @@ def step_check_contiguous_sequence_ids(context):
         assert ids[i] == ids[i - 1] + 1, (
             f"Non-contiguous sequenceIds: {ids[i - 1]} followed by {ids[i]}"
         )
+
+
+@then("the replayed messages have sequenceIds {id_list}")
+def step_check_replayed_sequence_ids(context, id_list):
+    expected = [int(x.strip()) for x in id_list.split(",")]
+    # Replayed messages are the most recent batch excluding the first message
+    # from the previous session (already verified)
+    replayed = context.all_lines[-len(expected):]
+    for i, line in enumerate(replayed):
+        fields = parse_syslog_line(line)
+        sd = fields.get("STRUCTURED_DATA", "")
+        match = re.search(r'sequenceId="(\d+)"', sd)
+        assert match, (
+            f"Replayed message {i + 1}: no sequenceId in structured data: {sd}"
+        )
+        actual = int(match.group(1))
+        assert actual == expected[i], (
+            f"Replayed message {i + 1}: expected sequenceId {expected[i]}, "
+            f"got {actual}"
+        )
+
+
+@then("the last message has sequenceId {value:d}")
+def step_check_last_sequence_id(context, value):
+    fields = parse_syslog_line(context.all_lines[-1])
+    sd = fields.get("STRUCTURED_DATA", "")
+    match = re.search(r'sequenceId="(\d+)"', sd)
+    assert match, (
+        f"No sequenceId in last message structured data: {sd}"
+    )
+    actual = int(match.group(1))
+    assert actual == value, (
+        f"Last message: expected sequenceId {value}, got {actual}"
+    )

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -495,6 +495,7 @@ def step_check_replayed_sequence_ids(context, id_list):
 
 @then("the last message has sequenceId {value:d}")
 def step_check_last_sequence_id(context, value):
+    assert context.all_lines, "No messages received to check last sequenceId"
     fields = parse_syslog_line(context.all_lines[-1])
     sd = fields.get("STRUCTURED_DATA", "")
     match = re.search(r'sequenceId="(\d+)"', sd)


### PR DESCRIPTION
## Purpose

Closes #82. After a power cycle, unsent messages persisted in the file store must be replayed before new messages. This BDD scenario proves the end-to-end behaviour across a simulated power cycle with real file-based persistence.

## Change Description

**New BDD scenario** (`power_cycle_replay.feature`) that:
1. Sends a message successfully (sequenceId 1)
2. Takes TCP down, sends 3 more messages (sequenceIds 2, 3, 4 — stored but unsent)
3. Kills the client with SIGKILL (simulates power loss)
4. Brings TCP back and restarts the client
5. Verifies the 3 stored messages are replayed with their original sequenceIds
6. Sends a new message and verifies it has sequenceId 1 (counter reset)

**New step definitions:**
- `the client is killed` — SIGKILL to simulate power loss
- `the replayed messages have sequenceIds X, Y, Z` — verify specific IDs
- `the last message has sequenceId N` — verify counter reset

**Infrastructure hardening:**
- Store file cleanup in `the file store is enabled` step (clean start)
- Store file cleanup in `after_scenario` (prevent cross-scenario contamination)

No production code changes — the existing `FileStore_Create`/`ResumeFromExistingFile` and `Service()` store-priority logic already handles this correctly.

## Test Evidence

BDD scenario passes: 15/15 steps green. Full suite: 13 features, 27 scenarios, 122 steps all green.

## Areas Affected

- `Bdd/features/` — new feature file and step definitions
- `Bdd/features/environment.py` — store file cleanup in teardown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added BDD coverage for power-cycle replay scenarios validating persisted-unsent message replay, ordering, and sequence IDs.
  * Added steps to simulate abrupt client termination and to assert replayed and final message sequence identifiers.
  * Enhanced test teardown to remove on-disk store artifacts between scenarios to prevent cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->