### PR TITLE
fix: S5.5 FormatFilename buffer overflow on long pathPrefix

### DIFF
--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -147,8 +147,17 @@ static inline void FormatFilename(uint8_t sequence)
 
     size_t len = 0;
     len += SolidSyslogFormat_BoundedString(instance.filename + len, instance.pathPrefix, MAX_PATH_SIZE - len);
-    len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence / TENS_DIVISOR));
-    len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence % TENS_DIVISOR));
+
+    if ((len + 1) < MAX_PATH_SIZE)
+    {
+        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence / TENS_DIVISOR));
+    }
+
+    if ((len + 1) < MAX_PATH_SIZE)
+    {
+        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence % TENS_DIVISOR));
+    }
+
     len += SolidSyslogFormat_BoundedString(instance.filename + len, ".log", MAX_PATH_SIZE - len);
     instance.filename[len] = '\0';
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -520,10 +520,13 @@ TEST(SolidSyslogFileStoreConfig, FilenameExactlyAtMaxPath)
 
 TEST(SolidSyslogFileStoreConfig, FilenameTruncatedWhenPrefixTooLong)
 {
-    /* Prefix longer than max — filename is truncated but store still works */
-    char prefix[140];
-    memset(prefix, 'B', 139);
-    prefix[139] = '\0';
+    /* MAX_PATH_SIZE=128. A 127-char prefix leaves 1 byte for digits and
+       suffix. FormatFilename must not write past the buffer — prior to
+       the fix, SolidSyslogFormat_Character wrote 2 bytes unconditionally
+       (char + null), overflowing filename[128]. ASan detects this. */
+    char prefix[128];
+    memset(prefix, 'B', 127);
+    prefix[127] = '\0';
 
     CreateWithPathPrefix(prefix);
     VerifyWriteAndReadBack();


### PR DESCRIPTION
## Purpose

Fixes buffer overflow in `FormatFilename` flagged by CodeRabbit on PR #103.
`SolidSyslogFormat_Character` writes 2 bytes unconditionally (char + null terminator)
without bounds checking. When `pathPrefix` nearly fills the 128-byte `filename` buffer,
the two digit-formatting calls write past the end.

## Change Description

Added bounds guards (`(len + 1) < MAX_PATH_SIZE`) before each `Character` call in
`FormatFilename`. No changes to the format library itself — the fix is scoped to
the two call sites in `FormatFilename`.

## Test Evidence

**Red:** Updated `FilenameTruncatedWhenPrefixTooLong` to use a 127-char prefix
(leaves 1 byte — not enough for `Character`'s 2-byte write). UBSan reports
`index 133 out of bounds for type 'char [128]'`.

**Green:** Bounds guards prevent the `Character` calls when space is insufficient.
UBSan clean, 402 tests pass.

## Areas Affected

- `Source/SolidSyslogFileStore.c` — `FormatFilename` only
- `Tests/SolidSyslogFileStoreTest.cpp` — tightened existing truncation test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential buffer overrun vulnerability when generating syslog filenames with sequence numbers by adding boundary validation checks.

* **Tests**
  * Updated test suite to properly validate buffer boundary protection in filename generation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->