### PR TITLE
feat: S5.6 file store corruption detection and recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,10 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogFileDefinition.h` | File implementors (extension point) | `SolidSyslogFile` vtable struct |
 | `SolidSyslogFile.h` | Any code using the file abstraction | `SolidSyslogFile_Open`, `_Close`, `_IsOpen`, `_Read`, `_Write`, `_SeekTo`, `_Size`, `_Truncate` |
 | `SolidSyslogFileStore.h` | System setup code using file-based store | `SolidSyslogFileStore_Create`, `_Destroy` |
+| `SolidSyslogSecurityPolicyDefinition.h` | SecurityPolicy implementors (extension point) | `SolidSyslogSecurityPolicy` vtable struct, `SOLIDSYSLOG_MAX_INTEGRITY_SIZE` |
+| `SolidSyslogNullSecurityPolicy.h` | System setup code (no integrity checking) | `SolidSyslogNullSecurityPolicy_Create`, `_Destroy` |
+| `SolidSyslogCrc16Policy.h` | System setup code using CRC-16 integrity | `SolidSyslogCrc16Policy_Create`, `_Destroy` |
+| `SolidSyslogCrc16.h` | Any code needing CRC-16 computation | `SolidSyslogCrc16_Compute` |
 | `SolidSyslogPosixFile.h` | System setup code using POSIX file I/O | `SolidSyslogPosixFile_Create`, `_Destroy` |
 | `SolidSyslogPosixClock.h` | System setup code using POSIX clock | `SolidSyslogPosixClock_GetTimestamp` |
 | `SolidSyslogPosixHostname.h` | System setup code using POSIX hostname | `SolidSyslogPosixHostname_Get` |

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -7,6 +7,7 @@
 #include "SolidSyslog.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogCrc16Policy.h"
 #include "SolidSyslogFileStore.h"
 #include "SolidSyslogMetaSd.h"
 #include "SolidSyslogOriginSd.h"
@@ -84,6 +85,7 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
         storeConfig.maxFileSize                              = DEFAULT_MAX_FILE_SIZE;
         storeConfig.maxFiles                                 = DEFAULT_MAX_FILES;
         storeConfig.discardPolicy                            = SOLIDSYSLOG_DISCARD_OLDEST;
+        storeConfig.securityPolicy                           = SolidSyslogCrc16Policy_Create();
         return SolidSyslogFileStore_Create(&storeConfig);
     }
 
@@ -111,6 +113,7 @@ static void DestroyStore(const struct ExampleOptions* options)
     if (useFile)
     {
         SolidSyslogFileStore_Destroy();
+        SolidSyslogCrc16Policy_Destroy();
         SolidSyslogPosixFile_Destroy(storeFile);
     }
     else

--- a/Interface/SolidSyslogCrc16.h
+++ b/Interface/SolidSyslogCrc16.h
@@ -1,0 +1,14 @@
+#ifndef SOLIDSYSLOGCRC16_H
+#define SOLIDSYSLOGCRC16_H
+
+#include "ExternC.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    uint16_t SolidSyslogCrc16_Compute(const uint8_t* data, uint16_t length);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGCRC16_H */

--- a/Interface/SolidSyslogCrc16Policy.h
+++ b/Interface/SolidSyslogCrc16Policy.h
@@ -1,0 +1,13 @@
+#ifndef SOLIDSYSLOGCRC16POLICY_H
+#define SOLIDSYSLOGCRC16POLICY_H
+
+#include "SolidSyslogSecurityPolicyDefinition.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogSecurityPolicy* SolidSyslogCrc16Policy_Create(void);
+    void                              SolidSyslogCrc16Policy_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGCRC16POLICY_H */

--- a/Interface/SolidSyslogFileStore.h
+++ b/Interface/SolidSyslogFileStore.h
@@ -8,6 +8,8 @@
 
 EXTERN_C_BEGIN
 
+    struct SolidSyslogSecurityPolicy;
+
     enum SolidSyslogDiscardPolicy
     {
         SOLIDSYSLOG_DISCARD_OLDEST,
@@ -16,12 +18,13 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogFileStoreConfig
     {
-        struct SolidSyslogFile*       readFile;
-        struct SolidSyslogFile*       writeFile;
-        const char*                   pathPrefix;
-        size_t                        maxFileSize;
-        size_t                        maxFiles;
-        enum SolidSyslogDiscardPolicy discardPolicy;
+        struct SolidSyslogFile*           readFile;
+        struct SolidSyslogFile*           writeFile;
+        const char*                       pathPrefix;
+        size_t                            maxFileSize;
+        size_t                            maxFiles;
+        enum SolidSyslogDiscardPolicy     discardPolicy;
+        struct SolidSyslogSecurityPolicy* securityPolicy;
     };
 
     struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config);

--- a/Interface/SolidSyslogNullSecurityPolicy.h
+++ b/Interface/SolidSyslogNullSecurityPolicy.h
@@ -1,0 +1,13 @@
+#ifndef SOLIDSYSLOGNULLSECURITYPOLICY_H
+#define SOLIDSYSLOGNULLSECURITYPOLICY_H
+
+#include "SolidSyslogSecurityPolicyDefinition.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogSecurityPolicy* SolidSyslogNullSecurityPolicy_Create(void);
+    void                              SolidSyslogNullSecurityPolicy_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGNULLSECURITYPOLICY_H */

--- a/Interface/SolidSyslogSecurityPolicyDefinition.h
+++ b/Interface/SolidSyslogSecurityPolicyDefinition.h
@@ -1,0 +1,19 @@
+#ifndef SOLIDSYSLOGSECURITYPOLICYDEFINITION_H
+#define SOLIDSYSLOGSECURITYPOLICYDEFINITION_H
+
+#include "ExternC.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogSecurityPolicy
+    {
+        void (*ComputeIntegrity)(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
+        bool (*VerifyIntegrity)(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
+    };
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSECURITYPOLICYDEFINITION_H */

--- a/Interface/SolidSyslogSecurityPolicyDefinition.h
+++ b/Interface/SolidSyslogSecurityPolicyDefinition.h
@@ -16,7 +16,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogSecurityPolicy
     {
-        uint16_t integrity_size;
+        uint16_t integritySize;
         void (*ComputeIntegrity)(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
         bool (*VerifyIntegrity)(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
     };

--- a/Interface/SolidSyslogSecurityPolicyDefinition.h
+++ b/Interface/SolidSyslogSecurityPolicyDefinition.h
@@ -8,8 +8,15 @@
 
 EXTERN_C_BEGIN
 
+    /* large enough for HMAC-SHA256 (32 bytes); CRC-16 uses 2 */
+    enum
+    {
+        SOLIDSYSLOG_MAX_INTEGRITY_SIZE = 32
+    };
+
     struct SolidSyslogSecurityPolicy
     {
+        uint16_t integrity_size;
         void (*ComputeIntegrity)(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
         bool (*VerifyIntegrity)(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
     };

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Public headers are split by audience (Interface Segregation Principle):
 - **`SolidSyslogTcpSender.h`** — TCP transport with RFC 6587 octet-counting framing. Note: RFC 6587
   is a Historic RFC — the IESG recommends TLS (RFC 5425) over plain TCP for new deployments.
   TCP is provided for interoperability with existing infrastructure
+- **`SolidSyslogStoreDefinition.h`** / **`SolidSyslogFileStore.h`** — file-based store-and-forward with rotating files
+- **`SolidSyslogSecurityPolicyDefinition.h`** — extension point for record integrity and encryption
+- **`SolidSyslogCrc16Policy.h`** — CRC-16/CCITT-FALSE integrity policy
 - **`SolidSyslogStructuredDataDefinition.h`** — extension point for custom structured data
 - **`SolidSyslogMetaSd.h`** — sequenceId structured data (RFC 5424 §7.3)
 - **`SolidSyslogTimeQualitySd.h`** — timeQuality structured data (RFC 5424 §7.1)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Public headers are split by audience (Interface Segregation Principle):
   is a Historic RFC — the IESG recommends TLS (RFC 5425) over plain TCP for new deployments.
   TCP is provided for interoperability with existing infrastructure
 - **`SolidSyslogStoreDefinition.h`** / **`SolidSyslogFileStore.h`** — file-based store-and-forward with rotating files
-- **`SolidSyslogSecurityPolicyDefinition.h`** — extension point for record integrity and encryption
+- **`SolidSyslogSecurityPolicyDefinition.h`** — extension point for record integrity policies
 - **`SolidSyslogCrc16Policy.h`** — CRC-16/CCITT-FALSE integrity policy
 - **`SolidSyslogStructuredDataDefinition.h`** — extension point for custom structured data
 - **`SolidSyslogMetaSd.h`** — sequenceId structured data (RFC 5424 §7.3)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SOURCES
     SolidSyslogStore.c
     SolidSyslogNullStore.c
     SolidSyslogNullSecurityPolicy.c
+    SolidSyslogCrc16.c
+    SolidSyslogCrc16Policy.c
     SolidSyslogStructuredData.c
     SolidSyslogTimeQualitySd.c
     SolidSyslogOriginSd.c

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     SolidSyslogSender.c
     SolidSyslogStore.c
     SolidSyslogNullStore.c
+    SolidSyslogNullSecurityPolicy.c
     SolidSyslogStructuredData.c
     SolidSyslogTimeQualitySd.c
     SolidSyslogOriginSd.c

--- a/Source/SolidSyslogCrc16.c
+++ b/Source/SolidSyslogCrc16.c
@@ -1,0 +1,41 @@
+/*
+ * CRC-16/CCITT-FALSE (ITU-T V.41)
+ *   Polynomial: 0x1021  Init: 0xFFFF  RefIn: false  RefOut: false  XorOut: 0x0000
+ *
+ * Check value 0x29B1 from Greg Cook's CRC catalogue:
+ * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-ibm-3740
+ */
+
+#include "SolidSyslogCrc16.h"
+
+enum
+{
+    CRC16_CCITT_INIT = 0xFFFF,
+    CRC16_CCITT_POLY = 0x1021,
+    BITS_PER_BYTE    = 8,
+    MSB_MASK         = 0x8000
+};
+
+uint16_t SolidSyslogCrc16_Compute(const uint8_t* data, uint16_t length)
+{
+    uint16_t crc = CRC16_CCITT_INIT;
+
+    for (uint16_t i = 0; i < length; i++)
+    {
+        crc ^= (uint16_t) ((uint16_t) data[i] << BITS_PER_BYTE);
+
+        for (int bit = 0; bit < BITS_PER_BYTE; bit++)
+        {
+            if ((crc & MSB_MASK) != 0)
+            {
+                crc = (uint16_t) ((crc << 1) ^ CRC16_CCITT_POLY);
+            }
+            else
+            {
+                crc = (uint16_t) (crc << 1);
+            }
+        }
+    }
+
+    return crc;
+}

--- a/Source/SolidSyslogCrc16Policy.c
+++ b/Source/SolidSyslogCrc16Policy.c
@@ -1,0 +1,39 @@
+#include "SolidSyslogCrc16Policy.h"
+#include "SolidSyslogCrc16.h"
+
+enum
+{
+    CRC16_SIZE = 2
+};
+
+static void Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
+static bool Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
+
+static struct SolidSyslogSecurityPolicy instance = {
+    CRC16_SIZE,
+    Crc16ComputeIntegrity,
+    Crc16VerifyIntegrity,
+};
+
+struct SolidSyslogSecurityPolicy* SolidSyslogCrc16Policy_Create(void)
+{
+    return &instance;
+}
+
+void SolidSyslogCrc16Policy_Destroy(void)
+{
+}
+
+static void Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
+{
+    uint16_t crc    = SolidSyslogCrc16_Compute(data, length);
+    integrityOut[0] = (uint8_t) (crc >> 8U);
+    integrityOut[1] = (uint8_t) (crc & 0xFFU);
+}
+
+static bool Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
+{
+    uint16_t crc      = SolidSyslogCrc16_Compute(data, length);
+    uint16_t expected = (uint16_t) ((uint16_t) (integrityIn[0] << 8U) | integrityIn[1]);
+    return crc == expected;
+}

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -2,6 +2,7 @@
 #include "SolidSyslog.h"
 #include "SolidSyslogFile.h"
 #include "SolidSyslogFormat.h"
+#include "SolidSyslogSecurityPolicyDefinition.h"
 #include "SolidSyslogStoreDefinition.h"
 
 #include <stdint.h>
@@ -65,6 +66,7 @@ static inline void SeekToWritePosition(void);
 static inline bool WriteRecordHeader(size_t dataSize);
 static inline bool WriteExact(const void* buf, size_t count);
 static inline bool WriteRecordBody(const void* data, size_t size);
+static inline void ComputeIntegrity(const void* data, size_t size);
 static inline bool WriteUnsentFlag(void);
 static inline void AdvanceWritePosition(size_t dataSize);
 
@@ -84,21 +86,22 @@ static inline void AdvanceReadCursor(void);
 
 struct SolidSyslogFileStore
 {
-    struct SolidSyslogStore       base;
-    struct SolidSyslogFile*       readFile;
-    struct SolidSyslogFile*       writeFile;
-    const char*                   pathPrefix;
-    char                          filename[MAX_PATH_SIZE];
-    size_t                        maxFileSize;
-    size_t                        maxFiles;
-    enum SolidSyslogDiscardPolicy discardPolicy;
-    uint8_t                       oldestSequence;
-    uint8_t                       readSequence;
-    uint8_t                       writeSequence;
-    size_t                        readCursor;
-    size_t                        writePosition;
-    size_t                        lastSentFlagOffset;
-    bool                          hasReadRecord;
+    struct SolidSyslogStore           base;
+    struct SolidSyslogFile*           readFile;
+    struct SolidSyslogFile*           writeFile;
+    struct SolidSyslogSecurityPolicy* securityPolicy;
+    const char*                       pathPrefix;
+    char                              filename[MAX_PATH_SIZE];
+    size_t                            maxFileSize;
+    size_t                            maxFiles;
+    enum SolidSyslogDiscardPolicy     discardPolicy;
+    uint8_t                           oldestSequence;
+    uint8_t                           readSequence;
+    uint8_t                           writeSequence;
+    size_t                            readCursor;
+    size_t                            writePosition;
+    size_t                            lastSentFlagOffset;
+    bool                              hasReadRecord;
 };
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
@@ -110,10 +113,11 @@ static struct SolidSyslogFileStore       instance;
 
 struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config)
 {
-    instance            = DEFAULT_INSTANCE;
-    instance.readFile   = config->readFile;
-    instance.writeFile  = config->writeFile;
-    instance.pathPrefix = config->pathPrefix;
+    instance                = DEFAULT_INSTANCE;
+    instance.readFile       = config->readFile;
+    instance.writeFile      = config->writeFile;
+    instance.securityPolicy = config->securityPolicy;
+    instance.pathPrefix     = config->pathPrefix;
     ValidateConfig(config);
     InitialiseVtable();
 
@@ -383,6 +387,7 @@ static bool WriteRecordToFile(const void* data, size_t size)
 
     if (WriteRecordHeader(size) && WriteRecordBody(data, size) && WriteUnsentFlag())
     {
+        ComputeIntegrity(data, size);
         AdvanceWritePosition(size);
         written = true;
     }
@@ -450,6 +455,14 @@ static inline bool WriteExact(const void* buf, size_t count)
 static inline bool WriteRecordBody(const void* data, size_t size)
 {
     return WriteExact(data, size);
+}
+
+static inline void ComputeIntegrity(const void* data, size_t size)
+{
+    if (instance.securityPolicy != NULL)
+    {
+        instance.securityPolicy->ComputeIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
+    }
 }
 
 static inline bool WriteUnsentFlag(void)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -163,6 +163,11 @@ static bool ReadRecordLength(size_t offset, uint16_t* length)
     return ReadExact(length, RECORD_LENGTH_SIZE);
 }
 
+static inline bool IsValidLength(uint16_t length)
+{
+    return length <= SOLIDSYSLOG_MAX_MESSAGE_SIZE;
+}
+
 static bool ReadSentFlag(size_t recordStart, uint16_t dataLength, uint8_t* flag)
 {
     SolidSyslogFile_SeekTo(instance.readFile, SentFlagOffset(recordStart, dataLength));
@@ -392,7 +397,7 @@ static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
     uint16_t length   = 0;
     bool     advanced = false;
 
-    if (ReadMagic(*cursor) && ReadRecordLength(*cursor + MAGIC_SIZE, &length))
+    if (ReadMagic(*cursor) && ReadRecordLength(*cursor + MAGIC_SIZE, &length) && IsValidLength(length))
     {
         if (IsRecordSent(*cursor, length))
         {
@@ -616,8 +621,8 @@ static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
     uint16_t length = 0;
     bool     read   = false;
 
-    if (ReadMagic(instance.readCursor) && ReadRecordLength(instance.readCursor + MAGIC_SIZE, &length) && VerifyIntegrity(instance.readCursor, length) &&
-        ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead))
+    if (ReadMagic(instance.readCursor) && ReadRecordLength(instance.readCursor + MAGIC_SIZE, &length) && IsValidLength(length) &&
+        VerifyIntegrity(instance.readCursor, length) && ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead))
     {
         RememberCurrentRecord(length);
         read = true;

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -2,7 +2,7 @@
 #include "SolidSyslog.h"
 #include "SolidSyslogFile.h"
 #include "SolidSyslogFormat.h"
-#include "SolidSyslogSecurityPolicyDefinition.h"
+#include "SolidSyslogNullSecurityPolicy.h"
 #include "SolidSyslogStoreDefinition.h"
 
 #include <stdint.h>
@@ -141,6 +141,11 @@ static inline void ValidateConfig(const struct SolidSyslogFileStoreConfig* confi
     instance.maxFiles      = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
     instance.maxFileSize   = ClampToRange(config->maxFileSize, MIN_MAX_FILE_SIZE, (size_t) -1);
     instance.discardPolicy = config->discardPolicy;
+
+    if (instance.securityPolicy == NULL)
+    {
+        instance.securityPolicy = SolidSyslogNullSecurityPolicy_Create();
+    }
 }
 
 static inline void FormatFilename(uint8_t sequence)
@@ -460,10 +465,7 @@ static inline bool WriteRecordBody(const void* data, size_t size)
 
 static inline void ComputeIntegrity(const void* data, size_t size)
 {
-    if (instance.securityPolicy != NULL)
-    {
-        instance.securityPolicy->ComputeIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
-    }
+    instance.securityPolicy->ComputeIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
 }
 
 static inline bool WriteUnsentFlag(void)
@@ -570,12 +572,7 @@ static bool ReadRecordData(size_t recordStart, uint32_t length, void* data, size
 
 static inline bool VerifyIntegrity(const void* data, size_t size)
 {
-    if (instance.securityPolicy != NULL)
-    {
-        return instance.securityPolicy->VerifyIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
-    }
-
-    return true;
+    return instance.securityPolicy->VerifyIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
 }
 
 static inline size_t DataOffset(size_t recordStart)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -6,14 +6,18 @@
 #include "SolidSyslogStoreDefinition.h"
 
 #include <stdint.h>
+#include <string.h>
 
 enum
 {
-    RECORD_LENGTH_SIZE = 4,
+    MAGIC_SIZE         = 2,
+    MAGIC_BYTE_0       = 0xA5,
+    MAGIC_BYTE_1       = 0x5A,
+    RECORD_LENGTH_SIZE = 2,
     SENT_FLAG_SIZE     = 1,
-    RECORD_OVERHEAD    = RECORD_LENGTH_SIZE + SENT_FLAG_SIZE,
-    SENT_FLAG_UNSENT   = 0,
-    SENT_FLAG_SENT     = 1,
+    RECORD_OVERHEAD    = MAGIC_SIZE + RECORD_LENGTH_SIZE + SENT_FLAG_SIZE,
+    SENT_FLAG_UNSENT   = 0xFF,
+    SENT_FLAG_SENT     = 0x00,
     MIN_MAX_FILES      = 2,
     MAX_MAX_FILES      = 99,
     SEQUENCE_MODULUS   = 100,
@@ -21,69 +25,56 @@ enum
     MAX_PATH_SIZE      = 128
 };
 
-/* vtable */
+/* vtable — forward-declared because InitialiseVtable references them before their definitions */
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
 static void MarkSent(struct SolidSyslogStore* self);
 static bool HasUnsent(struct SolidSyslogStore* self);
 
-/* Create helpers */
-static inline void   ValidateConfig(const struct SolidSyslogFileStoreConfig* config);
-static inline size_t ClampToRange(size_t value, size_t min, size_t max);
-static inline void   FormatFilename(uint8_t sequence);
-static void          ScanForExistingFiles(void);
-static inline void   InitialiseVtable(void);
-static inline bool   OpenWriteFile(const char* path);
-static inline bool   OpenReadFile(const char* path);
-static inline bool   IsWriteFileOpen(void);
-static inline bool   IsReadFileOpen(void);
-static void          ResumeFromExistingFile(void);
-static inline void   MeasureFileSize(void);
-static inline void   FindFirstUnsentRecord(void);
-static size_t        ScanForFirstUnsent(size_t fileSize);
-static bool          AdvancePastSentRecord(size_t* cursor, size_t fileSize);
-static bool          ReadRecordLength(size_t offset, uint32_t* length);
-static inline bool   ReadExact(void* buf, size_t count);
-static inline bool   IsRecordSent(size_t recordStart, uint32_t length);
-static bool          ReadSentFlag(size_t recordStart, uint32_t dataLength, uint8_t* flag);
-static inline size_t SentFlagOffset(size_t recordStart, uint32_t dataLength);
-static inline void   SkipRecord(size_t* cursor, uint32_t length);
-static inline size_t RecordSize(uint32_t dataLength);
-static inline void   SkipToEndOfValidData(size_t* cursor, size_t fileSize);
+/* ------------------------------------------------------------------
+ * Record buffer — single static buffer for integrity computation
+ * ----------------------------------------------------------------*/
 
-/* File rotation helpers */
-static inline bool    StoreIsFull(void);
-static inline bool    FileIsFull(size_t dataSize);
-static inline size_t  FileCount(void);
-static inline bool    ReadingOlderFile(void);
-static inline uint8_t NextSequence(uint8_t current);
-static void           RotateToNextFile(void);
-static void           DiscardOldestFile(void);
+enum
+{
+    INTEGRITY_BUFFER_SIZE = MAGIC_SIZE + RECORD_LENGTH_SIZE + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE
+};
 
-/* Write helpers */
-static bool        WriteRecordToFile(const void* data, size_t size);
-static inline void SeekToWritePosition(void);
-static inline bool WriteRecordHeader(size_t dataSize);
-static inline bool WriteExact(const void* buf, size_t count);
-static inline bool WriteRecordBody(const void* data, size_t size);
-static inline void ComputeIntegrity(const void* data, size_t size);
-static inline bool WriteUnsentFlag(void);
-static inline void AdvanceWritePosition(size_t dataSize);
+static uint8_t recordBuffer[INTEGRITY_BUFFER_SIZE];
 
-/* HasUnsent helpers */
-static inline bool HasUnsentRecords(void);
+static inline uint8_t* MagicAddress(void)
+{
+    return recordBuffer;
+}
 
-/* ReadNextUnsent helpers */
-static bool          ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
-static inline void   RememberCurrentRecord(uint32_t length);
-static bool          ReadRecordData(size_t recordStart, uint32_t length, void* data, size_t maxSize, size_t* bytesRead);
-static inline bool   VerifyIntegrity(const void* data, size_t size);
-static inline size_t DataOffset(size_t recordStart);
-static inline size_t BoundedSize(uint32_t length, size_t maxSize);
+static inline uint8_t* LengthAddress(void)
+{
+    return recordBuffer + MAGIC_SIZE;
+}
 
-/* MarkSent helpers */
-static inline bool WriteSentFlag(void);
-static inline void AdvanceReadCursor(void);
+static inline uint8_t* MessageAddress(void)
+{
+    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE;
+}
+
+static inline uint8_t* IntegrityChecksumAddress(size_t dataSize)
+{
+    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize;
+}
+
+static inline uint8_t* IntegrityRegionAddress(void)
+{
+    return MagicAddress();
+}
+
+static inline uint16_t IntegrityRegionSize(size_t dataSize)
+{
+    return (uint16_t) (MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize);
+}
+
+/* ------------------------------------------------------------------
+ * Instance
+ * ----------------------------------------------------------------*/
 
 struct SolidSyslogFileStore
 {
@@ -107,6 +98,172 @@ struct SolidSyslogFileStore
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
 static struct SolidSyslogFileStore       instance;
+
+/* ------------------------------------------------------------------
+ * Shared helpers — used by both Create (resume scan) and ReadNextUnsent
+ * ----------------------------------------------------------------*/
+
+static inline bool ReadExact(void* buf, size_t count)
+{
+    return SolidSyslogFile_Read(instance.readFile, buf, count);
+}
+
+static inline bool WriteExact(const void* buf, size_t count)
+{
+    return SolidSyslogFile_Write(instance.writeFile, buf, count);
+}
+
+static inline bool OpenWriteFile(const char* path)
+{
+    return SolidSyslogFile_Open(instance.writeFile, path);
+}
+
+static inline bool OpenReadFile(const char* path)
+{
+    return SolidSyslogFile_Open(instance.readFile, path);
+}
+
+static inline bool IsWriteFileOpen(void)
+{
+    return (instance.writeFile != NULL) && SolidSyslogFile_IsOpen(instance.writeFile);
+}
+
+static inline bool IsReadFileOpen(void)
+{
+    return (instance.readFile != NULL) && SolidSyslogFile_IsOpen(instance.readFile);
+}
+
+static inline size_t RecordSize(uint16_t dataLength)
+{
+    return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integrity_size + SENT_FLAG_SIZE;
+}
+
+static inline size_t SentFlagOffset(size_t recordStart, uint16_t dataLength)
+{
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integrity_size;
+}
+
+static inline size_t DataOffset(size_t recordStart)
+{
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE;
+}
+
+static inline bool ReadMagic(size_t offset)
+{
+    uint8_t magic[MAGIC_SIZE] = {0};
+
+    SolidSyslogFile_SeekTo(instance.readFile, offset);
+
+    return ReadExact(magic, MAGIC_SIZE) && (magic[0] == MAGIC_BYTE_0) && (magic[1] == MAGIC_BYTE_1);
+}
+
+static bool ReadRecordLength(size_t offset, uint16_t* length)
+{
+    SolidSyslogFile_SeekTo(instance.readFile, offset);
+    return ReadExact(length, RECORD_LENGTH_SIZE);
+}
+
+static bool ReadSentFlag(size_t recordStart, uint16_t dataLength, uint8_t* flag)
+{
+    SolidSyslogFile_SeekTo(instance.readFile, SentFlagOffset(recordStart, dataLength));
+    return ReadExact(flag, SENT_FLAG_SIZE);
+}
+
+static inline bool IsRecordSent(size_t recordStart, uint16_t length)
+{
+    uint8_t flag = SENT_FLAG_SENT;
+    ReadSentFlag(recordStart, length, &flag);
+    return flag == SENT_FLAG_SENT;
+}
+
+static inline void FormatFilename(uint8_t sequence)
+{
+    enum
+    {
+        TENS_DIVISOR = 10
+    };
+
+    size_t len = 0;
+    len += SolidSyslogFormat_BoundedString(instance.filename + len, instance.pathPrefix, MAX_PATH_SIZE - len);
+
+    if ((len + 1) < MAX_PATH_SIZE)
+    {
+        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence / TENS_DIVISOR));
+    }
+
+    if ((len + 1) < MAX_PATH_SIZE)
+    {
+        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence % TENS_DIVISOR));
+    }
+
+    len += SolidSyslogFormat_BoundedString(instance.filename + len, ".log", MAX_PATH_SIZE - len);
+    instance.filename[len] = '\0';
+}
+
+static inline uint8_t NextSequence(uint8_t current)
+{
+    return (uint8_t) ((current + 1) % SEQUENCE_MODULUS);
+}
+
+static inline size_t FileCount(void)
+{
+    return (size_t) ((instance.writeSequence - instance.oldestSequence + SEQUENCE_MODULUS) % SEQUENCE_MODULUS) + 1;
+}
+
+static inline bool ReadingOlderFile(void)
+{
+    return instance.readSequence != instance.writeSequence;
+}
+
+static inline bool HasUnsentRecords(void)
+{
+    return ReadingOlderFile() || (instance.readCursor < instance.writePosition);
+}
+
+/* Create helpers — forward-declared because they appear below Create for top-down reading */
+static inline void   ValidateConfig(const struct SolidSyslogFileStoreConfig* config);
+static inline size_t ClampToRange(size_t value, size_t min, size_t max);
+static inline void   InitialiseVtable(void);
+static void          ScanForExistingFiles(void);
+static void          ResumeFromExistingFile(void);
+static inline void   MeasureFileSize(void);
+static inline void   FindFirstUnsentRecord(void);
+static size_t        ScanForFirstUnsent(size_t fileSize);
+static bool          AdvancePastSentRecord(size_t* cursor, size_t fileSize);
+static inline void   SkipRecord(size_t* cursor, uint16_t length);
+static inline void   SkipToEndOfValidData(size_t* cursor, size_t fileSize);
+
+/* Write helpers — forward-declared because they appear below Write */
+static bool        WriteRecordToFile(const void* data, size_t size);
+static inline bool FileIsFull(size_t dataSize);
+static inline bool StoreIsFull(void);
+static void        RotateToNextFile(void);
+static void        DiscardOldestFile(void);
+static inline void SeekToWritePosition(void);
+static inline bool WriteMagic(void);
+static inline bool WriteRecordHeader(size_t dataSize);
+static inline bool WriteRecordBody(const void* data, size_t size);
+static bool        ComputeAndWriteIntegrity(const void* data, size_t size);
+static inline void AssembleIntegrityRegion(const void* data, size_t size);
+static inline bool WriteIntegrity(size_t dataSize);
+static inline bool WriteUnsentFlag(void);
+static inline void AdvanceWritePosition(size_t dataSize);
+
+/* ReadNextUnsent helpers */
+static void AdvanceToNextReadFile(void);
+static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
+static bool VerifyIntegrity(size_t recordStart, uint16_t length);
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, regionSize is a byte count; distinct semantics
+static bool          ReadIntegrityRegion(size_t recordStart, uint16_t regionSize);
+static inline bool   ReadIntegrity(size_t recordStart, uint16_t dataLength);
+static inline size_t IntegrityOffset(size_t recordStart, uint16_t dataLength);
+static bool          ReadRecordData(size_t recordStart, uint16_t length, void* data, size_t maxSize, size_t* bytesRead);
+static inline size_t BoundedSize(uint16_t length, size_t maxSize);
+static inline void   RememberCurrentRecord(uint16_t length);
+
+/* MarkSent helpers */
+static inline bool WriteSentFlag(void);
+static inline void AdvanceReadCursor(void);
 
 /* ------------------------------------------------------------------
  * Create
@@ -148,30 +305,6 @@ static inline void ValidateConfig(const struct SolidSyslogFileStoreConfig* confi
     }
 }
 
-static inline void FormatFilename(uint8_t sequence)
-{
-    enum
-    {
-        TENS_DIVISOR = 10
-    };
-
-    size_t len = 0;
-    len += SolidSyslogFormat_BoundedString(instance.filename + len, instance.pathPrefix, MAX_PATH_SIZE - len);
-
-    if ((len + 1) < MAX_PATH_SIZE)
-    {
-        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence / TENS_DIVISOR));
-    }
-
-    if ((len + 1) < MAX_PATH_SIZE)
-    {
-        len += SolidSyslogFormat_Character(instance.filename + len, SolidSyslogFormat_DigitToChar(sequence % TENS_DIVISOR));
-    }
-
-    len += SolidSyslogFormat_BoundedString(instance.filename + len, ".log", MAX_PATH_SIZE - len);
-    instance.filename[len] = '\0';
-}
-
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value, min, max have distinct semantics
 static inline size_t ClampToRange(size_t value, size_t min, size_t max)
 {
@@ -188,6 +321,14 @@ static inline size_t ClampToRange(size_t value, size_t min, size_t max)
     }
 
     return result;
+}
+
+static inline void InitialiseVtable(void)
+{
+    instance.base.Write          = Write;
+    instance.base.ReadNextUnsent = ReadNextUnsent;
+    instance.base.MarkSent       = MarkSent;
+    instance.base.HasUnsent      = HasUnsent;
 }
 
 static void ScanForExistingFiles(void)
@@ -215,34 +356,6 @@ static void ScanForExistingFiles(void)
             instance.writeSequence = (uint8_t) seq;
         }
     }
-}
-
-static inline void InitialiseVtable(void)
-{
-    instance.base.Write          = Write;
-    instance.base.ReadNextUnsent = ReadNextUnsent;
-    instance.base.MarkSent       = MarkSent;
-    instance.base.HasUnsent      = HasUnsent;
-}
-
-static inline bool OpenWriteFile(const char* path)
-{
-    return SolidSyslogFile_Open(instance.writeFile, path);
-}
-
-static inline bool OpenReadFile(const char* path)
-{
-    return SolidSyslogFile_Open(instance.readFile, path);
-}
-
-static inline bool IsWriteFileOpen(void)
-{
-    return (instance.writeFile != NULL) && SolidSyslogFile_IsOpen(instance.writeFile);
-}
-
-static inline bool IsReadFileOpen(void)
-{
-    return (instance.readFile != NULL) && SolidSyslogFile_IsOpen(instance.readFile);
 }
 
 static void ResumeFromExistingFile(void)
@@ -276,10 +389,10 @@ static size_t ScanForFirstUnsent(size_t fileSize)
 
 static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
 {
-    uint32_t length   = 0;
+    uint16_t length   = 0;
     bool     advanced = false;
 
-    if (ReadRecordLength(*cursor, &length))
+    if (ReadMagic(*cursor) && ReadRecordLength(*cursor + MAGIC_SIZE, &length))
     {
         if (IsRecordSent(*cursor, length))
         {
@@ -295,43 +408,9 @@ static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
     return advanced;
 }
 
-static bool ReadRecordLength(size_t offset, uint32_t* length)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, offset);
-    return ReadExact(length, RECORD_LENGTH_SIZE);
-}
-
-static inline bool ReadExact(void* buf, size_t count)
-{
-    return SolidSyslogFile_Read(instance.readFile, buf, count);
-}
-
-static inline bool IsRecordSent(size_t recordStart, uint32_t length)
-{
-    uint8_t flag = SENT_FLAG_SENT;
-    ReadSentFlag(recordStart, length, &flag);
-    return flag == SENT_FLAG_SENT;
-}
-
-static bool ReadSentFlag(size_t recordStart, uint32_t dataLength, uint8_t* flag)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, SentFlagOffset(recordStart, dataLength));
-    return ReadExact(flag, SENT_FLAG_SIZE);
-}
-
-static inline size_t SentFlagOffset(size_t recordStart, uint32_t dataLength)
-{
-    return recordStart + RECORD_LENGTH_SIZE + dataLength;
-}
-
-static inline void SkipRecord(size_t* cursor, uint32_t length)
+static inline void SkipRecord(size_t* cursor, uint16_t length)
 {
     *cursor += RecordSize(length);
-}
-
-static inline size_t RecordSize(uint32_t dataLength)
-{
-    return RECORD_LENGTH_SIZE + dataLength + SENT_FLAG_SIZE;
 }
 
 static inline void SkipToEndOfValidData(size_t* cursor, size_t fileSize)
@@ -391,9 +470,8 @@ static bool WriteRecordToFile(const void* data, size_t size)
 
     SeekToWritePosition();
 
-    if (WriteRecordHeader(size) && WriteRecordBody(data, size) && WriteUnsentFlag())
+    if (WriteMagic() && WriteRecordHeader(size) && WriteRecordBody(data, size) && ComputeAndWriteIntegrity(data, size) && WriteUnsentFlag())
     {
-        ComputeIntegrity(data, size);
         AdvanceWritePosition(size);
         written = true;
     }
@@ -401,14 +479,14 @@ static bool WriteRecordToFile(const void* data, size_t size)
     return written;
 }
 
+static inline bool FileIsFull(size_t dataSize)
+{
+    return (instance.writePosition + RecordSize((uint16_t) dataSize)) > instance.maxFileSize;
+}
+
 static inline bool StoreIsFull(void)
 {
     return (FileCount() >= instance.maxFiles) && (instance.discardPolicy == SOLIDSYSLOG_DISCARD_NEWEST);
-}
-
-static inline bool FileIsFull(size_t dataSize)
-{
-    return (instance.writePosition + RecordSize((uint32_t) dataSize)) > instance.maxFileSize;
 }
 
 static void RotateToNextFile(void)
@@ -425,16 +503,6 @@ static void RotateToNextFile(void)
     }
 }
 
-static inline uint8_t NextSequence(uint8_t current)
-{
-    return (uint8_t) ((current + 1) % SEQUENCE_MODULUS);
-}
-
-static inline size_t FileCount(void)
-{
-    return (size_t) ((instance.writeSequence - instance.oldestSequence + SEQUENCE_MODULUS) % SEQUENCE_MODULUS) + 1;
-}
-
 static void DiscardOldestFile(void)
 {
     FormatFilename(instance.oldestSequence);
@@ -447,15 +515,16 @@ static inline void SeekToWritePosition(void)
     SolidSyslogFile_SeekTo(instance.writeFile, instance.writePosition);
 }
 
-static inline bool WriteRecordHeader(size_t dataSize)
+static inline bool WriteMagic(void)
 {
-    uint32_t length = (uint32_t) dataSize;
-    return WriteExact(&length, RECORD_LENGTH_SIZE);
+    uint8_t magic[MAGIC_SIZE] = {MAGIC_BYTE_0, MAGIC_BYTE_1};
+    return WriteExact(magic, MAGIC_SIZE);
 }
 
-static inline bool WriteExact(const void* buf, size_t count)
+static inline bool WriteRecordHeader(size_t dataSize)
 {
-    return SolidSyslogFile_Write(instance.writeFile, buf, count);
+    uint16_t length = (uint16_t) dataSize;
+    return WriteExact(&length, RECORD_LENGTH_SIZE);
 }
 
 static inline bool WriteRecordBody(const void* data, size_t size)
@@ -463,9 +532,29 @@ static inline bool WriteRecordBody(const void* data, size_t size)
     return WriteExact(data, size);
 }
 
-static inline void ComputeIntegrity(const void* data, size_t size)
+static bool ComputeAndWriteIntegrity(const void* data, size_t size)
 {
-    instance.securityPolicy->ComputeIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
+    AssembleIntegrityRegion(data, size);
+    instance.securityPolicy->ComputeIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(size), IntegrityChecksumAddress(size));
+
+    return WriteIntegrity(size);
+}
+
+static inline void AssembleIntegrityRegion(const void* data, size_t size)
+{
+    MagicAddress()[0] = MAGIC_BYTE_0;
+    MagicAddress()[1] = MAGIC_BYTE_1;
+
+    uint16_t length = (uint16_t) size;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(LengthAddress(), &length, RECORD_LENGTH_SIZE);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(MessageAddress(), data, size);
+}
+
+static inline bool WriteIntegrity(size_t dataSize)
+{
+    return WriteExact(IntegrityChecksumAddress(dataSize), instance.securityPolicy->integrity_size);
 }
 
 static inline bool WriteUnsentFlag(void)
@@ -476,7 +565,7 @@ static inline bool WriteUnsentFlag(void)
 
 static inline void AdvanceWritePosition(size_t dataSize)
 {
-    instance.writePosition += RecordSize((uint32_t) dataSize);
+    instance.writePosition += RecordSize((uint16_t) dataSize);
 }
 
 /* ------------------------------------------------------------------
@@ -489,21 +578,9 @@ static bool HasUnsent(struct SolidSyslogStore* self)
     return HasUnsentRecords();
 }
 
-static inline bool ReadingOlderFile(void)
-{
-    return instance.readSequence != instance.writeSequence;
-}
-
-static inline bool HasUnsentRecords(void)
-{
-    return ReadingOlderFile() || (instance.readCursor < instance.writePosition);
-}
-
 /* ------------------------------------------------------------------
  * ReadNextUnsent
  * ----------------------------------------------------------------*/
-
-static void AdvanceToNextReadFile(void);
 
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
@@ -536,11 +613,11 @@ static void AdvanceToNextReadFile(void)
 
 static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
 {
-    uint32_t length = 0;
+    uint16_t length = 0;
     bool     read   = false;
 
-    if (ReadRecordLength(instance.readCursor, &length) && ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead) &&
-        VerifyIntegrity(data, length))
+    if (ReadMagic(instance.readCursor) && ReadRecordLength(instance.readCursor + MAGIC_SIZE, &length) && VerifyIntegrity(instance.readCursor, length) &&
+        ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead))
     {
         RememberCurrentRecord(length);
         read = true;
@@ -549,14 +626,41 @@ static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
     return read;
 }
 
-static inline void RememberCurrentRecord(uint32_t length)
+static bool VerifyIntegrity(size_t recordStart, uint16_t length)
 {
-    instance.lastSentFlagOffset = SentFlagOffset(instance.readCursor, length);
-    instance.hasReadRecord      = true;
+    if (!ReadIntegrityRegion(recordStart, IntegrityRegionSize(length)))
+    {
+        return false;
+    }
+
+    if (!ReadIntegrity(recordStart, length))
+    {
+        return false;
+    }
+
+    return instance.securityPolicy->VerifyIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(length), IntegrityChecksumAddress(length));
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, regionSize is a byte count; distinct semantics
+static bool ReadIntegrityRegion(size_t recordStart, uint16_t regionSize)
+{
+    SolidSyslogFile_SeekTo(instance.readFile, recordStart);
+    return ReadExact(IntegrityRegionAddress(), regionSize);
+}
+
+static inline bool ReadIntegrity(size_t recordStart, uint16_t dataLength)
+{
+    SolidSyslogFile_SeekTo(instance.readFile, IntegrityOffset(recordStart, dataLength));
+    return ReadExact(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integrity_size);
+}
+
+static inline size_t IntegrityOffset(size_t recordStart, uint16_t dataLength)
+{
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, length is a data size; distinct semantics
-static bool ReadRecordData(size_t recordStart, uint32_t length, void* data, size_t maxSize, size_t* bytesRead)
+static bool ReadRecordData(size_t recordStart, uint16_t length, void* data, size_t maxSize, size_t* bytesRead)
 {
     size_t copySize = BoundedSize(length, maxSize);
 
@@ -570,19 +674,15 @@ static bool ReadRecordData(size_t recordStart, uint32_t length, void* data, size
     return *bytesRead > 0;
 }
 
-static inline bool VerifyIntegrity(const void* data, size_t size)
-{
-    return instance.securityPolicy->VerifyIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
-}
-
-static inline size_t DataOffset(size_t recordStart)
-{
-    return recordStart + RECORD_LENGTH_SIZE;
-}
-
-static inline size_t BoundedSize(uint32_t length, size_t maxSize)
+static inline size_t BoundedSize(uint16_t length, size_t maxSize)
 {
     return (length < maxSize) ? length : maxSize;
+}
+
+static inline void RememberCurrentRecord(uint16_t length)
+{
+    instance.lastSentFlagOffset = SentFlagOffset(instance.readCursor, length);
+    instance.hasReadRecord      = true;
 }
 
 /* ------------------------------------------------------------------

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -77,6 +77,7 @@ static inline bool HasUnsentRecords(void);
 static bool          ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
 static inline void   RememberCurrentRecord(uint32_t length);
 static bool          ReadRecordData(size_t recordStart, uint32_t length, void* data, size_t maxSize, size_t* bytesRead);
+static inline bool   VerifyIntegrity(const void* data, size_t size);
 static inline size_t DataOffset(size_t recordStart);
 static inline size_t BoundedSize(uint32_t length, size_t maxSize);
 
@@ -536,7 +537,8 @@ static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
     uint32_t length = 0;
     bool     read   = false;
 
-    if (ReadRecordLength(instance.readCursor, &length) && ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead))
+    if (ReadRecordLength(instance.readCursor, &length) && ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead) &&
+        VerifyIntegrity(data, length))
     {
         RememberCurrentRecord(length);
         read = true;
@@ -564,6 +566,16 @@ static bool ReadRecordData(size_t recordStart, uint32_t length, void* data, size
     }
 
     return *bytesRead > 0;
+}
+
+static inline bool VerifyIntegrity(const void* data, size_t size)
+{
+    if (instance.securityPolicy != NULL)
+    {
+        return instance.securityPolicy->VerifyIntegrity((const uint8_t*) data, (uint16_t) size, NULL);
+    }
+
+    return true;
 }
 
 static inline size_t DataOffset(size_t recordStart)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -94,6 +94,7 @@ struct SolidSyslogFileStore
     size_t                            writePosition;
     size_t                            lastSentFlagFileOffset;
     bool                              hasReadRecord;
+    bool                              writeFileCorrupt;
 };
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
@@ -243,9 +244,8 @@ static inline void   InitialiseVtable(void);
 static void          ScanForExistingFiles(void);
 static void          ResumeFromExistingFile(void);
 static inline void   MeasureFileSize(void);
-static inline void   FindFirstUnsentRecord(void);
-static size_t        ScanForFirstUnsent(size_t fileSize);
-static bool          AdvancePastSentRecord(size_t* cursor, size_t fileSize);
+static size_t        ScanForFirstUnsent(size_t fileSize, bool* corrupt);
+static bool          AdvancePastSentRecord(size_t* cursor, size_t fileSize, bool* corrupt);
 static inline void   SkipRecord(size_t* cursor, uint16_t length);
 static inline void   SkipToEndOfValidData(size_t* cursor, size_t fileSize);
 
@@ -302,16 +302,26 @@ struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFil
     return &instance.base;
 }
 
+static inline size_t MinFileSize(void)
+{
+    return SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD + instance.securityPolicy->integritySize;
+}
+
 static inline void ValidateConfig(const struct SolidSyslogFileStoreConfig* config)
 {
-    instance.maxFiles      = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
-    instance.maxFileSize   = ClampToRange(config->maxFileSize, MIN_MAX_FILE_SIZE, (size_t) -1);
-    instance.discardPolicy = config->discardPolicy;
-
     if (instance.securityPolicy == NULL)
     {
         instance.securityPolicy = SolidSyslogNullSecurityPolicy_Create();
     }
+
+    if (instance.securityPolicy->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE)
+    {
+        instance.securityPolicy = SolidSyslogNullSecurityPolicy_Create();
+    }
+
+    instance.maxFiles      = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
+    instance.maxFileSize   = ClampToRange(config->maxFileSize, MinFileSize(), (size_t) -1);
+    instance.discardPolicy = config->discardPolicy;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value, min, max have distinct semantics
@@ -370,7 +380,11 @@ static void ScanForExistingFiles(void)
 static void ResumeFromExistingFile(void)
 {
     MeasureFileSize();
-    FindFirstUnsentRecord();
+
+    bool corrupt        = false;
+    instance.readCursor = ScanForFirstUnsent(instance.writePosition, &corrupt);
+
+    instance.writeFileCorrupt = corrupt;
 }
 
 static inline void MeasureFileSize(void)
@@ -378,30 +392,27 @@ static inline void MeasureFileSize(void)
     instance.writePosition = SolidSyslogFile_Size(instance.writeFile);
 }
 
-static inline void FindFirstUnsentRecord(void)
-{
-    instance.readCursor = ScanForFirstUnsent(instance.writePosition);
-}
-
-static size_t ScanForFirstUnsent(size_t fileSize)
+static size_t ScanForFirstUnsent(size_t fileSize, bool* corrupt)
 {
     size_t cursor   = 0;
     bool   scanning = true;
+    *corrupt        = false;
 
     while (scanning && (cursor < fileSize))
     {
-        scanning = AdvancePastSentRecord(&cursor, fileSize);
+        scanning = AdvancePastSentRecord(&cursor, fileSize, corrupt);
     }
 
     return cursor;
 }
 
-static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
+static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize, bool* corrupt)
 {
     uint16_t length   = 0;
     bool     advanced = false;
 
-    if (ReadRecordHeader(*cursor) && ValidateHeader(&length))
+    if (ReadRecordHeader(*cursor) && ValidateHeader(&length) && ReadRecordBody(*cursor, length) && ReadIntegrityChecksum(*cursor, length) &&
+        VerifyIntegrity(length))
     {
         if (IsRecordSent(*cursor, length))
         {
@@ -412,6 +423,7 @@ static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
     else
     {
         SkipToEndOfValidData(cursor, fileSize);
+        *corrupt = true;
     }
 
     return advanced;
@@ -494,7 +506,7 @@ static bool MakeSpaceForRecord(size_t dataSize)
 
 static inline bool FileIsFull(size_t dataSize)
 {
-    return (instance.writePosition + RecordSize((uint16_t) dataSize)) > instance.maxFileSize;
+    return instance.writeFileCorrupt || (instance.writePosition + RecordSize((uint16_t) dataSize)) > instance.maxFileSize;
 }
 
 static inline bool StoreIsFull(void)
@@ -505,8 +517,9 @@ static inline bool StoreIsFull(void)
 static void RotateToNextFile(void)
 {
     SolidSyslogFile_Close(instance.writeFile);
-    instance.writeSequence = NextSequence(instance.writeSequence);
-    instance.writePosition = 0;
+    instance.writeSequence    = NextSequence(instance.writeSequence);
+    instance.writePosition    = 0;
+    instance.writeFileCorrupt = false;
     FormatFilename(instance.writeSequence);
     OpenWriteFile(instance.filename);
 

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -135,12 +135,12 @@ static inline bool IsReadFileOpen(void)
 
 static inline size_t RecordSize(uint16_t dataLength)
 {
-    return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integrity_size + SENT_FLAG_SIZE;
+    return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize + SENT_FLAG_SIZE;
 }
 
 static inline size_t SentFlagOffset(size_t recordStart, uint16_t dataLength)
 {
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integrity_size;
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize;
 }
 
 static inline size_t DataOffset(size_t recordStart)
@@ -559,7 +559,7 @@ static inline void AssembleIntegrityRegion(const void* data, size_t size)
 
 static inline bool WriteIntegrity(size_t dataSize)
 {
-    return WriteExact(IntegrityChecksumAddress(dataSize), instance.securityPolicy->integrity_size);
+    return WriteExact(IntegrityChecksumAddress(dataSize), instance.securityPolicy->integritySize);
 }
 
 static inline bool WriteUnsentFlag(void)
@@ -656,7 +656,7 @@ static bool ReadIntegrityRegion(size_t recordStart, uint16_t regionSize)
 static inline bool ReadIntegrity(size_t recordStart, uint16_t dataLength)
 {
     SolidSyslogFile_SeekTo(instance.readFile, IntegrityOffset(recordStart, dataLength));
-    return ReadExact(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integrity_size);
+    return ReadExact(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integritySize);
 }
 
 static inline size_t IntegrityOffset(size_t recordStart, uint16_t dataLength)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -37,10 +37,10 @@ static bool HasUnsent(struct SolidSyslogStore* self);
 
 enum
 {
-    INTEGRITY_BUFFER_SIZE = MAGIC_SIZE + RECORD_LENGTH_SIZE + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE
+    RECORD_BUFFER_SIZE = MAGIC_SIZE + RECORD_LENGTH_SIZE + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE + SENT_FLAG_SIZE
 };
 
-static uint8_t recordBuffer[INTEGRITY_BUFFER_SIZE];
+static uint8_t recordBuffer[RECORD_BUFFER_SIZE];
 
 static inline uint8_t* MagicAddress(void)
 {
@@ -92,23 +92,28 @@ struct SolidSyslogFileStore
     uint8_t                           writeSequence;
     size_t                            readCursor;
     size_t                            writePosition;
-    size_t                            lastSentFlagOffset;
+    size_t                            lastSentFlagFileOffset;
     bool                              hasReadRecord;
 };
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
 static struct SolidSyslogFileStore       instance;
 
+static inline uint8_t* SentFlagAddress(size_t dataSize)
+{
+    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize + instance.securityPolicy->integritySize;
+}
+
 /* ------------------------------------------------------------------
  * Shared helpers — used by both Create (resume scan) and ReadNextUnsent
  * ----------------------------------------------------------------*/
 
-static inline bool ReadExact(void* buf, size_t count)
+static inline bool ReadFromFile(void* buf, size_t count)
 {
     return SolidSyslogFile_Read(instance.readFile, buf, count);
 }
 
-static inline bool WriteExact(const void* buf, size_t count)
+static inline bool WriteToFile(const void* buf, size_t count)
 {
     return SolidSyslogFile_Write(instance.writeFile, buf, count);
 }
@@ -138,29 +143,28 @@ static inline size_t RecordSize(uint16_t dataLength)
     return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize + SENT_FLAG_SIZE;
 }
 
-static inline size_t SentFlagOffset(size_t recordStart, uint16_t dataLength)
+static inline size_t SentFlagFileOffset(size_t recordStart, uint16_t dataLength)
 {
     return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize;
 }
 
-static inline size_t DataOffset(size_t recordStart)
-{
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE;
-}
-
-static inline bool ReadMagic(size_t offset)
-{
-    uint8_t magic[MAGIC_SIZE] = {0};
-
-    SolidSyslogFile_SeekTo(instance.readFile, offset);
-
-    return ReadExact(magic, MAGIC_SIZE) && (magic[0] == MAGIC_BYTE_0) && (magic[1] == MAGIC_BYTE_1);
-}
-
-static bool ReadRecordLength(size_t offset, uint16_t* length)
+static inline bool ReadRecordHeader(size_t offset)
 {
     SolidSyslogFile_SeekTo(instance.readFile, offset);
-    return ReadExact(length, RECORD_LENGTH_SIZE);
+    return ReadFromFile(IntegrityRegionAddress(), MAGIC_SIZE + RECORD_LENGTH_SIZE);
+}
+
+static inline bool IsMagicValid(void)
+{
+    return (MagicAddress()[0] == MAGIC_BYTE_0) && (MagicAddress()[1] == MAGIC_BYTE_1);
+}
+
+static inline uint16_t RecordLength(void)
+{
+    uint16_t length = 0;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(&length, LengthAddress(), RECORD_LENGTH_SIZE);
+    return length;
 }
 
 static inline bool IsValidLength(uint16_t length)
@@ -168,10 +172,17 @@ static inline bool IsValidLength(uint16_t length)
     return length <= SOLIDSYSLOG_MAX_MESSAGE_SIZE;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- offset is a file position, length is a data size; distinct semantics
+static bool ReadRecordBody(size_t offset, uint16_t length)
+{
+    SolidSyslogFile_SeekTo(instance.readFile, offset + MAGIC_SIZE + RECORD_LENGTH_SIZE);
+    return ReadFromFile(MessageAddress(), length);
+}
+
 static bool ReadSentFlag(size_t recordStart, uint16_t dataLength, uint8_t* flag)
 {
-    SolidSyslogFile_SeekTo(instance.readFile, SentFlagOffset(recordStart, dataLength));
-    return ReadExact(flag, SENT_FLAG_SIZE);
+    SolidSyslogFile_SeekTo(instance.readFile, SentFlagFileOffset(recordStart, dataLength));
+    return ReadFromFile(flag, SENT_FLAG_SIZE);
 }
 
 static inline bool IsRecordSent(size_t recordStart, uint16_t length)
@@ -239,30 +250,23 @@ static inline void   SkipRecord(size_t* cursor, uint16_t length);
 static inline void   SkipToEndOfValidData(size_t* cursor, size_t fileSize);
 
 /* Write helpers — forward-declared because they appear below Write */
-static bool        WriteRecordToFile(const void* data, size_t size);
+static bool        StoreRecord(const void* data, size_t size);
 static inline bool FileIsFull(size_t dataSize);
 static inline bool StoreIsFull(void);
 static void        RotateToNextFile(void);
 static void        DiscardOldestFile(void);
-static inline void SeekToWritePosition(void);
-static inline bool WriteMagic(void);
-static inline bool WriteRecordHeader(size_t dataSize);
-static inline bool WriteRecordBody(const void* data, size_t size);
-static bool        ComputeAndWriteIntegrity(const void* data, size_t size);
-static inline void AssembleIntegrityRegion(const void* data, size_t size);
-static inline bool WriteIntegrity(size_t dataSize);
-static inline bool WriteUnsentFlag(void);
-static inline void AdvanceWritePosition(size_t dataSize);
+static bool        MakeSpaceForRecord(size_t dataSize);
+static inline void AssembleRecord(const void* data, size_t size);
+static bool        FlushRecord(size_t dataSize);
 
 /* ReadNextUnsent helpers */
-static void AdvanceToNextReadFile(void);
-static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
-static bool VerifyIntegrity(size_t recordStart, uint16_t length);
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, regionSize is a byte count; distinct semantics
-static bool          ReadIntegrityRegion(size_t recordStart, uint16_t regionSize);
-static inline bool   ReadIntegrity(size_t recordStart, uint16_t dataLength);
-static inline size_t IntegrityOffset(size_t recordStart, uint16_t dataLength);
-static bool          ReadRecordData(size_t recordStart, uint16_t length, void* data, size_t maxSize, size_t* bytesRead);
+static void          AdvanceToNextReadFile(void);
+static bool          ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
+static bool          ValidateHeader(uint16_t* length);
+static bool          VerifyIntegrity(uint16_t length);
+static inline bool   ReadIntegrityChecksum(size_t recordStart, uint16_t dataLength);
+static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength);
+static inline void   CopyRecordData(uint16_t length, void* data, size_t maxSize, size_t* bytesRead);
 static inline size_t BoundedSize(uint16_t length, size_t maxSize);
 static inline void   RememberCurrentRecord(uint16_t length);
 
@@ -397,7 +401,7 @@ static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize)
     uint16_t length   = 0;
     bool     advanced = false;
 
-    if (ReadMagic(*cursor) && ReadRecordLength(*cursor + MAGIC_SIZE, &length) && IsValidLength(length))
+    if (ReadRecordHeader(*cursor) && ValidateHeader(&length))
     {
         if (IsRecordSent(*cursor, length))
         {
@@ -453,35 +457,39 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
 
     if (IsWriteFileOpen())
     {
-        written = WriteRecordToFile(data, size);
+        written = StoreRecord(data, size);
     }
 
     return written;
 }
 
-static bool WriteRecordToFile(const void* data, size_t size)
+static bool StoreRecord(const void* data, size_t size)
 {
     bool written = false;
 
-    if (FileIsFull(size))
+    if (MakeSpaceForRecord(size))
     {
-        if (StoreIsFull())
-        {
-            return false;
-        }
-
-        RotateToNextFile();
-    }
-
-    SeekToWritePosition();
-
-    if (WriteMagic() && WriteRecordHeader(size) && WriteRecordBody(data, size) && ComputeAndWriteIntegrity(data, size) && WriteUnsentFlag())
-    {
-        AdvanceWritePosition(size);
-        written = true;
+        AssembleRecord(data, size);
+        written = FlushRecord(size);
     }
 
     return written;
+}
+
+static bool MakeSpaceForRecord(size_t dataSize)
+{
+    bool spaceAvailable = true;
+
+    if (FileIsFull(dataSize) && StoreIsFull())
+    {
+        spaceAvailable = false;
+    }
+    else if (FileIsFull(dataSize))
+    {
+        RotateToNextFile();
+    }
+
+    return spaceAvailable;
 }
 
 static inline bool FileIsFull(size_t dataSize)
@@ -520,32 +528,7 @@ static inline void SeekToWritePosition(void)
     SolidSyslogFile_SeekTo(instance.writeFile, instance.writePosition);
 }
 
-static inline bool WriteMagic(void)
-{
-    uint8_t magic[MAGIC_SIZE] = {MAGIC_BYTE_0, MAGIC_BYTE_1};
-    return WriteExact(magic, MAGIC_SIZE);
-}
-
-static inline bool WriteRecordHeader(size_t dataSize)
-{
-    uint16_t length = (uint16_t) dataSize;
-    return WriteExact(&length, RECORD_LENGTH_SIZE);
-}
-
-static inline bool WriteRecordBody(const void* data, size_t size)
-{
-    return WriteExact(data, size);
-}
-
-static bool ComputeAndWriteIntegrity(const void* data, size_t size)
-{
-    AssembleIntegrityRegion(data, size);
-    instance.securityPolicy->ComputeIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(size), IntegrityChecksumAddress(size));
-
-    return WriteIntegrity(size);
-}
-
-static inline void AssembleIntegrityRegion(const void* data, size_t size)
+static inline void AssembleRecord(const void* data, size_t size)
 {
     MagicAddress()[0] = MAGIC_BYTE_0;
     MagicAddress()[1] = MAGIC_BYTE_1;
@@ -555,22 +538,29 @@ static inline void AssembleIntegrityRegion(const void* data, size_t size)
     memcpy(LengthAddress(), &length, RECORD_LENGTH_SIZE);
     // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
     memcpy(MessageAddress(), data, size);
-}
 
-static inline bool WriteIntegrity(size_t dataSize)
-{
-    return WriteExact(IntegrityChecksumAddress(dataSize), instance.securityPolicy->integritySize);
-}
+    instance.securityPolicy->ComputeIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(size), IntegrityChecksumAddress(size));
 
-static inline bool WriteUnsentFlag(void)
-{
-    uint8_t flag = SENT_FLAG_UNSENT;
-    return WriteExact(&flag, SENT_FLAG_SIZE);
+    *SentFlagAddress(size) = SENT_FLAG_UNSENT;
 }
 
 static inline void AdvanceWritePosition(size_t dataSize)
 {
     instance.writePosition += RecordSize((uint16_t) dataSize);
+}
+
+static bool FlushRecord(size_t dataSize)
+{
+    SeekToWritePosition();
+
+    bool written = WriteToFile(recordBuffer, RecordSize((uint16_t) dataSize));
+
+    if (written)
+    {
+        AdvanceWritePosition(dataSize);
+    }
+
+    return written;
 }
 
 /* ------------------------------------------------------------------
@@ -621,62 +611,52 @@ static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
     uint16_t length = 0;
     bool     read   = false;
 
-    if (ReadMagic(instance.readCursor) && ReadRecordLength(instance.readCursor + MAGIC_SIZE, &length) && IsValidLength(length) &&
-        VerifyIntegrity(instance.readCursor, length) && ReadRecordData(instance.readCursor, length, data, maxSize, bytesRead))
+    if (ReadRecordHeader(instance.readCursor) && ValidateHeader(&length) && ReadRecordBody(instance.readCursor, length) &&
+        ReadIntegrityChecksum(instance.readCursor, length) && VerifyIntegrity(length))
     {
+        CopyRecordData(length, data, maxSize, bytesRead);
         RememberCurrentRecord(length);
-        read = true;
+        read = *bytesRead > 0;
     }
 
     return read;
 }
 
-static bool VerifyIntegrity(size_t recordStart, uint16_t length)
+static bool ValidateHeader(uint16_t* length)
 {
-    if (!ReadIntegrityRegion(recordStart, IntegrityRegionSize(length)))
+    bool valid = IsMagicValid();
+
+    if (valid)
     {
-        return false;
+        *length = RecordLength();
+        valid   = IsValidLength(*length);
     }
 
-    if (!ReadIntegrity(recordStart, length))
-    {
-        return false;
-    }
+    return valid;
+}
 
+static bool VerifyIntegrity(uint16_t length)
+{
     return instance.securityPolicy->VerifyIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(length), IntegrityChecksumAddress(length));
 }
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, regionSize is a byte count; distinct semantics
-static bool ReadIntegrityRegion(size_t recordStart, uint16_t regionSize)
+static inline bool ReadIntegrityChecksum(size_t recordStart, uint16_t dataLength)
 {
-    SolidSyslogFile_SeekTo(instance.readFile, recordStart);
-    return ReadExact(IntegrityRegionAddress(), regionSize);
+    SolidSyslogFile_SeekTo(instance.readFile, IntegrityChecksumFileOffset(recordStart, dataLength));
+    return ReadFromFile(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integritySize);
 }
 
-static inline bool ReadIntegrity(size_t recordStart, uint16_t dataLength)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, IntegrityOffset(recordStart, dataLength));
-    return ReadExact(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integritySize);
-}
-
-static inline size_t IntegrityOffset(size_t recordStart, uint16_t dataLength)
+static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength)
 {
     return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
 }
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- recordStart is a file offset, length is a data size; distinct semantics
-static bool ReadRecordData(size_t recordStart, uint16_t length, void* data, size_t maxSize, size_t* bytesRead)
+static inline void CopyRecordData(uint16_t length, void* data, size_t maxSize, size_t* bytesRead)
 {
     size_t copySize = BoundedSize(length, maxSize);
-
-    SolidSyslogFile_SeekTo(instance.readFile, DataOffset(recordStart));
-
-    if (ReadExact(data, copySize))
-    {
-        *bytesRead = copySize;
-    }
-
-    return *bytesRead > 0;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(data, MessageAddress(), copySize);
+    *bytesRead = copySize;
 }
 
 static inline size_t BoundedSize(uint16_t length, size_t maxSize)
@@ -686,8 +666,8 @@ static inline size_t BoundedSize(uint16_t length, size_t maxSize)
 
 static inline void RememberCurrentRecord(uint16_t length)
 {
-    instance.lastSentFlagOffset = SentFlagOffset(instance.readCursor, length);
-    instance.hasReadRecord      = true;
+    instance.lastSentFlagFileOffset = SentFlagFileOffset(instance.readCursor, length);
+    instance.hasReadRecord          = true;
 }
 
 /* ------------------------------------------------------------------
@@ -708,12 +688,12 @@ static inline bool WriteSentFlag(void)
 {
     uint8_t flag = SENT_FLAG_SENT;
 
-    SolidSyslogFile_SeekTo(instance.readFile, instance.lastSentFlagOffset);
+    SolidSyslogFile_SeekTo(instance.readFile, instance.lastSentFlagFileOffset);
     return SolidSyslogFile_Write(instance.readFile, &flag, SENT_FLAG_SIZE);
 }
 
 static inline void AdvanceReadCursor(void)
 {
-    instance.readCursor    = instance.lastSentFlagOffset + SENT_FLAG_SIZE;
+    instance.readCursor    = instance.lastSentFlagFileOffset + SENT_FLAG_SIZE;
     instance.hasReadRecord = false;
 }

--- a/Source/SolidSyslogNullSecurityPolicy.c
+++ b/Source/SolidSyslogNullSecurityPolicy.c
@@ -1,0 +1,31 @@
+#include "SolidSyslogNullSecurityPolicy.h"
+
+// NOLINTNEXTLINE(readability-non-const-parameter) -- matches SecurityPolicy vtable signature
+static void NullComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
+{
+    (void) data;
+    (void) length;
+    (void) integrityOut;
+}
+
+static bool NullVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
+{
+    (void) data;
+    (void) length;
+    (void) integrityIn;
+    return true;
+}
+
+static struct SolidSyslogSecurityPolicy instance = {
+    NullComputeIntegrity,
+    NullVerifyIntegrity,
+};
+
+struct SolidSyslogSecurityPolicy* SolidSyslogNullSecurityPolicy_Create(void)
+{
+    return &instance;
+}
+
+void SolidSyslogNullSecurityPolicy_Destroy(void)
+{
+}

--- a/Source/SolidSyslogNullSecurityPolicy.c
+++ b/Source/SolidSyslogNullSecurityPolicy.c
@@ -17,6 +17,7 @@ static bool NullVerifyIntegrity(const uint8_t* data, uint16_t length, const uint
 }
 
 static struct SolidSyslogSecurityPolicy instance = {
+    0,
     NullComputeIntegrity,
     NullVerifyIntegrity,
 };

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -11,6 +11,8 @@ set(TEST_SOURCES
     SolidSyslogNullBufferTest.cpp
     SolidSyslogNullStoreTest.cpp
     SolidSyslogNullSecurityPolicyTest.cpp
+    SolidSyslogCrc16Test.cpp
+    SolidSyslogCrc16PolicyTest.cpp
     SolidSyslogPrivalTest.cpp
     BufferFakeTest.cpp
     BufferFake.c

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES
     SolidSyslogOriginSdTest.cpp
     SolidSyslogNullBufferTest.cpp
     SolidSyslogNullStoreTest.cpp
+    SolidSyslogNullSecurityPolicyTest.cpp
     SolidSyslogPrivalTest.cpp
     BufferFakeTest.cpp
     BufferFake.c

--- a/Tests/SolidSyslogCrc16PolicyTest.cpp
+++ b/Tests/SolidSyslogCrc16PolicyTest.cpp
@@ -1,0 +1,74 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogCrc16Policy.h"
+
+#include <cstring>
+
+// clang-format off
+TEST_GROUP(SolidSyslogCrc16Policy)
+{
+    struct SolidSyslogSecurityPolicy* policy = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        policy = SolidSyslogCrc16Policy_Create();
+    }
+
+    void teardown() override
+    {
+        SolidSyslogCrc16Policy_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogCrc16Policy, CreateReturnsNonNull)
+{
+    CHECK_TRUE(policy != nullptr);
+}
+
+TEST(SolidSyslogCrc16Policy, IntegritySizeIsTwo)
+{
+    LONGS_EQUAL(2, policy->integrity_size);
+}
+
+TEST(SolidSyslogCrc16Policy, ComputeIntegrityReturnsCrc16)
+{
+    const uint8_t data[]       = "123456789";
+    uint8_t       integrity[2] = {};
+    policy->ComputeIntegrity(data, 9, integrity);
+    /* CRC-16/CCITT-FALSE of "123456789" is 0x29B1 */
+    BYTES_EQUAL(0x29, integrity[0]);
+    BYTES_EQUAL(0xB1, integrity[1]);
+}
+
+TEST(SolidSyslogCrc16Policy, ComputeThenVerifyRoundTrip)
+{
+    const uint8_t data[]       = "hello";
+    uint8_t       integrity[2] = {};
+    policy->ComputeIntegrity(data, 5, integrity);
+    CHECK_TRUE(policy->VerifyIntegrity(data, 5, integrity));
+}
+
+TEST(SolidSyslogCrc16Policy, VerifyDetectsSingleBitFlip)
+{
+    const uint8_t data[]       = "hello";
+    uint8_t       integrity[2] = {};
+    policy->ComputeIntegrity(data, 5, integrity);
+    integrity[0] ^= 0x01;
+    CHECK_FALSE(policy->VerifyIntegrity(data, 5, integrity));
+}
+
+TEST(SolidSyslogCrc16Policy, VerifyDetectsDataCorruption)
+{
+    uint8_t data[]       = "hello";
+    uint8_t integrity[2] = {};
+    policy->ComputeIntegrity(data, 5, integrity);
+    data[0] ^= 0x01;
+    CHECK_FALSE(policy->VerifyIntegrity(data, 5, integrity));
+}
+
+TEST(SolidSyslogCrc16Policy, DestroyDoesNotCrash)
+{
+    SolidSyslogCrc16Policy_Destroy();
+}

--- a/Tests/SolidSyslogCrc16PolicyTest.cpp
+++ b/Tests/SolidSyslogCrc16PolicyTest.cpp
@@ -29,7 +29,7 @@ TEST(SolidSyslogCrc16Policy, CreateReturnsNonNull)
 
 TEST(SolidSyslogCrc16Policy, IntegritySizeIsTwo)
 {
-    LONGS_EQUAL(2, policy->integrity_size);
+    LONGS_EQUAL(2, policy->integritySize);
 }
 
 TEST(SolidSyslogCrc16Policy, ComputeIntegrityReturnsCrc16)

--- a/Tests/SolidSyslogCrc16Test.cpp
+++ b/Tests/SolidSyslogCrc16Test.cpp
@@ -1,0 +1,63 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogCrc16.h"
+#include "SolidSyslog.h"
+
+#include <cstring>
+
+// clang-format off
+TEST_GROUP(SolidSyslogCrc16)
+{
+};
+
+// clang-format on
+
+/* Check value 0x29B1 from Greg Cook's CRC catalogue:
+ * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-ibm-3740 */
+TEST(SolidSyslogCrc16, KnownTestVector)
+{
+    const uint8_t data[] = "123456789";
+    LONGS_EQUAL(0x29B1, SolidSyslogCrc16_Compute(data, 9));
+}
+
+/* Regression: init value 0xFFFF returned unchanged for zero-length input */
+TEST(SolidSyslogCrc16, EmptyInputReturnsInitValue)
+{
+    LONGS_EQUAL(0xFFFF, SolidSyslogCrc16_Compute(nullptr, 0));
+}
+
+/* Regression: single-byte boundary */
+TEST(SolidSyslogCrc16, SingleByteZero)
+{
+    const uint8_t data[] = {0x00};
+    LONGS_EQUAL(0xE1F0, SolidSyslogCrc16_Compute(data, 1));
+}
+
+TEST(SolidSyslogCrc16, FlippingAnyByteChangesCrc)
+{
+    const uint8_t original[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+    enum
+    {
+        DATA_LEN = 5
+    };
+
+    uint16_t originalCrc = SolidSyslogCrc16_Compute(original, DATA_LEN);
+
+    for (int i = 0; i < DATA_LEN; i++)
+    {
+        uint8_t modified[DATA_LEN];
+        memcpy(modified, original, DATA_LEN);
+        modified[i] ^= 0x01; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+        CHECK_TRUE(SolidSyslogCrc16_Compute(modified, DATA_LEN) != originalCrc);
+    }
+}
+
+TEST(SolidSyslogCrc16, BeyondMaxMessageSize)
+{
+    uint8_t data[SOLIDSYSLOG_MAX_MESSAGE_SIZE + 1];
+    memset(data, 'A', sizeof(data));
+    uint16_t crc = SolidSyslogCrc16_Compute(data, sizeof(data));
+
+    data[SOLIDSYSLOG_MAX_MESSAGE_SIZE] ^= 0x01;
+    CHECK_TRUE(SolidSyslogCrc16_Compute(data, sizeof(data)) != crc);
+}

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1064,8 +1064,13 @@ TEST(SolidSyslogFileStoreRotation, MultipleRecordsPerFileDrainAcrossRotation)
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/
 
+enum
+{
+    INTEGRITY_REGION_MAX = 2 + 2 + SOLIDSYSLOG_MAX_MESSAGE_SIZE /* magic + length + body */
+};
+
 static bool     computeIntegrityCalled;
-static uint8_t  computeIntegrityData[TEST_BUF_SIZE];
+static uint8_t  computeIntegrityData[INTEGRITY_REGION_MAX];
 static uint16_t computeIntegrityLength;
 
 // NOLINTNEXTLINE(readability-non-const-parameter) -- matches SecurityPolicy vtable signature
@@ -1078,7 +1083,7 @@ static void SpyComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* i
 }
 
 static bool     verifyIntegrityCalled;
-static uint8_t  verifyIntegrityData[TEST_BUF_SIZE];
+static uint8_t  verifyIntegrityData[INTEGRITY_REGION_MAX];
 static uint16_t verifyIntegrityLength;
 
 static bool SpyVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -636,7 +636,7 @@ TEST(SolidSyslogFileStoreErrors, MarkSentDoesNotAdvanceWhenWriteFails)
 // clang-format off
 TEST_GROUP(SolidSyslogFileStoreRotation)
 {
-    static const size_t RECORD_OVERHEAD    = 5; /* 4 (length) + 1 (sent flag) */
+    static const size_t RECORD_OVERHEAD    = 5; /* 2 (magic) + 2 (length) + 1 (sent flag) */
     static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD;
 
     struct FileFakeStorage readStorage = {};
@@ -1135,11 +1135,24 @@ TEST(SolidSyslogFileStoreIntegrity, WriteCallsComputeIntegrity)
     CHECK_TRUE(computeIntegrityCalled);
 }
 
-TEST(SolidSyslogFileStoreIntegrity, ComputeIntegrityReceivesWrittenData)
+TEST(SolidSyslogFileStoreIntegrity, ComputeIntegrityReceivesIntegrityRegion)
 {
+    enum
+    {
+        MAGIC_SIZE  = 2,
+        LENGTH_SIZE = 2,
+        REGION_SIZE = MAGIC_SIZE + LENGTH_SIZE + TEST_DATA_LEN
+    };
+
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
-    LONGS_EQUAL(TEST_DATA_LEN, computeIntegrityLength);
-    MEMCMP_EQUAL(TEST_DATA, computeIntegrityData, TEST_DATA_LEN);
+    LONGS_EQUAL(REGION_SIZE, computeIntegrityLength);
+
+    /* verify magic bytes */
+    BYTES_EQUAL(0xA5, computeIntegrityData[0]);
+    BYTES_EQUAL(0x5A, computeIntegrityData[1]);
+
+    /* verify body is included */
+    MEMCMP_EQUAL(TEST_DATA, computeIntegrityData + MAGIC_SIZE + LENGTH_SIZE, TEST_DATA_LEN);
 }
 
 TEST(SolidSyslogFileStoreIntegrity, ReadCallsVerifyIntegrity)
@@ -1151,12 +1164,25 @@ TEST(SolidSyslogFileStoreIntegrity, ReadCallsVerifyIntegrity)
     CHECK_TRUE(verifyIntegrityCalled);
 }
 
-TEST(SolidSyslogFileStoreIntegrity, VerifyIntegrityReceivesWrittenData)
+TEST(SolidSyslogFileStoreIntegrity, VerifyIntegrityReceivesIntegrityRegion)
 {
+    enum
+    {
+        MAGIC_SIZE  = 2,
+        LENGTH_SIZE = 2,
+        REGION_SIZE = MAGIC_SIZE + LENGTH_SIZE + TEST_DATA_LEN
+    };
+
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
     char   buf[TEST_BUF_SIZE];
     size_t bytesRead = 0;
     SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
-    LONGS_EQUAL(TEST_DATA_LEN, verifyIntegrityLength);
-    MEMCMP_EQUAL(TEST_DATA, verifyIntegrityData, TEST_DATA_LEN);
+    LONGS_EQUAL(REGION_SIZE, verifyIntegrityLength);
+
+    /* verify magic bytes */
+    BYTES_EQUAL(0xA5, verifyIntegrityData[0]);
+    BYTES_EQUAL(0x5A, verifyIntegrityData[1]);
+
+    /* verify body is included */
+    MEMCMP_EQUAL(TEST_DATA, verifyIntegrityData + MAGIC_SIZE + LENGTH_SIZE, TEST_DATA_LEN);
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1055,22 +1055,29 @@ TEST(SolidSyslogFileStoreRotation, MultipleRecordsPerFileDrainAcrossRotation)
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/
 
-static bool computeIntegrityCalled;
+static bool     computeIntegrityCalled;
+static uint8_t  computeIntegrityData[TEST_BUF_SIZE];
+static uint16_t computeIntegrityLength;
 
 // NOLINTNEXTLINE(readability-non-const-parameter) -- matches SecurityPolicy vtable signature
 static void SpyComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
 {
-    (void) data;
-    (void) length;
     (void) integrityOut;
     computeIntegrityCalled = true;
+    computeIntegrityLength = length;
+    memcpy(computeIntegrityData, data, length);
 }
+
+static bool     verifyIntegrityCalled;
+static uint8_t  verifyIntegrityData[TEST_BUF_SIZE];
+static uint16_t verifyIntegrityLength;
 
 static bool SpyVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
 {
-    (void) data;
-    (void) length;
     (void) integrityIn;
+    verifyIntegrityCalled = true;
+    verifyIntegrityLength = length;
+    memcpy(verifyIntegrityData, data, length);
     return true;
 }
 
@@ -1089,7 +1096,12 @@ TEST_GROUP(SolidSyslogFileStoreIntegrity)
     void setup() override
     {
         file = FileFake_Create(&storage);
-        computeIntegrityCalled = false;
+        computeIntegrityCalled  = false;
+        computeIntegrityLength  = 0;
+        memset(computeIntegrityData, 0, sizeof(computeIntegrityData));
+        verifyIntegrityCalled   = false;
+        verifyIntegrityLength   = 0;
+        memset(verifyIntegrityData, 0, sizeof(verifyIntegrityData));
 
         struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
         config.readFile       = file;
@@ -1112,4 +1124,30 @@ TEST(SolidSyslogFileStoreIntegrity, WriteCallsComputeIntegrity)
 {
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
     CHECK_TRUE(computeIntegrityCalled);
+}
+
+TEST(SolidSyslogFileStoreIntegrity, ComputeIntegrityReceivesWrittenData)
+{
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    LONGS_EQUAL(TEST_DATA_LEN, computeIntegrityLength);
+    MEMCMP_EQUAL(TEST_DATA, computeIntegrityData, TEST_DATA_LEN);
+}
+
+TEST(SolidSyslogFileStoreIntegrity, ReadCallsVerifyIntegrity)
+{
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    char   buf[TEST_BUF_SIZE];
+    size_t bytesRead = 0;
+    SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
+    CHECK_TRUE(verifyIntegrityCalled);
+}
+
+TEST(SolidSyslogFileStoreIntegrity, VerifyIntegrityReceivesWrittenData)
+{
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    char   buf[TEST_BUF_SIZE];
+    size_t bytesRead = 0;
+    SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
+    LONGS_EQUAL(TEST_DATA_LEN, verifyIntegrityLength);
+    MEMCMP_EQUAL(TEST_DATA, verifyIntegrityData, TEST_DATA_LEN);
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogFileStore.h"
+#include "SolidSyslogCrc16Policy.h"
 #include "SolidSyslogSecurityPolicyDefinition.h"
 #include "SolidSyslog.h"
 #include "FileFake.h"
@@ -1185,4 +1186,260 @@ TEST(SolidSyslogFileStoreIntegrity, VerifyIntegrityReceivesIntegrityRegion)
 
     /* verify body is included */
     MEMCMP_EQUAL(TEST_DATA, verifyIntegrityData + MAGIC_SIZE + LENGTH_SIZE, TEST_DATA_LEN);
+}
+
+/* ------------------------------------------------------------------
+ * Corruption detection
+ * ----------------------------------------------------------------*/
+
+// clang-format off
+TEST_GROUP(SolidSyslogFileStoreCorruption)
+{
+    struct FileFakeStorage storage = {};
+    struct SolidSyslogFile* file = nullptr;
+    struct SolidSyslogStore* store = nullptr;
+
+    void setup() override
+    {
+        file = FileFake_Create(&storage);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogFileStore_Destroy();
+        FileFake_Destroy();
+    }
+
+    void WriteRawBytes(const char* path, const void* data, size_t size) const
+    {
+        SolidSyslogFile_Open(file, path);
+        SolidSyslogFile_Write(file, data, size);
+        SolidSyslogFile_Close(file);
+    }
+
+    void CreateStore()
+    {
+        struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        store = SolidSyslogFileStore_Create(&config);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogFileStoreCorruption, TruncatedMagicHasNoUnsent)
+{
+    uint8_t oneByte = 0xA5;
+    WriteRawBytes("/tmp/test_store00.log", &oneByte, 1);
+    CreateStore();
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+TEST(SolidSyslogFileStoreCorruption, BadMagicHasNoUnsent)
+{
+    uint8_t badMagic[] = {0x00, 0x00, 0x05, 0x00, 'h', 'e', 'l', 'l', 'o', 0xFF};
+    WriteRawBytes("/tmp/test_store00.log", badMagic, sizeof(badMagic));
+    CreateStore();
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+TEST(SolidSyslogFileStoreCorruption, TruncatedLengthHasNoUnsent)
+{
+    uint8_t truncatedHeader[] = {0xA5, 0x5A, 0x05};
+    WriteRawBytes("/tmp/test_store00.log", truncatedHeader, sizeof(truncatedHeader));
+    CreateStore();
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+TEST(SolidSyslogFileStoreCorruption, TruncatedBodyHasNoUnsent)
+{
+    /* valid magic + length=5, but only 2 bytes of body, no integrity or sent flag */
+    uint8_t truncatedBody[] = {0xA5, 0x5A, 0x05, 0x00, 'h', 'e'};
+    WriteRawBytes("/tmp/test_store00.log", truncatedBody, sizeof(truncatedBody));
+    CreateStore();
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+TEST(SolidSyslogFileStoreCorruption, ValidRecordBeforeCorruptionIsReadable)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.securityPolicy                    = SolidSyslogCrc16Policy_Create();
+    store                                    = SolidSyslogFileStore_Create(&config);
+    SolidSyslogStore_Write(store, "first", 5);
+    SolidSyslogStore_Write(store, "second", 6);
+    SolidSyslogFileStore_Destroy();
+
+    /* Corrupt the second record's body */
+    enum
+    {
+        MAGIC                     = 2,
+        LENGTH                    = 2,
+        FIRST_BODY                = 5,
+        CRC                       = 2,
+        SENT                      = 1,
+        SECOND_RECORD_BODY_OFFSET = MAGIC + LENGTH + FIRST_BODY + CRC + SENT + MAGIC + LENGTH
+    };
+
+    SolidSyslogFile_Open(file, "/tmp/test_store00.log");
+    uint8_t corrupt = 0xFF;
+    SolidSyslogFile_SeekTo(file, SECOND_RECORD_BODY_OFFSET);
+    SolidSyslogFile_Write(file, &corrupt, 1);
+    SolidSyslogFile_Close(file);
+
+    /* Re-open: first record is valid, second is corrupt */
+    store                     = SolidSyslogFileStore_Create(&config);
+    char   buf[TEST_BUF_SIZE] = {};
+    size_t bytesRead          = 0;
+
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    LONGS_EQUAL(5, bytesRead);
+    MEMCMP_EQUAL("first", buf, 5);
+}
+
+TEST(SolidSyslogFileStoreCorruption, IntegrityFailureReadReturnsFalse)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.securityPolicy                    = SolidSyslogCrc16Policy_Create();
+    store                                    = SolidSyslogFileStore_Create(&config);
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    SolidSyslogFileStore_Destroy();
+
+    /* Corrupt one byte of the body in the stored record */
+    SolidSyslogFile_Open(file, "/tmp/test_store00.log");
+    uint8_t corrupt = 0xFF;
+    SolidSyslogFile_SeekTo(file, 4); /* offset past magic(2) + length(2) */
+    SolidSyslogFile_Write(file, &corrupt, 1);
+    SolidSyslogFile_Close(file);
+
+    store = SolidSyslogFileStore_Create(&config);
+    char   buf[TEST_BUF_SIZE];
+    size_t bytesRead = 0;
+    CHECK_FALSE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+}
+
+TEST(SolidSyslogFileStoreCorruption, InvalidLengthReadReturnsFalse)
+{
+    /* Write many records to make the file large enough that a bogus length
+     * doesn't hit EOF — the length check must reject it explicitly */
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    store                                    = SolidSyslogFileStore_Create(&config);
+
+    char largeMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(largeMsg, 'X', sizeof(largeMsg));
+    SolidSyslogStore_Write(store, largeMsg, sizeof(largeMsg));
+    SolidSyslogStore_Write(store, largeMsg, sizeof(largeMsg));
+    SolidSyslogFileStore_Destroy();
+
+    /* Overwrite the length field of the first record (bytes 2-3) */
+    SolidSyslogFile_Open(file, "/tmp/test_store00.log");
+    uint16_t badLength = SOLIDSYSLOG_MAX_MESSAGE_SIZE + 1;
+    SolidSyslogFile_SeekTo(file, 2);
+    SolidSyslogFile_Write(file, &badLength, 2);
+    SolidSyslogFile_Close(file);
+
+    store = SolidSyslogFileStore_Create(&config);
+    char   buf[TEST_BUF_SIZE];
+    size_t bytesRead = 0;
+    CHECK_FALSE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+}
+
+/* ------------------------------------------------------------------
+ * Corruption recovery
+ * ----------------------------------------------------------------*/
+
+// clang-format off
+TEST_GROUP(SolidSyslogFileStoreCorruptionRecovery)
+{
+    static const size_t RECORD_OVERHEAD    = 7; /* 2 (magic) + 2 (length) + 2 (crc) + 1 (sent) */
+    static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD;
+
+    struct FileFakeStorage readStorage = {};
+    struct FileFakeStorage writeStorage = {};
+    struct SolidSyslogFile* readFile = nullptr;
+    struct SolidSyslogFile* writeFile = nullptr;
+    struct SolidSyslogStore* store = nullptr;
+    struct SolidSyslogSecurityPolicy* policy = nullptr;
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+
+    void setup() override
+    {
+        readFile = FileFake_Create(&readStorage);
+        writeFile = FileFake_Create(&writeStorage);
+        policy = SolidSyslogCrc16Policy_Create();
+        memset(maxMsg, 'A', sizeof(maxMsg));
+    }
+
+    void teardown() override
+    {
+        SolidSyslogFileStore_Destroy();
+        FileFake_Destroy();
+    }
+
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- maxFileSize and maxFiles have distinct semantics
+    void CreateWithMaxFileSize(size_t maxFileSize, size_t maxFiles = 2)
+    {
+        struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
+        config.readFile        = readFile;
+        config.writeFile       = writeFile;
+        config.maxFileSize     = maxFileSize;
+        config.maxFiles        = maxFiles;
+        config.securityPolicy  = policy;
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        store = SolidSyslogFileStore_Create(&config);
+    }
+
+    void WriteMaxMsg()
+    {
+        SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg));
+    }
+
+    void CorruptFirstRecordBody(const char* path) const
+    {
+        SolidSyslogFile_Open(writeFile, path);
+        uint8_t corrupt = 0xFF;
+        SolidSyslogFile_SeekTo(writeFile, 4);
+        SolidSyslogFile_Write(writeFile, &corrupt, 1);
+        SolidSyslogFile_Close(writeFile);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogFileStoreCorruptionRecovery, ReadSkipsCorruptOlderFileToNextFile)
+{
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+
+    char firstMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(firstMsg, 'B', sizeof(firstMsg));
+    SolidSyslogStore_Write(store, firstMsg, sizeof(firstMsg)); /* file 00 */
+
+    WriteMaxMsg(); /* file 01 */
+    SolidSyslogFileStore_Destroy();
+
+    CorruptFirstRecordBody("/tmp/test_store00.log");
+
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+    size_t bytesRead                         = 0;
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    LONGS_EQUAL(SOLIDSYSLOG_MAX_MESSAGE_SIZE, bytesRead);
+    BYTES_EQUAL('A', buf[0]);
+}
+
+TEST(SolidSyslogFileStoreCorruptionRecovery, CorruptWriteFileRotatesOnNextWrite)
+{
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 */
+    SolidSyslogFileStore_Destroy();
+
+    CorruptFirstRecordBody("/tmp/test_store00.log");
+
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+
+    /* Next write should rotate to file 01 because file 00 is corrupt */
+    char newMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(newMsg, 'N', sizeof(newMsg));
+    CHECK_TRUE(SolidSyslogStore_Write(store, newMsg, sizeof(newMsg)));
+    CHECK_TRUE(SolidSyslogFile_Exists(writeFile, "/tmp/test_store01.log"));
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogFileStore.h"
+#include "SolidSyslogSecurityPolicyDefinition.h"
 #include "SolidSyslog.h"
 #include "FileFake.h"
 
@@ -18,7 +19,7 @@ enum
 };
 
 static const struct SolidSyslogFileStoreConfig DEFAULT_CONFIG = {
-    nullptr, nullptr, TEST_PATH_PREFIX, TEST_MAX_FILE_SIZE, TEST_MAX_FILES, SOLIDSYSLOG_DISCARD_OLDEST,
+    nullptr, nullptr, TEST_PATH_PREFIX, TEST_MAX_FILE_SIZE, TEST_MAX_FILES, SOLIDSYSLOG_DISCARD_OLDEST, nullptr,
 };
 
 static struct SolidSyslogFileStoreConfig MakeConfig(struct SolidSyslogFile* file)
@@ -1048,4 +1049,67 @@ TEST(SolidSyslogFileStoreRotation, MultipleRecordsPerFileDrainAcrossRotation)
     SolidSyslogStore_MarkSent(store);
 
     CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+/* ------------------------------------------------------------------
+ * Integrity (SecurityPolicy integration)
+ * ----------------------------------------------------------------*/
+
+static bool computeIntegrityCalled;
+
+// NOLINTNEXTLINE(readability-non-const-parameter) -- matches SecurityPolicy vtable signature
+static void SpyComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
+{
+    (void) data;
+    (void) length;
+    (void) integrityOut;
+    computeIntegrityCalled = true;
+}
+
+static bool SpyVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
+{
+    (void) data;
+    (void) length;
+    (void) integrityIn;
+    return true;
+}
+
+static struct SolidSyslogSecurityPolicy spyPolicy = {
+    SpyComputeIntegrity,
+    SpyVerifyIntegrity,
+};
+
+// clang-format off
+TEST_GROUP(SolidSyslogFileStoreIntegrity)
+{
+    struct FileFakeStorage storage = {};
+    struct SolidSyslogFile* file = nullptr;
+    struct SolidSyslogStore* store = nullptr;
+
+    void setup() override
+    {
+        file = FileFake_Create(&storage);
+        computeIntegrityCalled = false;
+
+        struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
+        config.readFile       = file;
+        config.writeFile      = file;
+        config.securityPolicy = &spyPolicy;
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        store = SolidSyslogFileStore_Create(&config);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogFileStore_Destroy();
+        FileFake_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogFileStoreIntegrity, WriteCallsComputeIntegrity)
+{
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    CHECK_TRUE(computeIntegrityCalled);
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1090,6 +1090,7 @@ static bool SpyVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8
 }
 
 static struct SolidSyslogSecurityPolicy spyPolicy = {
+    0,
     SpyComputeIntegrity,
     SpyVerifyIntegrity,
 };

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1434,15 +1434,19 @@ TEST(SolidSyslogFileStoreCorruptionRecovery, ReadSkipsCorruptOlderFileToNextFile
 
 TEST(SolidSyslogFileStoreCorruptionRecovery, CorruptWriteFileRotatesOnNextWrite)
 {
-    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
-    WriteMaxMsg(); /* file 00 */
+    /* Use a file size that fits two records — the first write leaves space,
+     * so rotation on the second write proves corruption forced it */
+    static const size_t TWO_MAX_MSG_RECORDS = 2 * ONE_MAX_MSG_RECORD;
+
+    CreateWithMaxFileSize(TWO_MAX_MSG_RECORDS);
+    WriteMaxMsg(); /* file 00 — partially filled */
     SolidSyslogFileStore_Destroy();
 
     CorruptFirstRecordBody("/tmp/test_store00.log");
 
-    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+    CreateWithMaxFileSize(TWO_MAX_MSG_RECORDS);
 
-    /* Next write should rotate to file 01 because file 00 is corrupt */
+    /* File 00 has space but is corrupt — write should rotate to file 01 */
     char newMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     memset(newMsg, 'N', sizeof(newMsg));
     CHECK_TRUE(SolidSyslogStore_Write(store, newMsg, sizeof(newMsg)));

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -533,6 +533,14 @@ TEST(SolidSyslogFileStoreConfig, FilenameTruncatedWhenPrefixTooLong)
     VerifyWriteAndReadBack();
 }
 
+TEST(SolidSyslogFileStoreConfig, NullSecurityPolicyDefaultsToNoOp)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.securityPolicy                    = nullptr;
+    store                                    = SolidSyslogFileStore_Create(&config);
+    VerifyWriteAndReadBack();
+}
+
 /* ------------------------------------------------------------------
  * Error paths
  * ----------------------------------------------------------------*/

--- a/Tests/SolidSyslogNullSecurityPolicyTest.cpp
+++ b/Tests/SolidSyslogNullSecurityPolicyTest.cpp
@@ -27,7 +27,7 @@ TEST(SolidSyslogNullSecurityPolicy, CreateReturnsNonNull)
 
 TEST(SolidSyslogNullSecurityPolicy, IntegritySizeIsZero)
 {
-    LONGS_EQUAL(0, policy->integrity_size);
+    LONGS_EQUAL(0, policy->integritySize);
 }
 
 TEST(SolidSyslogNullSecurityPolicy, VerifyIntegrityReturnsTrue)

--- a/Tests/SolidSyslogNullSecurityPolicyTest.cpp
+++ b/Tests/SolidSyslogNullSecurityPolicyTest.cpp
@@ -1,0 +1,36 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogNullSecurityPolicy.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogNullSecurityPolicy)
+{
+    struct SolidSyslogSecurityPolicy* policy = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        policy = SolidSyslogNullSecurityPolicy_Create();
+    }
+
+    void teardown() override
+    {
+        SolidSyslogNullSecurityPolicy_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogNullSecurityPolicy, CreateReturnsNonNull)
+{
+    CHECK_TRUE(policy != nullptr);
+}
+
+TEST(SolidSyslogNullSecurityPolicy, VerifyIntegrityReturnsTrue)
+{
+    CHECK_TRUE(policy->VerifyIntegrity(nullptr, 0, nullptr));
+}
+
+TEST(SolidSyslogNullSecurityPolicy, DestroyDoesNotCrash)
+{
+    SolidSyslogNullSecurityPolicy_Destroy();
+}

--- a/Tests/SolidSyslogNullSecurityPolicyTest.cpp
+++ b/Tests/SolidSyslogNullSecurityPolicyTest.cpp
@@ -25,6 +25,11 @@ TEST(SolidSyslogNullSecurityPolicy, CreateReturnsNonNull)
     CHECK_TRUE(policy != nullptr);
 }
 
+TEST(SolidSyslogNullSecurityPolicy, IntegritySizeIsZero)
+{
+    LONGS_EQUAL(0, policy->integrity_size);
+}
+
 TEST(SolidSyslogNullSecurityPolicy, VerifyIntegrityReturnsTrue)
 {
     CHECK_TRUE(policy->VerifyIntegrity(nullptr, 0, nullptr));


### PR DESCRIPTION
## Purpose

Closes #96. Detect and recover from corrupt store files so that FileStore degrades gracefully rather than looping or silently losing messages. Introduces an injectable security policy for record integrity.

## Change Description

**SecurityPolicy abstraction** — vtable with `ComputeIntegrity`, `VerifyIntegrity`, and `integrity_size`. FileStore calls through it on every write and read. NullSecurityPolicy (nil object pattern) substituted at the boundary when no policy is configured.

**CRC-16/CCITT-FALSE** — standalone library utility (`SolidSyslogCrc16_Compute`) plus a SecurityPolicy wrapper (`SolidSyslogCrc16Policy`). Available to any code that needs a simple checksum. Verified against published test vectors from Greg Cook's CRC catalogue.

**Binary record format change:**
```
[ MAGIC    : 2 bytes ]  ─┐
[ LENGTH   : 2 bytes ]   │  integrity region
[ BODY     : n bytes ]   │
[ CRC      : 2 bytes ]  ─┘
[ SENT     : 1 byte  ]     outside integrity
```
- Magic bytes `0xA5 0x5A` detect non-record data
- Length narrowed from uint32 to uint16
- Integrity bytes (policy-dependent size) between body and sent flag
- Sent flag inverted: 0xFF = unsent (erased flash), 0x00 = sent

**Corruption handling** — stop at first corrupt record, do not forward-scan:
- Bad magic, invalid length (> max message size), truncated header/body, integrity failure
- On read: skip to next file in rotation
- On write (corrupt file at startup): treat as full, rotate
- Corrupt files preserved for investigation, cleaned up by normal discard-oldest rotation

**Example** — threaded example wires CRC-16 policy into file store config by default.

## Test Evidence

432 unit tests (29 new), 100% function coverage, 99.8% line coverage. TDD throughout — each production change driven by a failing test.

New test groups:
- `SolidSyslogCrc16` — known test vector, empty input, single byte, all-bytes-included, beyond max message size
- `SolidSyslogCrc16Policy` — create, integrity_size, CRC value verification, round-trip, flip detection, data corruption
- `SolidSyslogNullSecurityPolicy` — create, integrity_size zero, verify returns true, destroy
- `SolidSyslogFileStoreIntegrity` — compute/verify called with correct integrity region data
- `SolidSyslogFileStoreCorruption` — truncated magic, bad magic, truncated length, truncated body, integrity failure, invalid length, valid records before corruption preserved
- `SolidSyslogFileStoreCorruptionRecovery` — read skips corrupt older file, corrupt write file rotates on next write

BDD: 13 features, 27 scenarios, 122 steps — all passing with CRC-16 integrity active in the threaded example.

## Areas Affected

- **Interface/** — 4 new public headers (SecurityPolicyDefinition, NullSecurityPolicy, Crc16Policy, Crc16)
- **Source/** — FileStore record format change, 3 new source files
- **Tests/** — 4 new test files, FileStore test updates
- **Example/Threaded/** — CRC-16 policy wired into file store config
- **CLAUDE.md, README.md** — header table and architecture section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable security policy framework for per-record integrity; CRC‑16 policy and a default no-op policy added
  * File-backed store now embeds integrity data per record and respects configured policy

* **Bug Fixes / Reliability**
  * Improved on-disk record validation, corruption detection, and recovery behavior during scanning/rotation

* **Documentation**
  * README and public headers list updated to document security policy and CRC support

* **Tests**
  * New unit tests covering CRC, policies, file-store integrity and corruption scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->