### PR TITLE
feat: S5.8 halt policy BDD scenarios and service halt state

### DIFF
--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -19,10 +19,9 @@ def wait_for_tcp_port_open(host="syslog-ng", port=5514, timeout=5):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.5)
-            s.connect((host, port))
-            s.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
             return
         except (ConnectionRefusedError, OSError):
             time.sleep(0.1)

--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -14,6 +14,21 @@ STORE_FILE_PATH = "/tmp/solidsyslog_store.dat"
 STORE_PATH_PREFIX = "/tmp/STORE"
 
 
+def wait_for_tcp_port_open(host="syslog-ng", port=5514, timeout=5):
+    """Poll until the TCP port accepts connections."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect((host, port))
+            s.close()
+            return
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    raise AssertionError(f"TCP port {port} not open after {timeout}s")
+
+
 def before_all(context):
     context.example_binary = os.environ.get(
         "EXAMPLE_BINARY", "build/debug/Example/ExampleProgram"
@@ -45,7 +60,7 @@ def after_scenario(context, scenario):
                 sock.connect(SYSLOG_NG_CTL)
                 sock.sendall(b"RELOAD\n")
                 sock.recv(1024)
-            time.sleep(0.5)
+            wait_for_tcp_port_open()
         except Exception as exc:
             logger.warning("Failed to restore syslog-ng config in teardown: %s", exc)
         context.syslog_ng_config_changed = False

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -268,10 +268,9 @@ def wait_for_tcp_port_closed(host="syslog-ng", port=5514, timeout=5):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.5)
-            s.connect((host, port))
-            s.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
             time.sleep(0.1)
         except (ConnectionRefusedError, OSError):
             return
@@ -283,10 +282,9 @@ def wait_for_tcp_port_open(host="syslog-ng", port=5514, timeout=5):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.5)
-            s.connect((host, port))
-            s.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
             return
         except (ConnectionRefusedError, OSError):
             time.sleep(0.1)

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -205,6 +205,8 @@ def build_threaded_command(context, transport, no_sd=False):
         cmd.extend(["--discard-policy", context.store_discard_policy])
     if no_sd:
         cmd.append("--no-sd")
+    if getattr(context, "halt_exit", False):
+        cmd.append("--halt-exit")
     return cmd
 
 
@@ -249,6 +251,11 @@ def step_file_store_enabled_with_config(context, max_files, max_file_size, polic
     clean_store_files()
 
 
+@given("the halt callback exits the process")
+def step_halt_callback_exits(context):
+    context.halt_exit = True
+
+
 @when("the client sends a message")
 def step_client_sends_message(context):
     send_command(context.interactive_process, "send")
@@ -256,15 +263,75 @@ def step_client_sends_message(context):
     time.sleep(0.2)
 
 
+def wait_for_tcp_port_closed(host="syslog-ng", port=5514, timeout=5):
+    """Poll until the TCP port refuses connections."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect((host, port))
+            s.close()
+            time.sleep(0.1)
+        except (ConnectionRefusedError, OSError):
+            return
+    raise AssertionError(f"TCP port {port} still open after {timeout}s")
+
+
+def wait_for_tcp_port_open(host="syslog-ng", port=5514, timeout=5):
+    """Poll until the TCP port accepts connections."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect((host, port))
+            s.close()
+            return
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.1)
+    raise AssertionError(f"TCP port {port} not open after {timeout}s")
+
+
+def wait_for_connection_teardown(probe_socket, timeout=5):
+    """Wait until an established TCP connection is broken by the server.
+
+    Sends data on the probe socket until a broken pipe or reset indicates
+    that syslog-ng has closed the connection after a config reload.
+    """
+    msg = b"<134>1 2026-01-01T00:00:00Z probe probe - - - probe"
+    frame = f"{len(msg)} ".encode() + msg
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            probe_socket.sendall(frame)
+            time.sleep(0.1)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            probe_socket.close()
+            return
+    probe_socket.close()
+    raise AssertionError(f"Probe connection still alive after {timeout}s")
+
+
 @when("the syslog server stops accepting TCP connections")
 def step_syslog_server_stops_tcp(context):
+    # Open a probe connection before the reload so we can detect teardown
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.settimeout(1)
+    probe.connect(("syslog-ng", 5514))
+
     syslog_ng_swap_config(SYSLOG_NG_UDP_ONLY_CONF)
+    wait_for_tcp_port_closed()
+    wait_for_connection_teardown(probe)
+    # Allow time for the sender's existing connection to receive RST
+    time.sleep(0.5)
     context.syslog_ng_config_changed = True
 
 
 @when("the syslog server resumes accepting TCP connections")
 def step_syslog_server_resumes_tcp(context):
     syslog_ng_swap_config(SYSLOG_NG_FULL_CONF)
+    wait_for_tcp_port_open()
 
 
 @when("the example program sends a syslog message")
@@ -399,6 +466,16 @@ def step_check_message_count(context, count):
     )
 
 
+@then("syslog-ng receives no more messages")
+def step_check_no_more_messages(context):
+    before = line_count(RECEIVED_LOG)
+    time.sleep(5)
+    after = line_count(RECEIVED_LOG)
+    assert after == before, (
+        f"Expected no more messages, but received {after - before} additional"
+    )
+
+
 @then('the structured data contains sequenceId "{value}"')
 def step_check_sequence_id(context, value):
     sd = context.fields.get("STRUCTURED_DATA", "")
@@ -481,6 +558,23 @@ def step_client_sends_n_messages(context, count):
     send_command(context.interactive_process, f"send {count}")
     # Allow time for the service thread to drain the buffer
     time.sleep(0.5)
+
+
+@when("the client attempts to send it exits with code {code:d}")
+def step_client_attempts_send_exits(context, code):
+    process = context.interactive_process
+    # Allow the service thread to drain the buffer and fill the store
+    time.sleep(3)
+    try:
+        process.stdin.write("send\n")
+        process.stdin.flush()
+    except (BrokenPipeError, OSError):
+        pass
+    process.wait(timeout=10)
+    assert process.returncode == code, (
+        f"Expected exit code {code}, got {process.returncode}"
+    )
+    del context.interactive_process
 
 
 @when("the client is killed")

--- a/Bdd/features/store_capacity.feature
+++ b/Bdd/features/store_capacity.feature
@@ -3,28 +3,48 @@ Feature: Store capacity limit and discard policy
   When the store is full, the discard policy determines whether
   the oldest or newest messages are dropped.
 
-  @wip
   Scenario: Discard-oldest drops oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 1100 and discard-policy oldest
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy oldest
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
     When the syslog server stops accepting TCP connections
-    And the client sends 6 messages
+    And the client sends 10 messages
     And the syslog server resumes accepting TCP connections
-    Then syslog-ng receives 5 messages
-    And the last 4 messages have contiguous sequenceIds starting from 4
+    Then syslog-ng receives 8 messages
+    And the last 7 messages have contiguous sequenceIds starting from 5
 
-  @wip
   Scenario: Discard-newest preserves oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 1100 and discard-policy newest
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy newest
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
     When the syslog server stops accepting TCP connections
-    And the client sends 6 messages
+    And the client sends 10 messages
     And the syslog server resumes accepting TCP connections
-    Then syslog-ng receives 5 messages
-    And the last 4 messages have contiguous sequenceIds starting from 2
+    Then syslog-ng receives 8 messages
+    And the last 7 messages have contiguous sequenceIds starting from 2
+
+  Scenario: Halt stops the application when store overflows
+    Given syslog-ng is running
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
+    And the halt callback exits the process
+    And the threaded example is running with transport tcp and no structured data
+    When the client sends a message
+    Then syslog-ng receives 1 message
+    When the syslog server stops accepting TCP connections
+    And the client sends 8 messages
+    And the client attempts to send it exits with code 2
+
+  Scenario: Halt prevents further service after store overflows
+    Given syslog-ng is running
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
+    And the threaded example is running with transport tcp and no structured data
+    When the client sends a message
+    Then syslog-ng receives 1 message
+    When the syslog server stops accepting TCP connections
+    And the client sends 10 messages
+    And the syslog server resumes accepting TCP connections
+    Then syslog-ng receives no more messages

--- a/Example/Common/ExampleCommandLine.c
+++ b/Example/Common/ExampleCommandLine.c
@@ -4,14 +4,35 @@
 #include <stdlib.h>
 #include <string.h>
 
+enum
+{
+    DEFAULT_MAX_FILES     = 10,
+    DEFAULT_MAX_FILE_SIZE = 65536,
+    OPT_MAX_FILES         = 256,
+    OPT_MAX_FILE_SIZE     = 257,
+    OPT_DISCARD_POLICY    = 258,
+    OPT_NO_SD             = 259,
+    OPT_HALT_EXIT         = 260
+};
+
+static bool IsValidDiscardPolicy(const char* policy)
+{
+    return (strcmp(policy, "oldest") == 0) || (strcmp(policy, "newest") == 0) || (strcmp(policy, "halt") == 0);
+}
+
 int ExampleCommandLine_Parse(int argc, char* argv[], struct ExampleOptions* options)
 {
-    options->facility  = SOLIDSYSLOG_FACILITY_LOCAL0;
-    options->severity  = SOLIDSYSLOG_SEVERITY_INFO;
-    options->messageId = NULL;
-    options->msg       = NULL;
-    options->transport = "udp";
-    options->store     = "null";
+    options->facility      = SOLIDSYSLOG_FACILITY_LOCAL0;
+    options->severity      = SOLIDSYSLOG_SEVERITY_INFO;
+    options->messageId     = NULL;
+    options->msg           = NULL;
+    options->transport     = "udp";
+    options->store         = "null";
+    options->maxFiles      = DEFAULT_MAX_FILES;
+    options->maxFileSize   = DEFAULT_MAX_FILE_SIZE;
+    options->discardPolicy = "oldest";
+    options->noSd          = false;
+    options->haltExit      = false;
 
     static struct option longOptions[] = {
         {"facility", required_argument, NULL, 'f'},
@@ -20,6 +41,11 @@ int ExampleCommandLine_Parse(int argc, char* argv[], struct ExampleOptions* opti
         {"message", required_argument, NULL, 'm'},
         {"transport", required_argument, NULL, 't'},
         {"store", required_argument, NULL, 'o'},
+        {"max-files", required_argument, NULL, OPT_MAX_FILES},
+        {"max-file-size", required_argument, NULL, OPT_MAX_FILE_SIZE},
+        {"discard-policy", required_argument, NULL, OPT_DISCARD_POLICY},
+        {"no-sd", no_argument, NULL, OPT_NO_SD},
+        {"halt-exit", no_argument, NULL, OPT_HALT_EXIT},
         {NULL, 0, NULL, 0},
     };
 
@@ -53,6 +79,25 @@ int ExampleCommandLine_Parse(int argc, char* argv[], struct ExampleOptions* opti
                     return 1;
                 }
                 options->store = optarg;
+                break;
+            case OPT_MAX_FILES:
+                options->maxFiles = (size_t) strtol(optarg, NULL, 10);
+                break;
+            case OPT_MAX_FILE_SIZE:
+                options->maxFileSize = (size_t) strtol(optarg, NULL, 10);
+                break;
+            case OPT_DISCARD_POLICY:
+                if (!IsValidDiscardPolicy(optarg))
+                {
+                    return 1;
+                }
+                options->discardPolicy = optarg;
+                break;
+            case OPT_NO_SD:
+                options->noSd = true;
+                break;
+            case OPT_HALT_EXIT:
+                options->haltExit = true;
                 break;
             default:
                 return 1;

--- a/Example/Common/ExampleCommandLine.h
+++ b/Example/Common/ExampleCommandLine.h
@@ -4,6 +4,9 @@
 #include "ExternC.h"
 #include "SolidSyslogPrival.h"
 
+#include <stdbool.h>
+#include <stddef.h>
+
 EXTERN_C_BEGIN
 
     struct ExampleOptions
@@ -14,6 +17,11 @@ EXTERN_C_BEGIN
         const char*               msg;
         const char*               transport;
         const char*               store;
+        size_t                    maxFiles;
+        size_t                    maxFileSize;
+        const char*               discardPolicy;
+        bool                      noSd;
+        bool                      haltExit;
     };
 
     int ExampleCommandLine_Parse(int argc, char* argv[], struct ExampleOptions* options);

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -26,13 +26,8 @@
 #include <unistd.h>
 
 static const char* const       STORE_PATH_PREFIX = "/tmp/STORE";
-static struct SolidSyslogFile* storeFile;
-
-enum
-{
-    DEFAULT_MAX_FILE_SIZE = 65536,
-    DEFAULT_MAX_FILES     = 10
-};
+static struct SolidSyslogFile* storeReadFile;
+static struct SolidSyslogFile* storeWriteFile;
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 {
@@ -68,24 +63,49 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     return SolidSyslogUdpSender_Create(&udpConfig);
 }
 
+static enum SolidSyslogDiscardPolicy MapDiscardPolicy(const char* policy)
+{
+    if (strcmp(policy, "newest") == 0)
+    {
+        return SOLIDSYSLOG_DISCARD_NEWEST;
+    }
+    if (strcmp(policy, "halt") == 0)
+    {
+        return SOLIDSYSLOG_HALT;
+    }
+    return SOLIDSYSLOG_DISCARD_OLDEST;
+}
+
+static volatile bool haltExit;
+
+static void OnStoreFull(void)
+{
+    if (haltExit)
+    {
+        _exit(2);
+    }
+}
+
 static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options)
 {
     bool useFile = (strcmp(options->store, "file") == 0);
 
     if (useFile)
     {
-        static struct SolidSyslogPosixFileStorage fileStorage;
-        storeFile                    = SolidSyslogPosixFile_Create(&fileStorage);
-        struct SolidSyslogFile* file = storeFile;
+        static struct SolidSyslogPosixFileStorage readStorage;
+        static struct SolidSyslogPosixFileStorage writeStorage;
+        storeReadFile  = SolidSyslogPosixFile_Create(&readStorage);
+        storeWriteFile = SolidSyslogPosixFile_Create(&writeStorage);
 
         static struct SolidSyslogFileStoreConfig storeConfig = {0};
-        storeConfig.readFile                                 = file;
-        storeConfig.writeFile                                = file;
+        storeConfig.readFile                                 = storeReadFile;
+        storeConfig.writeFile                                = storeWriteFile;
         storeConfig.pathPrefix                               = STORE_PATH_PREFIX;
-        storeConfig.maxFileSize                              = DEFAULT_MAX_FILE_SIZE;
-        storeConfig.maxFiles                                 = DEFAULT_MAX_FILES;
-        storeConfig.discardPolicy                            = SOLIDSYSLOG_DISCARD_OLDEST;
+        storeConfig.maxFileSize                              = options->maxFileSize;
+        storeConfig.maxFiles                                 = options->maxFiles;
+        storeConfig.discardPolicy                            = MapDiscardPolicy(options->discardPolicy);
         storeConfig.securityPolicy                           = SolidSyslogCrc16Policy_Create();
+        storeConfig.onStoreFull                              = OnStoreFull;
         return SolidSyslogFileStore_Create(&storeConfig);
     }
 
@@ -114,7 +134,8 @@ static void DestroyStore(const struct ExampleOptions* options)
     {
         SolidSyslogFileStore_Destroy();
         SolidSyslogCrc16Policy_Destroy();
-        SolidSyslogPosixFile_Destroy(storeFile);
+        SolidSyslogPosixFile_Destroy(storeWriteFile);
+        SolidSyslogPosixFile_Destroy(storeReadFile);
     }
     else
     {
@@ -135,13 +156,15 @@ int main(int argc, char* argv[])
     struct SolidSyslogSender* sender = CreateSender(&options);
     struct SolidSyslogStore*  store  = CreateStore(&options);
 
-    struct SolidSyslogBuffer*         buffer      = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
-    struct SolidSyslogAtomicCounter*  counter     = SolidSyslogAtomicCounter_Create();
-    struct SolidSyslogStructuredData* metaSd      = SolidSyslogMetaSd_Create(counter);
+    struct SolidSyslogBuffer*         buffer  = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
+    struct SolidSyslogAtomicCounter*  counter = SolidSyslogAtomicCounter_Create();
+    struct SolidSyslogStructuredData* metaSd  = SolidSyslogMetaSd_Create(counter);
+
     struct SolidSyslogStructuredData* timeQuality = SolidSyslogTimeQualitySd_Create(GetTimeQuality);
     struct SolidSyslogStructuredData* originSd    = SolidSyslogOriginSd_Create("SolidSyslogExample", "0.7.0");
 
-    struct SolidSyslogStructuredData* sdList[] = {metaSd, timeQuality, originSd};
+    struct SolidSyslogStructuredData* sdList[3] = {metaSd, timeQuality, originSd};
+    size_t                            sdCount   = options.noSd ? 1 : 3;
 
     struct SolidSyslogConfig config = {
         .buffer       = buffer,
@@ -152,11 +175,12 @@ int main(int argc, char* argv[])
         .getProcessId = SolidSyslogPosixProcessId_Get,
         .store        = store,
         .sd           = sdList,
-        .sdCount      = sizeof(sdList) / sizeof(sdList[0]),
+        .sdCount      = sdCount,
     };
     SolidSyslog_Create(&config);
 
     shutdown_flag = false;
+    haltExit      = options.haltExit;
 
     pthread_t serviceThread = 0;
     pthread_create(&serviceThread, NULL, ServiceThreadEntry, (void*) &shutdown_flag);

--- a/Interface/SolidSyslogStore.h
+++ b/Interface/SolidSyslogStore.h
@@ -13,6 +13,7 @@ EXTERN_C_BEGIN
     bool SolidSyslogStore_ReadNextUnsent(struct SolidSyslogStore * store, void* data, size_t maxSize, size_t* bytesRead);
     void SolidSyslogStore_MarkSent(struct SolidSyslogStore * store);
     bool SolidSyslogStore_HasUnsent(struct SolidSyslogStore * store);
+    bool SolidSyslogStore_IsHalted(struct SolidSyslogStore * store);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogStoreDefinition.h
+++ b/Interface/SolidSyslogStoreDefinition.h
@@ -11,6 +11,7 @@ EXTERN_C_BEGIN
         bool (*ReadNextUnsent)(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
         void (*MarkSent)(struct SolidSyslogStore* self);
         bool (*HasUnsent)(struct SolidSyslogStore* self);
+        bool (*IsHalted)(struct SolidSyslogStore* self);
     };
 
 EXTERN_C_END

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -23,6 +23,7 @@ static inline int16_t AbsoluteInt16(int16_t value);
 static inline bool    CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock);
 static inline uint8_t CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
 static inline bool    FacilityIsValid(uint8_t facility);
+static inline bool    FetchFromStore(char* buf, size_t maxSize, size_t* len);
 static inline size_t  FormatAppName(char* buffer, SolidSyslogStringFunction getAppName);
 static inline size_t  FormatAsHours(char* buffer, int16_t absoluteMinutes);
 static inline size_t  FormatAsMinutes(char* buffer, int16_t absoluteMinutes);
@@ -42,11 +43,14 @@ static inline size_t  FormatTimestamp(char* buffer, size_t size, SolidSyslogCloc
 static inline size_t  FormatTwoDigit(char* buffer, uint8_t value);
 static inline size_t  FormatUtcOffset(char* buffer, int16_t offsetMinutes);
 static inline size_t  FormatVersion(char* buffer);
+static inline bool    IsServiceEnabled(void);
 static inline size_t  FormatYear(char* buffer, uint16_t value);
 static inline uint8_t MakePrival(const struct SolidSyslogMessage* message);
 static void           NilClock(struct SolidSyslogTimestamp* ts);
 static size_t         NilStringFunction(char* buffer, size_t size);
 static inline bool    PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
+static void           ProcessMessages(void);
+static inline bool    ReceiveFromBufferIntoStore(char* buf, size_t maxSize, size_t* len);
 static inline bool    SeverityIsValid(uint8_t severity);
 static inline bool    StringIsValid(const char* value);
 static inline bool    TimestampIsValid(const struct SolidSyslogTimestamp* ts);
@@ -110,6 +114,39 @@ void SolidSyslog_Destroy(void)
     instance.sdCount      = 0;
 }
 
+void SolidSyslog_Service(void)
+{
+    if (IsServiceEnabled())
+    {
+        ProcessMessages();
+    }
+}
+
+static inline bool IsServiceEnabled(void)
+{
+    return !SolidSyslogStore_IsHalted(instance.store);
+}
+
+static void ProcessMessages(void)
+{
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    size_t len = 0;
+
+    bool haveMessage = ReceiveFromBufferIntoStore(buf, sizeof(buf), &len);
+    bool fromStore   = FetchFromStore(buf, sizeof(buf), &len);
+
+    if (fromStore || haveMessage)
+    {
+        if (SolidSyslogSender_Send(instance.sender, buf, len))
+        {
+            if (fromStore)
+            {
+                SolidSyslogStore_MarkSent(instance.store);
+            }
+        }
+    }
+}
+
 static inline bool ReceiveFromBufferIntoStore(char* buf, size_t maxSize, size_t* len)
 {
     bool received = SolidSyslogBuffer_Read(instance.buffer, buf, maxSize, len);
@@ -130,26 +167,6 @@ static inline bool FetchFromStore(char* buf, size_t maxSize, size_t* len)
     }
 
     return false;
-}
-
-void SolidSyslog_Service(void)
-{
-    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
-    size_t len = 0;
-
-    bool haveMessage = ReceiveFromBufferIntoStore(buf, sizeof(buf), &len);
-    bool fromStore   = FetchFromStore(buf, sizeof(buf), &len);
-
-    if (fromStore || haveMessage)
-    {
-        if (SolidSyslogSender_Send(instance.sender, buf, len))
-        {
-            if (fromStore)
-            {
-                SolidSyslogStore_MarkSent(instance.store);
-            }
-        }
-    }
 }
 
 void SolidSyslog_Log(const struct SolidSyslogMessage* message)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -525,11 +525,14 @@ static inline bool StoreIsFull(void)
 
 static inline void NotifyStoreFull(void)
 {
-    instance.halted = true;
-
-    if ((instance.discardPolicy == SOLIDSYSLOG_HALT) && (instance.onStoreFull != NULL))
+    if (instance.discardPolicy == SOLIDSYSLOG_HALT)
     {
-        instance.onStoreFull();
+        instance.halted = true;
+
+        if (instance.onStoreFull != NULL)
+        {
+            instance.onStoreFull();
+        }
     }
 }
 

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -30,6 +30,7 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
 static void MarkSent(struct SolidSyslogStore* self);
 static bool HasUnsent(struct SolidSyslogStore* self);
+static bool IsHalted(struct SolidSyslogStore* self);
 
 /* ------------------------------------------------------------------
  * Record buffer — single static buffer for integrity computation
@@ -88,6 +89,7 @@ struct SolidSyslogFileStore
     size_t                            maxFiles;
     enum SolidSyslogDiscardPolicy     discardPolicy;
     SolidSyslogStoreFullCallback      onStoreFull;
+    bool                              halted;
     uint8_t                           oldestSequence;
     uint8_t                           readSequence;
     uint8_t                           writeSequence;
@@ -257,6 +259,8 @@ static inline bool StoreIsFull(void);
 static inline void NotifyStoreFull(void);
 static void        RotateToNextFile(void);
 static void        DiscardOldestFile(void);
+static void        DeleteOldestFile(void);
+static void        SwitchReadFile(uint8_t newSequence);
 static bool        MakeSpaceForRecord(size_t dataSize);
 static inline void AssembleRecord(const void* data, size_t size);
 static bool        FlushRecord(size_t dataSize);
@@ -351,6 +355,7 @@ static inline void InitialiseVtable(void)
     instance.base.ReadNextUnsent = ReadNextUnsent;
     instance.base.MarkSent       = MarkSent;
     instance.base.HasUnsent      = HasUnsent;
+    instance.base.IsHalted       = IsHalted;
 }
 
 static void ScanForExistingFiles(void)
@@ -520,6 +525,8 @@ static inline bool StoreIsFull(void)
 
 static inline void NotifyStoreFull(void)
 {
+    instance.halted = true;
+
     if ((instance.discardPolicy == SOLIDSYSLOG_HALT) && (instance.onStoreFull != NULL))
     {
         instance.onStoreFull();
@@ -541,11 +548,38 @@ static void RotateToNextFile(void)
     }
 }
 
-static void DiscardOldestFile(void)
+static void DeleteOldestFile(void)
 {
     FormatFilename(instance.oldestSequence);
     SolidSyslogFile_Delete(instance.writeFile, instance.filename);
     instance.oldestSequence = NextSequence(instance.oldestSequence);
+}
+
+static void SwitchReadFile(uint8_t newSequence)
+{
+    SolidSyslogFile_Close(instance.readFile);
+    instance.readSequence  = newSequence;
+    instance.readCursor    = 0;
+    instance.hasReadRecord = false;
+    FormatFilename(instance.readSequence);
+    OpenReadFile(instance.filename);
+}
+
+static void ResetReadToOldestFile(void)
+{
+    SwitchReadFile(instance.oldestSequence);
+}
+
+static void DiscardOldestFile(void)
+{
+    bool readingOldestFile = (instance.readSequence == instance.oldestSequence);
+
+    DeleteOldestFile();
+
+    if (readingOldestFile)
+    {
+        ResetReadToOldestFile();
+    }
 }
 
 static inline void SeekToWritePosition(void)
@@ -598,6 +632,12 @@ static bool HasUnsent(struct SolidSyslogStore* self)
     return HasUnsentRecords();
 }
 
+static bool IsHalted(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return instance.halted;
+}
+
 /* ------------------------------------------------------------------
  * ReadNextUnsent
  * ----------------------------------------------------------------*/
@@ -624,11 +664,7 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
 
 static void AdvanceToNextReadFile(void)
 {
-    SolidSyslogFile_Close(instance.readFile);
-    instance.readSequence = NextSequence(instance.readSequence);
-    instance.readCursor   = 0;
-    FormatFilename(instance.readSequence);
-    OpenReadFile(instance.filename);
+    SwitchReadFile(NextSequence(instance.readSequence));
 }
 
 static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)

--- a/Source/SolidSyslogNullStore.c
+++ b/Source/SolidSyslogNullStore.c
@@ -5,6 +5,7 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
 static void MarkSent(struct SolidSyslogStore* self);
 static bool HasUnsent(struct SolidSyslogStore* self);
+static bool IsHalted(struct SolidSyslogStore* self);
 
 struct SolidSyslogNullStore
 {
@@ -19,6 +20,7 @@ struct SolidSyslogStore* SolidSyslogNullStore_Create(void)
     instance.base.ReadNextUnsent = ReadNextUnsent;
     instance.base.MarkSent       = MarkSent;
     instance.base.HasUnsent      = HasUnsent;
+    instance.base.IsHalted       = IsHalted;
     return &instance.base;
 }
 
@@ -28,6 +30,7 @@ void SolidSyslogNullStore_Destroy(void)
     instance.base.ReadNextUnsent = NULL;
     instance.base.MarkSent       = NULL;
     instance.base.HasUnsent      = NULL;
+    instance.base.IsHalted       = NULL;
 }
 
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
@@ -53,6 +56,12 @@ static void MarkSent(struct SolidSyslogStore* self)
 }
 
 static bool HasUnsent(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static bool IsHalted(struct SolidSyslogStore* self)
 {
     (void) self;
     return false;

--- a/Source/SolidSyslogStore.c
+++ b/Source/SolidSyslogStore.c
@@ -19,3 +19,8 @@ bool SolidSyslogStore_HasUnsent(struct SolidSyslogStore* store)
 {
     return store->HasUnsent(store);
 }
+
+bool SolidSyslogStore_IsHalted(struct SolidSyslogStore* store)
+{
+    return store->IsHalted(store);
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -43,6 +43,7 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogUdpSenderTest.cpp
         SolidSyslogTcpSenderTest.cpp
         SolidSyslogPosixFileTest.cpp
+        SolidSyslogFileStorePosixTest.cpp
     )
 endif()
 

--- a/Tests/Example/CMakeLists.txt
+++ b/Tests/Example/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EXAMPLE_TEST_SOURCES
+    ExampleCommandLineTest.cpp
     SolidSyslogExampleTest.cpp
     ExampleServiceThreadTest.cpp
     main.cpp

--- a/Tests/Example/ExampleCommandLineTest.cpp
+++ b/Tests/Example/ExampleCommandLineTest.cpp
@@ -1,0 +1,122 @@
+#include "CppUTest/TestHarness.h"
+#include "ExampleCommandLine.h"
+
+#include <getopt.h>
+
+// clang-format off
+TEST_GROUP(ExampleCommandLine)
+{
+    struct ExampleOptions options = {};
+
+    void setup() override
+    {
+        optind = 1;
+    }
+
+    int Parse(int argc, char* argv[])
+    {
+        return ExampleCommandLine_Parse(argc, argv, &options);
+    }
+};
+
+// clang-format on
+
+TEST(ExampleCommandLine, DefaultMaxFiles)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    LONGS_EQUAL(10, options.maxFiles);
+}
+
+TEST(ExampleCommandLine, DefaultMaxFileSize)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    LONGS_EQUAL(65536, options.maxFileSize);
+}
+
+TEST(ExampleCommandLine, DefaultDiscardPolicy)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    STRCMP_EQUAL("oldest", options.discardPolicy);
+}
+
+TEST(ExampleCommandLine, DefaultNoSd)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    CHECK_FALSE(options.noSd);
+}
+
+TEST(ExampleCommandLine, MaxFilesFlag)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-files";
+    char  arg2[] = "5";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(0, Parse(3, argv));
+    LONGS_EQUAL(5, options.maxFiles);
+}
+
+TEST(ExampleCommandLine, MaxFileSizeFlag)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-file-size";
+    char  arg2[] = "1024";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(0, Parse(3, argv));
+    LONGS_EQUAL(1024, options.maxFileSize);
+}
+
+TEST(ExampleCommandLine, DiscardPolicyOldest)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--discard-policy";
+    char  arg2[] = "oldest";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(0, Parse(3, argv));
+    STRCMP_EQUAL("oldest", options.discardPolicy);
+}
+
+TEST(ExampleCommandLine, DiscardPolicyNewest)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--discard-policy";
+    char  arg2[] = "newest";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(0, Parse(3, argv));
+    STRCMP_EQUAL("newest", options.discardPolicy);
+}
+
+TEST(ExampleCommandLine, DiscardPolicyHalt)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--discard-policy";
+    char  arg2[] = "halt";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(0, Parse(3, argv));
+    STRCMP_EQUAL("halt", options.discardPolicy);
+}
+
+TEST(ExampleCommandLine, InvalidDiscardPolicyReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--discard-policy";
+    char  arg2[] = "invalid";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, NoSdFlag)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--no-sd";
+    char* argv[] = {arg0, arg1, nullptr};
+    LONGS_EQUAL(0, Parse(2, argv));
+    CHECK_TRUE(options.noSd);
+}

--- a/Tests/SolidSyslogFileStorePosixTest.cpp
+++ b/Tests/SolidSyslogFileStorePosixTest.cpp
@@ -1,0 +1,159 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogFileStore.h"
+#include "SolidSyslogPosixFile.h"
+#include "SolidSyslog.h"
+
+#include <cstdio>
+#include <cstring>
+#include <glob.h>
+
+static const char* const TEST_PATH_PREFIX = "/tmp/test_posix_store";
+
+static void CleanStoreFiles()
+{
+    glob_t      results = {};
+    std::string pattern = std::string(TEST_PATH_PREFIX) + "*.log";
+    if (glob(pattern.c_str(), 0, nullptr, &results) == 0)
+    {
+        for (size_t i = 0; i < results.gl_pathc; i++)
+        {
+            std::remove(results.gl_pathv[i]);
+        }
+        globfree(&results);
+    }
+}
+
+/* Integration tests using real POSIX files instead of FileFake.
+ * These catch issues that only surface with real file handles —
+ * e.g. reading from a deleted file, handle reuse after close,
+ * or cursor state surviving across rotate/discard cycles. */
+
+// clang-format off
+TEST_GROUP(SolidSyslogFileStorePosix)
+{
+    static const size_t RECORD_OVERHEAD    = 5; /* 2 (magic) + 2 (length) + 1 (sent flag) */
+    static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD;
+
+    struct SolidSyslogPosixFileStorage readStorage = {};
+    struct SolidSyslogPosixFileStorage writeStorage = {};
+    struct SolidSyslogFile* readFile = nullptr;
+    struct SolidSyslogFile* writeFile = nullptr;
+    struct SolidSyslogStore* store = nullptr;
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+
+    void setup() override
+    {
+        CleanStoreFiles();
+        readFile = SolidSyslogPosixFile_Create(&readStorage);
+        writeFile = SolidSyslogPosixFile_Create(&writeStorage);
+        std::memset(maxMsg, 'A', sizeof(maxMsg));
+    }
+
+    void teardown() override
+    {
+        SolidSyslogFileStore_Destroy();
+        SolidSyslogPosixFile_Destroy(writeFile);
+        SolidSyslogPosixFile_Destroy(readFile);
+        CleanStoreFiles();
+    }
+
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- test helper mirrors rotation test group signature
+    void CreateStore(size_t maxFileSize = ONE_MAX_MSG_RECORD, size_t maxFiles = 2)
+    {
+        struct SolidSyslogFileStoreConfig config = {};
+        config.readFile      = readFile;
+        config.writeFile     = writeFile;
+        config.pathPrefix    = TEST_PATH_PREFIX;
+        config.maxFileSize   = maxFileSize;
+        config.maxFiles      = maxFiles;
+        config.discardPolicy = SOLIDSYSLOG_DISCARD_OLDEST;
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        store = SolidSyslogFileStore_Create(&config);
+    }
+
+    void WriteMaxMsg()
+    {
+        SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg));
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogFileStorePosix, DiscardOldestDrainYieldsOnlySurvivingRecords)
+{
+    CreateStore();
+
+    char firstMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    std::memset(firstMsg, 'B', sizeof(firstMsg));
+    SolidSyslogStore_Write(store, firstMsg, sizeof(firstMsg)); /* file 00 — will be discarded */
+
+    char secondMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    std::memset(secondMsg, 'C', sizeof(secondMsg));
+    SolidSyslogStore_Write(store, secondMsg, sizeof(secondMsg)); /* file 01 — survives */
+
+    WriteMaxMsg(); /* file 02 — triggers discard of file 00 */
+
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+    size_t bytesRead                         = 0;
+
+    /* First record should be from surviving file 01, not discarded file 00 */
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('C', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    /* Second record from file 02 */
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('A', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    /* No more records */
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
+TEST(SolidSyslogFileStorePosix, DiscardOldestWhenReadIsPartwayThroughOldestFile)
+{
+    static const size_t TWO_MAX_MSG_RECORDS = 2 * ONE_MAX_MSG_RECORD;
+    CreateStore(TWO_MAX_MSG_RECORDS);
+
+    char msgA[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    char msgB[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    char msgC[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    char msgD[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    std::memset(msgA, 'A', sizeof(msgA));
+    std::memset(msgB, 'B', sizeof(msgB));
+    std::memset(msgC, 'C', sizeof(msgC));
+    std::memset(msgD, 'D', sizeof(msgD));
+
+    /* Fill file 00 with two records */
+    SolidSyslogStore_Write(store, msgA, sizeof(msgA));
+    SolidSyslogStore_Write(store, msgB, sizeof(msgB));
+
+    /* Fill file 01 with two records */
+    SolidSyslogStore_Write(store, msgC, sizeof(msgC));
+    SolidSyslogStore_Write(store, msgD, sizeof(msgD));
+
+    /* Read and send first record from file 00 — read cursor is now partway through */
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+    size_t bytesRead                         = 0;
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('A', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    /* Write one more — triggers rotation to file 02 and discard of file 00 */
+    WriteMaxMsg();
+
+    /* Should get record B is lost (discarded with file 00), then C, D from file 01, then E from file 02 */
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('C', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('D', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('A', buf[0]); /* maxMsg filled with 'A' */
+    SolidSyslogStore_MarkSent(store);
+
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -796,6 +796,37 @@ TEST(SolidSyslogFileStoreRotation, DiscardOldestSurvivingDataIsReadable)
     BYTES_EQUAL('C', buf[0]);
 }
 
+TEST(SolidSyslogFileStoreRotation, DiscardOldestDrainYieldsOnlySurvivingRecords)
+{
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
+
+    char firstMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(firstMsg, 'B', sizeof(firstMsg));
+    SolidSyslogStore_Write(store, firstMsg, sizeof(firstMsg)); /* file 00 — will be discarded */
+
+    char secondMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(secondMsg, 'C', sizeof(secondMsg));
+    SolidSyslogStore_Write(store, secondMsg, sizeof(secondMsg)); /* file 01 — survives */
+
+    WriteMaxMsg(); /* file 02 — triggers discard of file 00 */
+
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
+    size_t bytesRead                         = 0;
+
+    /* First record should be from surviving file 01, not discarded file 00 */
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('C', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    /* Second record from file 02 */
+    CHECK_TRUE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
+    BYTES_EQUAL('A', buf[0]);
+    SolidSyslogStore_MarkSent(store);
+
+    /* No more records */
+    CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
+}
+
 TEST(SolidSyslogFileStoreRotation, DiscardNewestReturnsFalseWhenAtMaxFiles)
 {
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_DISCARD_NEWEST);
@@ -847,6 +878,25 @@ TEST(SolidSyslogFileStoreRotation, HaltWithNullCallbackDoesNotCrash)
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
 
     CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+}
+
+TEST(SolidSyslogFileStoreRotation, HaltSetsIsHaltedTrue)
+{
+    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
+    config.readFile                          = readFile;
+    config.writeFile                         = writeFile;
+    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
+    config.maxFiles                          = 2;
+    config.discardPolicy                     = SOLIDSYSLOG_HALT;
+    config.onStoreFull                       = nullptr;
+    store                                    = SolidSyslogFileStore_Create(&config);
+
+    WriteMaxMsg(); /* file 00 */
+    WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
+
+    CHECK_FALSE(SolidSyslogStore_IsHalted(store));
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* triggers halt */
+    CHECK_TRUE(SolidSyslogStore_IsHalted(store));
 }
 
 TEST(SolidSyslogFileStoreRotation, DiscardNewestDoesNotInvokeCallback)

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1287,6 +1287,28 @@ TEST(SolidSyslog, ServiceDoesNotMarkSentWhenSendingFromBuffer)
     BufferFake_Destroy();
 }
 
+TEST(SolidSyslog, ServiceDoesNothingWhenStoreIsHalted)
+{
+    SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
+    SolidSyslogStore*  fakeStore     = StoreFake_Create();
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Create(&serviceConfig);
+
+    SolidSyslogBuffer_Write(fakeBuffer, "test", 4);
+    StoreFake_SetHalted();
+    SenderFake_Reset();
+    SolidSyslog_Service();
+
+    LONGS_EQUAL(0, SenderFake_CallCount());
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Create(&config);
+    StoreFake_Destroy();
+    BufferFake_Destroy();
+}
+
 TEST(SolidSyslog, LogAfterDestroyAndRecreateWithNullFunctionsProducesNilvalues)
 {
     SolidSyslog_Destroy();

--- a/Tests/StoreFake.c
+++ b/Tests/StoreFake.c
@@ -13,6 +13,7 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
 static void MarkSent(struct SolidSyslogStore* self);
 static bool HasUnsent(struct SolidSyslogStore* self);
+static bool IsHalted(struct SolidSyslogStore* self);
 
 struct StoreFake
 {
@@ -22,6 +23,7 @@ struct StoreFake
     bool                    unsent;
     bool                    failNextWrite;
     bool                    failNextRead;
+    bool                    halted;
 };
 
 static struct StoreFake instance;
@@ -33,6 +35,7 @@ struct SolidSyslogStore* StoreFake_Create(void)
     instance.base.ReadNextUnsent = ReadNextUnsent;
     instance.base.MarkSent       = MarkSent;
     instance.base.HasUnsent      = HasUnsent;
+    instance.base.IsHalted       = IsHalted;
     return &instance.base;
 }
 
@@ -106,4 +109,15 @@ static bool HasUnsent(struct SolidSyslogStore* self)
 {
     struct StoreFake* fake = (struct StoreFake*) self;
     return fake->unsent;
+}
+
+static bool IsHalted(struct SolidSyslogStore* self)
+{
+    struct StoreFake* fake = (struct StoreFake*) self;
+    return fake->halted;
+}
+
+void StoreFake_SetHalted(void)
+{
+    instance.halted = true;
 }

--- a/Tests/StoreFake.h
+++ b/Tests/StoreFake.h
@@ -9,6 +9,7 @@ EXTERN_C_BEGIN
     void                     StoreFake_Destroy(void);
     void                     StoreFake_FailNextWrite(void);
     void                     StoreFake_FailNextRead(void);
+    void                     StoreFake_SetHalted(void);
 
 EXTERN_C_END
 


### PR DESCRIPTION
## Purpose
Closes #108. Completes S5.8 by adding BDD scenarios for the halt discard policy and implementing
the IEC 62443 halt behaviour: once the store overflows with SOLIDSYSLOG_HALT policy, the service
loop becomes permanently disabled.

## Change Description
- **BDD**: Two halt scenarios — one where the callback exits the process (`_exit(2)`), one where it
  returns and service is permanently halted (no replay after TCP resumes)
- **Store vtable**: Added `IsHalted` to `SolidSyslogStore` vtable. FileStore sets a `halted` flag
  in `NotifyStoreFull`; NullStore always returns false
- **Service guard**: `SolidSyslog_Service` checks `IsServiceEnabled()` (delegates to `IsHalted`)
  and returns immediately when halted. Extracted `ProcessMessages` for single-exit-point clarity
- **Example CLI**: `--halt-exit` flag controls whether the callback calls `_exit(2)` or is a no-op.
  `--no-sd` simplified to pass `sdCount=1` (metaSd only) instead of conditional create/destroy
- **Refactors**: `DiscardOldestFile` decomposed into `DeleteOldestFile` + `ResetReadToOldestFile`.
  DRY: `SwitchReadFile` extracted from duplicate read-file-switch logic
- **POSIX integration tests**: New test group exercising real file handles for discard edge cases

## Test Evidence
- TDD: `ServiceDoesNothingWhenStoreIsHalted` (red→green in SolidSyslog), `HaltSetsIsHaltedTrue`
  (red→green in FileStore), `DiscardOldestWhenReadIsPartwayThroughOldestFile` (POSIX integration)
- 440 unit tests pass (debug, clang, sanitize, tidy)
- Coverage: 99.9% lines, 100% functions
- BDD: 31 scenarios pass (was 29)
- cppcheck and format clean

## Areas Affected
- `Interface/SolidSyslogStore.h`, `SolidSyslogStoreDefinition.h` — new `IsHalted` vtable entry
- `Source/SolidSyslog.c` — service halt guard, function reordering
- `Source/SolidSyslogFileStore.c` — halted flag, DiscardOldestFile refactor, SwitchReadFile DRY
- `Source/SolidSyslogNullStore.c`, `Source/SolidSyslogStore.c` — IsHalted dispatch
- `Example/Threaded/main.c`, `Example/Common/ExampleCommandLine.*` — halt-exit flag, no-sd simplification
- `Tests/StoreFake.*` — IsHalted + SetHalted support
- `Bdd/features/store_capacity.feature` — two new halt scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI options: max-files, max-file-size, discard-policy (oldest/newest/halt), no-sd, halt-exit
  * Store exposes halted state for status checks

* **Behavior**
  * Halt mode can terminate the process on store overflow; clients may observe failed writes or exit codes
  * Improved TCP port polling, reconnection and connection-teardown detection during reloads
  * Service no-ops when store is halted

* **Tests**
  * Expanded unit, integration, and BDD scenarios; updated overflow scenarios and expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->