### PR TITLE
fix: validate numeric CLI args for --max-files and --max-file-size

### DIFF
--- a/Example/Common/ExampleCommandLine.c
+++ b/Example/Common/ExampleCommandLine.c
@@ -15,6 +15,20 @@ enum
     OPT_HALT_EXIT         = 260
 };
 
+static bool ParsePositiveNumber(const char* str, size_t* result)
+{
+    char* end   = NULL;
+    long  value = strtol(str, &end, 10);
+
+    if ((*str == '\0') || (*end != '\0') || (value < 0))
+    {
+        return false;
+    }
+
+    *result = (size_t) value;
+    return true;
+}
+
 static bool IsValidDiscardPolicy(const char* policy)
 {
     return (strcmp(policy, "oldest") == 0) || (strcmp(policy, "newest") == 0) || (strcmp(policy, "halt") == 0);
@@ -81,10 +95,16 @@ int ExampleCommandLine_Parse(int argc, char* argv[], struct ExampleOptions* opti
                 options->store = optarg;
                 break;
             case OPT_MAX_FILES:
-                options->maxFiles = (size_t) strtol(optarg, NULL, 10);
+                if (!ParsePositiveNumber(optarg, &options->maxFiles))
+                {
+                    return 1;
+                }
                 break;
             case OPT_MAX_FILE_SIZE:
-                options->maxFileSize = (size_t) strtol(optarg, NULL, 10);
+                if (!ParsePositiveNumber(optarg, &options->maxFileSize))
+                {
+                    return 1;
+                }
                 break;
             case OPT_DISCARD_POLICY:
                 if (!IsValidDiscardPolicy(optarg))

--- a/Tests/Example/ExampleCommandLineTest.cpp
+++ b/Tests/Example/ExampleCommandLineTest.cpp
@@ -112,6 +112,60 @@ TEST(ExampleCommandLine, InvalidDiscardPolicyReturnsOne)
     LONGS_EQUAL(1, Parse(3, argv));
 }
 
+TEST(ExampleCommandLine, NegativeMaxFilesReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-files";
+    char  arg2[] = "-1";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, NonNumericMaxFilesReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-files";
+    char  arg2[] = "abc";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, TrailingTextMaxFilesReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-files";
+    char  arg2[] = "5abc";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, NegativeMaxFileSizeReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-file-size";
+    char  arg2[] = "-1";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, NonNumericMaxFileSizeReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-file-size";
+    char  arg2[] = "abc";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
+TEST(ExampleCommandLine, TrailingTextMaxFileSizeReturnsOne)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--max-file-size";
+    char  arg2[] = "1024abc";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    LONGS_EQUAL(1, Parse(3, argv));
+}
+
 TEST(ExampleCommandLine, NoSdFlag)
 {
     char  arg0[] = "test";


### PR DESCRIPTION
## Purpose
Fixes the strtol validation gap flagged by CodeRabbit in #109. Negative values
and non-numeric input for `--max-files` and `--max-file-size` are now rejected
at parse time, consistent with how `--transport`, `--store`, and `--discard-policy`
validate their inputs.

## Change Description
Extracted `ParsePositiveNumber` helper that uses `strtol` with endptr validation,
rejects negative values and trailing non-numeric characters. Both `OPT_MAX_FILES`
and `OPT_MAX_FILE_SIZE` now return 1 on invalid input.

## Test Evidence
Six new tests: negative, non-numeric, and trailing-text cases for both options.
All 440 unit tests pass (debug, clang, sanitize, tidy). Coverage 99.9%.
cppcheck and format clean.

## Areas Affected
- `Example/Common/ExampleCommandLine.c` — new ParsePositiveNumber helper, updated option handling
- `Tests/Example/ExampleCommandLineTest.cpp` — six new validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument validation for `--max-files` and `--max-file-size` options to properly reject invalid inputs including negative values, non-numeric strings, and malformed arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->