### PR TITLE
feat: S12.3 buffer overflow protection at FormatCharacter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Headers in `Interface/` are split by audience — each user includes only what t
 |---|---|---|
 | `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log`, `SolidSyslog_Service` |
 | `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy`, `SolidSyslogStringFunction` |
-| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_PaddedUint32`, `_Data`, `_Length` |
+| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_PaddedUint32`, `_AsString`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Headers in `Interface/` are split by audience — each user includes only what t
 |---|---|---|
 | `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log`, `SolidSyslog_Service` |
 | `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy`, `SolidSyslogStringFunction` |
-| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_PaddedUint32`, `_AsString`, `_Length` |
+| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsString`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Headers in `Interface/` are split by audience — each user includes only what t
 |---|---|---|
 | `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log`, `SolidSyslog_Service` |
 | `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy`, `SolidSyslogStringFunction` |
-| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_PaddedUint32`, `_Data`, `_Length`, `_Remaining` |
+| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_PaddedUint32`, `_Data`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct |

--- a/Interface/SolidSyslogFormatter.h
+++ b/Interface/SolidSyslogFormatter.h
@@ -30,7 +30,9 @@ EXTERN_C_BEGIN
     void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
-    void                         SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter * formatter, uint32_t value, size_t width);
+    void                         SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
+    void                         SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
+    void                         SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     const char*                  SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter);
     size_t                       SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
 

--- a/Interface/SolidSyslogFormatter.h
+++ b/Interface/SolidSyslogFormatter.h
@@ -27,11 +27,10 @@ EXTERN_C_BEGIN
     }
 
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
-    size_t                       SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
-    size_t                       SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
-    size_t                       SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
-    size_t                       SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter * formatter, uint32_t value, size_t width);
-    size_t                       SolidSyslogFormatter_Remaining(const struct SolidSyslogFormatter* formatter);
+    void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
+    void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
+    void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
+    void                         SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter * formatter, uint32_t value, size_t width);
     const char*                  SolidSyslogFormatter_Data(const struct SolidSyslogFormatter* formatter);
     size_t                       SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
 

--- a/Interface/SolidSyslogFormatter.h
+++ b/Interface/SolidSyslogFormatter.h
@@ -31,7 +31,7 @@ EXTERN_C_BEGIN
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter * formatter, uint32_t value, size_t width);
-    const char*                  SolidSyslogFormatter_Data(const struct SolidSyslogFormatter* formatter);
+    const char*                  SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter);
     size_t                       SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
 
 EXTERN_C_END

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -162,7 +162,7 @@ void SolidSyslog_Log(const struct SolidSyslogMessage* message)
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
     FormatMessage(f, message);
-    SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_Data(f), SolidSyslogFormatter_Length(f));
+    SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsString(f), SolidSyslogFormatter_Length(f));
 }
 
 static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)
@@ -323,7 +323,7 @@ static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslog
 
     if (fieldLength > 0)
     {
-        SolidSyslogFormatter_BoundedString(f, SolidSyslogFormatter_Data(field), fieldLength);
+        SolidSyslogFormatter_BoundedString(f, SolidSyslogFormatter_AsString(field), fieldLength);
     }
     else
     {

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -333,14 +333,14 @@ static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslog
 
 static inline void FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId)
 {
-    size_t len = 0;
+    size_t lengthBefore = SolidSyslogFormatter_Length(f);
 
     if (StringIsValid(messageId))
     {
-        len = SolidSyslogFormatter_BoundedString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
+        SolidSyslogFormatter_BoundedString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
     }
 
-    if (len == 0)
+    if (SolidSyslogFormatter_Length(f) == lengthBefore)
     {
         FormatNilvalue(f);
     }
@@ -371,7 +371,7 @@ static inline void FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
     if (StringIsValid(msg))
     {
         SolidSyslogFormatter_Character(f, ' ');
-        SolidSyslogFormatter_BoundedString(f, msg, SolidSyslogFormatter_Remaining(f) - 1);
+        SolidSyslogFormatter_BoundedString(f, msg, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
     }
 }
 

--- a/Source/SolidSyslog.c
+++ b/Source/SolidSyslog.c
@@ -262,19 +262,19 @@ static inline bool TimestampIsValid(const struct SolidSyslogTimestamp* ts)
 
 static inline void FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts)
 {
-    SolidSyslogFormatter_PaddedUint32(f, ts->year, 4);
+    SolidSyslogFormatter_FourDigit(f, ts->year);
     SolidSyslogFormatter_Character(f, '-');
-    SolidSyslogFormatter_PaddedUint32(f, ts->month, 2);
+    SolidSyslogFormatter_TwoDigit(f, ts->month);
     SolidSyslogFormatter_Character(f, '-');
-    SolidSyslogFormatter_PaddedUint32(f, ts->day, 2);
+    SolidSyslogFormatter_TwoDigit(f, ts->day);
     SolidSyslogFormatter_Character(f, 'T');
-    SolidSyslogFormatter_PaddedUint32(f, ts->hour, 2);
+    SolidSyslogFormatter_TwoDigit(f, ts->hour);
     SolidSyslogFormatter_Character(f, ':');
-    SolidSyslogFormatter_PaddedUint32(f, ts->minute, 2);
+    SolidSyslogFormatter_TwoDigit(f, ts->minute);
     SolidSyslogFormatter_Character(f, ':');
-    SolidSyslogFormatter_PaddedUint32(f, ts->second, 2);
+    SolidSyslogFormatter_TwoDigit(f, ts->second);
     SolidSyslogFormatter_Character(f, '.');
-    SolidSyslogFormatter_PaddedUint32(f, ts->microsecond, 6);
+    SolidSyslogFormatter_SixDigit(f, ts->microsecond);
     FormatUtcOffset(f, ts->utcOffsetMinutes);
 }
 
@@ -295,9 +295,9 @@ static inline void FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_
     int16_t absoluteMinutes = AbsoluteInt16(offsetMinutes);
 
     SolidSyslogFormatter_Character(f, (offsetMinutes > 0) ? '+' : '-');
-    SolidSyslogFormatter_PaddedUint32(f, (uint32_t) (absoluteMinutes / 60), 2);
+    SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes / 60));
     SolidSyslogFormatter_Character(f, ':');
-    SolidSyslogFormatter_PaddedUint32(f, (uint32_t) (absoluteMinutes % 60), 2);
+    SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes % 60));
 }
 
 static inline int16_t AbsoluteInt16(int16_t value)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -209,7 +209,7 @@ static inline const char* FormatFilename(SolidSyslogFormatterStorage* storage, u
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, MAX_PATH_SIZE);
 
     SolidSyslogFormatter_BoundedString(f, instance.pathPrefix, MAX_PREFIX_LENGTH);
-    SolidSyslogFormatter_PaddedUint32(f, sequence, SEQUENCE_DIGITS);
+    SolidSyslogFormatter_TwoDigit(f, sequence);
     SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
 
     return SolidSyslogFormatter_AsString(f);

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -212,7 +212,7 @@ static inline const char* FormatFilename(SolidSyslogFormatterStorage* storage, u
     SolidSyslogFormatter_PaddedUint32(f, sequence, SEQUENCE_DIGITS);
     SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
 
-    return SolidSyslogFormatter_Data(f);
+    return SolidSyslogFormatter_AsString(f);
 }
 
 static inline uint8_t NextSequence(uint8_t current)

--- a/Source/SolidSyslogFileStore.c
+++ b/Source/SolidSyslogFileStore.c
@@ -197,12 +197,19 @@ static inline bool IsRecordSent(size_t recordStart, uint16_t length)
 
 static const char FILE_EXTENSION[] = ".log";
 
+enum
+{
+    SEQUENCE_DIGITS   = 2,
+    FILENAME_SUFFIX   = SEQUENCE_DIGITS + sizeof(FILE_EXTENSION) - 1,
+    MAX_PREFIX_LENGTH = MAX_PATH_SIZE - FILENAME_SUFFIX - 1
+};
+
 static inline const char* FormatFilename(SolidSyslogFormatterStorage* storage, uint8_t sequence)
 {
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, MAX_PATH_SIZE);
 
-    SolidSyslogFormatter_BoundedString(f, instance.pathPrefix, MAX_PATH_SIZE);
-    SolidSyslogFormatter_PaddedUint32(f, sequence, 2);
+    SolidSyslogFormatter_BoundedString(f, instance.pathPrefix, MAX_PREFIX_LENGTH);
+    SolidSyslogFormatter_PaddedUint32(f, sequence, SEQUENCE_DIGITS);
     SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
 
     return SolidSyslogFormatter_Data(f);

--- a/Source/SolidSyslogFormatter.c
+++ b/Source/SolidSyslogFormatter.c
@@ -86,18 +86,31 @@ void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_
     NullTerminate(formatter);
 }
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value is the number, width is the output field width; distinct semantics
-void SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter* formatter, uint32_t value, size_t width)
+void SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    size_t digits  = CountDigits(value);
-    size_t padding = (width > digits) ? width - digits : 0;
+    WriteChar(formatter, DigitToChar(value / 10U));
+    WriteChar(formatter, DigitToChar(value));
+    NullTerminate(formatter);
+}
 
-    for (size_t i = 0; i < padding; i++)
-    {
-        WriteChar(formatter, '0');
-    }
+void SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
+{
+    WriteChar(formatter, DigitToChar(value / 1000U));
+    WriteChar(formatter, DigitToChar(value / 100U));
+    WriteChar(formatter, DigitToChar(value / 10U));
+    WriteChar(formatter, DigitToChar(value));
+    NullTerminate(formatter);
+}
 
-    SolidSyslogFormatter_Uint32(formatter, value);
+void SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
+{
+    WriteChar(formatter, DigitToChar(value / 100000U));
+    WriteChar(formatter, DigitToChar(value / 10000U));
+    WriteChar(formatter, DigitToChar(value / 1000U));
+    WriteChar(formatter, DigitToChar(value / 100U));
+    WriteChar(formatter, DigitToChar(value / 10U));
+    WriteChar(formatter, DigitToChar(value));
+    NullTerminate(formatter);
 }
 
 const char* SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter)

--- a/Source/SolidSyslogFormatter.c
+++ b/Source/SolidSyslogFormatter.c
@@ -100,7 +100,7 @@ void SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter* formatter, u
     SolidSyslogFormatter_Uint32(formatter, value);
 }
 
-const char* SolidSyslogFormatter_Data(const struct SolidSyslogFormatter* formatter)
+const char* SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter)
 {
     return formatter->buffer;
 }

--- a/Source/SolidSyslogFormatter.c
+++ b/Source/SolidSyslogFormatter.c
@@ -49,14 +49,13 @@ struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterSto
     return formatter;
 }
 
-size_t SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char value)
+void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char value)
 {
     WriteChar(formatter, value);
     NullTerminate(formatter);
-    return 1;
 }
 
-size_t SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
+void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
 {
     size_t len = 0;
 
@@ -66,11 +65,9 @@ size_t SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter
         len++;
     }
     NullTerminate(formatter);
-
-    return len;
 }
 
-size_t SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)
+void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
     size_t   digits  = CountDigits(value);
     uint32_t divisor = 1;
@@ -87,12 +84,10 @@ size_t SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint3
         divisor /= 10U;
     }
     NullTerminate(formatter);
-
-    return digits;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value is the number, width is the output field width; distinct semantics
-size_t SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter* formatter, uint32_t value, size_t width)
+void SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter* formatter, uint32_t value, size_t width)
 {
     size_t digits  = CountDigits(value);
     size_t padding = (width > digits) ? width - digits : 0;
@@ -103,13 +98,6 @@ size_t SolidSyslogFormatter_PaddedUint32(struct SolidSyslogFormatter* formatter,
     }
 
     SolidSyslogFormatter_Uint32(formatter, value);
-
-    return padding + digits;
-}
-
-size_t SolidSyslogFormatter_Remaining(const struct SolidSyslogFormatter* formatter)
-{
-    return formatter->size - formatter->position;
 }
 
 const char* SolidSyslogFormatter_Data(const struct SolidSyslogFormatter* formatter)

--- a/Source/SolidSyslogOriginSd.c
+++ b/Source/SolidSyslogOriginSd.c
@@ -52,5 +52,5 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     struct SolidSyslogOriginSd*  origin    = (struct SolidSyslogOriginSd*) self;
     struct SolidSyslogFormatter* preformat = SolidSyslogFormatter_FromStorage(origin->formattedStorage);
 
-    SolidSyslogFormatter_BoundedString(formatter, SolidSyslogFormatter_Data(preformat), SolidSyslogFormatter_Length(preformat));
+    SolidSyslogFormatter_BoundedString(formatter, SolidSyslogFormatter_AsString(preformat), SolidSyslogFormatter_Length(preformat));
 }

--- a/Source/SolidSyslogPosixMessageQueueBuffer.c
+++ b/Source/SolidSyslogPosixMessageQueueBuffer.c
@@ -28,7 +28,7 @@ static struct SolidSyslogPosixMessageQueueBuffer instance;
 
 static inline const char* QueueName(void)
 {
-    return SolidSyslogFormatter_Data(SolidSyslogFormatter_FromStorage(instance.nameStorage));
+    return SolidSyslogFormatter_AsString(SolidSyslogFormatter_FromStorage(instance.nameStorage));
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- distinct semantic meaning; struct wrapper would over-engineer

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -69,7 +69,7 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
         SolidSyslogFormatterStorage  prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
         struct SolidSyslogFormatter* prefix = FormatOctetCountingPrefix(prefixStorage, size);
 
-        sent = SendData(tcp, SolidSyslogFormatter_Data(prefix), SolidSyslogFormatter_Length(prefix)) && SendData(tcp, buffer, size);
+        sent = SendData(tcp, SolidSyslogFormatter_AsString(prefix), SolidSyslogFormatter_Length(prefix)) && SendData(tcp, buffer, size);
     }
 
     return sent;

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -33,78 +33,78 @@ TEST_GROUP(SolidSyslogFormatter)
         CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
 
-    void FormatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
-    void FormatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
-    void FormatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
-    void FormatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
-    void FormatFourDigit(uint32_t value) const { SolidSyslogFormatter_FourDigit(formatter, value); }
-    void FormatSixDigit(uint32_t value) const { SolidSyslogFormatter_SixDigit(formatter, value); }
+    void formatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
+    void formatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
+    void formatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
+    void formatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
+    void formatFourDigit(uint32_t value) const { SolidSyslogFormatter_FourDigit(formatter, value); }
+    void formatSixDigit(uint32_t value) const { SolidSyslogFormatter_SixDigit(formatter, value); }
 };
 
 // clang-format on
 
 TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
 {
-    FormatCharacter('A');
+    formatCharacter('A');
 
     CHECK_FORMATTED("A");
 }
 
 TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
 {
-    FormatCharacter('A');
-    FormatCharacter('B');
+    formatCharacter('A');
+    formatCharacter('B');
 
     CHECK_FORMATTED("AB");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
 {
-    FormatBoundedString("hello", 10);
+    formatBoundedString("hello", 10);
 
     CHECK_FORMATTED("hello");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
-    FormatBoundedString("hello", 3);
+    formatBoundedString("hello", 3);
 
     CHECK_FORMATTED("hel");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
 {
-    FormatCharacter('<');
-    FormatBoundedString("hello", 10);
+    formatCharacter('<');
+    formatBoundedString("hello", 10);
 
     CHECK_FORMATTED("<hello");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
 {
-    FormatUint32(7);
+    formatUint32(7);
 
     CHECK_FORMATTED("7");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsZero)
 {
-    FormatUint32(0);
+    formatUint32(0);
 
     CHECK_FORMATTED("0");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
 {
-    FormatUint32(134);
+    formatUint32(134);
 
     CHECK_FORMATTED("134");
 }
 
 TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
 {
-    FormatCharacter('<');
-    FormatUint32(42);
+    formatCharacter('<');
+    formatUint32(42);
 
     CHECK_FORMATTED("<42");
 }
@@ -116,14 +116,14 @@ TEST(SolidSyslogFormatter, LengthStartsAtZero)
 
 TEST(SolidSyslogFormatter, LengthAdvancesWithWrites)
 {
-    FormatBoundedString("hello", 10);
+    formatBoundedString("hello", 10);
 
     CHECK_LENGTH(5);
 }
 
 TEST(SolidSyslogFormatter, AsStringReturnsFormattedContent)
 {
-    FormatBoundedString("test", 4);
+    formatBoundedString("test", 4);
 
     CHECK_FORMATTED("test");
 }
@@ -132,7 +132,7 @@ TEST(SolidSyslogFormatter, ZeroSizeCharacterIsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    FormatCharacter('A');
+    formatCharacter('A');
 
     CHECK_LENGTH(0);
 }
@@ -141,7 +141,7 @@ TEST(SolidSyslogFormatter, ZeroSizeBoundedStringIsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    FormatBoundedString("hello", 5);
+    formatBoundedString("hello", 5);
 
     CHECK_LENGTH(0);
 }
@@ -150,7 +150,7 @@ TEST(SolidSyslogFormatter, ZeroSizeUint32IsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    FormatUint32(42);
+    formatUint32(42);
 
     CHECK_LENGTH(0);
 }
@@ -159,91 +159,91 @@ TEST(SolidSyslogFormatter, OneByteBufferHoldsOnlyNullTerminator)
 {
     CREATE_FORMATTER(1);
 
-    FormatCharacter('X');
+    formatCharacter('X');
 
     CHECK_FORMATTED("");
 }
 
 TEST(SolidSyslogFormatter, TwoDigitFormatsAllDigits)
 {
-    FormatTwoDigit(59);
+    formatTwoDigit(59);
 
     CHECK_FORMATTED("59");
 }
 
 TEST(SolidSyslogFormatter, TwoDigitFormatsZero)
 {
-    FormatTwoDigit(0);
+    formatTwoDigit(0);
 
     CHECK_FORMATTED("00");
 }
 
 TEST(SolidSyslogFormatter, TwoDigitFormatsMax)
 {
-    FormatTwoDigit(99);
+    formatTwoDigit(99);
 
     CHECK_FORMATTED("99");
 }
 
 TEST(SolidSyslogFormatter, TwoDigitBeyondMaxFormatsLeastSignificant)
 {
-    FormatTwoDigit(123);
+    formatTwoDigit(123);
 
     CHECK_FORMATTED("23");
 }
 
 TEST(SolidSyslogFormatter, FourDigitFormatsAllDigits)
 {
-    FormatFourDigit(2009);
+    formatFourDigit(2009);
 
     CHECK_FORMATTED("2009");
 }
 
 TEST(SolidSyslogFormatter, FourDigitFormatsZero)
 {
-    FormatFourDigit(0);
+    formatFourDigit(0);
 
     CHECK_FORMATTED("0000");
 }
 
 TEST(SolidSyslogFormatter, FourDigitFormatsMax)
 {
-    FormatFourDigit(9999);
+    formatFourDigit(9999);
 
     CHECK_FORMATTED("9999");
 }
 
 TEST(SolidSyslogFormatter, FourDigitBeyondMaxFormatsLeastSignificant)
 {
-    FormatFourDigit(12345);
+    formatFourDigit(12345);
 
     CHECK_FORMATTED("2345");
 }
 
 TEST(SolidSyslogFormatter, SixDigitFormatsAllDigits)
 {
-    FormatSixDigit(123456);
+    formatSixDigit(123456);
 
     CHECK_FORMATTED("123456");
 }
 
 TEST(SolidSyslogFormatter, SixDigitFormatsZero)
 {
-    FormatSixDigit(0);
+    formatSixDigit(0);
 
     CHECK_FORMATTED("000000");
 }
 
 TEST(SolidSyslogFormatter, SixDigitFormatsMax)
 {
-    FormatSixDigit(999999);
+    formatSixDigit(999999);
 
     CHECK_FORMATTED("999999");
 }
 
 TEST(SolidSyslogFormatter, SixDigitBeyondMaxFormatsLeastSignificant)
 {
-    FormatSixDigit(1234567);
+    formatSixDigit(1234567);
 
     CHECK_FORMATTED("234567");
 }
@@ -252,7 +252,7 @@ TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
 {
     CREATE_FORMATTER(4);
 
-    FormatBoundedString("abcdef", 10);
+    formatBoundedString("abcdef", 10);
 
     CHECK_FORMATTED("abc");
 }
@@ -261,7 +261,7 @@ TEST(SolidSyslogFormatter, BoundedStringFillsExactCapacity)
 {
     CREATE_FORMATTER(4);
 
-    FormatBoundedString("abcdef", 6);
+    formatBoundedString("abc", 3);
 
     CHECK_FORMATTED("abc");
 }
@@ -270,8 +270,8 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
 {
     CREATE_FORMATTER(4);
 
-    FormatBoundedString("abc", 3);
-    FormatBoundedString("xyz", 3);
+    formatBoundedString("abc", 3);
+    formatBoundedString("xyz", 3);
 
     CHECK_FORMATTED("abc");
 }
@@ -280,9 +280,9 @@ TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
 {
     CREATE_FORMATTER(3);
 
-    FormatCharacter('A');
-    FormatCharacter('B');
-    FormatCharacter('C');
+    formatCharacter('A');
+    formatCharacter('B');
+    formatCharacter('C');
 
     CHECK_FORMATTED("AB");
 }
@@ -291,7 +291,7 @@ TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
 {
     CREATE_FORMATTER(3);
 
-    FormatUint32(12345);
+    formatUint32(12345);
 
     CHECK_FORMATTED("12");
 }
@@ -300,7 +300,7 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
 {
     CREATE_FORMATTER(4);
 
-    FormatUint32(123);
+    formatUint32(123);
 
     CHECK_FORMATTED("123");
 }

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -36,7 +36,9 @@ TEST_GROUP(SolidSyslogFormatter)
     void FormatCharacter(char value) { SolidSyslogFormatter_Character(formatter, value); }
     void FormatBoundedString(const char* source, size_t maxLength) { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
     void FormatUint32(uint32_t value) { SolidSyslogFormatter_Uint32(formatter, value); }
-    void FormatPaddedUint32(uint32_t value, size_t width) { SolidSyslogFormatter_PaddedUint32(formatter, value, width); }
+    void FormatTwoDigit(uint32_t value) { SolidSyslogFormatter_TwoDigit(formatter, value); }
+    void FormatFourDigit(uint32_t value) { SolidSyslogFormatter_FourDigit(formatter, value); }
+    void FormatSixDigit(uint32_t value) { SolidSyslogFormatter_SixDigit(formatter, value); }
 };
 // clang-format on
 
@@ -106,41 +108,6 @@ TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
     CHECK_FORMATTED("<42");
 }
 
-TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
-{
-    FormatPaddedUint32(5, 2);
-
-    CHECK_FORMATTED("05");
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
-{
-    FormatPaddedUint32(12, 2);
-
-    CHECK_FORMATTED("12");
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
-{
-    FormatPaddedUint32(2009, 4);
-
-    CHECK_FORMATTED("2009");
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
-{
-    FormatPaddedUint32(123, 6);
-
-    CHECK_FORMATTED("000123");
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
-{
-    FormatPaddedUint32(0, 2);
-
-    CHECK_FORMATTED("00");
-}
-
 TEST(SolidSyslogFormatter, LengthStartsAtZero)
 {
     CHECK_LENGTH(0);
@@ -194,6 +161,90 @@ TEST(SolidSyslogFormatter, OneByteBufferHoldsOnlyNullTerminator)
     FormatCharacter('X');
 
     CHECK_FORMATTED("");
+}
+
+TEST(SolidSyslogFormatter, TwoDigitFormatsAllDigits)
+{
+    FormatTwoDigit(59);
+
+    CHECK_FORMATTED("59");
+}
+
+TEST(SolidSyslogFormatter, TwoDigitFormatsZero)
+{
+    FormatTwoDigit(0);
+
+    CHECK_FORMATTED("00");
+}
+
+TEST(SolidSyslogFormatter, TwoDigitFormatsMax)
+{
+    FormatTwoDigit(99);
+
+    CHECK_FORMATTED("99");
+}
+
+TEST(SolidSyslogFormatter, TwoDigitBeyondMaxFormatsLeastSignificant)
+{
+    FormatTwoDigit(123);
+
+    CHECK_FORMATTED("23");
+}
+
+TEST(SolidSyslogFormatter, FourDigitFormatsAllDigits)
+{
+    FormatFourDigit(2009);
+
+    CHECK_FORMATTED("2009");
+}
+
+TEST(SolidSyslogFormatter, FourDigitFormatsZero)
+{
+    FormatFourDigit(0);
+
+    CHECK_FORMATTED("0000");
+}
+
+TEST(SolidSyslogFormatter, FourDigitFormatsMax)
+{
+    FormatFourDigit(9999);
+
+    CHECK_FORMATTED("9999");
+}
+
+TEST(SolidSyslogFormatter, FourDigitBeyondMaxFormatsLeastSignificant)
+{
+    FormatFourDigit(12345);
+
+    CHECK_FORMATTED("2345");
+}
+
+TEST(SolidSyslogFormatter, SixDigitFormatsAllDigits)
+{
+    FormatSixDigit(123456);
+
+    CHECK_FORMATTED("123456");
+}
+
+TEST(SolidSyslogFormatter, SixDigitFormatsZero)
+{
+    FormatSixDigit(0);
+
+    CHECK_FORMATTED("000000");
+}
+
+TEST(SolidSyslogFormatter, SixDigitFormatsMax)
+{
+    FormatSixDigit(999999);
+
+    CHECK_FORMATTED("999999");
+}
+
+TEST(SolidSyslogFormatter, SixDigitBeyondMaxFormatsLeastSignificant)
+{
+    FormatSixDigit(1234567);
+
+    CHECK_FORMATTED("234567");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
@@ -253,20 +304,3 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
     CHECK_FORMATTED("123");
 }
 
-TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
-{
-    CREATE_FORMATTER(3);
-
-    FormatPaddedUint32(5, 4);
-
-    CHECK_FORMATTED("00");
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
-{
-    CREATE_FORMATTER(5);
-
-    FormatPaddedUint32(9, 4);
-
-    CHECK_FORMATTED("0009");
-}

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -1,6 +1,16 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogFormatter.h"
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- test helper macros for readability; CppUTest requires macros for correct failure location
+
+#define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
+
+#define CHECK_FORMATTED(expected) STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter))
+
+#define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
 enum
 {
     TEST_BUFFER_SIZE = 64
@@ -15,7 +25,7 @@ TEST_GROUP(SolidSyslogFormatter)
     void setup() override
     {
         // cppcheck-suppress unreadVariable -- formatter is used across TEST() bodies via CppUTest macro
-        formatter = SolidSyslogFormatter_Create(storage, TEST_BUFFER_SIZE);
+        CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
 };
 
@@ -23,8 +33,8 @@ TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
 {
     SolidSyslogFormatter_Character(formatter, 'A');
 
-    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("A", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(1);
+    CHECK_FORMATTED("A");
 }
 
 TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
@@ -32,23 +42,23 @@ TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
     SolidSyslogFormatter_Character(formatter, 'A');
     SolidSyslogFormatter_Character(formatter, 'B');
 
-    STRCMP_EQUAL("AB", SolidSyslogFormatter_AsString(formatter));
+    CHECK_FORMATTED("AB");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
 {
     SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
-    LONGS_EQUAL(5, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("hello", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(5);
+    CHECK_FORMATTED("hello");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
     SolidSyslogFormatter_BoundedString(formatter, "hello", 3);
 
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("hel", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("hel");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
@@ -56,30 +66,30 @@ TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
     SolidSyslogFormatter_Character(formatter, '<');
     SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
-    STRCMP_EQUAL("<hello", SolidSyslogFormatter_AsString(formatter));
+    CHECK_FORMATTED("<hello");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
 {
     SolidSyslogFormatter_Uint32(formatter, 7);
 
-    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("7", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(1);
+    CHECK_FORMATTED("7");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsZero)
 {
     SolidSyslogFormatter_Uint32(formatter, 0);
 
-    STRCMP_EQUAL("0", SolidSyslogFormatter_AsString(formatter));
+    CHECK_FORMATTED("0");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
 {
     SolidSyslogFormatter_Uint32(formatter, 134);
 
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("134", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("134");
 }
 
 TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
@@ -87,193 +97,184 @@ TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
     SolidSyslogFormatter_Character(formatter, '<');
     SolidSyslogFormatter_Uint32(formatter, 42);
 
-    STRCMP_EQUAL("<42", SolidSyslogFormatter_AsString(formatter));
+    CHECK_FORMATTED("<42");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
 {
     SolidSyslogFormatter_PaddedUint32(formatter, 5, 2);
 
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("05", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("05");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
 {
     SolidSyslogFormatter_PaddedUint32(formatter, 12, 2);
 
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("12", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("12");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
 {
     SolidSyslogFormatter_PaddedUint32(formatter, 2009, 4);
 
-    LONGS_EQUAL(4, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("2009", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(4);
+    CHECK_FORMATTED("2009");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
 {
     SolidSyslogFormatter_PaddedUint32(formatter, 123, 6);
 
-    LONGS_EQUAL(6, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("000123", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(6);
+    CHECK_FORMATTED("000123");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
 {
     SolidSyslogFormatter_PaddedUint32(formatter, 0, 2);
 
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("00", SolidSyslogFormatter_AsString(formatter));
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("00");
 }
 
-TEST(SolidSyslogFormatter, LengthReturnsNumberOfCharactersWritten)
+TEST(SolidSyslogFormatter, LengthStartsAtZero)
 {
-    LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
+    CHECK_LENGTH(0);
+}
 
+TEST(SolidSyslogFormatter, LengthAdvancesWithWrites)
+{
     SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
-    LONGS_EQUAL(5, SolidSyslogFormatter_Length(formatter));
+    CHECK_LENGTH(5);
 }
 
-TEST(SolidSyslogFormatter, DataReturnsFormattedString)
+TEST(SolidSyslogFormatter, AsStringReturnsFormattedContent)
 {
     SolidSyslogFormatter_BoundedString(formatter, "test", 4);
 
-    STRCMP_EQUAL("test", SolidSyslogFormatter_AsString(formatter));
+    CHECK_FORMATTED("test");
 }
 
-TEST(SolidSyslogFormatter, ZeroSizeBufferDoesNotCrash)
+TEST(SolidSyslogFormatter, ZeroSizeCharacterIsNoOp)
 {
-    SolidSyslogFormatterStorage  zeroStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
-    struct SolidSyslogFormatter* zeroFormatter = SolidSyslogFormatter_Create(zeroStorage, 0);
+    CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_Character(zeroFormatter, 'A');
+    SolidSyslogFormatter_Character(formatter, 'A');
 
-    LONGS_EQUAL(0, SolidSyslogFormatter_Length(zeroFormatter));
-}
-
-TEST(SolidSyslogFormatter, WritesUpToExactCapacity)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
-
-    SolidSyslogFormatter_BoundedString(small, "abcdef", 6);
-
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(3)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 3);
-
-    SolidSyslogFormatter_Character(small, 'A');
-    SolidSyslogFormatter_Character(small, 'B');
-    SolidSyslogFormatter_Character(small, 'C');
-
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("AB", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, CharacterFillsExactlyOneByteBuffer)
-{
-    SolidSyslogFormatterStorage  tinyStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(1)];
-    struct SolidSyslogFormatter* tiny = SolidSyslogFormatter_Create(tinyStorage, 1);
-
-    SolidSyslogFormatter_Character(tiny, 'X');
-
-    LONGS_EQUAL(0, SolidSyslogFormatter_Length(tiny));
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(tiny));
-}
-
-TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
-
-    SolidSyslogFormatter_BoundedString(small, "abcdef", 10);
-
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
-
-    SolidSyslogFormatter_BoundedString(small, "abc", 3);
-    SolidSyslogFormatter_BoundedString(small, "xyz", 3);
-
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(3)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 3);
-
-    SolidSyslogFormatter_Uint32(small, 12345);
-
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("12", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, Uint32FitsExactly)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
-
-    SolidSyslogFormatter_Uint32(small, 123);
-
-    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("123", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(3)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 3);
-
-    SolidSyslogFormatter_PaddedUint32(small, 5, 4);
-
-    LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("00", SolidSyslogFormatter_AsString(small));
-}
-
-TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
-{
-    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(5)];
-    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 5);
-
-    SolidSyslogFormatter_PaddedUint32(small, 9, 4);
-
-    LONGS_EQUAL(4, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("0009", SolidSyslogFormatter_AsString(small));
+    CHECK_LENGTH(0);
 }
 
 TEST(SolidSyslogFormatter, ZeroSizeBoundedStringIsNoOp)
 {
-    SolidSyslogFormatterStorage  zeroStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
-    struct SolidSyslogFormatter* zero = SolidSyslogFormatter_Create(zeroStorage, 0);
+    CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_BoundedString(zero, "hello", 5);
+    SolidSyslogFormatter_BoundedString(formatter, "hello", 5);
 
-    LONGS_EQUAL(0, SolidSyslogFormatter_Length(zero));
+    CHECK_LENGTH(0);
 }
 
 TEST(SolidSyslogFormatter, ZeroSizeUint32IsNoOp)
 {
-    SolidSyslogFormatterStorage  zeroStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
-    struct SolidSyslogFormatter* zero = SolidSyslogFormatter_Create(zeroStorage, 0);
+    CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_Uint32(zero, 42);
+    SolidSyslogFormatter_Uint32(formatter, 42);
 
-    LONGS_EQUAL(0, SolidSyslogFormatter_Length(zero));
+    CHECK_LENGTH(0);
+}
+
+TEST(SolidSyslogFormatter, OneByteBufferHoldsOnlyNullTerminator)
+{
+    CREATE_FORMATTER(1);
+
+    SolidSyslogFormatter_Character(formatter, 'X');
+
+    CHECK_LENGTH(0);
+    CHECK_FORMATTED("");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
+{
+    CREATE_FORMATTER(4);
+
+    SolidSyslogFormatter_BoundedString(formatter, "abcdef", 10);
+
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("abc");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringFillsExactCapacity)
+{
+    CREATE_FORMATTER(4);
+
+    SolidSyslogFormatter_BoundedString(formatter, "abcdef", 6);
+
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("abc");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
+{
+    CREATE_FORMATTER(4);
+
+    SolidSyslogFormatter_BoundedString(formatter, "abc", 3);
+    SolidSyslogFormatter_BoundedString(formatter, "xyz", 3);
+
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("abc");
+}
+
+TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
+{
+    CREATE_FORMATTER(3);
+
+    SolidSyslogFormatter_Character(formatter, 'A');
+    SolidSyslogFormatter_Character(formatter, 'B');
+    SolidSyslogFormatter_Character(formatter, 'C');
+
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("AB");
+}
+
+TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
+{
+    CREATE_FORMATTER(3);
+
+    SolidSyslogFormatter_Uint32(formatter, 12345);
+
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("12");
+}
+
+TEST(SolidSyslogFormatter, Uint32FitsExactly)
+{
+    CREATE_FORMATTER(4);
+
+    SolidSyslogFormatter_Uint32(formatter, 123);
+
+    CHECK_LENGTH(3);
+    CHECK_FORMATTED("123");
+}
+
+TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
+{
+    CREATE_FORMATTER(3);
+
+    SolidSyslogFormatter_PaddedUint32(formatter, 5, 4);
+
+    CHECK_LENGTH(2);
+    CHECK_FORMATTED("00");
+}
+
+TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
+{
+    CREATE_FORMATTER(5);
+
+    SolidSyslogFormatter_PaddedUint32(formatter, 9, 4);
+
+    CHECK_LENGTH(4);
+    CHECK_FORMATTED("0009");
 }

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -21,9 +21,9 @@ TEST_GROUP(SolidSyslogFormatter)
 
 TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
 {
-    size_t written = SolidSyslogFormatter_Character(formatter, 'A');
+    SolidSyslogFormatter_Character(formatter, 'A');
 
-    LONGS_EQUAL(1, written);
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("A", SolidSyslogFormatter_Data(formatter));
 }
 
@@ -37,17 +37,17 @@ TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
 {
-    size_t written = SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
+    SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
-    LONGS_EQUAL(5, written);
+    LONGS_EQUAL(5, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("hello", SolidSyslogFormatter_Data(formatter));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
-    size_t written = SolidSyslogFormatter_BoundedString(formatter, "hello", 3);
+    SolidSyslogFormatter_BoundedString(formatter, "hello", 3);
 
-    LONGS_EQUAL(3, written);
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("hel", SolidSyslogFormatter_Data(formatter));
 }
 
@@ -61,9 +61,9 @@ TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
 
 TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
 {
-    size_t written = SolidSyslogFormatter_Uint32(formatter, 7);
+    SolidSyslogFormatter_Uint32(formatter, 7);
 
-    LONGS_EQUAL(1, written);
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("7", SolidSyslogFormatter_Data(formatter));
 }
 
@@ -76,9 +76,9 @@ TEST(SolidSyslogFormatter, Uint32FormatsZero)
 
 TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
 {
-    size_t written = SolidSyslogFormatter_Uint32(formatter, 134);
+    SolidSyslogFormatter_Uint32(formatter, 134);
 
-    LONGS_EQUAL(3, written);
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("134", SolidSyslogFormatter_Data(formatter));
 }
 
@@ -92,51 +92,42 @@ TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
 {
-    size_t written = SolidSyslogFormatter_PaddedUint32(formatter, 5, 2);
+    SolidSyslogFormatter_PaddedUint32(formatter, 5, 2);
 
-    LONGS_EQUAL(2, written);
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("05", SolidSyslogFormatter_Data(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
 {
-    size_t written = SolidSyslogFormatter_PaddedUint32(formatter, 12, 2);
+    SolidSyslogFormatter_PaddedUint32(formatter, 12, 2);
 
-    LONGS_EQUAL(2, written);
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("12", SolidSyslogFormatter_Data(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
 {
-    size_t written = SolidSyslogFormatter_PaddedUint32(formatter, 2009, 4);
+    SolidSyslogFormatter_PaddedUint32(formatter, 2009, 4);
 
-    LONGS_EQUAL(4, written);
+    LONGS_EQUAL(4, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("2009", SolidSyslogFormatter_Data(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
 {
-    size_t written = SolidSyslogFormatter_PaddedUint32(formatter, 123, 6);
+    SolidSyslogFormatter_PaddedUint32(formatter, 123, 6);
 
-    LONGS_EQUAL(6, written);
+    LONGS_EQUAL(6, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("000123", SolidSyslogFormatter_Data(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
 {
-    size_t written = SolidSyslogFormatter_PaddedUint32(formatter, 0, 2);
+    SolidSyslogFormatter_PaddedUint32(formatter, 0, 2);
 
-    LONGS_EQUAL(2, written);
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
     STRCMP_EQUAL("00", SolidSyslogFormatter_Data(formatter));
-}
-
-TEST(SolidSyslogFormatter, RemainingReturnsSpaceLeft)
-{
-    LONGS_EQUAL(TEST_BUFFER_SIZE, SolidSyslogFormatter_Remaining(formatter));
-
-    SolidSyslogFormatter_Character(formatter, 'A');
-
-    LONGS_EQUAL(TEST_BUFFER_SIZE - 1, SolidSyslogFormatter_Remaining(formatter));
 }
 
 TEST(SolidSyslogFormatter, LengthReturnsNumberOfCharactersWritten)
@@ -187,4 +178,102 @@ TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
     STRCMP_EQUAL("AB", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, CharacterFillsExactlyOneByteBuffer)
+{
+    SolidSyslogFormatterStorage  tinyStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(1)];
+    struct SolidSyslogFormatter* tiny = SolidSyslogFormatter_Create(tinyStorage, 1);
+
+    SolidSyslogFormatter_Character(tiny, 'X');
+
+    LONGS_EQUAL(0, SolidSyslogFormatter_Length(tiny));
+    STRCMP_EQUAL("", SolidSyslogFormatter_Data(tiny));
+}
+
+TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
+
+    SolidSyslogFormatter_BoundedString(small, "abcdef", 10);
+
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("abc", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
+
+    SolidSyslogFormatter_BoundedString(small, "abc", 3);
+    SolidSyslogFormatter_BoundedString(small, "xyz", 3);
+
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("abc", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(3)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 3);
+
+    SolidSyslogFormatter_Uint32(small, 12345);
+
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("12", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, Uint32FitsExactly)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 4);
+
+    SolidSyslogFormatter_Uint32(small, 123);
+
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("123", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(3)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 3);
+
+    SolidSyslogFormatter_PaddedUint32(small, 5, 4);
+
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("00", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
+{
+    SolidSyslogFormatterStorage  smallStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(5)];
+    struct SolidSyslogFormatter* small = SolidSyslogFormatter_Create(smallStorage, 5);
+
+    SolidSyslogFormatter_PaddedUint32(small, 9, 4);
+
+    LONGS_EQUAL(4, SolidSyslogFormatter_Length(small));
+    STRCMP_EQUAL("0009", SolidSyslogFormatter_Data(small));
+}
+
+TEST(SolidSyslogFormatter, ZeroSizeBoundedStringIsNoOp)
+{
+    SolidSyslogFormatterStorage  zeroStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
+    struct SolidSyslogFormatter* zero = SolidSyslogFormatter_Create(zeroStorage, 0);
+
+    SolidSyslogFormatter_BoundedString(zero, "hello", 5);
+
+    LONGS_EQUAL(0, SolidSyslogFormatter_Length(zero));
+}
+
+TEST(SolidSyslogFormatter, ZeroSizeUint32IsNoOp)
+{
+    SolidSyslogFormatterStorage  zeroStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
+    struct SolidSyslogFormatter* zero = SolidSyslogFormatter_Create(zeroStorage, 0);
+
+    SolidSyslogFormatter_Uint32(zero, 42);
+
+    LONGS_EQUAL(0, SolidSyslogFormatter_Length(zero));
 }

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -7,8 +7,8 @@
 
 #define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
 
-#define CHECK_FORMATTED(expected)                                              \
-    STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter));            \
+#define CHECK_FORMATTED(expected)                                     \
+    STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter)); \
     LONGS_EQUAL(strlen(expected), SolidSyslogFormatter_Length(formatter))
 
 #define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
@@ -33,13 +33,14 @@ TEST_GROUP(SolidSyslogFormatter)
         CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
 
-    void FormatCharacter(char value) { SolidSyslogFormatter_Character(formatter, value); }
-    void FormatBoundedString(const char* source, size_t maxLength) { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
-    void FormatUint32(uint32_t value) { SolidSyslogFormatter_Uint32(formatter, value); }
-    void FormatTwoDigit(uint32_t value) { SolidSyslogFormatter_TwoDigit(formatter, value); }
-    void FormatFourDigit(uint32_t value) { SolidSyslogFormatter_FourDigit(formatter, value); }
-    void FormatSixDigit(uint32_t value) { SolidSyslogFormatter_SixDigit(formatter, value); }
+    void FormatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
+    void FormatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
+    void FormatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
+    void FormatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
+    void FormatFourDigit(uint32_t value) const { SolidSyslogFormatter_FourDigit(formatter, value); }
+    void FormatSixDigit(uint32_t value) const { SolidSyslogFormatter_SixDigit(formatter, value); }
 };
+
 // clang-format on
 
 TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
@@ -303,4 +304,3 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
 
     CHECK_FORMATTED("123");
 }
-

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -24,7 +24,7 @@ TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
     SolidSyslogFormatter_Character(formatter, 'A');
 
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("A", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("A", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
@@ -32,7 +32,7 @@ TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
     SolidSyslogFormatter_Character(formatter, 'A');
     SolidSyslogFormatter_Character(formatter, 'B');
 
-    STRCMP_EQUAL("AB", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("AB", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
@@ -40,7 +40,7 @@ TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
     SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
     LONGS_EQUAL(5, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("hello", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("hello", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
@@ -48,7 +48,7 @@ TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
     SolidSyslogFormatter_BoundedString(formatter, "hello", 3);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("hel", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("hel", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
@@ -56,7 +56,7 @@ TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
     SolidSyslogFormatter_Character(formatter, '<');
     SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
 
-    STRCMP_EQUAL("<hello", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("<hello", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
@@ -64,14 +64,14 @@ TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
     SolidSyslogFormatter_Uint32(formatter, 7);
 
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("7", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("7", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsZero)
 {
     SolidSyslogFormatter_Uint32(formatter, 0);
 
-    STRCMP_EQUAL("0", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("0", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
@@ -79,7 +79,7 @@ TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
     SolidSyslogFormatter_Uint32(formatter, 134);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("134", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("134", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
@@ -87,7 +87,7 @@ TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
     SolidSyslogFormatter_Character(formatter, '<');
     SolidSyslogFormatter_Uint32(formatter, 42);
 
-    STRCMP_EQUAL("<42", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("<42", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
@@ -95,7 +95,7 @@ TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
     SolidSyslogFormatter_PaddedUint32(formatter, 5, 2);
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("05", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("05", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
@@ -103,7 +103,7 @@ TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
     SolidSyslogFormatter_PaddedUint32(formatter, 12, 2);
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("12", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("12", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
@@ -111,7 +111,7 @@ TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
     SolidSyslogFormatter_PaddedUint32(formatter, 2009, 4);
 
     LONGS_EQUAL(4, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("2009", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("2009", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
@@ -119,7 +119,7 @@ TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
     SolidSyslogFormatter_PaddedUint32(formatter, 123, 6);
 
     LONGS_EQUAL(6, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("000123", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("000123", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
@@ -127,7 +127,7 @@ TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
     SolidSyslogFormatter_PaddedUint32(formatter, 0, 2);
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-    STRCMP_EQUAL("00", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("00", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, LengthReturnsNumberOfCharactersWritten)
@@ -143,7 +143,7 @@ TEST(SolidSyslogFormatter, DataReturnsFormattedString)
 {
     SolidSyslogFormatter_BoundedString(formatter, "test", 4);
 
-    STRCMP_EQUAL("test", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("test", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogFormatter, ZeroSizeBufferDoesNotCrash)
@@ -164,7 +164,7 @@ TEST(SolidSyslogFormatter, WritesUpToExactCapacity)
     SolidSyslogFormatter_BoundedString(small, "abcdef", 6);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
@@ -177,7 +177,7 @@ TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
     SolidSyslogFormatter_Character(small, 'C');
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("AB", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("AB", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, CharacterFillsExactlyOneByteBuffer)
@@ -188,7 +188,7 @@ TEST(SolidSyslogFormatter, CharacterFillsExactlyOneByteBuffer)
     SolidSyslogFormatter_Character(tiny, 'X');
 
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(tiny));
-    STRCMP_EQUAL("", SolidSyslogFormatter_Data(tiny));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(tiny));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
@@ -199,7 +199,7 @@ TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
     SolidSyslogFormatter_BoundedString(small, "abcdef", 10);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
@@ -211,7 +211,7 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
     SolidSyslogFormatter_BoundedString(small, "xyz", 3);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("abc", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("abc", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
@@ -222,7 +222,7 @@ TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
     SolidSyslogFormatter_Uint32(small, 12345);
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("12", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("12", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, Uint32FitsExactly)
@@ -233,7 +233,7 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
     SolidSyslogFormatter_Uint32(small, 123);
 
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("123", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("123", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
@@ -244,7 +244,7 @@ TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
     SolidSyslogFormatter_PaddedUint32(small, 5, 4);
 
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("00", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("00", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
@@ -255,7 +255,7 @@ TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
     SolidSyslogFormatter_PaddedUint32(small, 9, 4);
 
     LONGS_EQUAL(4, SolidSyslogFormatter_Length(small));
-    STRCMP_EQUAL("0009", SolidSyslogFormatter_Data(small));
+    STRCMP_EQUAL("0009", SolidSyslogFormatter_AsString(small));
 }
 
 TEST(SolidSyslogFormatter, ZeroSizeBoundedStringIsNoOp)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -1,11 +1,15 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogFormatter.h"
 
+#include <cstring>
+
 // NOLINTBEGIN(cppcoreguidelines-macro-usage) -- test helper macros for readability; CppUTest requires macros for correct failure location
 
 #define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
 
-#define CHECK_FORMATTED(expected) STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter))
+#define CHECK_FORMATTED(expected)                                              \
+    STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter));            \
+    LONGS_EQUAL(strlen(expected), SolidSyslogFormatter_Length(formatter))
 
 #define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
 
@@ -16,6 +20,7 @@ enum
     TEST_BUFFER_SIZE = 64
 };
 
+// clang-format off
 TEST_GROUP(SolidSyslogFormatter)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
@@ -27,116 +32,112 @@ TEST_GROUP(SolidSyslogFormatter)
         // cppcheck-suppress unreadVariable -- formatter is used across TEST() bodies via CppUTest macro
         CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
+
+    void FormatCharacter(char value) { SolidSyslogFormatter_Character(formatter, value); }
+    void FormatBoundedString(const char* source, size_t maxLength) { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
+    void FormatUint32(uint32_t value) { SolidSyslogFormatter_Uint32(formatter, value); }
+    void FormatPaddedUint32(uint32_t value, size_t width) { SolidSyslogFormatter_PaddedUint32(formatter, value, width); }
 };
+// clang-format on
 
 TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
 {
-    SolidSyslogFormatter_Character(formatter, 'A');
+    FormatCharacter('A');
 
-    CHECK_LENGTH(1);
     CHECK_FORMATTED("A");
 }
 
 TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
 {
-    SolidSyslogFormatter_Character(formatter, 'A');
-    SolidSyslogFormatter_Character(formatter, 'B');
+    FormatCharacter('A');
+    FormatCharacter('B');
 
     CHECK_FORMATTED("AB");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
 {
-    SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
+    FormatBoundedString("hello", 10);
 
-    CHECK_LENGTH(5);
     CHECK_FORMATTED("hello");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
-    SolidSyslogFormatter_BoundedString(formatter, "hello", 3);
+    FormatBoundedString("hello", 3);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("hel");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
 {
-    SolidSyslogFormatter_Character(formatter, '<');
-    SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
+    FormatCharacter('<');
+    FormatBoundedString("hello", 10);
 
     CHECK_FORMATTED("<hello");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsSingleDigit)
 {
-    SolidSyslogFormatter_Uint32(formatter, 7);
+    FormatUint32(7);
 
-    CHECK_LENGTH(1);
     CHECK_FORMATTED("7");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsZero)
 {
-    SolidSyslogFormatter_Uint32(formatter, 0);
+    FormatUint32(0);
 
     CHECK_FORMATTED("0");
 }
 
 TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
 {
-    SolidSyslogFormatter_Uint32(formatter, 134);
+    FormatUint32(134);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("134");
 }
 
 TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
 {
-    SolidSyslogFormatter_Character(formatter, '<');
-    SolidSyslogFormatter_Uint32(formatter, 42);
+    FormatCharacter('<');
+    FormatUint32(42);
 
     CHECK_FORMATTED("<42");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsSingleDigitToWidth2)
 {
-    SolidSyslogFormatter_PaddedUint32(formatter, 5, 2);
+    FormatPaddedUint32(5, 2);
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("05");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32NoPaddingWhenValueFillsWidth)
 {
-    SolidSyslogFormatter_PaddedUint32(formatter, 12, 2);
+    FormatPaddedUint32(12, 2);
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("12");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsYearToWidth4)
 {
-    SolidSyslogFormatter_PaddedUint32(formatter, 2009, 4);
+    FormatPaddedUint32(2009, 4);
 
-    CHECK_LENGTH(4);
     CHECK_FORMATTED("2009");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32PadsMicrosecondsToWidth6)
 {
-    SolidSyslogFormatter_PaddedUint32(formatter, 123, 6);
+    FormatPaddedUint32(123, 6);
 
-    CHECK_LENGTH(6);
     CHECK_FORMATTED("000123");
 }
 
 TEST(SolidSyslogFormatter, PaddedUint32ZeroPadsToFullWidth)
 {
-    SolidSyslogFormatter_PaddedUint32(formatter, 0, 2);
+    FormatPaddedUint32(0, 2);
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("00");
 }
 
@@ -147,14 +148,14 @@ TEST(SolidSyslogFormatter, LengthStartsAtZero)
 
 TEST(SolidSyslogFormatter, LengthAdvancesWithWrites)
 {
-    SolidSyslogFormatter_BoundedString(formatter, "hello", 10);
+    FormatBoundedString("hello", 10);
 
     CHECK_LENGTH(5);
 }
 
 TEST(SolidSyslogFormatter, AsStringReturnsFormattedContent)
 {
-    SolidSyslogFormatter_BoundedString(formatter, "test", 4);
+    FormatBoundedString("test", 4);
 
     CHECK_FORMATTED("test");
 }
@@ -163,7 +164,7 @@ TEST(SolidSyslogFormatter, ZeroSizeCharacterIsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_Character(formatter, 'A');
+    FormatCharacter('A');
 
     CHECK_LENGTH(0);
 }
@@ -172,7 +173,7 @@ TEST(SolidSyslogFormatter, ZeroSizeBoundedStringIsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_BoundedString(formatter, "hello", 5);
+    FormatBoundedString("hello", 5);
 
     CHECK_LENGTH(0);
 }
@@ -181,7 +182,7 @@ TEST(SolidSyslogFormatter, ZeroSizeUint32IsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    SolidSyslogFormatter_Uint32(formatter, 42);
+    FormatUint32(42);
 
     CHECK_LENGTH(0);
 }
@@ -190,9 +191,8 @@ TEST(SolidSyslogFormatter, OneByteBufferHoldsOnlyNullTerminator)
 {
     CREATE_FORMATTER(1);
 
-    SolidSyslogFormatter_Character(formatter, 'X');
+    FormatCharacter('X');
 
-    CHECK_LENGTH(0);
     CHECK_FORMATTED("");
 }
 
@@ -200,9 +200,8 @@ TEST(SolidSyslogFormatter, BoundedStringStopsAtBufferCapacity)
 {
     CREATE_FORMATTER(4);
 
-    SolidSyslogFormatter_BoundedString(formatter, "abcdef", 10);
+    FormatBoundedString("abcdef", 10);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("abc");
 }
 
@@ -210,9 +209,8 @@ TEST(SolidSyslogFormatter, BoundedStringFillsExactCapacity)
 {
     CREATE_FORMATTER(4);
 
-    SolidSyslogFormatter_BoundedString(formatter, "abcdef", 6);
+    FormatBoundedString("abcdef", 6);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("abc");
 }
 
@@ -220,10 +218,9 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
 {
     CREATE_FORMATTER(4);
 
-    SolidSyslogFormatter_BoundedString(formatter, "abc", 3);
-    SolidSyslogFormatter_BoundedString(formatter, "xyz", 3);
+    FormatBoundedString("abc", 3);
+    FormatBoundedString("xyz", 3);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("abc");
 }
 
@@ -231,11 +228,10 @@ TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
 {
     CREATE_FORMATTER(3);
 
-    SolidSyslogFormatter_Character(formatter, 'A');
-    SolidSyslogFormatter_Character(formatter, 'B');
-    SolidSyslogFormatter_Character(formatter, 'C');
+    FormatCharacter('A');
+    FormatCharacter('B');
+    FormatCharacter('C');
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("AB");
 }
 
@@ -243,9 +239,8 @@ TEST(SolidSyslogFormatter, Uint32TruncatedWhenBufferTooSmall)
 {
     CREATE_FORMATTER(3);
 
-    SolidSyslogFormatter_Uint32(formatter, 12345);
+    FormatUint32(12345);
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("12");
 }
 
@@ -253,9 +248,8 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
 {
     CREATE_FORMATTER(4);
 
-    SolidSyslogFormatter_Uint32(formatter, 123);
+    FormatUint32(123);
 
-    CHECK_LENGTH(3);
     CHECK_FORMATTED("123");
 }
 
@@ -263,9 +257,8 @@ TEST(SolidSyslogFormatter, PaddedUint32TruncatedWhenBufferTooSmall)
 {
     CREATE_FORMATTER(3);
 
-    SolidSyslogFormatter_PaddedUint32(formatter, 5, 4);
+    FormatPaddedUint32(5, 4);
 
-    CHECK_LENGTH(2);
     CHECK_FORMATTED("00");
 }
 
@@ -273,8 +266,7 @@ TEST(SolidSyslogFormatter, PaddedUint32FitsExactly)
 {
     CREATE_FORMATTER(5);
 
-    SolidSyslogFormatter_PaddedUint32(formatter, 9, 4);
+    FormatPaddedUint32(9, 4);
 
-    CHECK_LENGTH(4);
     CHECK_FORMATTED("0009");
 }

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -56,7 +56,7 @@ TEST(SolidSyslogMetaSd, CreateReturnsNonNull)
 TEST(SolidSyslogMetaSd, FirstFormatProducesSequenceId1)
 {
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogMetaSd, SecondFormatProducesSequenceId2)
@@ -64,7 +64,7 @@ TEST(SolidSyslogMetaSd, SecondFormatProducesSequenceId2)
     format();
     resetFormatter();
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogMetaSd, ThirdFormatProducesSequenceId3)
@@ -73,7 +73,7 @@ TEST(SolidSyslogMetaSd, ThirdFormatProducesSequenceId3)
     format();
     resetFormatter();
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"3\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"3\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogMetaSd, FormatAdvancesFormatterLength)
@@ -81,7 +81,7 @@ TEST(SolidSyslogMetaSd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_Data(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogMetaSd, DestroyDoesNotCrash)

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -51,19 +51,19 @@ TEST(SolidSyslogOriginSd, CreateReturnsNonNull)
 TEST(SolidSyslogOriginSd, FormatContainsSoftwareName)
 {
     format();
-    CHECK(strstr(SolidSyslogFormatter_Data(formatter), "software=\"TestSoftware\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "software=\"TestSoftware\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, FormatContainsSwVersion)
 {
     format();
-    CHECK(strstr(SolidSyslogFormatter_Data(formatter), "swVersion=\"9.8.7\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "swVersion=\"9.8.7\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, FormatProducesCompleteOriginSd)
 {
     format();
-    STRCMP_EQUAL("[origin software=\"TestSoftware\" swVersion=\"9.8.7\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"TestSoftware\" swVersion=\"9.8.7\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, FormatAdvancesFormatterLength)
@@ -71,7 +71,7 @@ TEST(SolidSyslogOriginSd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_Data(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogOriginSd, DifferentValuesProduceDifferentOutput)
@@ -81,7 +81,7 @@ TEST(SolidSyslogOriginSd, DifferentValuesProduceDifferentOutput)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"OtherSoft\" swVersion=\"1.2.3\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"OtherSoft\" swVersion=\"1.2.3\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, SoftwareAtMaxLength)
@@ -91,7 +91,7 @@ TEST(SolidSyslogOriginSd, SoftwareAtMaxLength)
 
     resetFormatter();
     format();
-    CHECK(strstr(SolidSyslogFormatter_Data(formatter), "software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, SoftwareTruncatedBeyondMaxLength)
@@ -101,7 +101,7 @@ TEST(SolidSyslogOriginSd, SoftwareTruncatedBeyondMaxLength)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\" swVersion=\"1.0\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, SwVersionAtMaxLength)
@@ -111,7 +111,7 @@ TEST(SolidSyslogOriginSd, SwVersionAtMaxLength)
 
     resetFormatter();
     format();
-    CHECK(strstr(SolidSyslogFormatter_Data(formatter), "swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, SwVersionTruncatedBeyondMaxLength)
@@ -121,7 +121,7 @@ TEST(SolidSyslogOriginSd, SwVersionTruncatedBeyondMaxLength)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, EmptySoftwareString)
@@ -131,7 +131,7 @@ TEST(SolidSyslogOriginSd, EmptySoftwareString)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"\" swVersion=\"1.0\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, EmptySwVersionString)
@@ -141,7 +141,7 @@ TEST(SolidSyslogOriginSd, EmptySwVersionString)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogOriginSd, NullSoftwareReturnsNull)

--- a/Tests/SolidSyslogTimeQualitySdTest.cpp
+++ b/Tests/SolidSyslogTimeQualitySdTest.cpp
@@ -59,7 +59,7 @@ TEST(SolidSyslogTimeQualitySd, CreateReturnsNonNull)
 TEST(SolidSyslogTimeQualitySd, FormatProducesTzKnownAndIsSynced)
 {
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatWithFalseValues)
@@ -67,46 +67,46 @@ TEST(SolidSyslogTimeQualitySd, FormatWithFalseValues)
     stubTimeQuality.tzKnown  = false;
     stubTimeQuality.isSynced = false;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"0\" isSynced=\"0\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"0\" isSynced=\"0\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatIncludesSyncAccuracyWhenNonZero)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 50;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"50\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"50\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, SyncAccuracyOfOneIsSmallestNonOmitValue)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 1;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"1\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"1\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, SyncAccuracyAtMaxUint32)
 {
     stubTimeQuality.syncAccuracyMicroseconds = UINT32_MAX;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"4294967295\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"4294967295\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, OmitSyncAccuracyUsesDefinedConstant)
 {
     stubTimeQuality.syncAccuracyMicroseconds = SOLIDSYSLOG_SYNC_ACCURACY_OMIT;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, CallbackIsInvokedOnEachFormat)
 {
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
 
     stubTimeQuality.isSynced = false;
     resetFormatter();
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"0\"]", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"0\"]", SolidSyslogFormatter_AsString(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatAdvancesFormatterLength)
@@ -114,14 +114,14 @@ TEST(SolidSyslogTimeQualitySd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_Data(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatAdvancesLengthWithSyncAccuracy)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 50;
     format();
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_Data(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, DestroyDoesNotCrash)

--- a/Tests/StringFakeTest.cpp
+++ b/Tests/StringFakeTest.cpp
@@ -27,7 +27,7 @@ TEST_GROUP(StringFake)
 TEST(StringFake, ReturnsEmptyStringAfterReset)
 {
     StringFake_GetHostname(formatter);
-    STRCMP_EQUAL("", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
 }
 
@@ -35,6 +35,6 @@ TEST(StringFake, ReturnsConfiguredHostname)
 {
     StringFake_SetHostname("MyHost");
     StringFake_GetHostname(formatter);
-    STRCMP_EQUAL("MyHost", SolidSyslogFormatter_Data(formatter));
+    STRCMP_EQUAL("MyHost", SolidSyslogFormatter_AsString(formatter));
     LONGS_EQUAL(6, SolidSyslogFormatter_Length(formatter));
 }


### PR DESCRIPTION
## Purpose

Story S12.3 (closes #87). TDD-driven buffer overflow protection at the Formatter's
single write point (WriteChar). Every buffer write is now bounded — writes past capacity
are silently stopped and the null terminator is always maintained.

## Change Description

**Overflow protection** — `HasCapacity` guard in `WriteChar` checks both `size > 0` and
`position < size - 1` before every write. This is the single enforcement point for all
Formatter output.

**Write functions return void** — `Character`, `BoundedString`, `Uint32`, `PaddedUint32`
no longer return sizes. No caller used the return values; callers that need to know if
content was written use the `Length` before/after pattern.

**`Remaining` removed from public API** — with bounds checking in WriteChar, callers no
longer need to pre-check capacity. `FormatMsg` uses `SOLIDSYSLOG_MAX_MESSAGE_SIZE` as the
maxLength for the message body, relying on WriteChar to stop at the buffer boundary.

**FileStore pathPrefix reservation** — `FormatFilename` now caps the pathPrefix to
`MAX_PREFIX_LENGTH` (= `MAX_PATH_SIZE - sequence digits - extension - null`), preventing
long prefixes from collapsing different sequence numbers to the same truncated filename.

**FormatMsgId** — converted from return-value check to Length before/after pattern,
consistent with FormatStructuredData and FormatStringField.

## Test Evidence

11 new boundary tests covering all write functions:
- `ZeroSizeBufferDoesNotCrash` — Character, BoundedString, Uint32 on zero-size formatter
- `CharacterFillsExactlyOneByteBuffer` — 1-byte buffer = null terminator only
- `CharacterStopsWhenFull` — writes beyond capacity silently dropped
- `BoundedStringStopsAtBufferCapacity` — truncates at buffer boundary
- `BoundedStringWritesNothingWhenFull` — second write to full buffer is no-op
- `Uint32TruncatedWhenBufferTooSmall` — partial digit output
- `Uint32FitsExactly` — value fills buffer exactly
- `PaddedUint32TruncatedWhenBufferTooSmall` — padding truncated at boundary
- `PaddedUint32FitsExactly` — padded value fills buffer exactly

467 tests pass across debug, clang, sanitize. Coverage 99.9%.
clang-tidy, cppcheck, clang-format clean. BDD 31/31 scenarios pass.

## Areas Affected

- `Interface/SolidSyslogFormatter.h` — write functions return void, Remaining removed
- `Source/SolidSyslogFormatter.c` — void returns, Remaining removed
- `Source/SolidSyslog.c` — FormatMsgId uses Length pattern, FormatMsg drops Remaining
- `Source/SolidSyslogFileStore.c` — pathPrefix capped to reserve suffix space
- `Tests/SolidSyslogFormatterTest.cpp` — 11 new boundary tests, return value checks removed
- `CLAUDE.md` — Remaining removed from header table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified formatter API: output operations no longer return write counts.
  * Removed the buffer-capacity query.
  * Renamed raw-data accessor to a clearer string-view accessor.
  * Added new fixed-width digit formatters (2-, 4-, 6-digit) and updated codepaths to use them.

* **Tests**
  * Added comprehensive tests for buffer edge cases, truncation, and zero-size behavior.
  * Updated tests to validate output via the new string-view accessor and length checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->