### PR TITLE
refactor: S13.2 C99 portability — portable static assert and document MSVC suppressions

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: ghcr.io/davidcozens/cpputest:sha-6acaccf
     volumes:
       - ..:/workspaces/SolidSyslog:cached
-      - ${SSH_AUTH_SOCK}:/ssh-agent
-      - ${HOME}/.claude:/home/developer/.claude
-      - ${HOME}/.config/gh:/home/developer/.config/gh
+      - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      - ${HOME:-/tmp}/.claude:/home/developer/.claude
+      - ${HOME:-/tmp}/.config/gh:/home/developer/.config/gh
     cap_add:
       - SYS_PTRACE
     security_opt:
@@ -49,9 +49,9 @@ services:
       - ..:/workspaces/SolidSyslog:cached
       - ../Bdd/output:/workspaces/SolidSyslog/Bdd/output
       - syslog-ng-ctl:/var/lib/syslog-ng
-      - ${SSH_AUTH_SOCK}:/ssh-agent
-      - ${HOME}/.claude:/home/developer/.claude
-      - ${HOME}/.config/gh:/home/developer/.config/gh
+      - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      - ${HOME:-/tmp}/.claude:/home/developer/.claude
+      - ${HOME:-/tmp}/.config/gh:/home/developer/.config/gh
     environment:
       - SSH_AUTH_SOCK=/ssh-agent
     user: developer
@@ -64,9 +64,9 @@ services:
     image: ghcr.io/davidcozens/cpputest-clang:sha-6ea3f95
     volumes:
       - ..:/workspaces/SolidSyslog:cached
-      - ${SSH_AUTH_SOCK}:/ssh-agent
-      - ${HOME}/.claude:/home/developer/.claude
-      - ${HOME}/.config/gh:/home/developer/.config/gh
+      - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
+      - ${HOME:-/tmp}/.claude:/home/developer/.claude
+      - ${HOME:-/tmp}/.config/gh:/home/developer/.config/gh
     cap_add:
       - SYS_PTRACE
     security_opt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ find_package(CppUTest REQUIRED)
 find_package(Threads REQUIRED)
 
 if(MSVC)
+    # /wd4200: char buffer[] (C99 flexible array member) — valid C99, MSVC warns as nonstandard extension
+    # /wd4297: test infrastructure throws C++ exceptions from extern "C" functions
+    # to propagate assertion failures from C fakes through CppUTest. Permanent suppression.
     add_compile_options(/W4 /WX /wd4200 /wd4297)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()

--- a/Source/SolidSyslogFormatter.c
+++ b/Source/SolidSyslogFormatter.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogMacros.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -10,8 +11,8 @@ struct SolidSyslogFormatter
     char   buffer[];
 };
 
-_Static_assert(sizeof(struct SolidSyslogFormatter) == SOLIDSYSLOG_FORMATTER_OVERHEAD * sizeof(SolidSyslogFormatterStorage),
-               "SOLIDSYSLOG_FORMATTER_OVERHEAD does not match struct layout");
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogFormatter) == SOLIDSYSLOG_FORMATTER_OVERHEAD * sizeof(SolidSyslogFormatterStorage),
+                          "SOLIDSYSLOG_FORMATTER_OVERHEAD does not match struct layout");
 
 static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void NullTerminate(struct SolidSyslogFormatter* formatter);

--- a/Source/SolidSyslogMacros.h
+++ b/Source/SolidSyslogMacros.h
@@ -16,4 +16,9 @@
         }                                \
     } while (0)
 
+/* Portable compile-time assertion. Uses the negative-array-size trick
+   which works from C89 through C23 and all C++ versions — no C11 required. */
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) typedef char solidsyslog_static_assert_[(cond) ? 1 : -1]
+
 #endif /* SOLIDSYSLOGMACROS_H */

--- a/Source/SolidSyslogPosixFile.c
+++ b/Source/SolidSyslogPosixFile.c
@@ -1,5 +1,6 @@
 #include "SolidSyslogPosixFile.h"
 #include "SolidSyslogFileDefinition.h"
+#include "SolidSyslogMacros.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -30,8 +31,8 @@ struct SolidSyslogPosixFile
     int                    fd;
 };
 
-_Static_assert(sizeof(struct SolidSyslogPosixFile) == sizeof(struct SolidSyslogPosixFileStorage),
-               "SolidSyslogPosixFileStorage size does not match struct SolidSyslogPosixFile");
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixFile) == sizeof(struct SolidSyslogPosixFileStorage),
+                          "SolidSyslogPosixFileStorage size does not match struct SolidSyslogPosixFile");
 
 static const struct SolidSyslogPosixFile DEFAULT_INSTANCE = {
     {Open, Close, IsOpen, Read, Write, SeekTo, Size, Truncate, Exists, Delete},

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -1,5 +1,6 @@
 #include "FileFake.h"
 #include "SolidSyslogFileDefinition.h"
+#include "SolidSyslogMacros.h"
 #include "TestAssert.h"
 
 #include <string.h>
@@ -53,7 +54,7 @@ struct FileFake
     bool                   failNextRead;
 };
 
-_Static_assert(sizeof(struct FileFake) == sizeof(struct FileFakeStorage), "FileFakeStorage size does not match struct FileFake");
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct FileFake) == sizeof(struct FileFakeStorage), "FileFakeStorage size does not match struct FileFake");
 
 /* shared in-memory filesystem */
 static struct FileEntry filesystem[FILEFAKE_MAX_FILES];


### PR DESCRIPTION
Replace _Static_assert with SOLIDSYSLOG_STATIC_ASSERT macro using the negative-array-size typedef trick — works from C89 through C23 with no conditional compilation.

Document /wd4200 (C99 flexible array member) and /wd4297 (extern C throw in test infrastructure) MSVC suppressions in CMakeLists.txt.

Verified builds and passes 362 tests at both C11 (normal build) and C99 (temporary verification).

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a unified compile-time assertion macro and standardized its use across the codebase to improve build-time checks and diagnostics.

* **Tests**
  * Updated tests to use the new compile-time assertion mechanism.

* **Documentation**
  * Added MSVC compiler-option annotations documenting specific warning suppressions for clearer build guidance.

* **Chores**
  * Made development container volume mounts resilient by using safe default environment values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->