### PR TITLE
refactor: replace strncpy with SafeString abstraction for MSVC SDL compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,3 +206,22 @@ When updating an image:
 2. Update the SHA tag in all files that reference it (see [`docs/containers.md`](docs/containers.md) for the full list)
 3. Rebuild the devcontainer and verify the new tooling works locally
 4. Then commit — use `chore: bump container image to <sha>`
+
+---
+
+## Banned API Policy (Microsoft SDL)
+
+Production code must never use Microsoft SDL banned functions (`strncpy`, `sprintf`, `sscanf`,
+`strtok`, etc.). The library uses `SolidSyslogFormatter` for string building and `strtol` for
+parsing — this is deliberate and must be maintained.
+
+Test code uses the `SafeString` abstraction (`Tests/Support/SafeString.h`) instead of calling
+`strncpy` directly. CMake selects the platform implementation at build time:
+
+- **Windows** (`SafeStringWindows.c`): wraps `strncpy_s` with `_TRUNCATE`
+- **Default** (`SafeStringStandard.c`): wraps `strncpy` + null-terminate
+
+SafeString is compiled into test executables only — never linked into the production library.
+
+`_CRT_SECURE_NO_WARNINGS` was removed from CMakeLists.txt and must not be re-added.
+`memset`, `memcpy`, and `strcmp` are not SDL-banned and do not trigger MSVC C4996.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ if(MSVC)
     # /wd4297: test infrastructure throws C++ exceptions from extern "C" functions
     # to propagate assertion failures from C fakes through CppUTest. Permanent suppression.
     add_compile_options(/W4 /WX /wd4200 /wd4297)
-    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
     add_compile_options(-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Werror)
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -30,6 +30,12 @@ set(TEST_SOURCES
     main.cpp
 )
 
+if(MSVC)
+    list(APPEND TEST_SOURCES Support/SafeStringWindows.c)
+else()
+    list(APPEND TEST_SOURCES Support/SafeStringStandard.c)
+endif()
+
 if(HAVE_ATOMIC_COUNTER)
     list(APPEND TEST_SOURCES
         SolidSyslogAtomicCounterTest.cpp
@@ -51,7 +57,7 @@ endif()
 add_executable(${PROJECT_NAME}Tests ${TEST_SOURCES})
 
 target_link_libraries(${PROJECT_NAME}Tests PRIVATE ${PROJECT_NAME} CppUTest CppUTestExt Threads::Threads)
-target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Source)
+target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Source ${CMAKE_CURRENT_SOURCE_DIR}/Support)
 
 if(SOLIDSYSLOG_POSIX)
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE PosixFakes)

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -1,4 +1,5 @@
 #include "FileFake.h"
+#include "SafeString.h"
 #include "SolidSyslogFileDefinition.h"
 #include "SolidSyslogMacros.h"
 #include "TestAssert.h"
@@ -270,9 +271,7 @@ static inline bool IsSlotFree(const struct FileEntry* entry)
 static inline void InitialiseEntry(struct FileEntry* entry, const char* path)
 {
     entry->inUse = true;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- strncpy with bounded size; strncpy_s is not portable
-    strncpy(entry->path, path, FILEFAKE_MAX_PATH - 1);
-    entry->path[FILEFAKE_MAX_PATH - 1] = '\0';
+    SafeString_Copy(entry->path, FILEFAKE_MAX_PATH, path);
 }
 
 /* ------------------------------------------------------------------

--- a/Tests/Support/CMakeLists.txt
+++ b/Tests/Support/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(POSIX_FAKES_SOURCES
     ClockFake.c
+    SafeStringStandard.c
     SocketFake.c
 )
 

--- a/Tests/Support/SafeString.h
+++ b/Tests/Support/SafeString.h
@@ -1,0 +1,12 @@
+#ifndef SAFESTRING_H
+#define SAFESTRING_H
+
+/* Portable safe string copy: MSVC bans strncpy (C4996) and provides strncpy_s,
+   which is not available on other toolchains. CMake selects the platform-specific
+   implementation (SafeStringWindows.c or SafeStringStandard.c). */
+
+#include <stddef.h>
+
+void SafeString_Copy(char* dest, size_t destSize, const char* src);
+
+#endif /* SAFESTRING_H */

--- a/Tests/Support/SafeStringStandard.c
+++ b/Tests/Support/SafeStringStandard.c
@@ -8,6 +8,7 @@ void SafeString_Copy(char* dest, size_t destSize, const char* src)
     {
         return;
     }
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- wrapping strncpy is the whole point of this abstraction
     strncpy(dest, src, destSize - 1);
     dest[destSize - 1] = '\0';
 }

--- a/Tests/Support/SafeStringStandard.c
+++ b/Tests/Support/SafeStringStandard.c
@@ -1,0 +1,13 @@
+#include "SafeString.h"
+
+#include <string.h>
+
+void SafeString_Copy(char* dest, size_t destSize, const char* src)
+{
+    if (destSize == 0)
+    {
+        return;
+    }
+    strncpy(dest, src, destSize - 1);
+    dest[destSize - 1] = '\0';
+}

--- a/Tests/Support/SafeStringWindows.c
+++ b/Tests/Support/SafeStringWindows.c
@@ -1,0 +1,8 @@
+#include "SafeString.h"
+
+#include <string.h>
+
+void SafeString_Copy(char* dest, size_t destSize, const char* src)
+{
+    strncpy_s(dest, destSize, src, _TRUNCATE);
+}

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -1,4 +1,5 @@
 #include "SocketFake.h"
+#include "SafeString.h"
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -395,9 +396,7 @@ int getaddrinfo(const char* node, const char* service, const struct addrinfo* hi
     (void) service;
     (void) hints;
     getAddrInfoCallCount++;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- bounded; null-term below
-    strncpy(lastGetAddrInfoHostname, node ? node : "", sizeof(lastGetAddrInfoHostname) - 1);
-    lastGetAddrInfoHostname[sizeof(lastGetAddrInfoHostname) - 1] = '\0';
+    SafeString_Copy(lastGetAddrInfoHostname, sizeof(lastGetAddrInfoHostname), node ? node : "");
     inet_pton(AF_INET, node, &fakeResolvedAddr.sin_addr);
     *res = &fakeAddrInfo;
     return 0;


### PR DESCRIPTION
Closes #126

Introduces a portable SafeString abstraction for test code, replacing direct strncpy calls that trigger MSVC C4996 warnings.

**Changes:**
- **SafeString.h** — common interface with platform comment
- **SafeStringWindows.c** — wraps strncpy_s with _TRUNCATE
- **SafeStringStandard.c** — wraps strncpy + null-terminate (standard C, not POSIX-specific)
- **CMake** — platform selection: MSVC gets Windows impl, everything else gets Standard
- **FileFake.c / SocketFake.c** — replaced strncpy call sites with SafeString_Copy
- **CMakeLists.txt** — removed _CRT_SECURE_NO_WARNINGS
- **CLAUDE.md** — documented banned API policy
- **PosixFakes** — includes SafeStringStandard.c so ExampleTests links correctly

Tested: MSVC (362 tests), GCC via Docker (473 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Banned API Policy (Microsoft SDL)" section documenting allowed and disallowed string/parse APIs.

* **Chores**
  * Removed a compiler-level suppression for secure CRT warnings.
  * Improved test infrastructure with platform-specific safe string handling.
  * Updated tests and test utilities to use a unified, bounded string-copy abstraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->