### PR TITLE
ci: enable vcpkg binary caching for Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,8 +311,17 @@ jobs:
     permissions:
       contents: read
       checks: write
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Enable vcpkg binary cache
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install CppUTest
         run: |


### PR DESCRIPTION
## Purpose

Speed up the Windows CI job by caching compiled vcpkg packages.

## Change Description

Enable vcpkg's built-in GitHub Actions binary cache (`x-gha`). The `vcpkg install cpputest` step currently builds CppUTest from source on every run (~2 minutes). With binary caching, the first run populates the cache and subsequent runs pull pre-built binaries in seconds.

Uses `actions/github-script` to export the required `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables, following [vcpkg's recommended approach](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache).

## Test Evidence

No code changes — CI-only. The first run on this PR will populate the cache (same speed as before). The speedup will be visible on subsequent runs.

## Areas Affected

`.github/workflows/ci.yml` — `windows-build-and-test` job only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows CI pipeline efficiency through optimized binary caching, enabling faster and more reliable build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->