### PR TITLE
refactor: S13.7 extract Datagram abstraction from UdpSender

### DIFF
--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -5,6 +5,7 @@
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogMetaSd.h"
@@ -35,7 +36,8 @@ int SolidSyslogExample_Run(int argc, char* argv[])
     }
 
     struct SolidSyslogResolver*       resolver    = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
-    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver};
+    struct SolidSyslogDatagram*       datagram    = SolidSyslogPosixDatagram_Create();
+    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
     struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();
@@ -76,6 +78,7 @@ int SolidSyslogExample_Run(int argc, char* argv[])
     SolidSyslogNullStore_Destroy();
     SolidSyslogNullBuffer_Destroy();
     SolidSyslogUdpSender_Destroy();
+    SolidSyslogPosixDatagram_Destroy();
     SolidSyslogGetAddrInfoResolver_Destroy();
 
     return 0;

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -19,6 +19,7 @@
 #include "SolidSyslogPosixMessageQueueBuffer.h"
 #include "SolidSyslogPosixProcessId.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogTcpSender.h"
 #include "SolidSyslogUdpSender.h"
 
@@ -59,6 +60,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
 
     static struct SolidSyslogUdpSenderConfig udpConfig = {0};
     udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
+    udpConfig.datagram                                 = SolidSyslogPosixDatagram_Create();
     return SolidSyslogUdpSender_Create(&udpConfig);
 }
 
@@ -122,6 +124,7 @@ static void DestroySender(const struct ExampleOptions* options)
     else
     {
         SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
     }
     SolidSyslogGetAddrInfoResolver_Destroy();
 }

--- a/Interface/SolidSyslogDatagram.h
+++ b/Interface/SolidSyslogDatagram.h
@@ -1,0 +1,19 @@
+#ifndef SOLIDSYSLOGDATAGRAM_H
+#define SOLIDSYSLOGDATAGRAM_H
+
+#include "ExternC.h"
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogDatagram;
+
+    void SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram);
+    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct sockaddr_in* addr);
+    void SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGDATAGRAM_H */

--- a/Interface/SolidSyslogDatagram.h
+++ b/Interface/SolidSyslogDatagram.h
@@ -10,9 +10,9 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogDatagram;
 
-    void SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram);
-    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct sockaddr_in* addr);
-    void SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram);
+    void SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
+    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size, const struct sockaddr_in* addr);
+    void SolidSyslogDatagram_Close(struct SolidSyslogDatagram * datagram);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogDatagramDefinition.h
+++ b/Interface/SolidSyslogDatagramDefinition.h
@@ -1,0 +1,19 @@
+#ifndef SOLIDSYSLOGDATAGRAMDEFINITION_H
+#define SOLIDSYSLOGDATAGRAMDEFINITION_H
+
+#include "SolidSyslogDatagram.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogDatagram
+    {
+        /* void return: failure reporting deferred to Epic #31 (error handling) */
+        void (*Open)(struct SolidSyslogDatagram* self);
+        bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
+        /* void return: failure reporting deferred to Epic #31 (error handling) */
+        void (*Close)(struct SolidSyslogDatagram* self);
+    };
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGDATAGRAMDEFINITION_H */

--- a/Interface/SolidSyslogPosixDatagram.h
+++ b/Interface/SolidSyslogPosixDatagram.h
@@ -1,0 +1,13 @@
+#ifndef SOLIDSYSLOGPOSIXDATAGRAM_H
+#define SOLIDSYSLOGPOSIXDATAGRAM_H
+
+#include "SolidSyslogDatagram.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogDatagram* SolidSyslogPosixDatagram_Create(void);
+    void                        SolidSyslogPosixDatagram_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGPOSIXDATAGRAM_H */

--- a/Interface/SolidSyslogUdpSender.h
+++ b/Interface/SolidSyslogUdpSender.h
@@ -1,6 +1,7 @@
 #ifndef SOLIDSYSLOGUDPSENDER_H
 #define SOLIDSYSLOGUDPSENDER_H
 
+#include "SolidSyslogDatagram.h"
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogSender.h"
 
@@ -14,6 +15,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogUdpSenderConfig
     {
         struct SolidSyslogResolver* resolver;
+        struct SolidSyslogDatagram* datagram;
     };
 
     struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config);

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -31,6 +31,8 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogPosixProcessId.c
         SolidSyslogResolver.c
         SolidSyslogGetAddrInfoResolver.c
+        SolidSyslogDatagram.c
+        SolidSyslogPosixDatagram.c
         SolidSyslogUdpSender.c
         SolidSyslogTcpSender.c
         SolidSyslogPosixFile.c

--- a/Source/SolidSyslogDatagram.c
+++ b/Source/SolidSyslogDatagram.c
@@ -1,0 +1,16 @@
+#include "SolidSyslogDatagramDefinition.h"
+
+void SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
+{
+    datagram->Open(datagram);
+}
+
+bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct sockaddr_in* addr)
+{
+    return datagram->SendTo(datagram, buffer, size, addr);
+}
+
+void SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram)
+{
+    datagram->Close(datagram);
+}

--- a/Source/SolidSyslogPosixDatagram.c
+++ b/Source/SolidSyslogPosixDatagram.c
@@ -1,0 +1,56 @@
+#include "SolidSyslogPosixDatagram.h"
+#include "SolidSyslogDatagramDefinition.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static void Open(struct SolidSyslogDatagram* self);
+static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
+static void Close(struct SolidSyslogDatagram* self);
+
+struct SolidSyslogPosixDatagram
+{
+    struct SolidSyslogDatagram base;
+    int                        fd;
+};
+
+static struct SolidSyslogPosixDatagram instance = {.fd = -1};
+
+struct SolidSyslogDatagram* SolidSyslogPosixDatagram_Create(void)
+{
+    instance.base.Open   = Open;
+    instance.base.SendTo = SendTo;
+    instance.base.Close  = Close;
+    return &instance.base;
+}
+
+void SolidSyslogPosixDatagram_Destroy(void)
+{
+    instance.base.Open   = NULL;
+    instance.base.SendTo = NULL;
+    instance.base.Close  = NULL;
+}
+
+static void Open(struct SolidSyslogDatagram* self)
+{
+    struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
+    datagram->fd                              = socket(AF_INET, SOCK_DGRAM, 0);
+}
+
+static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr)
+{
+    struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
+    return sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) addr, sizeof(*addr)) >= 0;
+}
+
+static void Close(struct SolidSyslogDatagram* self)
+{
+    struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
+    if (datagram->fd >= 0)
+    {
+        close(datagram->fd);
+        datagram->fd = -1;
+    }
+}

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -1,27 +1,25 @@
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
 
-#include <sys/socket.h>
-#include <unistd.h>
+#include <stddef.h>
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
 
 struct SolidSyslogUdpSender
 {
     struct SolidSyslogSender          base;
-    int                               fd;
     struct SolidSyslogUdpSenderConfig config;
     struct sockaddr_in                addr;
 };
 
-static struct SolidSyslogUdpSender instance = {.fd = -1};
+static struct SolidSyslogUdpSender instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
     instance.config    = *config;
     instance.base.Send = Send;
-    instance.fd        = socket(AF_INET, SOCK_DGRAM, 0);
 
+    SolidSyslogDatagram_Open(config->datagram);
     SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
 
     return &instance.base;
@@ -29,17 +27,17 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
 
 void SolidSyslogUdpSender_Destroy(void)
 {
-    if (instance.fd >= 0)
+    if (instance.config.datagram != NULL)
     {
-        close(instance.fd);
+        SolidSyslogDatagram_Close(instance.config.datagram);
     }
-    instance.fd        = -1;
     instance.base.Send = NULL;
     instance.addr      = (struct sockaddr_in) {0};
+    instance.config    = (struct SolidSyslogUdpSenderConfig) {0};
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     struct SolidSyslogUdpSender* udpSender = (struct SolidSyslogUdpSender*) self;
-    return sendto(udpSender->fd, buffer, size, 0, (struct sockaddr*) &udpSender->addr, sizeof(udpSender->addr)) >= 0;
+    return SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, &udpSender->addr);
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -52,6 +52,7 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogPosixFileTest.cpp
         SolidSyslogFileStorePosixTest.cpp
         SolidSyslogGetAddrInfoResolverTest.cpp
+        SolidSyslogPosixDatagramTest.cpp
     )
 endif()
 

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -5,6 +5,7 @@
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogPosixMessageQueueBuffer.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogNullStore.h"
 #include "SocketFake.h"
@@ -26,7 +27,7 @@ TEST_GROUP(ExampleServiceThread)
         ClockFake_SetTime(1743768600, 0);
         shutdown = true;
 
-        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort)};
+        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort), SolidSyslogPosixDatagram_Create()};
         sender = SolidSyslogUdpSender_Create(&udpConfig);
         buffer = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
         store  = SolidSyslogNullStore_Create();
@@ -41,6 +42,7 @@ TEST_GROUP(ExampleServiceThread)
         SolidSyslogNullStore_Destroy();
         SolidSyslogPosixMessageQueueBuffer_Destroy();
         SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -1,0 +1,144 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogDatagram.h"
+#include "SolidSyslogPosixDatagram.h"
+#include "SocketFake.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+// clang-format off
+static const char* const TEST_MESSAGE     = "hello";
+static const size_t      TEST_MESSAGE_LEN = 5;
+static const char* const TEST_ADDRESS     = "127.0.0.1";
+static const int         TEST_PORT        = 514;
+
+TEST_GROUP(SolidSyslogPosixDatagram)
+{
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogDatagram* datagram = nullptr;
+    struct sockaddr_in          addr{};
+
+    void setup() override
+    {
+        SocketFake_Reset();
+        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
+        datagram = SolidSyslogPosixDatagram_Create();
+        std::memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_ADDRESS, &addr.sin_addr);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogPosixDatagram_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogPosixDatagram, CreateDestroyWorksWithoutCrashing)
+{
+}
+
+TEST(SolidSyslogPosixDatagram, OpenCallsSocketOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(1, SocketFake_SocketCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, OpenCallsSocketWithAF_INET)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(AF_INET, SocketFake_SocketDomain());
+}
+
+TEST(SolidSyslogPosixDatagram, OpenCallsSocketWithSOCK_DGRAM)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(SOCK_DGRAM, SocketFake_SocketType());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToCallsSendtoOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(1, SocketFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesBuffer)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    STRCMP_EQUAL(TEST_MESSAGE, SocketFake_LastBufAsString());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesLength)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(TEST_MESSAGE_LEN, SocketFake_LastLen());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesFlagsZero)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(0, SocketFake_LastFlags());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesSocketFd)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastSendtoFd());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesAddressPort)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(TEST_PORT, SocketFake_LastPort());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesAddressHost)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    STRCMP_EQUAL(TEST_ADDRESS, SocketFake_LastAddrAsString());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToPassesAddrlenOfSockaddrIn)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    LONGS_EQUAL(sizeof(struct sockaddr_in), SocketFake_LastAddrLen());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToReturnsTrueOnSuccess)
+{
+    SolidSyslogDatagram_Open(datagram);
+    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr));
+}
+
+TEST(SolidSyslogPosixDatagram, SendToReturnsFalseOnSendtoFailure)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SocketFake_SetSendtoFails(true);
+    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr));
+}
+
+TEST(SolidSyslogPosixDatagram, CloseCallsCloseOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, CloseCalledWithSocketFd)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
+}

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSender.h"
 #include "SocketFake.h"
@@ -51,6 +52,7 @@ static int SpyGetPort()
 TEST_GROUP(SolidSyslogUdpSender)
 {
     struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogDatagram* datagram = nullptr;
     struct SolidSyslogUdpSenderConfig config;
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
@@ -60,7 +62,8 @@ TEST_GROUP(SolidSyslogUdpSender)
     {
         SocketFake_Reset();
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
-        config = {resolver};
+        datagram = SolidSyslogPosixDatagram_Create();
+        config = {resolver, datagram};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogUdpSender_Create(&config);
     }
@@ -68,6 +71,7 @@ TEST_GROUP(SolidSyslogUdpSender)
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -190,18 +194,21 @@ IGNORE_TEST(SolidSyslogUdpSender, HappyPathOnly)
 TEST_GROUP(SolidSyslogUdpSenderDestroy)
 {
     struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogDatagram* datagram = nullptr;
     struct SolidSyslogUdpSenderConfig config;
 
     void setup() override
     {
         SocketFake_Reset();
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        datagram = SolidSyslogPosixDatagram_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver};
+        config = {resolver, datagram};
     }
 
     void teardown() override
     {
+        SolidSyslogPosixDatagram_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -262,13 +269,15 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
     void CreateSender()
     {
         struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
-        struct SolidSyslogUdpSenderConfig config = {resolver};
+        struct SolidSyslogDatagram* datagram = SolidSyslogPosixDatagram_Create();
+        struct SolidSyslogUdpSenderConfig config = {resolver, datagram};
         sender = SolidSyslogUdpSender_Create(&config);
     }
 


### PR DESCRIPTION
## Purpose

Closes #133. Extract UDP socket operations from `UdpSender` into a `SolidSyslogDatagram` vtable abstraction, with `PosixDatagram` as the first implementation. Preparatory refactoring for S13.4 (Winsock UDP support) — once Datagram is extracted, adding Windows support is just a new `WinsockDatagram` implementation.

Parent epic: #40. Depends on S13.6 (#132, already merged).

## Change Description

Follows the same vtable/dispatch pattern as Sender, Buffer, Store, Resolver:

- `SolidSyslogDatagramDefinition.h` — vtable struct with `Open`, `SendTo`, `Close`
- `SolidSyslogDatagram.h` / `.c` — forward declaration and dispatch functions
- `SolidSyslogPosixDatagram.h` / `.c` — POSIX implementation using `socket`/`sendto`/`close`
- `UdpSender` refactored to accept a `SolidSyslogDatagram*` in its config; no longer touches sockets directly.

**Design decisions (following S13.6 pattern):**

- `Open` and `Close` return `void` (not `bool` as the issue draft suggested). The existing `UdpSender` does not check the return values of `socket()` or `close()`, so adding a bool return would introduce behaviour that has no caller and no tests. Error handling is deferred to Epic #31. `SendTo` returns `bool`, preserving the existing `sendto(...) >= 0` semantics.
- **Address ownership:** the resolved `struct sockaddr_in` stays in `UdpSender` (which owns the resolver) and is passed through to `SendTo` on each call. The Datagram is stateless w.r.t. addressing. The POSIX sockaddr_in type still leaks through the Datagram interface — same situation as the Resolver — hiding it is deferred until Winsock or connection-lifecycle work demands it.
- **Singleton pattern:** same as `GetAddrInfoResolver`. One Datagram per UdpSender. Limitation tracked in #110 / memory.

Pure refactor — no new functionality, no behaviour change.

## Test Evidence

**New tests** — `Tests/SolidSyslogPosixDatagramTest.cpp`: 14 tests drove the PosixDatagram implementation via strict TDD (red/green for each behaviour). Covers Open (socket called, AF_INET, SOCK_DGRAM), SendTo (called once, buffer/length/flags/fd/address/addrlen propagation, return value on success and failure), and Close (called with correct fd).

**Existing tests preserved** — `SolidSyslogUdpSenderTest.cpp` (22 tests across 3 test groups) remain unchanged in their assertions and test bodies. Only the setup/teardown wiring changed to create/destroy a `PosixDatagram`. Because `SocketFake` intercepts at the libc level, all existing assertions (`SocketFake_SocketCallCount`, `SocketFake_LastPort`, `SocketFake_CloseCallCount`, etc.) continue to pass, proving the refactor preserves behaviour.

**Local CI — all presets green:**
- `debug`, `clang-debug`, `sanitize`: 498 tests pass
- `coverage`: 100% on new files (SolidSyslogDatagram.c, SolidSyslogPosixDatagram.c); 99.9% overall (pre-existing gap in SolidSyslogFileStore.c, unrelated)
- `tidy`, `cppcheck`: clean
- `clang-format --dry-run --Werror`: clean
- BDD: 14 features / 31 scenarios / 160 steps passed

## Areas Affected

**New:**
- `Interface/SolidSyslogDatagram.h`, `SolidSyslogDatagramDefinition.h`, `SolidSyslogPosixDatagram.h`
- `Source/SolidSyslogDatagram.c`, `SolidSyslogPosixDatagram.c`
- `Tests/SolidSyslogPosixDatagramTest.cpp`

**Modified:**
- `Interface/SolidSyslogUdpSender.h` — config gains `datagram` field
- `Source/SolidSyslogUdpSender.c` — delegates socket operations to injected Datagram; removed `fd` field
- `Tests/SolidSyslogUdpSenderTest.cpp` — setup/teardown wire in PosixDatagram
- `Tests/Example/ExampleServiceThreadTest.cpp` — same wiring update
- `Example/SingleTask/SolidSyslogExample.c`, `Example/Threaded/main.c` — create/destroy PosixDatagram
- `Source/CMakeLists.txt`, `Tests/CMakeLists.txt` — add new source files

**Not affected:** `TcpSender` — S13.8 will extract the Stream abstraction for TCP connection operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a modular datagram abstraction layer for flexible network communication
  * Added POSIX-compatible datagram implementation with complete lifecycle management

* **Tests**
  * Added comprehensive test coverage for datagram operations and UDP sender integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->