### PR TITLE
refactor: S13.8 extract Stream abstraction from TcpSender

### DIFF
--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -20,6 +20,7 @@
 #include "SolidSyslogPosixProcessId.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixDatagram.h"
+#include "SolidSyslogPosixTcpStream.h"
 #include "SolidSyslogTcpSender.h"
 #include "SolidSyslogUdpSender.h"
 
@@ -55,6 +56,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     {
         static struct SolidSyslogTcpSenderConfig tcpConfig = {0};
         tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleTcpConfig_GetHost, ExampleTcpConfig_GetPort);
+        tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
         return SolidSyslogTcpSender_Create(&tcpConfig);
     }
 
@@ -120,6 +122,7 @@ static void DestroySender(const struct ExampleOptions* options)
     if (useTcp)
     {
         SolidSyslogTcpSender_Destroy();
+        SolidSyslogPosixTcpStream_Destroy();
     }
     else
     {

--- a/Interface/SolidSyslogPosixTcpStream.h
+++ b/Interface/SolidSyslogPosixTcpStream.h
@@ -1,0 +1,13 @@
+#ifndef SOLIDSYSLOGPOSIXTCPSTREAM_H
+#define SOLIDSYSLOGPOSIXTCPSTREAM_H
+
+#include "SolidSyslogStream.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void);
+    void                      SolidSyslogPosixTcpStream_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGPOSIXTCPSTREAM_H */

--- a/Interface/SolidSyslogStream.h
+++ b/Interface/SolidSyslogStream.h
@@ -1,0 +1,19 @@
+#ifndef SOLIDSYSLOGSTREAM_H
+#define SOLIDSYSLOGSTREAM_H
+
+#include "ExternC.h"
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogStream;
+
+    bool SolidSyslogStream_Open(struct SolidSyslogStream* stream, const struct sockaddr_in* addr);
+    bool SolidSyslogStream_Send(struct SolidSyslogStream* stream, const void* buffer, size_t size);
+    void SolidSyslogStream_Close(struct SolidSyslogStream* stream);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSTREAM_H */

--- a/Interface/SolidSyslogStream.h
+++ b/Interface/SolidSyslogStream.h
@@ -10,9 +10,9 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogStream;
 
-    bool SolidSyslogStream_Open(struct SolidSyslogStream* stream, const struct sockaddr_in* addr);
-    bool SolidSyslogStream_Send(struct SolidSyslogStream* stream, const void* buffer, size_t size);
-    void SolidSyslogStream_Close(struct SolidSyslogStream* stream);
+    bool SolidSyslogStream_Open(struct SolidSyslogStream * stream, const struct sockaddr_in* addr);
+    bool SolidSyslogStream_Send(struct SolidSyslogStream * stream, const void* buffer, size_t size);
+    void SolidSyslogStream_Close(struct SolidSyslogStream * stream);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogStreamDefinition.h
+++ b/Interface/SolidSyslogStreamDefinition.h
@@ -1,0 +1,18 @@
+#ifndef SOLIDSYSLOGSTREAMDEFINITION_H
+#define SOLIDSYSLOGSTREAMDEFINITION_H
+
+#include "SolidSyslogStream.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogStream
+    {
+        bool (*Open)(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
+        bool (*Send)(struct SolidSyslogStream* self, const void* buffer, size_t size);
+        /* void return: failure reporting deferred to Epic #31 (error handling) */
+        void (*Close)(struct SolidSyslogStream* self);
+    };
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSTREAMDEFINITION_H */

--- a/Interface/SolidSyslogTcpSender.h
+++ b/Interface/SolidSyslogTcpSender.h
@@ -2,6 +2,7 @@
 #define SOLIDSYSLOG_TCP_SENDER_H
 
 #include "SolidSyslogResolver.h"
+#include "SolidSyslogStream.h"
 
 struct SolidSyslogSender;
 
@@ -13,6 +14,7 @@ enum
 struct SolidSyslogTcpSenderConfig
 {
     struct SolidSyslogResolver* resolver;
+    struct SolidSyslogStream*   stream;
 };
 
 EXTERN_C_BEGIN

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -33,6 +33,8 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogGetAddrInfoResolver.c
         SolidSyslogDatagram.c
         SolidSyslogPosixDatagram.c
+        SolidSyslogStream.c
+        SolidSyslogPosixTcpStream.c
         SolidSyslogUdpSender.c
         SolidSyslogTcpSender.c
         SolidSyslogPosixFile.c

--- a/Source/SolidSyslogPosixTcpStream.c
+++ b/Source/SolidSyslogPosixTcpStream.c
@@ -42,6 +42,7 @@ static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr)
     stream->fd = socket(AF_INET, SOCK_STREAM, 0);
     EnableTcpNoDelay(stream->fd);
 
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions) -- socket() failure handling deferred to error handling epic
     bool connected = connect(stream->fd, (const struct sockaddr*) addr, sizeof(*addr)) == 0;
 
     if (!connected)

--- a/Source/SolidSyslogPosixTcpStream.c
+++ b/Source/SolidSyslogPosixTcpStream.c
@@ -1,0 +1,76 @@
+#include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogStreamDefinition.h"
+
+#include <netinet/tcp.h>
+#include <stddef.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
+static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
+static void Close(struct SolidSyslogStream* self);
+
+static void EnableTcpNoDelay(int fd);
+
+struct SolidSyslogPosixTcpStream
+{
+    struct SolidSyslogStream base;
+    int                      fd;
+};
+
+static struct SolidSyslogPosixTcpStream instance = {.fd = -1};
+
+struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void)
+{
+    instance.base.Open  = Open;
+    instance.base.Send  = Send;
+    instance.base.Close = Close;
+    return &instance.base;
+}
+
+void SolidSyslogPosixTcpStream_Destroy(void)
+{
+    instance.base.Open  = NULL;
+    instance.base.Send  = NULL;
+    instance.base.Close = NULL;
+}
+
+static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr)
+{
+    struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
+
+    stream->fd = socket(AF_INET, SOCK_STREAM, 0);
+    EnableTcpNoDelay(stream->fd);
+
+    bool connected = connect(stream->fd, (const struct sockaddr*) addr, sizeof(*addr)) == 0;
+
+    if (!connected)
+    {
+        close(stream->fd);
+        stream->fd = -1;
+    }
+
+    return connected;
+}
+
+static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
+{
+    struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
+    return send(stream->fd, buffer, size, MSG_NOSIGNAL) >= 0;
+}
+
+static void Close(struct SolidSyslogStream* self)
+{
+    struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
+    if (stream->fd >= 0)
+    {
+        close(stream->fd);
+        stream->fd = -1;
+    }
+}
+
+static void EnableTcpNoDelay(int fd)
+{
+    int enable = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
+}

--- a/Source/SolidSyslogStream.c
+++ b/Source/SolidSyslogStream.c
@@ -1,0 +1,16 @@
+#include "SolidSyslogStreamDefinition.h"
+
+bool SolidSyslogStream_Open(struct SolidSyslogStream* stream, const struct sockaddr_in* addr)
+{
+    return stream->Open(stream, addr);
+}
+
+bool SolidSyslogStream_Send(struct SolidSyslogStream* stream, const void* buffer, size_t size)
+{
+    return stream->Send(stream, buffer, size);
+}
+
+void SolidSyslogStream_Close(struct SolidSyslogStream* stream)
+{
+    stream->Close(stream);
+}

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -2,20 +2,17 @@
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogSenderDefinition.h"
 
-#include <netinet/tcp.h>
 #include <stdbool.h>
-#include <sys/socket.h>
-#include <unistd.h>
+#include <stddef.h>
 
 struct SolidSyslogTcpSender
 {
     struct SolidSyslogSender          base;
-    int                               fd;
     struct SolidSyslogTcpSenderConfig config;
     bool                              connected;
 };
 
-static struct SolidSyslogTcpSender instance = {.fd = -1};
+static struct SolidSyslogTcpSender instance;
 
 enum
 {
@@ -26,32 +23,28 @@ enum
 };
 
 static bool                         Connect(struct SolidSyslogTcpSender* tcp);
-static void                         CreateSocket(struct SolidSyslogTcpSender* tcp);
-static void                         Disconnect(struct SolidSyslogTcpSender* tcp);
 static bool                         EnsureConnected(struct SolidSyslogTcpSender* tcp);
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
 static bool                         Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
 static bool                         SendData(struct SolidSyslogTcpSender* tcp, const void* data, size_t len);
-static void                         EnableTcpNoDelay(int fd);
 
 struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTcpSenderConfig* config)
 {
     instance.config    = *config;
     instance.base.Send = Send;
     instance.connected = false;
-    instance.fd        = -1;
     return &instance.base;
 }
 
 void SolidSyslogTcpSender_Destroy(void)
 {
-    if (instance.fd >= 0)
+    if (instance.connected && instance.config.stream != NULL)
     {
-        close(instance.fd);
+        SolidSyslogStream_Close(instance.config.stream);
     }
-    instance.fd        = -1;
     instance.base.Send = NULL;
     instance.connected = false;
+    instance.config    = (struct SolidSyslogTcpSenderConfig) {0};
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
@@ -84,42 +77,12 @@ static bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
 
 static bool Connect(struct SolidSyslogTcpSender* tcp)
 {
-    CreateSocket(tcp);
-
     struct sockaddr_in addr;
     SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, &addr);
-    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions) -- socket() failure handling deferred to error handling epic
-    bool connected = connect(tcp->fd, (struct sockaddr*) &addr, sizeof(addr)) == 0;
 
-    if (connected)
-    {
-        tcp->connected = true;
-    }
-    else
-    {
-        Disconnect(tcp);
-    }
+    tcp->connected = SolidSyslogStream_Open(tcp->config.stream, &addr);
 
-    return connected;
-}
-
-static void CreateSocket(struct SolidSyslogTcpSender* tcp)
-{
-    tcp->fd = socket(AF_INET, SOCK_STREAM, 0);
-    EnableTcpNoDelay(tcp->fd);
-}
-
-static void EnableTcpNoDelay(int fd)
-{
-    int enable = 1;
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
-}
-
-static void Disconnect(struct SolidSyslogTcpSender* tcp)
-{
-    close(tcp->fd);
-    tcp->fd        = -1;
-    tcp->connected = false;
+    return tcp->connected;
 }
 
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)
@@ -132,11 +95,12 @@ static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatt
 
 static bool SendData(struct SolidSyslogTcpSender* tcp, const void* data, size_t len)
 {
-    bool sent = send(tcp->fd, data, len, MSG_NOSIGNAL) >= 0;
+    bool sent = SolidSyslogStream_Send(tcp->config.stream, data, len);
 
     if (!sent)
     {
-        Disconnect(tcp);
+        SolidSyslogStream_Close(tcp->config.stream);
+        tcp->connected = false;
     }
 
     return sent;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -53,6 +53,7 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogFileStorePosixTest.cpp
         SolidSyslogGetAddrInfoResolverTest.cpp
         SolidSyslogPosixDatagramTest.cpp
+        SolidSyslogPosixTcpStreamTest.cpp
     )
 endif()
 

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -1,0 +1,171 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogStream.h"
+#include "SocketFake.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+// clang-format off
+static const char* const TEST_MESSAGE     = "hello";
+static const size_t      TEST_MESSAGE_LEN = 5;
+static const char* const TEST_ADDRESS     = "127.0.0.1";
+static const int         TEST_PORT        = 514;
+
+TEST_GROUP(SolidSyslogPosixTcpStream)
+{
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogStream* stream = nullptr;
+    struct sockaddr_in        addr{};
+
+    void setup() override
+    {
+        SocketFake_Reset();
+        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
+        stream = SolidSyslogPosixTcpStream_Create();
+        std::memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_ADDRESS, &addr.sin_addr);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogPosixTcpStream_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
+{
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenCallsSocketOnce)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(1, SocketFake_SocketCallCount());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenCallsSocketWithAF_INET)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(AF_INET, SocketFake_SocketDomain());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenCallsSocketWithSOCK_STREAM)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(SOCK_STREAM, SocketFake_SocketType());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenEnablesTcpNoDelay)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(1, SocketFake_SetSockOptCallCount());
+    LONGS_EQUAL(IPPROTO_TCP, SocketFake_LastSetSockOptLevel());
+    LONGS_EQUAL(TCP_NODELAY, SocketFake_LastSetSockOptOptname());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenCallsConnectWithSocketFd)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(1, SocketFake_ConnectCallCount());
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastConnectFd());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenCallsConnectWithProvidedAddress)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(TEST_PORT, SocketFake_LastConnectPort());
+    STRCMP_EQUAL(TEST_ADDRESS, SocketFake_LastConnectAddrAsString());
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(SolidSyslogStream_Open(stream, &addr));
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenReturnsFalseOnConnectFailure)
+{
+    SocketFake_SetConnectFails(true);
+    CHECK_FALSE(SolidSyslogStream_Open(stream, &addr));
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenClosesSocketOnConnectFailure)
+{
+    SocketFake_SetConnectFails(true);
+    SolidSyslogStream_Open(stream, &addr);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
+}
+
+TEST(SolidSyslogPosixTcpStream, SendCallsSendOnce)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, SocketFake_SendCallCount());
+}
+
+TEST(SolidSyslogPosixTcpStream, SendPassesBuffer)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    STRCMP_EQUAL(TEST_MESSAGE, SocketFake_SendBufAsString(0));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendPassesLength)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(TEST_MESSAGE_LEN, SocketFake_SendLen(0));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendPassesMSG_NOSIGNALFlag)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(MSG_NOSIGNAL, SocketFake_SendFlags(0));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendPassesSocketFd)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastSendFd());
+}
+
+TEST(SolidSyslogPosixTcpStream, SendReturnsTrueOnSuccess)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    CHECK_TRUE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendReturnsFalseOnSendFailure)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SocketFake_SetSendFails(true);
+    CHECK_FALSE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogPosixTcpStream, CloseCallsCloseOnce)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Close(stream);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogPosixTcpStream, CloseCalledWithSocketFd)
+{
+    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Close(stream);
+    LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
+}
+
+TEST(SolidSyslogPosixTcpStream, CloseIsNoOpWhenNotOpen)
+{
+    SolidSyslogStream_Close(stream);
+    LONGS_EQUAL(0, SocketFake_CloseCallCount());
+}

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogPosixTcpStream.h"
 #include "SolidSyslogSender.h"
 #include "SolidSyslogTcpSender.h"
 #include "SocketFake.h"
@@ -55,6 +56,7 @@ static const char* SpyGetHost()
 TEST_GROUP(SolidSyslogTcpSender)
 {
     struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogStream*   stream   = nullptr;
     struct SolidSyslogTcpSenderConfig config;
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
@@ -64,7 +66,8 @@ TEST_GROUP(SolidSyslogTcpSender)
     {
         SocketFake_Reset();
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-        config = {resolver};
+        stream   = SolidSyslogPosixTcpStream_Create();
+        config = {resolver, stream};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -72,6 +75,7 @@ TEST_GROUP(SolidSyslogTcpSender)
     void teardown() override
     {
         SolidSyslogTcpSender_Destroy();
+        SolidSyslogPosixTcpStream_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -113,18 +117,21 @@ TEST(SolidSyslogTcpSender, FirstSendSetsTcpNoDelay)
 TEST_GROUP(SolidSyslogTcpSenderDestroy)
 {
     struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogStream*   stream   = nullptr;
     struct SolidSyslogTcpSenderConfig config;
 
     void setup() override
     {
         SocketFake_Reset();
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        stream   = SolidSyslogPosixTcpStream_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver};
+        config = {resolver, stream};
     }
 
     void teardown() override
     {
+        SolidSyslogPosixTcpStream_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -233,13 +240,15 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
     void teardown() override
     {
         SolidSyslogTcpSender_Destroy();
+        SolidSyslogPosixTcpStream_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
     void CreateSender()
     {
         struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
-        struct SolidSyslogTcpSenderConfig config = {resolver};
+        struct SolidSyslogStream*   stream   = SolidSyslogPosixTcpStream_Create();
+        struct SolidSyslogTcpSenderConfig config = {resolver, stream};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -316,6 +325,7 @@ TEST(SolidSyslogTcpSenderConfig, GetAddrInfoCalledWithHostname)
 TEST_GROUP(SolidSyslogTcpSenderFailure)
 {
     struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogStream*   stream   = nullptr;
     struct SolidSyslogTcpSenderConfig config;
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
@@ -325,7 +335,8 @@ TEST_GROUP(SolidSyslogTcpSenderFailure)
     {
         SocketFake_Reset();
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-        config = {resolver};
+        stream   = SolidSyslogPosixTcpStream_Create();
+        config = {resolver, stream};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -344,6 +344,7 @@ TEST_GROUP(SolidSyslogTcpSenderFailure)
     void teardown() override
     {
         SolidSyslogTcpSender_Destroy();
+        SolidSyslogPosixTcpStream_Destroy();
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 


### PR DESCRIPTION
## Purpose

Closes #134. Extract TCP socket operations from `TcpSender` into a `SolidSyslogStream` vtable abstraction, with `PosixTcpStream` as the first implementation. Preparatory refactoring for S13.9 (Winsock TCP) and also the composition point for E3 (TLS transport — a future `TlsStream` wraps any `SolidSyslogStream*`).

Parent epic: #40. Builds on S13.6 (Resolver) and S13.7 (Datagram), both merged.

## Change Description

Same vtable/dispatch pattern as Sender, Buffer, Store, Resolver, Datagram:

- `SolidSyslogStreamDefinition.h` — vtable: `Open(self, addr) -> bool`, `Send(self, buf, size) -> bool`, `Close(self)`
- `SolidSyslogStream.h` / `.c` — forward declaration and dispatch functions
- `SolidSyslogPosixTcpStream.h` / `.c` — POSIX implementation using `socket`/`setsockopt(TCP_NODELAY)`/`connect`/`send(MSG_NOSIGNAL)`/`close`
- `TcpSender` refactored to accept a `SolidSyslogStream*` in its config; no longer touches sockets directly.

**Design decisions:**

- **Return types** follow existing behaviour: `Open` returns `bool` (current `connect() == 0` is checked), `Send` returns `bool` (current `send() >= 0` is checked), `Close` returns `void` (current code ignores `close()` errors — Epic #31).
- **`connected` stays in TcpSender**, not Stream. It's a policy flag — "should I attempt reconnect on the next Send?" — which is the sender's concern, not the stream's resource state. This also composes cleanly with a future `TlsStream` (E3) whose inner handshake state is distinct from TcpSender's connection policy.
- **TCP_NODELAY is part of `Open`** — it's a POSIX socket-setup detail. A future TLS Stream can choose whether to apply it without TcpSender needing to know.
- **Self-recovery on failed `Open`**: the POSIX implementation closes the socket if `connect` fails, so `Close` is always safe afterward (idempotent).
- **Address ownership**: same as S13.7 — `sockaddr_in*` passes through the interface; hiding deferred until Winsock/E3 demands it.
- **Singleton pattern**: same as `PosixDatagram`, `GetAddrInfoResolver`.

Pure refactor — no new functionality, no behaviour change.

## Test Evidence

**New tests** — `Tests/SolidSyslogPosixTcpStreamTest.cpp`: 20 tests driven by strict TDD (red/green for each behaviour). Covers:
- `Open`: socket count, AF_INET, SOCK_STREAM, TCP_NODELAY via setsockopt, connect fd/address propagation, success/failure return, close-on-connect-failure (self-recovery).
- `Send`: call count, buffer/length/flags/fd propagation, MSG_NOSIGNAL, success/failure return.
- `Close`: calls `close()` when open, called with the right fd, no-op when not open.

**Existing tests preserved** — `SolidSyslogTcpSenderTest.cpp` (37 tests across 4 TEST_GROUPs) unchanged in their assertions and test bodies. Only the setup/teardown wiring changed to create/destroy a `PosixTcpStream`. SocketFake intercepts at libc level, so all existing assertions continue to pass.

**Local CI — all presets green:**
- `debug`, `clang-debug`, `sanitize`: 518 tests pass
- `coverage`: 100% on new files (`SolidSyslogStream.c`, `SolidSyslogPosixTcpStream.c`); 99.9% overall (pre-existing gap in `SolidSyslogFileStore.c`, unrelated)
- `tidy`, `cppcheck`: clean (NOLINTNEXTLINE on connect mirrors the existing suppression that was on the original TcpSender for the same reason)
- `clang-format --dry-run --Werror`: clean
- BDD: 14 features / 31 scenarios / 160 steps passed

## Areas Affected

**New:**
- `Interface/SolidSyslogStream.h`, `SolidSyslogStreamDefinition.h`, `SolidSyslogPosixTcpStream.h`
- `Source/SolidSyslogStream.c`, `SolidSyslogPosixTcpStream.c`
- `Tests/SolidSyslogPosixTcpStreamTest.cpp`

**Modified:**
- `Interface/SolidSyslogTcpSender.h` — config gains `stream` field
- `Source/SolidSyslogTcpSender.c` — delegates socket operations to injected Stream; removed `fd` field, `CreateSocket`, `EnableTcpNoDelay`, `Disconnect` helpers
- `Tests/SolidSyslogTcpSenderTest.cpp` — 4 TEST_GROUPs wire in PosixTcpStream
- `Example/Threaded/main.c` — TCP path creates/destroys PosixTcpStream
- `Source/CMakeLists.txt`, `Tests/CMakeLists.txt` — add new source files

**Not affected:** `UdpSender` (handled in S13.6/S13.7), `SingleTask` example (UDP-only).

## What this unblocks

- **S13.9 (#135)**: WinsockTcpStream — just a new Stream implementation, no TcpSender changes needed.
- **E3 (#5)**: TLS transport can be implemented as a `TlsStream` that wraps any `SolidSyslogStream*`, providing a composition boundary for SSL handshake/write/shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POSIX TCP stream abstraction to improve modular handling of TCP syslog transport.
  * TCP sender updated to use the new stream abstraction, simplifying connection management and lifecycle handling.

* **Tests**
  * Added extensive POSIX TCP stream tests covering creation, connect behavior, send semantics, and cleanup.
  * Updated TCP sender tests to exercise the stream-backed configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->