### PR TITLE
feat: S12.11 honest error reporting for Resolver and Datagram vtables

### DIFF
--- a/Interface/SolidSyslogDatagram.h
+++ b/Interface/SolidSyslogDatagram.h
@@ -10,7 +10,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogDatagram;
 
-    void SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
+    bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
     bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size, const struct sockaddr_in* addr);
     void SolidSyslogDatagram_Close(struct SolidSyslogDatagram * datagram);
 

--- a/Interface/SolidSyslogDatagramDefinition.h
+++ b/Interface/SolidSyslogDatagramDefinition.h
@@ -7,8 +7,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogDatagram
     {
-        /* void return: failure reporting deferred to Epic #31 (error handling) */
-        void (*Open)(struct SolidSyslogDatagram* self);
+        bool (*Open)(struct SolidSyslogDatagram* self);
         bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
         /* void return: failure reporting deferred to Epic #31 (error handling) */
         void (*Close)(struct SolidSyslogDatagram* self);

--- a/Interface/SolidSyslogDatagramDefinition.h
+++ b/Interface/SolidSyslogDatagramDefinition.h
@@ -9,7 +9,6 @@ EXTERN_C_BEGIN
     {
         bool (*Open)(struct SolidSyslogDatagram* self);
         bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
-        /* void return: failure reporting deferred to Epic #31 (error handling) */
         void (*Close)(struct SolidSyslogDatagram* self);
     };
 

--- a/Interface/SolidSyslogResolver.h
+++ b/Interface/SolidSyslogResolver.h
@@ -4,12 +4,13 @@
 #include "ExternC.h"
 #include "SolidSyslogTransport.h"
 #include <netinet/in.h>
+#include <stdbool.h>
 
 EXTERN_C_BEGIN
 
     struct SolidSyslogResolver;
 
-    void SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct sockaddr_in * result);
+    bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct sockaddr_in * result);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogResolverDefinition.h
+++ b/Interface/SolidSyslogResolverDefinition.h
@@ -8,8 +8,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogResolver
     {
-        /* void return: failure reporting deferred to Epic #31 (error handling) */
-        void (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
+        bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
     };
 
 EXTERN_C_END

--- a/Interface/SolidSyslogStreamDefinition.h
+++ b/Interface/SolidSyslogStreamDefinition.h
@@ -9,7 +9,6 @@ EXTERN_C_BEGIN
     {
         bool (*Open)(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
         bool (*Send)(struct SolidSyslogStream* self, const void* buffer, size_t size);
-        /* void return: failure reporting deferred to Epic #31 (error handling) */
         void (*Close)(struct SolidSyslogStream* self);
     };
 

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
@@ -2,10 +2,16 @@
 #include "SolidSyslogResolverDefinition.h"
 
 #include <netdb.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <sys/socket.h>
 
-static void Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
+enum
+{
+    GETADDRINFO_SUCCESS = 0
+};
+
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
 
 static int MapTransport(enum SolidSyslogTransport transport);
 
@@ -26,21 +32,26 @@ struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(const char* (*
     return &instance.base;
 }
 
-static void Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result)
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result)
 {
     struct SolidSyslogGetAddrInfoResolver* resolver = (struct SolidSyslogGetAddrInfoResolver*) self;
 
-    struct addrinfo  hints    = {0};
-    struct addrinfo* resolved = NULL;
-    hints.ai_family           = AF_INET;
-    hints.ai_socktype         = MapTransport(transport);
+    struct addrinfo hints = {0};
+    hints.ai_family       = AF_INET;
+    hints.ai_socktype     = MapTransport(transport);
 
-    // NOLINTNEXTLINE(bugprone-unused-return-value) -- error handling deferred to Epic #31
-    getaddrinfo(resolver->getHost(), NULL, &hints, &resolved);
+    struct addrinfo* info     = NULL;
+    bool             resolved = false;
 
-    *result          = *(struct sockaddr_in*) resolved->ai_addr;
-    result->sin_port = htons((uint16_t) resolver->getPort());
-    freeaddrinfo(resolved);
+    if (getaddrinfo(resolver->getHost(), NULL, &hints, &info) == GETADDRINFO_SUCCESS)
+    {
+        *result          = *(struct sockaddr_in*) info->ai_addr;
+        result->sin_port = htons((uint16_t) resolver->getPort());
+        freeaddrinfo(info);
+        resolved = true;
+    }
+
+    return resolved;
 }
 
 static int MapTransport(enum SolidSyslogTransport transport)

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -6,9 +6,15 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-static void Open(struct SolidSyslogDatagram* self);
-static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
-static void Close(struct SolidSyslogDatagram* self);
+enum
+{
+    INVALID_FD = -1
+};
+
+static bool        Open(struct SolidSyslogDatagram* self);
+static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
+static void        Close(struct SolidSyslogDatagram* self);
+static inline bool IsFileDescriptorValid(int fd);
 
 struct SolidSyslogPosixDatagram
 {
@@ -16,7 +22,7 @@ struct SolidSyslogPosixDatagram
     int                        fd;
 };
 
-static struct SolidSyslogPosixDatagram instance = {.fd = -1};
+static struct SolidSyslogPosixDatagram instance = {.fd = INVALID_FD};
 
 struct SolidSyslogDatagram* SolidSyslogPosixDatagram_Create(void)
 {
@@ -33,10 +39,16 @@ void SolidSyslogPosixDatagram_Destroy(void)
     instance.base.Close  = NULL;
 }
 
-static void Open(struct SolidSyslogDatagram* self)
+static bool Open(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     datagram->fd                              = socket(AF_INET, SOCK_DGRAM, 0);
+    return IsFileDescriptorValid(datagram->fd);
+}
+
+static inline bool IsFileDescriptorValid(int fd)
+{
+    return fd >= 0;
 }
 
 static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr)
@@ -48,9 +60,9 @@ static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t 
 static void Close(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
-    if (datagram->fd >= 0)
+    if (IsFileDescriptorValid(datagram->fd))
     {
         close(datagram->fd);
-        datagram->fd = -1;
+        datagram->fd = INVALID_FD;
     }
 }

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -6,11 +6,16 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
-static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
-static void Close(struct SolidSyslogStream* self);
+enum
+{
+    INVALID_FD = -1
+};
 
-static void EnableTcpNoDelay(int fd);
+static bool        Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
+static bool        Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
+static void        Close(struct SolidSyslogStream* self);
+static void        EnableTcpNoDelay(int fd);
+static inline bool IsFileDescriptorValid(int fd);
 
 struct SolidSyslogPosixTcpStream
 {
@@ -18,7 +23,7 @@ struct SolidSyslogPosixTcpStream
     int                      fd;
 };
 
-static struct SolidSyslogPosixTcpStream instance = {.fd = -1};
+static struct SolidSyslogPosixTcpStream instance = {.fd = INVALID_FD};
 
 struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void)
 {
@@ -48,10 +53,16 @@ static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr)
     if (!connected)
     {
         close(stream->fd);
-        stream->fd = -1;
+        stream->fd = INVALID_FD;
     }
 
     return connected;
+}
+
+static void EnableTcpNoDelay(int fd)
+{
+    int enable = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
 }
 
 static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
@@ -63,15 +74,14 @@ static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size
 static void Close(struct SolidSyslogStream* self)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
-    if (stream->fd >= 0)
+    if (IsFileDescriptorValid(stream->fd))
     {
         close(stream->fd);
-        stream->fd = -1;
+        stream->fd = INVALID_FD;
     }
 }
 
-static void EnableTcpNoDelay(int fd)
+static inline bool IsFileDescriptorValid(int fd)
 {
-    int enable = 1;
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
+    return fd >= 0;
 }

--- a/Source/SolidSyslogDatagram.c
+++ b/Source/SolidSyslogDatagram.c
@@ -1,8 +1,8 @@
 #include "SolidSyslogDatagramDefinition.h"
 
-void SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
+bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
 {
-    datagram->Open(datagram);
+    return datagram->Open(datagram);
 }
 
 bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct sockaddr_in* addr)

--- a/Source/SolidSyslogResolver.c
+++ b/Source/SolidSyslogResolver.c
@@ -1,6 +1,6 @@
 #include "SolidSyslogResolverDefinition.h"
 
-void SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, struct sockaddr_in* result)
+bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, struct sockaddr_in* result)
 {
-    resolver->Resolve(resolver, transport, result);
+    return resolver->Resolve(resolver, transport, result);
 }

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -78,9 +78,11 @@ static bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
 static bool Connect(struct SolidSyslogTcpSender* tcp)
 {
     struct sockaddr_in addr;
-    SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, &addr);
 
-    tcp->connected = SolidSyslogStream_Open(tcp->config.stream, &addr);
+    if (SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, &addr))
+    {
+        tcp->connected = SolidSyslogStream_Open(tcp->config.stream, &addr);
+    }
 
     return tcp->connected;
 }

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -21,7 +21,12 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     instance.base.Send = Send;
 
     bool opened   = SolidSyslogDatagram_Open(config->datagram);
-    bool resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
+    bool resolved = false;
+
+    if (opened)
+    {
+        resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
+    }
 
     instance.ready = opened && resolved;
 

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -10,6 +10,7 @@ struct SolidSyslogUdpSender
     struct SolidSyslogSender          base;
     struct SolidSyslogUdpSenderConfig config;
     struct sockaddr_in                addr;
+    bool                              ready;
 };
 
 static struct SolidSyslogUdpSender instance;
@@ -19,8 +20,10 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     instance.config    = *config;
     instance.base.Send = Send;
 
-    SolidSyslogDatagram_Open(config->datagram);
-    SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
+    bool opened   = SolidSyslogDatagram_Open(config->datagram);
+    bool resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
+
+    instance.ready = opened && resolved;
 
     return &instance.base;
 }
@@ -34,10 +37,18 @@ void SolidSyslogUdpSender_Destroy(void)
     instance.base.Send = NULL;
     instance.addr      = (struct sockaddr_in) {0};
     instance.config    = (struct SolidSyslogUdpSenderConfig) {0};
+    instance.ready     = false;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     struct SolidSyslogUdpSender* udpSender = (struct SolidSyslogUdpSender*) self;
-    return SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, &udpSender->addr);
+    bool                         sent      = false;
+
+    if (udpSender->ready)
+    {
+        sent = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, &udpSender->addr);
+    }
+
+    return sent;
 }

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -114,3 +114,27 @@ TEST(SolidSyslogGetAddrInfoResolver, TcpTransportPassesStreamSocktype)
     resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_TCP, &result);
     LONGS_EQUAL(SOCK_STREAM, SocketFake_LastGetAddrInfoSocktype());
 }
+
+TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsFalseWhenGetAddrInfoFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result));
+}
+
+TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result));
+}
+
+TEST(SolidSyslogGetAddrInfoResolver, ResolveDoesNotFreeAddrInfoWhenGetAddrInfoFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+    LONGS_EQUAL(0, SocketFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogGetAddrInfoResolver, ResolveFreesAddrInfoOnSuccess)
+{
+    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+    LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
+}

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -60,6 +60,17 @@ TEST(SolidSyslogPosixDatagram, OpenCallsSocketWithSOCK_DGRAM)
     LONGS_EQUAL(SOCK_DGRAM, SocketFake_SocketType());
 }
 
+TEST(SolidSyslogPosixDatagram, OpenReturnsFalseWhenSocketFails)
+{
+    SocketFake_SetSocketFails(true);
+    CHECK_FALSE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(SolidSyslogPosixDatagram, OpenReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(SolidSyslogDatagram_Open(datagram));
+}
+
 TEST(SolidSyslogPosixDatagram, SendToCallsSendtoOnce)
 {
     SolidSyslogDatagram_Open(datagram);

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -473,3 +473,22 @@ TEST(SolidSyslogTcpSenderFailure, BodySendFailureClosesSocket)
     Send();
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
+
+TEST(SolidSyslogTcpSenderFailure, SendReturnsFalseWhenResolverFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(Send());
+}
+
+TEST(SolidSyslogTcpSenderFailure, SendDoesNotOpenStreamWhenResolverFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    Send();
+    LONGS_EQUAL(0, SocketFake_SocketCallCount());
+    LONGS_EQUAL(0, SocketFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogTcpSenderFailure, SendReturnsTrueWhenResolverSucceeds)
+{
+    CHECK_TRUE(Send());
+}

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -329,3 +329,65 @@ TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithResolvedAddress)
     Send();
     STRCMP_EQUAL(TEST_DEFAULT_HOST, SocketFake_LastAddrAsString());
 }
+
+// clang-format off
+TEST_GROUP(SolidSyslogUdpSenderFailure)
+{
+    struct SolidSyslogResolver*       resolver = nullptr;
+    struct SolidSyslogDatagram*       datagram = nullptr;
+    struct SolidSyslogUdpSenderConfig config;
+    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
+    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
+    struct SolidSyslogSender*         sender = nullptr;
+
+    void setup() override
+    {
+        SocketFake_Reset();
+    }
+
+    void teardown() override
+    {
+        SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
+        SolidSyslogGetAddrInfoResolver_Destroy();
+    }
+
+    void CreateSender()
+    {
+        resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        datagram = SolidSyslogPosixDatagram_Create();
+        config   = {resolver, datagram};
+        // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest macros
+        sender   = SolidSyslogUdpSender_Create(&config);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenResolverFailedAtCreate)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CreateSender();
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenSocketFailedAtCreate)
+{
+    SocketFake_SetSocketFails(true);
+    CreateSender();
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderFailure, SendDoesNotCallSendtoWhenResolverFailed)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CreateSender();
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(0, SocketFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogUdpSenderFailure, SendReturnsTrueWhenResolverAndSocketSucceed)
+{
+    CreateSender();
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -378,6 +378,13 @@ TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenSocketFailedAtCreate)
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
+TEST(SolidSyslogUdpSenderFailure, DoesNotResolveWhenSocketFailedAtCreate)
+{
+    SocketFake_SetSocketFails(true);
+    CreateSender();
+    LONGS_EQUAL(0, SocketFake_GetAddrInfoCallCount());
+}
+
 TEST(SolidSyslogUdpSenderFailure, SendDoesNotCallSendtoWhenResolverFailed)
 {
     SocketFake_SetGetAddrInfoFails(true);

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -53,11 +53,13 @@ static int lastClosedFd;
 
 static char lastAddrString[INET_ADDRSTRLEN];
 
+static bool               getAddrInfoFails;
 static int                getAddrInfoCallCount;
 static char               lastGetAddrInfoHostname[256];
 static int                lastGetAddrInfoSocktype;
 static struct sockaddr_in fakeResolvedAddr;
 static struct addrinfo    fakeAddrInfo;
+static int                freeAddrInfoCallCount;
 
 void SocketFake_Reset(void)
 {
@@ -95,9 +97,11 @@ void SocketFake_Reset(void)
     lastClosedFd             = -1;
     lastAddrString[0]        = '\0';
 
+    getAddrInfoFails            = false;
     getAddrInfoCallCount        = 0;
     lastGetAddrInfoHostname[0]  = '\0';
     lastGetAddrInfoSocktype     = 0;
+    freeAddrInfoCallCount       = 0;
     fakeResolvedAddr            = (struct sockaddr_in) {0};
     fakeResolvedAddr.sin_family = AF_INET;
     fakeAddrInfo                = (struct addrinfo) {0};
@@ -296,6 +300,13 @@ int SocketFake_LastClosedFd(void)
     return lastClosedFd;
 }
 
+/* getaddrinfo configuration */
+
+void SocketFake_SetGetAddrInfoFails(bool fails)
+{
+    getAddrInfoFails = fails;
+}
+
 /* getaddrinfo accessors */
 
 int SocketFake_GetAddrInfoCallCount(void)
@@ -311,6 +322,13 @@ const char* SocketFake_LastGetAddrInfoHostname(void)
 int SocketFake_LastGetAddrInfoSocktype(void)
 {
     return lastGetAddrInfoSocktype;
+}
+
+/* freeaddrinfo accessors */
+
+int SocketFake_FreeAddrInfoCallCount(void)
+{
+    return freeAddrInfoCallCount;
 }
 
 /* POSIX strong-symbol fakes */
@@ -404,6 +422,10 @@ int getaddrinfo(const char* node, const char* service, const struct addrinfo* hi
     getAddrInfoCallCount++;
     lastGetAddrInfoSocktype = hints ? hints->ai_socktype : 0;
     SafeString_Copy(lastGetAddrInfoHostname, sizeof(lastGetAddrInfoHostname), node ? node : "");
+    if (getAddrInfoFails)
+    {
+        return EAI_FAIL;
+    }
     inet_pton(AF_INET, node, &fakeResolvedAddr.sin_addr);
     *res = &fakeAddrInfo;
     return 0;
@@ -413,4 +435,5 @@ int getaddrinfo(const char* node, const char* service, const struct addrinfo* hi
 void freeaddrinfo(struct addrinfo* res)
 {
     (void) res;
+    freeAddrInfoCallCount++;
 }

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -20,10 +20,11 @@ static struct sockaddr_in lastAddr;
 static socklen_t          lastAddrLen;
 static int                lastSendtoFd;
 
-static int socketCallCount;
-static int socketFd;
-static int lastSocketDomain;
-static int lastSocketType;
+static bool socketFails;
+static int  socketCallCount;
+static int  socketFd;
+static int  lastSocketDomain;
+static int  lastSocketType;
 
 enum
 {
@@ -89,6 +90,7 @@ void SocketFake_Reset(void)
     setSockOptCallCount      = 0;
     lastSetSockOptLevel      = 0;
     lastSetSockOptOptname    = 0;
+    socketFails              = false;
     socketCallCount          = 0;
     socketFd                 = -1;
     lastSocketDomain         = 0;
@@ -166,6 +168,13 @@ socklen_t SocketFake_LastAddrLen(void)
 int SocketFake_LastSendtoFd(void)
 {
     return lastSendtoFd;
+}
+
+/* socket configuration */
+
+void SocketFake_SetSocketFails(bool fails)
+{
+    socketFails = fails;
 }
 
 /* socket accessors */
@@ -340,7 +349,14 @@ int socket(int domain, int type, int protocol)
     socketCallCount++;
     lastSocketDomain = domain;
     lastSocketType   = type;
-    socketFd         = socketCallCount; /* deterministic fake fd */
+    if (socketFails)
+    {
+        socketFd = -1;
+    }
+    else
+    {
+        socketFd = socketCallCount; /* deterministic fake fd */
+    }
     return socketFd;
 }
 

--- a/Tests/Support/SocketFake.h
+++ b/Tests/Support/SocketFake.h
@@ -60,10 +60,16 @@ EXTERN_C_BEGIN
     int SocketFake_CloseCallCount(void);
     int SocketFake_LastClosedFd(void);
 
+    /* getaddrinfo configuration */
+    void SocketFake_SetGetAddrInfoFails(bool fails);
+
     /* getaddrinfo accessors */
     int         SocketFake_GetAddrInfoCallCount(void);
     const char* SocketFake_LastGetAddrInfoHostname(void);
     int         SocketFake_LastGetAddrInfoSocktype(void);
+
+    /* freeaddrinfo accessors */
+    int SocketFake_FreeAddrInfoCallCount(void);
 
 EXTERN_C_END
 

--- a/Tests/Support/SocketFake.h
+++ b/Tests/Support/SocketFake.h
@@ -25,6 +25,9 @@ EXTERN_C_BEGIN
     socklen_t   SocketFake_LastAddrLen(void);
     int         SocketFake_LastSendtoFd(void);
 
+    /* socket configuration */
+    void SocketFake_SetSocketFails(bool fails);
+
     /* socket accessors */
     int SocketFake_SocketCallCount(void);
     int SocketFake_SocketFd(void);


### PR DESCRIPTION
## Purpose

Closes #141. Thread real failure propagation through the Resolver and Datagram vtable boundary and up into the sender layer. Today several underlying POSIX calls (\`getaddrinfo\`, \`socket\`) can fail silently — the vtables returned \`void\` and the implementations discarded the return. This PR makes those contracts honest so every implementation — including the upcoming Winsock variants — shares a consistent error model.

Narrow scope by design: vtable contracts honest, senders propagate what they already check, no new lifecycle behaviour. Sender lazy init and reconnection policy live in #33 and are consumed by those stories on top of these contracts.

## Change Description

Four logical steps, one commit each:

1. **Resolver.Resolve returns bool** — vtable, dispatch, and GetAddrInfoResolver all updated; GetAddrInfoResolver now honestly checks \`getaddrinfo\` and frees the addrinfo list only on the success path (calling \`freeaddrinfo\` on a failed result is UB per POSIX). Two red/green cycles drive the contract; two more drive the \`freeaddrinfo\` guard.
2. **Datagram.Open returns bool** — same shape for the socket-creation boundary. PosixDatagram.Open honestly checks \`socket()\`. Follow-on cleanup in the same commit: introduces \`INVALID_FD = -1\` and a \`IsFileDescriptorValid(int)\` inline helper in both \`PosixDatagram.c\` and \`PosixTcpStream.c\`, and fixes function ordering so helpers sit directly below their first caller.
3. **UdpSender propagates failures** — new \`ready\` flag populated at Create from \`Datagram.Open && Resolver.Resolve\`. When \`!ready\`, Send short-circuits to \`false\` without calling Datagram.SendTo. Four new tests in a dedicated \`SolidSyslogUdpSenderFailure\` group.
4. **TcpSender propagates Resolve failure** — \`Connect\` now checks Resolve's return before calling Stream.Open. Lazy connect and reconnect semantics preserved.

## Test Evidence

**Strict TDD throughout.** Every bool return is driven by a failing test before the production change; every new branch has both the failure and the symmetric positive test documented next to each other.

**New SocketFake controls:**
- \`SocketFake_SetGetAddrInfoFails(bool)\` — forces \`getaddrinfo\` to return \`EAI_FAIL\`
- \`SocketFake_SetSocketFails(bool)\` — forces \`socket()\` to return \`-1\`
- \`SocketFake_FreeAddrInfoCallCount()\` — tracks free calls so the resource-leak guard is test-driven

**Test counts:** 528 → 531 passing (13 new tests added across the GetAddrInfoResolver, PosixDatagram, UdpSender-Failure and TcpSender-Failure groups; no existing test changed).

**Local CI — all presets green:**
- \`debug\`, \`clang-debug\`, \`sanitize\`: 531 tests pass
- \`coverage\`: 99.9% (993/994 lines — same pre-existing FileStore gap, unrelated)
- \`tidy\`, \`cppcheck\`: clean
- \`clang-format --dry-run --Werror\`: clean
- BDD: 14 features / 31 scenarios / 160 steps passed

## Areas Affected

**Interface changes (public contract):**
- \`SolidSyslogResolver.Resolve\`: \`void\` → \`bool\`
- \`SolidSyslogDatagram.Open\`: \`void\` → \`bool\`
- \`SolidSyslogDatagram.Close\` and \`SolidSyslogStream.Close\` remain \`void\` — close errors are uniformly ignored today and unrecoverable anyway (Epic #31)

**Implementations updated:**
- \`Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c\` — honest \`getaddrinfo\` check, \`GETADDRINFO_SUCCESS\` named constant, \`freeaddrinfo\` moved to the single success path
- \`Platform/Posix/Source/SolidSyslogPosixDatagram.c\` — honest \`socket()\` check, \`INVALID_FD\`, \`IsFileDescriptorValid\`
- \`Platform/Posix/Source/SolidSyslogPosixTcpStream.c\` — same cleanup (\`INVALID_FD\`, \`IsFileDescriptorValid\`), function ordering fixed

**Senders:**
- \`Source/SolidSyslogUdpSender.c\` — gains \`ready\` flag; \`Send\` short-circuits when not ready
- \`Source/SolidSyslogTcpSender.c\` — \`Connect\` guards Stream.Open on Resolve's return

**Tests:** 13 new across four groups; no existing tests changed.

## Out of scope

- NULL guards on public API (existing S12.4, S12.5, S12.6, S12.8).
- Structured error codes or enums — bool is sufficient for today's caller action (\"try again\"). Revisit if a caller needs to distinguish failure modes.
- UdpSender going lazy like TcpSender (#33).
- Reconnection policy on send failure (#33).
- Allocation failure paths — not applicable (singletons).

## What this unblocks

- **Winsock stories (S13.4, S13.9)** — implement the same honest-bool contracts with \`WSAGetLastError\` instead of \`errno\`.
- **S13.11 (opaque address)** — same interface boundary, can slot in cleanly now that the signatures have stabilised.
- **#33 (sender lazy init + reconnection)** — consumes the honest contracts to decide when to reopen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core operations now return explicit success/failure status, enabling callers to detect errors.

* **Bug Fixes**
  * Senders validate initialization/resolution before sending, preventing actions on unready connections.
  * File-descriptor handling and resolver failures are now handled explicitly to avoid resource misuse.

* **Tests**
  * Added unit tests covering resolver, datagram, TCP/UDP sender success and failure paths and fake socket behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->