### PR TITLE
refactor: S13.11 introduce opaque SolidSyslogAddress type

### DIFF
--- a/Interface/SolidSyslogDatagram.h
+++ b/Interface/SolidSyslogDatagram.h
@@ -2,7 +2,7 @@
 #define SOLIDSYSLOGDATAGRAM_H
 
 #include "ExternC.h"
-#include <netinet/in.h>
+#include "SolidSyslogAddress.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -11,7 +11,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogDatagram;
 
     bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
-    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size, const struct sockaddr_in* addr);
+    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
     void SolidSyslogDatagram_Close(struct SolidSyslogDatagram * datagram);
 
 EXTERN_C_END

--- a/Interface/SolidSyslogDatagramDefinition.h
+++ b/Interface/SolidSyslogDatagramDefinition.h
@@ -8,7 +8,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogDatagram
     {
         bool (*Open)(struct SolidSyslogDatagram* self);
-        bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
+        bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
         void (*Close)(struct SolidSyslogDatagram* self);
     };
 

--- a/Interface/SolidSyslogResolver.h
+++ b/Interface/SolidSyslogResolver.h
@@ -2,15 +2,15 @@
 #define SOLIDSYSLOGRESOLVER_H
 
 #include "ExternC.h"
+#include "SolidSyslogAddress.h"
 #include "SolidSyslogTransport.h"
-#include <netinet/in.h>
 #include <stdbool.h>
 
 EXTERN_C_BEGIN
 
     struct SolidSyslogResolver;
 
-    bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct sockaddr_in * result);
+    bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct SolidSyslogAddress * result);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogResolverDefinition.h
+++ b/Interface/SolidSyslogResolverDefinition.h
@@ -8,7 +8,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogResolver
     {
-        bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
+        bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
     };
 
 EXTERN_C_END

--- a/Interface/SolidSyslogStream.h
+++ b/Interface/SolidSyslogStream.h
@@ -2,7 +2,7 @@
 #define SOLIDSYSLOGSTREAM_H
 
 #include "ExternC.h"
-#include <netinet/in.h>
+#include "SolidSyslogAddress.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -10,7 +10,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogStream;
 
-    bool SolidSyslogStream_Open(struct SolidSyslogStream * stream, const struct sockaddr_in* addr);
+    bool SolidSyslogStream_Open(struct SolidSyslogStream * stream, const struct SolidSyslogAddress* addr);
     bool SolidSyslogStream_Send(struct SolidSyslogStream * stream, const void* buffer, size_t size);
     void SolidSyslogStream_Close(struct SolidSyslogStream * stream);
 

--- a/Interface/SolidSyslogStreamDefinition.h
+++ b/Interface/SolidSyslogStreamDefinition.h
@@ -7,7 +7,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogStream
     {
-        bool (*Open)(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
+        bool (*Open)(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
         bool (*Send)(struct SolidSyslogStream* self, const void* buffer, size_t size);
         void (*Close)(struct SolidSyslogStream* self);
     };

--- a/Platform/Posix/CMakeLists.txt
+++ b/Platform/Posix/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     Source/SolidSyslogPosixHostname.c
     Source/SolidSyslogPosixMessageQueueBuffer.c
     Source/SolidSyslogPosixProcessId.c
+    Source/SolidSyslogAddress.c
     Source/SolidSyslogGetAddrInfoResolver.c
     Source/SolidSyslogPosixDatagram.c
     Source/SolidSyslogPosixTcpStream.c

--- a/Platform/Posix/Interface/SolidSyslogAddress.h
+++ b/Platform/Posix/Interface/SolidSyslogAddress.h
@@ -1,0 +1,25 @@
+#ifndef SOLIDSYSLOGADDRESS_H
+#define SOLIDSYSLOGADDRESS_H
+
+#include "ExternC.h"
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    enum
+    {
+        SOLIDSYSLOG_ADDRESS_SIZE = 128 /* bytes; covers struct sockaddr_storage on glibc and Winsock */
+    };
+
+    typedef struct
+    {
+        intptr_t slots[SOLIDSYSLOG_ADDRESS_SIZE / sizeof(intptr_t)];
+    } SolidSyslogAddressStorage;
+
+    struct SolidSyslogAddress;
+
+    struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage* storage);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGADDRESS_H */

--- a/Platform/Posix/Interface/SolidSyslogAddress.h
+++ b/Platform/Posix/Interface/SolidSyslogAddress.h
@@ -8,7 +8,7 @@ EXTERN_C_BEGIN
 
     enum
     {
-        SOLIDSYSLOG_ADDRESS_SIZE = 128 /* bytes; covers struct sockaddr_storage on glibc and Winsock */
+        SOLIDSYSLOG_ADDRESS_SIZE = 128 /* bytes; sized to cover struct sockaddr_storage for cross-platform parity (glibc, Winsock) */
     };
 
     typedef struct

--- a/Platform/Posix/Interface/SolidSyslogAddress.h
+++ b/Platform/Posix/Interface/SolidSyslogAddress.h
@@ -18,7 +18,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogAddress;
 
-    struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage* storage);
+    struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage * storage);
 
 EXTERN_C_END
 

--- a/Platform/Posix/Source/SolidSyslogAddress.c
+++ b/Platform/Posix/Source/SolidSyslogAddress.c
@@ -1,0 +1,6 @@
+#include "SolidSyslogAddress.h"
+
+struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage* storage)
+{
+    return (struct SolidSyslogAddress*) storage;
+}

--- a/Platform/Posix/Source/SolidSyslogAddressInternal.h
+++ b/Platform/Posix/Source/SolidSyslogAddressInternal.h
@@ -2,9 +2,13 @@
 #define SOLIDSYSLOGADDRESSINTERNAL_H
 
 #include "SolidSyslogAddress.h"
+#include "SolidSyslogMacros.h"
 
 #include <netinet/in.h>
 #include <stdint.h>
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct sockaddr_in) <= SOLIDSYSLOG_ADDRESS_SIZE,
+                          SolidSyslogAddressStorage_too_small_for_sockaddr_in);
 
 static inline struct sockaddr_in* SolidSyslogAddress_AsSockaddrIn(struct SolidSyslogAddress* address)
 {

--- a/Platform/Posix/Source/SolidSyslogAddressInternal.h
+++ b/Platform/Posix/Source/SolidSyslogAddressInternal.h
@@ -1,0 +1,21 @@
+#ifndef SOLIDSYSLOGADDRESSINTERNAL_H
+#define SOLIDSYSLOGADDRESSINTERNAL_H
+
+#include "SolidSyslogAddress.h"
+
+#include <netinet/in.h>
+#include <stdint.h>
+
+static inline struct sockaddr_in* SolidSyslogAddress_AsSockaddrIn(struct SolidSyslogAddress* address)
+{
+    uint8_t* bytes = (uint8_t*) address;
+    return (struct sockaddr_in*) bytes;
+}
+
+static inline const struct sockaddr_in* SolidSyslogAddress_AsConstSockaddrIn(const struct SolidSyslogAddress* address)
+{
+    const uint8_t* bytes = (const uint8_t*) address;
+    return (const struct sockaddr_in*) bytes;
+}
+
+#endif /* SOLIDSYSLOGADDRESSINTERNAL_H */

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogResolverDefinition.h"
 
 #include <netdb.h>
@@ -11,7 +12,7 @@ enum
     GETADDRINFO_SUCCESS = 0
 };
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result);
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
 
 static int MapTransport(enum SolidSyslogTransport transport);
 
@@ -32,7 +33,7 @@ struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(const char* (*
     return &instance.base;
 }
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct sockaddr_in* result)
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
 {
     struct SolidSyslogGetAddrInfoResolver* resolver = (struct SolidSyslogGetAddrInfoResolver*) self;
 
@@ -45,8 +46,9 @@ static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport 
 
     if (getaddrinfo(resolver->getHost(), NULL, &hints, &info) == GETADDRINFO_SUCCESS)
     {
-        *result          = *(struct sockaddr_in*) info->ai_addr;
-        result->sin_port = htons((uint16_t) resolver->getPort());
+        struct sockaddr_in* sin = SolidSyslogAddress_AsSockaddrIn(result);
+        *sin                    = *(struct sockaddr_in*) info->ai_addr;
+        sin->sin_port           = htons((uint16_t) resolver->getPort());
         freeaddrinfo(info);
         resolved = true;
     }

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogPosixDatagram.h"
+#include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogDatagramDefinition.h"
 
 #include <stdbool.h>
@@ -12,7 +13,7 @@ enum
 };
 
 static bool        Open(struct SolidSyslogDatagram* self);
-static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr);
+static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
 static void        Close(struct SolidSyslogDatagram* self);
 static inline bool IsFileDescriptorValid(int fd);
 
@@ -51,10 +52,11 @@ static inline bool IsFileDescriptorValid(int fd)
     return fd >= 0;
 }
 
-static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct sockaddr_in* addr)
+static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
-    return sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) addr, sizeof(*addr)) >= 0;
+    const struct sockaddr_in*        sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
+    return sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin)) >= 0;
 }
 
 static void Close(struct SolidSyslogDatagram* self)

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogStreamDefinition.h"
 
 #include <netinet/tcp.h>
@@ -11,7 +12,7 @@ enum
     INVALID_FD = -1
 };
 
-static bool        Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr);
+static bool        Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
 static bool        Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
 static void        Close(struct SolidSyslogStream* self);
 static void        EnableTcpNoDelay(int fd);
@@ -40,15 +41,16 @@ void SolidSyslogPosixTcpStream_Destroy(void)
     instance.base.Close = NULL;
 }
 
-static bool Open(struct SolidSyslogStream* self, const struct sockaddr_in* addr)
+static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
+    const struct sockaddr_in*         sin    = SolidSyslogAddress_AsConstSockaddrIn(addr);
 
     stream->fd = socket(AF_INET, SOCK_STREAM, 0);
     EnableTcpNoDelay(stream->fd);
 
     // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions) -- socket() failure handling deferred to error handling epic
-    bool connected = connect(stream->fd, (const struct sockaddr*) addr, sizeof(*addr)) == 0;
+    bool connected = connect(stream->fd, (const struct sockaddr*) sin, sizeof(*sin)) == 0;
 
     if (!connected)
     {

--- a/Source/SolidSyslogDatagram.c
+++ b/Source/SolidSyslogDatagram.c
@@ -5,7 +5,7 @@ bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
     return datagram->Open(datagram);
 }
 
-bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct sockaddr_in* addr)
+bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     return datagram->SendTo(datagram, buffer, size, addr);
 }

--- a/Source/SolidSyslogResolver.c
+++ b/Source/SolidSyslogResolver.c
@@ -1,6 +1,6 @@
 #include "SolidSyslogResolverDefinition.h"
 
-bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, struct sockaddr_in* result)
+bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
 {
     return resolver->Resolve(resolver, transport, result);
 }

--- a/Source/SolidSyslogStream.c
+++ b/Source/SolidSyslogStream.c
@@ -1,6 +1,6 @@
 #include "SolidSyslogStreamDefinition.h"
 
-bool SolidSyslogStream_Open(struct SolidSyslogStream* stream, const struct sockaddr_in* addr)
+bool SolidSyslogStream_Open(struct SolidSyslogStream* stream, const struct SolidSyslogAddress* addr)
 {
     return stream->Open(stream, addr);
 }

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -77,11 +77,12 @@ static bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
 
 static bool Connect(struct SolidSyslogTcpSender* tcp)
 {
-    struct sockaddr_in addr;
+    SolidSyslogAddressStorage  addrStorage = {0};
+    struct SolidSyslogAddress* addr        = SolidSyslogAddress_FromStorage(&addrStorage);
 
-    if (SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, &addr))
+    if (SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, addr))
     {
-        tcp->connected = SolidSyslogStream_Open(tcp->config.stream, &addr);
+        tcp->connected = SolidSyslogStream_Open(tcp->config.stream, addr);
     }
 
     return tcp->connected;

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -9,7 +9,7 @@ struct SolidSyslogUdpSender
 {
     struct SolidSyslogSender          base;
     struct SolidSyslogUdpSenderConfig config;
-    struct sockaddr_in                addr;
+    SolidSyslogAddressStorage         addrStorage;
     bool                              ready;
 };
 
@@ -20,12 +20,14 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     instance.config    = *config;
     instance.base.Send = Send;
 
+    struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&instance.addrStorage);
+
     bool opened   = SolidSyslogDatagram_Open(config->datagram);
     bool resolved = false;
 
     if (opened)
     {
-        resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, &instance.addr);
+        resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, addr);
     }
 
     instance.ready = opened && resolved;
@@ -40,7 +42,7 @@ void SolidSyslogUdpSender_Destroy(void)
         SolidSyslogDatagram_Close(instance.config.datagram);
     }
     instance.base.Send = NULL;
-    instance.addr      = (struct sockaddr_in) {0};
+    instance.addrStorage = (SolidSyslogAddressStorage) {0};
     instance.config    = (struct SolidSyslogUdpSenderConfig) {0};
     instance.ready     = false;
 }
@@ -52,7 +54,8 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
 
     if (udpSender->ready)
     {
-        sent = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, &udpSender->addr);
+        struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&udpSender->addrStorage);
+        sent = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, addr);
     }
 
     return sent;

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -41,10 +41,10 @@ void SolidSyslogUdpSender_Destroy(void)
     {
         SolidSyslogDatagram_Close(instance.config.datagram);
     }
-    instance.base.Send = NULL;
+    instance.base.Send   = NULL;
     instance.addrStorage = (SolidSyslogAddressStorage) {0};
-    instance.config    = (struct SolidSyslogUdpSenderConfig) {0};
-    instance.ready     = false;
+    instance.config      = (struct SolidSyslogUdpSenderConfig) {0};
+    instance.ready       = false;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
@@ -55,7 +55,7 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
     if (udpSender->ready)
     {
         struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&udpSender->addrStorage);
-        sent = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, addr);
+        sent                            = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, addr);
     }
 
     return sent;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -54,6 +54,7 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogGetAddrInfoResolverTest.cpp
         SolidSyslogPosixDatagramTest.cpp
         SolidSyslogPosixTcpStreamTest.cpp
+        SolidSyslogAddressTest.cpp
     )
 endif()
 

--- a/Tests/SolidSyslogAddressTest.cpp
+++ b/Tests/SolidSyslogAddressTest.cpp
@@ -1,0 +1,22 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogAddress.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogAddress)
+{
+    SolidSyslogAddressStorage storage{};
+};
+
+// clang-format on
+
+TEST(SolidSyslogAddress, FromStorageReturnsNonNull)
+{
+    CHECK_TRUE(SolidSyslogAddress_FromStorage(&storage) != nullptr);
+}
+
+TEST(SolidSyslogAddress, FromStorageReturnsSamePointerOnSuccessiveCalls)
+{
+    struct SolidSyslogAddress* first  = SolidSyslogAddress_FromStorage(&storage);
+    struct SolidSyslogAddress* second = SolidSyslogAddress_FromStorage(&storage);
+    POINTERS_EQUAL(first, second);
+}

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -59,9 +59,12 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolver)
     }
 
     // Test-only peek: the resolver fills the storage per the POSIX sockaddr_in layout.
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through the accessor syntax in tests
     const struct sockaddr_in* Result() const
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
         const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
         return reinterpret_cast<const struct sockaddr_in*>(bytes);
     }
 };

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -1,8 +1,10 @@
 #include "CppUTest/TestHarness.h"
+#include "SolidSyslogAddress.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogResolverDefinition.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
+#include <cstdint>
 #include <netinet/in.h>
 #include <sys/socket.h>
 
@@ -37,7 +39,7 @@ static int GetAlternatePort()
 TEST_GROUP(SolidSyslogGetAddrInfoResolver)
 {
     struct SolidSyslogResolver* resolver = nullptr;
-    struct sockaddr_in result = {};
+    SolidSyslogAddressStorage   resultStorage{};
 
     void setup() override
     {
@@ -50,9 +52,17 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolver)
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
-    void Resolve()
+    bool Resolve(enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
     {
-        resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
+        return resolver->Resolve(resolver, transport, address);
+    }
+
+    // Test-only peek: the resolver fills the storage per the POSIX sockaddr_in layout.
+    const struct sockaddr_in* Result() const
+    {
+        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
+        return reinterpret_cast<const struct sockaddr_in*>(bytes);
     }
 };
 
@@ -65,21 +75,21 @@ TEST(SolidSyslogGetAddrInfoResolver, CreateDestroyWorksWithoutCrashing)
 TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesAddressFamily)
 {
     Resolve();
-    LONGS_EQUAL(AF_INET, result.sin_family);
+    LONGS_EQUAL(AF_INET, Result()->sin_family);
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesResolvedAddress)
 {
     Resolve();
     char addrString[INET_ADDRSTRLEN];
-    inet_ntop(AF_INET, &result.sin_addr, addrString, sizeof(addrString));
+    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
     STRCMP_EQUAL(TEST_HOST, addrString);
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesPort)
 {
     Resolve();
-    LONGS_EQUAL(TEST_PORT, ntohs(result.sin_port));
+    LONGS_EQUAL(TEST_PORT, ntohs(Result()->sin_port));
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, GetAddrInfoCalledWithHostname)
@@ -100,41 +110,41 @@ TEST(SolidSyslogGetAddrInfoResolver, AlternatePortResolvesCorrectly)
 {
     resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetAlternatePort);
     Resolve();
-    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(result.sin_port));
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, UdpTransportPassesDatagramSocktype)
 {
-    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+    Resolve(SOLIDSYSLOG_TRANSPORT_UDP);
     LONGS_EQUAL(SOCK_DGRAM, SocketFake_LastGetAddrInfoSocktype());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, TcpTransportPassesStreamSocktype)
 {
-    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_TCP, &result);
+    Resolve(SOLIDSYSLOG_TRANSPORT_TCP);
     LONGS_EQUAL(SOCK_STREAM, SocketFake_LastGetAddrInfoSocktype());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsFalseWhenGetAddrInfoFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
-    CHECK_FALSE(resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result));
+    CHECK_FALSE(Resolve());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsTrueOnSuccess)
 {
-    CHECK_TRUE(resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result));
+    CHECK_TRUE(Resolve());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolveDoesNotFreeAddrInfoWhenGetAddrInfoFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
-    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+    Resolve();
     LONGS_EQUAL(0, SocketFake_FreeAddrInfoCallCount());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, ResolveFreesAddrInfoOnSuccess)
 {
-    resolver->Resolve(resolver, SOLIDSYSLOG_TRANSPORT_UDP, &result);
+    Resolve();
     LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
 }

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -26,12 +26,15 @@ TEST_GROUP(SolidSyslogPosixDatagram)
     {
         SocketFake_Reset();
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
-        datagram       = SolidSyslogPosixDatagram_Create();
-        auto* bytes    = reinterpret_cast<std::uint8_t*>(&addrStorage);
-        auto* sin      = reinterpret_cast<struct sockaddr_in*>(bytes);
+        datagram = SolidSyslogPosixDatagram_Create();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        auto* bytes = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
+        auto* sin       = reinterpret_cast<struct sockaddr_in*>(bytes);
         sin->sin_family = AF_INET;
         sin->sin_port   = htons(TEST_PORT);
         inet_pton(AF_INET, TEST_ADDRESS, &sin->sin_addr);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         addr = SolidSyslogAddress_FromStorage(&addrStorage);
     }
 

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -3,6 +3,7 @@
 #include "SolidSyslogPosixDatagram.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
+#include <cstdint>
 #include <cstring>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -17,17 +18,21 @@ TEST_GROUP(SolidSyslogPosixDatagram)
 {
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogDatagram* datagram = nullptr;
-    struct sockaddr_in          addr{};
+    SolidSyslogAddressStorage   addrStorage{};
+    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
+    struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
     {
         SocketFake_Reset();
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
-        datagram = SolidSyslogPosixDatagram_Create();
-        std::memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_port   = htons(TEST_PORT);
-        inet_pton(AF_INET, TEST_ADDRESS, &addr.sin_addr);
+        datagram       = SolidSyslogPosixDatagram_Create();
+        auto* bytes    = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        auto* sin      = reinterpret_cast<struct sockaddr_in*>(bytes);
+        sin->sin_family = AF_INET;
+        sin->sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_ADDRESS, &sin->sin_addr);
+        addr = SolidSyslogAddress_FromStorage(&addrStorage);
     }
 
     void teardown() override
@@ -74,70 +79,70 @@ TEST(SolidSyslogPosixDatagram, OpenReturnsTrueOnSuccess)
 TEST(SolidSyslogPosixDatagram, SendToCallsSendtoOnce)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(1, SocketFake_SendtoCallCount());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesBuffer)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     STRCMP_EQUAL(TEST_MESSAGE, SocketFake_LastBufAsString());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesLength)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(TEST_MESSAGE_LEN, SocketFake_LastLen());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesFlagsZero)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(0, SocketFake_LastFlags());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesSocketFd)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastSendtoFd());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesAddressPort)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(TEST_PORT, SocketFake_LastPort());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesAddressHost)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     STRCMP_EQUAL(TEST_ADDRESS, SocketFake_LastAddrAsString());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToPassesAddrlenOfSockaddrIn)
 {
     SolidSyslogDatagram_Open(datagram);
-    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
     LONGS_EQUAL(sizeof(struct sockaddr_in), SocketFake_LastAddrLen());
 }
 
 TEST(SolidSyslogPosixDatagram, SendToReturnsTrueOnSuccess)
 {
     SolidSyslogDatagram_Open(datagram);
-    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr));
+    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
 TEST(SolidSyslogPosixDatagram, SendToReturnsFalseOnSendtoFailure)
 {
     SolidSyslogDatagram_Open(datagram);
     SocketFake_SetSendtoFails(true);
-    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, &addr));
+    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
 TEST(SolidSyslogPosixDatagram, CloseCallsCloseOnce)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -1,9 +1,10 @@
 #include "CppUTest/TestHarness.h"
+#include "SolidSyslogAddress.h"
 #include "SolidSyslogPosixTcpStream.h"
 #include "SolidSyslogStream.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
-#include <cstring>
+#include <cstdint>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
@@ -18,17 +19,21 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
 {
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStream* stream = nullptr;
-    struct sockaddr_in        addr{};
+    SolidSyslogAddressStorage addrStorage{};
+    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
+    struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
     {
         SocketFake_Reset();
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
-        stream = SolidSyslogPosixTcpStream_Create();
-        std::memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_port   = htons(TEST_PORT);
-        inet_pton(AF_INET, TEST_ADDRESS, &addr.sin_addr);
+        stream          = SolidSyslogPosixTcpStream_Create();
+        auto* bytes     = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        auto* sin       = reinterpret_cast<struct sockaddr_in*>(bytes);
+        sin->sin_family = AF_INET;
+        sin->sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_ADDRESS, &sin->sin_addr);
+        addr = SolidSyslogAddress_FromStorage(&addrStorage);
     }
 
     void teardown() override
@@ -45,25 +50,25 @@ TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsSocketOnce)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, SocketFake_SocketCallCount());
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsSocketWithAF_INET)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(AF_INET, SocketFake_SocketDomain());
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsSocketWithSOCK_STREAM)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(SOCK_STREAM, SocketFake_SocketType());
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenEnablesTcpNoDelay)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, SocketFake_SetSockOptCallCount());
     LONGS_EQUAL(IPPROTO_TCP, SocketFake_LastSetSockOptLevel());
     LONGS_EQUAL(TCP_NODELAY, SocketFake_LastSetSockOptOptname());
@@ -71,95 +76,95 @@ TEST(SolidSyslogPosixTcpStream, OpenEnablesTcpNoDelay)
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsConnectWithSocketFd)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, SocketFake_ConnectCallCount());
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastConnectFd());
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsConnectWithProvidedAddress)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(TEST_PORT, SocketFake_LastConnectPort());
     STRCMP_EQUAL(TEST_ADDRESS, SocketFake_LastConnectAddrAsString());
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenReturnsTrueOnSuccess)
 {
-    CHECK_TRUE(SolidSyslogStream_Open(stream, &addr));
+    CHECK_TRUE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenReturnsFalseOnConnectFailure)
 {
     SocketFake_SetConnectFails(true);
-    CHECK_FALSE(SolidSyslogStream_Open(stream, &addr));
+    CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenClosesSocketOnConnectFailure)
 {
     SocketFake_SetConnectFails(true);
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
 
 TEST(SolidSyslogPosixTcpStream, SendCallsSendOnce)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(1, SocketFake_SendCallCount());
 }
 
 TEST(SolidSyslogPosixTcpStream, SendPassesBuffer)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
     STRCMP_EQUAL(TEST_MESSAGE, SocketFake_SendBufAsString(0));
 }
 
 TEST(SolidSyslogPosixTcpStream, SendPassesLength)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(TEST_MESSAGE_LEN, SocketFake_SendLen(0));
 }
 
 TEST(SolidSyslogPosixTcpStream, SendPassesMSG_NOSIGNALFlag)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(MSG_NOSIGNAL, SocketFake_SendFlags(0));
 }
 
 TEST(SolidSyslogPosixTcpStream, SendPassesSocketFd)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastSendFd());
 }
 
 TEST(SolidSyslogPosixTcpStream, SendReturnsTrueOnSuccess)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     CHECK_TRUE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
 TEST(SolidSyslogPosixTcpStream, SendReturnsFalseOnSendFailure)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SocketFake_SetSendFails(true);
     CHECK_FALSE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
 TEST(SolidSyslogPosixTcpStream, CloseCallsCloseOnce)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Close(stream);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
 
 TEST(SolidSyslogPosixTcpStream, CloseCalledWithSocketFd)
 {
-    SolidSyslogStream_Open(stream, &addr);
+    SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Close(stream);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -27,12 +27,15 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
     {
         SocketFake_Reset();
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
-        stream          = SolidSyslogPosixTcpStream_Create();
-        auto* bytes     = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        stream = SolidSyslogPosixTcpStream_Create();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        auto* bytes = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
         auto* sin       = reinterpret_cast<struct sockaddr_in*>(bytes);
         sin->sin_family = AF_INET;
         sin->sin_port   = htons(TEST_PORT);
         inet_pton(AF_INET, TEST_ADDRESS, &sin->sin_addr);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         addr = SolidSyslogAddress_FromStorage(&addrStorage);
     }
 


### PR DESCRIPTION
## Purpose

Closes #142. Hide \`struct sockaddr_in\` from the public library surface. Platform-agnostic code (senders, dispatch, public interfaces) no longer includes \`<netinet/in.h>\`; POSIX socket types are reached only inside the platform implementation layer via a private internal header.

Makes the Winsock stories (S13.4, S13.9) a drop-in — they can ship their own \`SolidSyslogAddress.h\` without touching senders or dispatch. Also unblocks a future user-supplied platform slot (RTOS / embedded) that defines its own \`SolidSyslogAddress\` layout to match its network stack.

## Change Description

### Design

\`SolidSyslogAddressStorage\` is a fixed 128-byte buffer (matches \`sizeof(struct sockaddr_storage)\` on glibc and Winsock), expressed as an \`intptr_t\` array so the alignment matches the platform's natural word alignment — sufficient for \`sockaddr_in\`, \`sockaddr_in6\`, and any \`sockaddr_*\` variant. No unions (MISRA 19.2 compliant).

\`struct SolidSyslogAddress\` stays **purely forward-declared**. No concrete body anywhere — just a type identity for passing pointers through interfaces. Platform implementations reach the underlying \`sockaddr_in\` via a shared internal helper (\`Platform/Posix/Source/SolidSyslogAddressInternal.h\`) that casts through a \`uint8_t*\` intermediate. Character-type aliasing is permitted by C99 strict aliasing, which sidesteps the concerns around reinterpret-casting between unrelated pointer types.

### Phased commits

1. **Phase A** — Introduce the \`SolidSyslogAddress\` type + \`FromStorage\` accessor + smoke tests.
2. **Phase B** — Migrate all three vtables (\`Resolver.Resolve\`, \`Datagram.SendTo\`, \`Stream.Open\`) to take \`struct SolidSyslogAddress*\` atomically; senders switch their internal address buffer from \`struct sockaddr_in\` to \`SolidSyslogAddressStorage\`; platform impls include the internal helper and cast inside; tests that previously constructed \`sockaddr_in\` directly now hold storage and peek via the same \`uint8_t*/sockaddr_in*\` pattern.
3. **Style/tidy sweep** — suppress clang-tidy warnings on the justified reinterpret-casts in the platform-specific test peek helpers, apply clang-format.

### Leak sweep

After Phase B:

\`\`\`
grep -r "netinet/in.h\|sockaddr_in" Interface/ Source/   # → nothing
\`\`\`

All remaining mentions of \`sockaddr_in\` are in:
- \`Platform/Posix/Source/\` — the POSIX implementations, by design
- \`Tests/Support/SocketFake.c\` — mocks the POSIX API
- Platform-specific test files — legitimately peek at platform layout for behavioural verification

## Test Evidence

- **Phase A tests**: \`FromStorageReturnsNonNull\`, \`FromStorageReturnsSamePointerOnSuccessiveCalls\`.
- **Phase B**: no new behaviour, so no new tests. Every existing test continues to pass — the observable behaviour of every sender, dispatch, and platform impl is unchanged. Tests that constructed \`sockaddr_in\` directly were adapted to hold a \`SolidSyslogAddressStorage\` and populate via the same \`uint8_t*\` → \`sockaddr_in*\` cast that platform impls use.

**Local CI — all presets green:**
- \`debug\`, \`clang-debug\`, \`sanitize\`: 534 tests pass
- \`coverage\`: 99.9% (1010/1011 lines — same pre-existing \`SolidSyslogFileStore.c\` gap, unrelated)
- \`tidy\`, \`cppcheck\`: clean (NOLINT suppressions on the two legitimate reinterpret-casts in platform-specific test peek helpers)
- \`clang-format --dry-run --Werror\`: clean
- BDD: 14 features / 31 scenarios / 160 steps passed

## Areas Affected

**New files:**
- \`Platform/Posix/Interface/SolidSyslogAddress.h\` — forward decl, \`SolidSyslogAddressStorage\`, \`SolidSyslogAddress_FromStorage\`.
- \`Platform/Posix/Source/SolidSyslogAddress.c\` — trivial \`FromStorage\` (pointer reinterpretation).
- \`Platform/Posix/Source/SolidSyslogAddressInternal.h\` — private header with \`AsSockaddrIn\` / \`AsConstSockaddrIn\` helpers.
- \`Tests/SolidSyslogAddressTest.cpp\` — 2 smoke tests.

**Interface changes (public contract):**
- \`SolidSyslogResolver.h\`, \`SolidSyslogDatagram.h\`, \`SolidSyslogStream.h\` — drop \`<netinet/in.h>\`; all three signatures switch from \`sockaddr_in*\` / \`const sockaddr_in*\` to \`SolidSyslogAddress*\` / \`const SolidSyslogAddress*\`.
- Corresponding \`Definition.h\` headers — matching vtable signature changes.

**Implementations updated:**
- \`Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c\`, \`SolidSyslogPosixDatagram.c\`, \`SolidSyslogPosixTcpStream.c\` — cast opaque pointer via internal helper.
- \`Source/SolidSyslogUdpSender.c\`, \`SolidSyslogTcpSender.c\` — switch internal/local address buffer to \`SolidSyslogAddressStorage\`.

**Tests updated:**
- \`SolidSyslogGetAddrInfoResolverTest.cpp\`, \`SolidSyslogPosixDatagramTest.cpp\`, \`SolidSyslogPosixTcpStreamTest.cpp\` — hold \`SolidSyslogAddressStorage\` and peek via \`uint8_t*\` / \`sockaddr_in*\` pattern for verification.

**Not affected:** any platform-agnostic production code other than the senders, examples, or other tests.

## What this unblocks

- **Winsock transport stories (S13.4, S13.9)** — ship their own \`Platform/Windows/Interface/SolidSyslogAddress.h\` with matching contract and Winsock-compatible concrete struct. Senders, dispatch and tests require no further change.
- **User-supplied platform slot** (tracked in memory as future idea) — an RTOS or bare-metal port defines its own \`SolidSyslogAddress.h\` with whatever size/alignment its stack needs.

## Size tuning

\`SOLIDSYSLOG_ADDRESS_SIZE\` defaults to 128 bytes. If a target is memory-constrained and IPv4-only, a \`-DSOLIDSYSLOG_ADDRESS_SIZE=16\` compile-time override would shrink per-sender storage from 128 to 16 bytes. CMake wiring for this knob is deferred — belongs with a future \"resource sizing knobs\" pass alongside message size, SD count, and buffer capacity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a cross-platform SolidSyslogAddress abstraction for representing network destinations.

* **Refactor**
  * Public APIs for sending, resolving, and opening streams now accept the new address abstraction instead of platform-specific address structs; POSIX platform now provides the corresponding address implementation.

* **Tests**
  * Added and updated tests to validate the new address abstraction across affected operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->