### PR TITLE
feat: S13.4 Winsock UDP transport (resolver + datagram)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ include(CheckSymbolExists)
 check_symbol_exists(sendto "sys/socket.h" HAVE_POSIX_SOCKETS)
 option(SOLIDSYSLOG_POSIX "Include POSIX UDP sender" ${HAVE_POSIX_SOCKETS})
 
+check_symbol_exists(sendto "winsock2.h" HAVE_WINSOCK)
+option(SOLIDSYSLOG_WINSOCK "Include Winsock UDP sender" ${HAVE_WINSOCK})
+
 include(CheckIncludeFile)
 check_include_file(stdatomic.h HAVE_STDATOMIC_H)
 check_symbol_exists(InterlockedIncrement "windows.h" HAVE_WINDOWS_INTERLOCKED)
@@ -80,7 +83,7 @@ if(SOLIDSYSLOG_POSIX)
     add_subdirectory(Platform/Posix)
 endif()
 
-if(HAVE_WINDOWS_INTERLOCKED)
+if(HAVE_WINDOWS_INTERLOCKED OR SOLIDSYSLOG_WINSOCK)
     add_subdirectory(Platform/Windows)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,11 @@ include(CheckSymbolExists)
 check_symbol_exists(sendto "sys/socket.h" HAVE_POSIX_SOCKETS)
 option(SOLIDSYSLOG_POSIX "Include POSIX UDP sender" ${HAVE_POSIX_SOCKETS})
 
+set(_SOLIDSYSLOG_PREV_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+set(CMAKE_REQUIRED_LIBRARIES ws2_32)
 check_symbol_exists(sendto "winsock2.h" HAVE_WINSOCK)
+set(CMAKE_REQUIRED_LIBRARIES "${_SOLIDSYSLOG_PREV_CMAKE_REQUIRED_LIBRARIES}")
+unset(_SOLIDSYSLOG_PREV_CMAKE_REQUIRED_LIBRARIES)
 option(SOLIDSYSLOG_WINSOCK "Include Winsock UDP sender" ${HAVE_WINSOCK})
 
 include(CheckIncludeFile)

--- a/Platform/Windows/CMakeLists.txt
+++ b/Platform/Windows/CMakeLists.txt
@@ -1,6 +1,19 @@
-target_sources(${PROJECT_NAME} PRIVATE
-    Source/SolidSyslogWindowsAtomicCounter.c
-)
+if(HAVE_WINDOWS_INTERLOCKED)
+    target_sources(${PROJECT_NAME} PRIVATE
+        Source/SolidSyslogWindowsAtomicCounter.c
+    )
+endif()
 
-# Interface headers are installed once Winsock stories (S13.4, S13.9) populate
-# Platform/Windows/Interface/.
+if(SOLIDSYSLOG_WINSOCK)
+    target_sources(${PROJECT_NAME} PRIVATE
+        Source/SolidSyslogAddress.c
+        Source/SolidSyslogWinsockResolver.c
+        Source/SolidSyslogWinsockDatagram.c
+    )
+    target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32)
+    target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Interface)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+    )
+endif()

--- a/Platform/Windows/Interface/SolidSyslogAddress.h
+++ b/Platform/Windows/Interface/SolidSyslogAddress.h
@@ -1,0 +1,25 @@
+#ifndef SOLIDSYSLOGADDRESS_H
+#define SOLIDSYSLOGADDRESS_H
+
+#include "ExternC.h"
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    enum
+    {
+        SOLIDSYSLOG_ADDRESS_SIZE = 128 /* bytes; sized to cover struct sockaddr_storage for cross-platform parity (glibc, Winsock) */
+    };
+
+    typedef struct
+    {
+        intptr_t slots[SOLIDSYSLOG_ADDRESS_SIZE / sizeof(intptr_t)];
+    } SolidSyslogAddressStorage;
+
+    struct SolidSyslogAddress;
+
+    struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage * storage);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGADDRESS_H */

--- a/Platform/Windows/Interface/SolidSyslogWinsockDatagram.h
+++ b/Platform/Windows/Interface/SolidSyslogWinsockDatagram.h
@@ -1,0 +1,16 @@
+#ifndef SOLIDSYSLOGWINSOCKDATAGRAM_H
+#define SOLIDSYSLOGWINSOCKDATAGRAM_H
+
+#include "SolidSyslogDatagram.h"
+
+EXTERN_C_BEGIN
+
+    /* Precondition: caller has invoked WSAStartup() before using the datagram,
+       and will call WSACleanup() on shutdown. The library does not manage
+       Winsock lifecycle. */
+    struct SolidSyslogDatagram* SolidSyslogWinsockDatagram_Create(void);
+    void                        SolidSyslogWinsockDatagram_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINSOCKDATAGRAM_H */

--- a/Platform/Windows/Interface/SolidSyslogWinsockResolver.h
+++ b/Platform/Windows/Interface/SolidSyslogWinsockResolver.h
@@ -1,0 +1,17 @@
+#ifndef SOLIDSYSLOGWINSOCKRESOLVERH
+#define SOLIDSYSLOGWINSOCKRESOLVERH
+
+#include "SolidSyslogResolver.h"
+
+EXTERN_C_BEGIN
+
+    /* Precondition: caller has invoked WSAStartup() before using the resolver,
+       and will call WSACleanup() on shutdown. The library does not manage
+       Winsock lifecycle. */
+    struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(const char* (*getHost)(void), // NOLINT(modernize-redundant-void-arg) -- C idiom
+                                                                  int (*getPort)(void));        // NOLINT(modernize-redundant-void-arg) -- C idiom
+    void                        SolidSyslogWinsockResolver_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINSOCKRESOLVERH */

--- a/Platform/Windows/Source/SolidSyslogAddress.c
+++ b/Platform/Windows/Source/SolidSyslogAddress.c
@@ -1,0 +1,6 @@
+#include "SolidSyslogAddress.h"
+
+struct SolidSyslogAddress* SolidSyslogAddress_FromStorage(SolidSyslogAddressStorage* storage)
+{
+    return (struct SolidSyslogAddress*) storage;
+}

--- a/Platform/Windows/Source/SolidSyslogAddressInternal.h
+++ b/Platform/Windows/Source/SolidSyslogAddressInternal.h
@@ -1,0 +1,24 @@
+#ifndef SOLIDSYSLOGADDRESSINTERNAL_H
+#define SOLIDSYSLOGADDRESSINTERNAL_H
+
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogMacros.h"
+
+#include <stdint.h>
+#include <winsock2.h>
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct sockaddr_in) <= SOLIDSYSLOG_ADDRESS_SIZE, SolidSyslogAddressStorage_too_small_for_sockaddr_in);
+
+static inline struct sockaddr_in* SolidSyslogAddress_AsSockaddrIn(struct SolidSyslogAddress* address)
+{
+    uint8_t* bytes = (uint8_t*) address;
+    return (struct sockaddr_in*) bytes;
+}
+
+static inline const struct sockaddr_in* SolidSyslogAddress_AsConstSockaddrIn(const struct SolidSyslogAddress* address)
+{
+    const uint8_t* bytes = (const uint8_t*) address;
+    return (const struct sockaddr_in*) bytes;
+}
+
+#endif /* SOLIDSYSLOGADDRESSINTERNAL_H */

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -6,9 +6,32 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-WinsockSocketFn      Winsock_socket      = socket;
-WinsockSendToFn      Winsock_sendto      = sendto;
-WinsockCloseSocketFn Winsock_closesocket = closesocket;
+/* File-local forwarders. Taking the address of a __declspec(dllimport)
+   Winsock function for static initialisation triggers MSVC C4232 (the address
+   isn't a compile-time constant); forwarding through a static function whose
+   address IS a compile-time constant avoids the warning without a suppression. */
+static SOCKET WSAAPI CallSocket(int af, int type, int protocol);
+static int WSAAPI    CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
+static int WSAAPI    CallCloseSocket(SOCKET s);
+
+WinsockSocketFn      Winsock_socket      = CallSocket;
+WinsockSendToFn      Winsock_sendto      = CallSendTo;
+WinsockCloseSocketFn Winsock_closesocket = CallCloseSocket;
+
+static SOCKET WSAAPI CallSocket(int af, int type, int protocol)
+{
+    return socket(af, type, protocol);
+}
+
+static int WSAAPI CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
+{
+    return sendto(s, buf, len, flags, to, tolen);
+}
+
+static int WSAAPI CallCloseSocket(SOCKET s)
+{
+    return closesocket(s);
+}
 
 static bool        Open(struct SolidSyslogDatagram* self);
 static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -1,0 +1,68 @@
+#include "SolidSyslogWinsockDatagram.h"
+#include "SolidSyslogAddressInternal.h"
+#include "SolidSyslogDatagramDefinition.h"
+#include "SolidSyslogWinsockDatagramInternal.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+WinsockSocketFn      Winsock_socket      = socket;
+WinsockSendToFn      Winsock_sendto      = sendto;
+WinsockCloseSocketFn Winsock_closesocket = closesocket;
+
+static bool        Open(struct SolidSyslogDatagram* self);
+static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static void        Close(struct SolidSyslogDatagram* self);
+static inline bool IsSocketValid(SOCKET fd);
+
+struct SolidSyslogWinsockDatagram
+{
+    struct SolidSyslogDatagram base;
+    SOCKET                     fd;
+};
+
+static struct SolidSyslogWinsockDatagram instance = {.fd = INVALID_SOCKET};
+
+struct SolidSyslogDatagram* SolidSyslogWinsockDatagram_Create(void)
+{
+    instance.base.Open   = Open;
+    instance.base.SendTo = SendTo;
+    instance.base.Close  = Close;
+    return &instance.base;
+}
+
+void SolidSyslogWinsockDatagram_Destroy(void)
+{
+    instance.base.Open   = NULL;
+    instance.base.SendTo = NULL;
+    instance.base.Close  = NULL;
+}
+
+static bool Open(struct SolidSyslogDatagram* self)
+{
+    struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
+    datagram->fd                                = Winsock_socket(AF_INET, SOCK_DGRAM, 0);
+    return IsSocketValid(datagram->fd);
+}
+
+static inline bool IsSocketValid(SOCKET fd)
+{
+    return fd != INVALID_SOCKET;
+}
+
+static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+{
+    struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
+    const struct sockaddr_in*          sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
+    return Winsock_sendto(datagram->fd, (const char*) buffer, (int) size, 0, (const struct sockaddr*) sin, (int) sizeof(*sin)) != SOCKET_ERROR;
+}
+
+static void Close(struct SolidSyslogDatagram* self)
+{
+    struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
+    if (IsSocketValid(datagram->fd))
+    {
+        Winsock_closesocket(datagram->fd);
+        datagram->fd = INVALID_SOCKET;
+    }
+}

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagramInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagramInternal.h
@@ -1,0 +1,24 @@
+#ifndef SOLIDSYSLOGWINSOCKDATAGRAMINTERNAL_H
+#define SOLIDSYSLOGWINSOCKDATAGRAMINTERNAL_H
+
+/* Library-internal test seam. Tests replace these function pointers via
+   CppUTest's UT_PTR_SET to inject fakes (MSVC does not support GCC's
+   weak/strong symbol override trick used by the POSIX SocketFake). */
+
+#include "ExternC.h"
+
+#include <winsock2.h>
+
+EXTERN_C_BEGIN
+
+    typedef SOCKET(WSAAPI * WinsockSocketFn)(int, int, int);
+    typedef int(WSAAPI * WinsockSendToFn)(SOCKET, const char*, int, int, const struct sockaddr*, int);
+    typedef int(WSAAPI * WinsockCloseSocketFn)(SOCKET);
+
+    extern WinsockSocketFn      Winsock_socket;
+    extern WinsockSendToFn      Winsock_sendto;
+    extern WinsockCloseSocketFn Winsock_closesocket;
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINSOCKDATAGRAMINTERNAL_H */

--- a/Platform/Windows/Source/SolidSyslogWinsockResolver.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolver.c
@@ -1,0 +1,79 @@
+#include "SolidSyslogWinsockResolver.h"
+#include "SolidSyslogAddressInternal.h"
+#include "SolidSyslogResolverDefinition.h"
+#include "SolidSyslogWinsockResolverInternal.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+WinsockGetAddrInfoFn  Winsock_getaddrinfo  = getaddrinfo;
+WinsockFreeAddrInfoFn Winsock_freeaddrinfo = freeaddrinfo;
+
+enum
+{
+    GETADDRINFO_SUCCESS = 0
+};
+
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
+
+static int MapTransport(enum SolidSyslogTransport transport);
+
+struct SolidSyslogWinsockResolver
+{
+    struct SolidSyslogResolver base;
+    const char* (*getHost)(void);
+    int (*getPort)(void);
+};
+
+static struct SolidSyslogWinsockResolver instance;
+
+struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(const char* (*getHost)(void), int (*getPort)(void))
+{
+    instance.base.Resolve = Resolve;
+    instance.getHost      = getHost;
+    instance.getPort      = getPort;
+    return &instance.base;
+}
+
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
+{
+    struct SolidSyslogWinsockResolver* resolver = (struct SolidSyslogWinsockResolver*) self;
+
+    struct addrinfo hints = {0};
+    hints.ai_family       = AF_INET;
+    hints.ai_socktype     = MapTransport(transport);
+
+    struct addrinfo* info     = NULL;
+    bool             resolved = false;
+
+    if (Winsock_getaddrinfo(resolver->getHost(), NULL, &hints, &info) == GETADDRINFO_SUCCESS)
+    {
+        struct sockaddr_in* sin = SolidSyslogAddress_AsSockaddrIn(result);
+        *sin                    = *(struct sockaddr_in*) info->ai_addr;
+        sin->sin_port           = htons((uint16_t) resolver->getPort());
+        Winsock_freeaddrinfo(info);
+        resolved = true;
+    }
+
+    return resolved;
+}
+
+static int MapTransport(enum SolidSyslogTransport transport)
+{
+    int socktype = SOCK_DGRAM;
+
+    if (transport == SOLIDSYSLOG_TRANSPORT_TCP)
+    {
+        socktype = SOCK_STREAM;
+    }
+
+    return socktype;
+}
+
+void SolidSyslogWinsockResolver_Destroy(void)
+{
+    instance.base.Resolve = NULL;
+    instance.getHost      = NULL;
+    instance.getPort      = NULL;
+}

--- a/Platform/Windows/Source/SolidSyslogWinsockResolver.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolver.c
@@ -7,8 +7,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
-WinsockGetAddrInfoFn  Winsock_getaddrinfo  = getaddrinfo;
-WinsockFreeAddrInfoFn Winsock_freeaddrinfo = freeaddrinfo;
+/* File-local forwarders. Taking the address of a __declspec(dllimport)
+   Winsock function for static initialisation triggers MSVC C4232 (the address
+   isn't a compile-time constant); forwarding through a static function whose
+   address IS a compile-time constant avoids the warning without a suppression. */
+static int WSAAPI  CallGetAddrInfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res);
+static void WSAAPI CallFreeAddrInfo(struct addrinfo* res);
+
+WinsockGetAddrInfoFn  Winsock_getaddrinfo  = CallGetAddrInfo;
+WinsockFreeAddrInfoFn Winsock_freeaddrinfo = CallFreeAddrInfo;
+
+static int WSAAPI CallGetAddrInfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res)
+{
+    return getaddrinfo(node, service, hints, res);
+}
+
+static void WSAAPI CallFreeAddrInfo(struct addrinfo* res)
+{
+    freeaddrinfo(res);
+}
 
 enum
 {

--- a/Platform/Windows/Source/SolidSyslogWinsockResolverInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolverInternal.h
@@ -1,0 +1,23 @@
+#ifndef SOLIDSYSLOGWINSOCKRESOLVERINTERNAL_H
+#define SOLIDSYSLOGWINSOCKRESOLVERINTERNAL_H
+
+/* Library-internal test seam. Tests replace these function pointers via
+   CppUTest's UT_PTR_SET to inject fakes (MSVC does not support GCC's
+   weak/strong symbol override trick used by the POSIX SocketFake). */
+
+#include "ExternC.h"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+EXTERN_C_BEGIN
+
+    typedef int(WSAAPI * WinsockGetAddrInfoFn)(const char*, const char*, const struct addrinfo*, struct addrinfo**);
+    typedef void(WSAAPI * WinsockFreeAddrInfoFn)(struct addrinfo*);
+
+    extern WinsockGetAddrInfoFn  Winsock_getaddrinfo;
+    extern WinsockFreeAddrInfoFn Winsock_freeaddrinfo;
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINSOCKRESOLVERINTERNAL_H */

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -21,10 +21,15 @@ if(HAVE_STDATOMIC_H)
     list(APPEND SOURCES SolidSyslogAtomicCounter.c)
 endif()
 
-if(SOLIDSYSLOG_POSIX)
+if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
     list(APPEND SOURCES
         SolidSyslogResolver.c
         SolidSyslogDatagram.c
+    )
+endif()
+
+if(SOLIDSYSLOG_POSIX)
+    list(APPEND SOURCES
         SolidSyslogStream.c
         SolidSyslogUdpSender.c
         SolidSyslogTcpSender.c

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,5 +1,8 @@
-if(SOLIDSYSLOG_POSIX)
+if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
     add_subdirectory(Support)
+endif()
+
+if(SOLIDSYSLOG_POSIX)
     add_subdirectory(Example)
 endif()
 
@@ -54,7 +57,18 @@ if(SOLIDSYSLOG_POSIX)
         SolidSyslogGetAddrInfoResolverTest.cpp
         SolidSyslogPosixDatagramTest.cpp
         SolidSyslogPosixTcpStreamTest.cpp
-        SolidSyslogAddressTest.cpp
+    )
+endif()
+
+if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
+    list(APPEND TEST_SOURCES SolidSyslogAddressTest.cpp)
+endif()
+
+if(SOLIDSYSLOG_WINSOCK)
+    list(APPEND TEST_SOURCES
+        WinsockFakeTest.cpp
+        SolidSyslogWinsockResolverTest.cpp
+        SolidSyslogWinsockDatagramTest.cpp
     )
 endif()
 
@@ -65,6 +79,11 @@ target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Sour
 
 if(SOLIDSYSLOG_POSIX)
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE PosixFakes)
+endif()
+
+if(SOLIDSYSLOG_WINSOCK)
+    target_link_libraries(${PROJECT_NAME}Tests PRIVATE WinsockFakes)
+    target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Platform/Windows/Source)
 endif()
 
 # Standard CppUTest console output via ctest -V

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -1,0 +1,165 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogDatagram.h"
+#include "SolidSyslogWinsockDatagram.h"
+#include "SolidSyslogWinsockDatagramInternal.h"
+#include "WinsockFake.h"
+#include <cstdint>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+// clang-format off
+static const char* const TEST_MESSAGE     = "hello";
+static const size_t      TEST_MESSAGE_LEN = 5;
+static const char* const TEST_ADDRESS     = "127.0.0.1";
+static const int         TEST_PORT        = 514;
+
+TEST_GROUP(SolidSyslogWinsockDatagram)
+{
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogDatagram* datagram = nullptr;
+    SolidSyslogAddressStorage   addrStorage{};
+    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
+    struct SolidSyslogAddress* addr = nullptr;
+
+    void setup() override
+    {
+        WinsockFake_Reset();
+        UT_PTR_SET(Winsock_socket, WinsockFake_socket);
+        UT_PTR_SET(Winsock_sendto, WinsockFake_sendto);
+        UT_PTR_SET(Winsock_closesocket, WinsockFake_closesocket);
+        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
+        datagram = SolidSyslogWinsockDatagram_Create();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        auto* bytes = reinterpret_cast<std::uint8_t*>(&addrStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
+        auto* sin       = reinterpret_cast<struct sockaddr_in*>(bytes);
+        sin->sin_family = AF_INET;
+        sin->sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_ADDRESS, &sin->sin_addr);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        addr = SolidSyslogAddress_FromStorage(&addrStorage);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogWinsockDatagram_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWinsockDatagram, CreateDestroyWorksWithoutCrashing)
+{
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenCallsSocketOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(1, WinsockFake_SocketCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenCallsSocketWithAF_INET)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(AF_INET, WinsockFake_SocketDomain());
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenCallsSocketWithSOCK_DGRAM)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_SocketType());
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenReturnsFalseWhenSocketFails)
+{
+    WinsockFake_SetSocketFails(true);
+    CHECK_FALSE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToCallsSendtoOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(1, WinsockFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesBuffer)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    STRCMP_EQUAL(TEST_MESSAGE, WinsockFake_LastBufAsString());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesLength)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(TEST_MESSAGE_LEN, WinsockFake_LastLen());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesFlagsZero)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(0, WinsockFake_LastFlags());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesSocketFd)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    CHECK(WinsockFake_SocketFd() == WinsockFake_LastSendtoFd());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesAddressPort)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(TEST_PORT, WinsockFake_LastPort());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesAddressHost)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    STRCMP_EQUAL(TEST_ADDRESS, WinsockFake_LastAddrAsString());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToPassesAddrlenOfSockaddrIn)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL((int) sizeof(struct sockaddr_in), WinsockFake_LastAddrLen());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToReturnsTrueOnSuccess)
+{
+    SolidSyslogDatagram_Open(datagram);
+    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToReturnsFalseOnSendtoFailure)
+{
+    SolidSyslogDatagram_Open(datagram);
+    WinsockFake_SetSendtoFails(true);
+    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+}
+
+TEST(SolidSyslogWinsockDatagram, CloseCallsCloseOnce)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(1, WinsockFake_CloseCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, CloseCalledWithSocketFd)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    CHECK(WinsockFake_SocketFd() == WinsockFake_LastClosedFd());
+}

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -1,0 +1,154 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogResolverDefinition.h"
+#include "SolidSyslogWinsockResolver.h"
+#include "SolidSyslogWinsockResolverInternal.h"
+#include "WinsockFake.h"
+#include <cstdint>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+// clang-format off
+static const char* const TEST_HOST           = "127.0.0.1";
+static const int         TEST_PORT           = 514;
+static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";
+static const int         TEST_ALTERNATE_PORT = 9999;
+// clang-format on
+
+static const char* GetHost()
+{
+    return TEST_HOST;
+}
+
+static int GetPort()
+{
+    return TEST_PORT;
+}
+
+static const char* GetAlternateHost()
+{
+    return TEST_ALTERNATE_HOST;
+}
+
+static int GetAlternatePort()
+{
+    return TEST_ALTERNATE_PORT;
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogWinsockResolver)
+{
+    struct SolidSyslogResolver* resolver = nullptr;
+    SolidSyslogAddressStorage   resultStorage{};
+
+    void setup() override
+    {
+        WinsockFake_Reset();
+        UT_PTR_SET(Winsock_getaddrinfo, WinsockFake_getaddrinfo);
+        UT_PTR_SET(Winsock_freeaddrinfo, WinsockFake_freeaddrinfo);
+        resolver = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogWinsockResolver_Destroy();
+    }
+
+    bool Resolve(enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    {
+        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
+        return resolver->Resolve(resolver, transport, address);
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
+    const struct sockaddr_in* Result() const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
+        return reinterpret_cast<const struct sockaddr_in*>(bytes);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWinsockResolver, CreateDestroyWorksWithoutCrashing)
+{
+}
+
+TEST(SolidSyslogWinsockResolver, ResolvePopulatesAddressFamily)
+{
+    Resolve();
+    LONGS_EQUAL(AF_INET, Result()->sin_family);
+}
+
+TEST(SolidSyslogWinsockResolver, ResolvePopulatesResolvedAddress)
+{
+    Resolve();
+    char addrString[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
+    STRCMP_EQUAL(TEST_HOST, addrString);
+}
+
+TEST(SolidSyslogWinsockResolver, ResolvePopulatesPort)
+{
+    Resolve();
+    LONGS_EQUAL(TEST_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogWinsockResolver, GetAddrInfoCalledWithHostname)
+{
+    Resolve();
+    LONGS_EQUAL(1, WinsockFake_GetAddrInfoCallCount());
+    STRCMP_EQUAL(TEST_HOST, WinsockFake_LastGetAddrInfoHostname());
+}
+
+TEST(SolidSyslogWinsockResolver, AlternateHostResolvesCorrectly)
+{
+    resolver = SolidSyslogWinsockResolver_Create(GetAlternateHost, GetPort);
+    Resolve();
+    STRCMP_EQUAL(TEST_ALTERNATE_HOST, WinsockFake_LastGetAddrInfoHostname());
+}
+
+TEST(SolidSyslogWinsockResolver, AlternatePortResolvesCorrectly)
+{
+    resolver = SolidSyslogWinsockResolver_Create(GetHost, GetAlternatePort);
+    Resolve();
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogWinsockResolver, UdpTransportPassesDatagramSocktype)
+{
+    Resolve(SOLIDSYSLOG_TRANSPORT_UDP);
+    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogWinsockResolver, TcpTransportPassesStreamSocktype)
+{
+    Resolve(SOLIDSYSLOG_TRANSPORT_TCP);
+    LONGS_EQUAL(SOCK_STREAM, WinsockFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogWinsockResolver, ResolveReturnsFalseWhenGetAddrInfoFails)
+{
+    WinsockFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(Resolve());
+}
+
+TEST(SolidSyslogWinsockResolver, ResolveReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(Resolve());
+}
+
+TEST(SolidSyslogWinsockResolver, ResolveDoesNotFreeAddrInfoWhenGetAddrInfoFails)
+{
+    WinsockFake_SetGetAddrInfoFails(true);
+    Resolve();
+    LONGS_EQUAL(0, WinsockFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogWinsockResolver, ResolveFreesAddrInfoOnSuccess)
+{
+    Resolve();
+    LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
+}

--- a/Tests/Support/CMakeLists.txt
+++ b/Tests/Support/CMakeLists.txt
@@ -1,11 +1,21 @@
-set(POSIX_FAKES_SOURCES
-    ClockFake.c
-    SafeStringStandard.c
-    SocketFake.c
-)
+if(SOLIDSYSLOG_POSIX)
+    set(POSIX_FAKES_SOURCES
+        ClockFake.c
+        SafeStringStandard.c
+        SocketFake.c
+    )
 
-add_library(PosixFakes STATIC ${POSIX_FAKES_SOURCES})
+    add_library(PosixFakes STATIC ${POSIX_FAKES_SOURCES})
 
-target_include_directories(PosixFakes PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+    target_include_directories(PosixFakes PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(PosixFakes PUBLIC ${PROJECT_NAME})
+    target_link_libraries(PosixFakes PUBLIC ${PROJECT_NAME})
+endif()
+
+if(SOLIDSYSLOG_WINSOCK)
+    add_library(WinsockFakes STATIC WinsockFake.c SafeStringWindows.c)
+
+    target_include_directories(WinsockFakes PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+    target_link_libraries(WinsockFakes PUBLIC ${PROJECT_NAME})
+endif()

--- a/Tests/Support/WinsockFake.c
+++ b/Tests/Support/WinsockFake.c
@@ -261,7 +261,14 @@ int WSAAPI WinsockFake_getaddrinfo(const char* node, const char* service, const 
     {
         return EAI_FAIL;
     }
-    inet_pton(AF_INET, node, &fakeResolvedAddr.sin_addr);
+    if (node == NULL || res == NULL)
+    {
+        return EAI_FAIL;
+    }
+    if (inet_pton(AF_INET, node, &fakeResolvedAddr.sin_addr) != 1)
+    {
+        return EAI_FAIL;
+    }
     *res = &fakeAddrInfo;
     return 0;
 }

--- a/Tests/Support/WinsockFake.c
+++ b/Tests/Support/WinsockFake.c
@@ -1,0 +1,262 @@
+#include "WinsockFake.h"
+#include "SafeString.h"
+#include <string.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+enum
+{
+    WINSOCKFAKE_MAX_BUFFER_SIZE   = 2048,
+    WINSOCKFAKE_MAX_HOSTNAME_SIZE = 256
+};
+
+static bool               sendtoFails;
+static int                sendtoCallCount;
+static char               lastBufCopy[WINSOCKFAKE_MAX_BUFFER_SIZE];
+static size_t             lastLen;
+static int                lastFlags;
+static struct sockaddr_in lastAddr;
+static int                lastAddrLen;
+static SOCKET             lastSendtoFd;
+
+static bool   socketFails;
+static int    socketCallCount;
+static SOCKET socketFd;
+static int    lastSocketDomain;
+static int    lastSocketType;
+
+static int    closeCallCount;
+static SOCKET lastClosedFd;
+
+static char lastAddrString[INET_ADDRSTRLEN];
+
+static bool               getAddrInfoFails;
+static int                getAddrInfoCallCount;
+static char               lastGetAddrInfoHostname[WINSOCKFAKE_MAX_HOSTNAME_SIZE];
+static int                lastGetAddrInfoSocktype;
+static struct sockaddr_in fakeResolvedAddr;
+static struct addrinfo    fakeAddrInfo;
+static int                freeAddrInfoCallCount;
+
+void WinsockFake_Reset(void)
+{
+    sendtoFails     = false;
+    sendtoCallCount = 0;
+    lastBufCopy[0]  = '\0';
+    lastLen         = 0;
+    lastFlags       = 0;
+    lastAddr        = (struct sockaddr_in) {0};
+    lastAddrLen     = 0;
+    lastSendtoFd    = INVALID_SOCKET;
+
+    socketFails      = false;
+    socketCallCount  = 0;
+    socketFd         = INVALID_SOCKET;
+    lastSocketDomain = 0;
+    lastSocketType   = 0;
+
+    closeCallCount = 0;
+    lastClosedFd   = INVALID_SOCKET;
+
+    lastAddrString[0] = '\0';
+
+    getAddrInfoFails            = false;
+    getAddrInfoCallCount        = 0;
+    lastGetAddrInfoHostname[0]  = '\0';
+    lastGetAddrInfoSocktype     = 0;
+    freeAddrInfoCallCount       = 0;
+    fakeResolvedAddr            = (struct sockaddr_in) {0};
+    fakeResolvedAddr.sin_family = AF_INET;
+    fakeAddrInfo                = (struct addrinfo) {0};
+    fakeAddrInfo.ai_family      = AF_INET;
+    fakeAddrInfo.ai_addr        = (struct sockaddr*) &fakeResolvedAddr;
+    fakeAddrInfo.ai_addrlen     = sizeof(fakeResolvedAddr);
+}
+
+/* socket configuration */
+
+void WinsockFake_SetSocketFails(bool fails)
+{
+    socketFails = fails;
+}
+
+/* socket accessors */
+
+int WinsockFake_SocketCallCount(void)
+{
+    return socketCallCount;
+}
+
+SOCKET WinsockFake_SocketFd(void)
+{
+    return socketFd;
+}
+
+int WinsockFake_SocketDomain(void)
+{
+    return lastSocketDomain;
+}
+
+int WinsockFake_SocketType(void)
+{
+    return lastSocketType;
+}
+
+/* sendto configuration */
+
+void WinsockFake_SetSendtoFails(bool fails)
+{
+    sendtoFails = fails;
+}
+
+/* sendto accessors */
+
+int WinsockFake_SendtoCallCount(void)
+{
+    return sendtoCallCount;
+}
+
+const char* WinsockFake_LastBufAsString(void)
+{
+    return lastBufCopy;
+}
+
+size_t WinsockFake_LastLen(void)
+{
+    return lastLen;
+}
+
+int WinsockFake_LastFlags(void)
+{
+    return lastFlags;
+}
+
+int WinsockFake_LastAddrFamily(void)
+{
+    return lastAddr.sin_family;
+}
+
+int WinsockFake_LastPort(void)
+{
+    return ntohs(lastAddr.sin_port);
+}
+
+const char* WinsockFake_LastAddrAsString(void)
+{
+    inet_ntop(AF_INET, &lastAddr.sin_addr, lastAddrString, sizeof(lastAddrString));
+    return lastAddrString;
+}
+
+int WinsockFake_LastAddrLen(void)
+{
+    return lastAddrLen;
+}
+
+SOCKET WinsockFake_LastSendtoFd(void)
+{
+    return lastSendtoFd;
+}
+
+/* closesocket accessors */
+
+int WinsockFake_CloseCallCount(void)
+{
+    return closeCallCount;
+}
+
+SOCKET WinsockFake_LastClosedFd(void)
+{
+    return lastClosedFd;
+}
+
+/* getaddrinfo configuration */
+
+void WinsockFake_SetGetAddrInfoFails(bool fails)
+{
+    getAddrInfoFails = fails;
+}
+
+/* getaddrinfo accessors */
+
+int WinsockFake_GetAddrInfoCallCount(void)
+{
+    return getAddrInfoCallCount;
+}
+
+const char* WinsockFake_LastGetAddrInfoHostname(void)
+{
+    return lastGetAddrInfoHostname;
+}
+
+int WinsockFake_LastGetAddrInfoSocktype(void)
+{
+    return lastGetAddrInfoSocktype;
+}
+
+/* freeaddrinfo accessors */
+
+int WinsockFake_FreeAddrInfoCallCount(void)
+{
+    return freeAddrInfoCallCount;
+}
+
+/* Winsock fake functions (UT_PTR_SET injection targets) */
+
+SOCKET WSAAPI WinsockFake_socket(int af, int type, int protocol)
+{
+    (void) protocol;
+    socketCallCount++;
+    lastSocketDomain = af;
+    lastSocketType   = type;
+    if (socketFails)
+    {
+        socketFd = INVALID_SOCKET;
+    }
+    else
+    {
+        socketFd = (SOCKET) socketCallCount; /* deterministic fake handle */
+    }
+    return socketFd;
+}
+
+int WSAAPI WinsockFake_sendto(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
+{
+    sendtoCallCount++;
+    lastSendtoFd    = s;
+    size_t copySize = (size_t) len < sizeof(lastBufCopy) - 1 ? (size_t) len : sizeof(lastBufCopy) - 1;
+    memcpy(lastBufCopy, buf, copySize);
+    lastBufCopy[copySize] = '\0';
+    lastLen               = (size_t) len;
+    lastFlags             = flags;
+    lastAddr              = *(const struct sockaddr_in*) to;
+    lastAddrLen           = tolen;
+    return sendtoFails ? SOCKET_ERROR : len;
+}
+
+int WSAAPI WinsockFake_closesocket(SOCKET s)
+{
+    closeCallCount++;
+    lastClosedFd = s;
+    return 0;
+}
+
+int WSAAPI WinsockFake_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res)
+{
+    (void) service;
+    getAddrInfoCallCount++;
+    lastGetAddrInfoSocktype = hints ? hints->ai_socktype : 0;
+    SafeString_Copy(lastGetAddrInfoHostname, sizeof(lastGetAddrInfoHostname), node ? node : "");
+    if (getAddrInfoFails)
+    {
+        return EAI_FAIL;
+    }
+    inet_pton(AF_INET, node, &fakeResolvedAddr.sin_addr);
+    *res = &fakeAddrInfo;
+    return 0;
+}
+
+void WSAAPI WinsockFake_freeaddrinfo(struct addrinfo* res)
+{
+    (void) res;
+    freeAddrInfoCallCount++;
+}

--- a/Tests/Support/WinsockFake.c
+++ b/Tests/Support/WinsockFake.c
@@ -222,14 +222,25 @@ SOCKET WSAAPI WinsockFake_socket(int af, int type, int protocol)
 int WSAAPI WinsockFake_sendto(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
 {
     sendtoCallCount++;
-    lastSendtoFd    = s;
-    size_t copySize = (size_t) len < sizeof(lastBufCopy) - 1 ? (size_t) len : sizeof(lastBufCopy) - 1;
-    memcpy(lastBufCopy, buf, copySize);
-    lastBufCopy[copySize] = '\0';
-    lastLen               = (size_t) len;
-    lastFlags             = flags;
-    lastAddr              = *(const struct sockaddr_in*) to;
-    lastAddrLen           = tolen;
+    lastSendtoFd = s;
+    lastFlags    = flags;
+    lastAddrLen  = tolen;
+    if (buf != NULL && len >= 0)
+    {
+        size_t copySize = (size_t) len < sizeof(lastBufCopy) - 1 ? (size_t) len : sizeof(lastBufCopy) - 1;
+        memcpy(lastBufCopy, buf, copySize);
+        lastBufCopy[copySize] = '\0';
+        lastLen               = (size_t) len;
+    }
+    else
+    {
+        lastBufCopy[0] = '\0';
+        lastLen        = 0;
+    }
+    if (to != NULL && tolen >= (int) sizeof(struct sockaddr_in))
+    {
+        lastAddr = *(const struct sockaddr_in*) to;
+    }
     return sendtoFails ? SOCKET_ERROR : len;
 }
 

--- a/Tests/Support/WinsockFake.h
+++ b/Tests/Support/WinsockFake.h
@@ -54,7 +54,7 @@ EXTERN_C_BEGIN
     int WSAAPI    WinsockFake_sendto(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
     int WSAAPI    WinsockFake_closesocket(SOCKET s);
     int WSAAPI    WinsockFake_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res);
-    void WSAAPI   WinsockFake_freeaddrinfo(struct addrinfo* res);
+    void WSAAPI   WinsockFake_freeaddrinfo(struct addrinfo * res);
 
 EXTERN_C_END
 

--- a/Tests/Support/WinsockFake.h
+++ b/Tests/Support/WinsockFake.h
@@ -1,0 +1,61 @@
+#ifndef WINSOCKFAKE_H
+#define WINSOCKFAKE_H
+
+#include "ExternC.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+EXTERN_C_BEGIN
+
+    void WinsockFake_Reset(void);
+
+    /* socket configuration */
+    void WinsockFake_SetSocketFails(bool fails);
+
+    /* socket accessors */
+    int    WinsockFake_SocketCallCount(void);
+    SOCKET WinsockFake_SocketFd(void);
+    int    WinsockFake_SocketDomain(void);
+    int    WinsockFake_SocketType(void);
+
+    /* sendto configuration */
+    void WinsockFake_SetSendtoFails(bool fails);
+
+    /* sendto accessors */
+    int         WinsockFake_SendtoCallCount(void);
+    const char* WinsockFake_LastBufAsString(void);
+    size_t      WinsockFake_LastLen(void);
+    int         WinsockFake_LastFlags(void);
+    int         WinsockFake_LastAddrFamily(void);
+    const char* WinsockFake_LastAddrAsString(void);
+    int         WinsockFake_LastPort(void);
+    int         WinsockFake_LastAddrLen(void);
+    SOCKET      WinsockFake_LastSendtoFd(void);
+
+    /* closesocket accessors */
+    int    WinsockFake_CloseCallCount(void);
+    SOCKET WinsockFake_LastClosedFd(void);
+
+    /* getaddrinfo configuration */
+    void WinsockFake_SetGetAddrInfoFails(bool fails);
+
+    /* getaddrinfo accessors */
+    int         WinsockFake_GetAddrInfoCallCount(void);
+    const char* WinsockFake_LastGetAddrInfoHostname(void);
+    int         WinsockFake_LastGetAddrInfoSocktype(void);
+
+    /* freeaddrinfo accessors */
+    int WinsockFake_FreeAddrInfoCallCount(void);
+
+    /* Fake Winsock functions — injected into production via UT_PTR_SET. */
+    SOCKET WSAAPI WinsockFake_socket(int af, int type, int protocol);
+    int WSAAPI    WinsockFake_sendto(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
+    int WSAAPI    WinsockFake_closesocket(SOCKET s);
+    int WSAAPI    WinsockFake_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res);
+    void WSAAPI   WinsockFake_freeaddrinfo(struct addrinfo* res);
+
+EXTERN_C_END
+
+#endif /* WINSOCKFAKE_H */

--- a/Tests/WinsockFakeTest.cpp
+++ b/Tests/WinsockFakeTest.cpp
@@ -1,0 +1,120 @@
+#include "CppUTest/TestHarness.h"
+#include "WinsockFake.h"
+#include <cstring>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+// clang-format off
+static const char* const TEST_MESSAGE     = "hello";
+static const int         TEST_MESSAGE_LEN = 5;
+static const char* const TEST_HOST        = "127.0.0.1";
+static const int         TEST_PORT        = 514;
+
+TEST_GROUP(WinsockFake)
+{
+    struct sockaddr_in destination{};
+
+    void setup() override
+    {
+        WinsockFake_Reset();
+        destination.sin_family = AF_INET;
+        destination.sin_port   = htons(TEST_PORT);
+        inet_pton(AF_INET, TEST_HOST, &destination.sin_addr);
+    }
+};
+// clang-format on
+
+TEST(WinsockFake, SocketRecordsCall)
+{
+    WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    LONGS_EQUAL(1, WinsockFake_SocketCallCount());
+    LONGS_EQUAL(AF_INET, WinsockFake_SocketDomain());
+    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_SocketType());
+}
+
+TEST(WinsockFake, SocketReturnsInvalidSocketWhenFailing)
+{
+    WinsockFake_SetSocketFails(true);
+    SOCKET fd = WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(fd == INVALID_SOCKET);
+}
+
+TEST(WinsockFake, SocketReturnsValidHandleOnSuccess)
+{
+    SOCKET fd = WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(fd != INVALID_SOCKET);
+}
+
+TEST(WinsockFake, SendtoRecordsBufferAndAddress)
+{
+    SOCKET fd = WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    WinsockFake_sendto(fd, TEST_MESSAGE, TEST_MESSAGE_LEN, 0, (const struct sockaddr*) &destination, sizeof(destination));
+    LONGS_EQUAL(1, WinsockFake_SendtoCallCount());
+    STRCMP_EQUAL(TEST_MESSAGE, WinsockFake_LastBufAsString());
+    LONGS_EQUAL(TEST_MESSAGE_LEN, (int) WinsockFake_LastLen());
+    LONGS_EQUAL(TEST_PORT, WinsockFake_LastPort());
+    STRCMP_EQUAL(TEST_HOST, WinsockFake_LastAddrAsString());
+    LONGS_EQUAL((int) sizeof(destination), WinsockFake_LastAddrLen());
+}
+
+TEST(WinsockFake, SendtoReturnsSocketErrorWhenFailing)
+{
+    WinsockFake_SetSendtoFails(true);
+    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0,
+                                    (const struct sockaddr*) &destination, sizeof(destination));
+    LONGS_EQUAL(SOCKET_ERROR, result);
+}
+
+TEST(WinsockFake, SendtoReturnsLengthOnSuccess)
+{
+    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0,
+                                    (const struct sockaddr*) &destination, sizeof(destination));
+    LONGS_EQUAL(TEST_MESSAGE_LEN, result);
+}
+
+TEST(WinsockFake, ClosesocketRecordsCall)
+{
+    SOCKET fd = WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    WinsockFake_closesocket(fd);
+    LONGS_EQUAL(1, WinsockFake_CloseCallCount());
+    CHECK(WinsockFake_LastClosedFd() == fd);
+}
+
+TEST(WinsockFake, GetAddrInfoRecordsHostnameAndSocktype)
+{
+    struct addrinfo  hints = {0, 0, 0, 0, 0, nullptr, nullptr, nullptr};
+    hints.ai_socktype      = SOCK_DGRAM;
+    struct addrinfo* res   = nullptr;
+    WinsockFake_getaddrinfo(TEST_HOST, nullptr, &hints, &res);
+    LONGS_EQUAL(1, WinsockFake_GetAddrInfoCallCount());
+    STRCMP_EQUAL(TEST_HOST, WinsockFake_LastGetAddrInfoHostname());
+    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_LastGetAddrInfoSocktype());
+    CHECK(res != nullptr);
+}
+
+TEST(WinsockFake, GetAddrInfoReturnsFailureCode)
+{
+    WinsockFake_SetGetAddrInfoFails(true);
+    struct addrinfo* res = nullptr;
+    int              rc  = WinsockFake_getaddrinfo(TEST_HOST, nullptr, nullptr, &res);
+    LONGS_EQUAL(EAI_FAIL, rc);
+}
+
+TEST(WinsockFake, FreeAddrInfoRecordsCall)
+{
+    struct addrinfo* res = nullptr;
+    WinsockFake_getaddrinfo(TEST_HOST, nullptr, nullptr, &res);
+    WinsockFake_freeaddrinfo(res);
+    LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
+}
+
+TEST(WinsockFake, ResetClearsCounters)
+{
+    WinsockFake_socket(AF_INET, SOCK_DGRAM, 0);
+    WinsockFake_Reset();
+    LONGS_EQUAL(0, WinsockFake_SocketCallCount());
+    LONGS_EQUAL(0, WinsockFake_SendtoCallCount());
+    LONGS_EQUAL(0, WinsockFake_CloseCallCount());
+    LONGS_EQUAL(0, WinsockFake_GetAddrInfoCallCount());
+    LONGS_EQUAL(0, WinsockFake_FreeAddrInfoCallCount());
+}

--- a/Tests/WinsockFakeTest.cpp
+++ b/Tests/WinsockFakeTest.cpp
@@ -22,6 +22,7 @@ TEST_GROUP(WinsockFake)
         inet_pton(AF_INET, TEST_HOST, &destination.sin_addr);
     }
 };
+
 // clang-format on
 
 TEST(WinsockFake, SocketRecordsCall)
@@ -60,15 +61,13 @@ TEST(WinsockFake, SendtoRecordsBufferAndAddress)
 TEST(WinsockFake, SendtoReturnsSocketErrorWhenFailing)
 {
     WinsockFake_SetSendtoFails(true);
-    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0,
-                                    (const struct sockaddr*) &destination, sizeof(destination));
+    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0, (const struct sockaddr*) &destination, sizeof(destination));
     LONGS_EQUAL(SOCKET_ERROR, result);
 }
 
 TEST(WinsockFake, SendtoReturnsLengthOnSuccess)
 {
-    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0,
-                                    (const struct sockaddr*) &destination, sizeof(destination));
+    int result = WinsockFake_sendto(INVALID_SOCKET, TEST_MESSAGE, TEST_MESSAGE_LEN, 0, (const struct sockaddr*) &destination, sizeof(destination));
     LONGS_EQUAL(TEST_MESSAGE_LEN, result);
 }
 
@@ -82,9 +81,9 @@ TEST(WinsockFake, ClosesocketRecordsCall)
 
 TEST(WinsockFake, GetAddrInfoRecordsHostnameAndSocktype)
 {
-    struct addrinfo  hints = {0, 0, 0, 0, 0, nullptr, nullptr, nullptr};
-    hints.ai_socktype      = SOCK_DGRAM;
-    struct addrinfo* res   = nullptr;
+    struct addrinfo hints = {0, 0, 0, 0, 0, nullptr, nullptr, nullptr};
+    hints.ai_socktype     = SOCK_DGRAM;
+    struct addrinfo* res  = nullptr;
     WinsockFake_getaddrinfo(TEST_HOST, nullptr, &hints, &res);
     LONGS_EQUAL(1, WinsockFake_GetAddrInfoCallCount());
     STRCMP_EQUAL(TEST_HOST, WinsockFake_LastGetAddrInfoHostname());


### PR DESCRIPTION
## Summary

- Windows-side `SolidSyslogResolver` + `SolidSyslogDatagram` implementations, parallel to the POSIX `GetAddrInfoResolver` / `PosixDatagram`. Brings up UDP syslog delivery on MSVC and validates the platform-abstraction layer put in place by S13.6 – S13.11.
- New `WinsockFake` test support library + `SolidSyslogWinsockResolverTest` / `SolidSyslogWinsockDatagramTest` on the `msvc-debug` preset, using CppUTest `UT_PTR_SET` to swap Winsock function-pointer seams at setup (MSVC does not support the POSIX SocketFake's symbol-override approach).
- `Platform/Windows/Interface/SolidSyslogAddress.h` companion to the POSIX opaque-address header. Layout-compatible `sockaddr_in` means the S13.11 static-assert still holds.

Closes #128.

## Design notes

- **No `#ifdef _WIN32`** — platform selection lives entirely in CMake. `SOLIDSYSLOG_WINSOCK` option auto-detects from `check_symbol_exists(sendto "winsock2.h" ...)`. Link to `ws2_32` and install Windows-side Interface headers when enabled.
- **Per-consumer function-pointer seam** — each translation unit owns its pointers via a sibling `*Internal.h` in `Platform/Windows/Source/`:
  - `WinsockResolver` owns `Winsock_getaddrinfo`, `Winsock_freeaddrinfo`
  - `WinsockDatagram` owns `Winsock_socket`, `Winsock_sendto`, `Winsock_closesocket`
- **Preconditions documented in header** — caller is responsible for `WSAStartup` / `WSACleanup`, consistent with how POSIX callers don't need `socket_init()`.
- `WSAGetLastError` / TCP (S13.9) deliberately out of scope.

## Test plan

- [x] `debug` (gcc): 534 tests ✓
- [x] `clang-debug`: 534 tests ✓
- [x] `sanitize` (ASan + UBSan): 534 tests ✓
- [x] `coverage`: 99.9% lines, 100% functions ✓
- [x] `tidy`: clean ✓
- [x] `cppcheck`: clean ✓
- [x] `format`: clean ✓
- [ ] `msvc-debug` (windows-build-and-test): validated by CI — 13 WinsockResolver + 18 WinsockDatagram + 11 WinsockFake tests run on MSVC for the first time here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Windows Winsock support (SOLIDSYSLOG_WINSOCK) with Winsock-backed resolver, UDP datagram, and public address storage/type.

* **Tests**
  * Added comprehensive Winsock test harness, fakes, and unit tests validating resolver and datagram behaviors and failure paths.

* **Chores**
  * Build system updated to conditionally include Windows platform code, headers, tests, and fakes when Winsock support is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->