### PR TITLE
feat: S13.13-15 Windows clock, hostname, and process-id helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,9 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogPosixClock.h` | System setup code using POSIX clock | `SolidSyslogPosixClock_GetTimestamp` |
 | `SolidSyslogPosixHostname.h` | String callback implementor using POSIX hostname | `SolidSyslogPosixHostname_Get` (writes into `SolidSyslogFormatter*`) |
 | `SolidSyslogPosixProcessId.h` | String callback implementor using POSIX process ID | `SolidSyslogPosixProcessId_Get` (writes into `SolidSyslogFormatter*`) |
+| `SolidSyslogWindowsClock.h` | System setup code using Windows clock | `SolidSyslogWindowsClock_GetTimestamp` |
+| `SolidSyslogWindowsHostname.h` | String callback implementor using Windows hostname | `SolidSyslogWindowsHostname_Get` (writes into `SolidSyslogFormatter*`) |
+| `SolidSyslogWindowsProcessId.h` | String callback implementor using Windows process ID | `SolidSyslogWindowsProcessId_Get` (writes into `SolidSyslogFormatter*`) |
 | `SolidSyslogStructuredData.h` | Library internals (SD dispatch) | `SolidSyslogStructuredData_Format` (writes into `SolidSyslogFormatter*`) |
 | `SolidSyslogStructuredDataDefinition.h` | SD implementors (extension point) | `SolidSyslogStructuredData` vtable struct (Format takes `SolidSyslogFormatter*`) |
 | `SolidSyslogMetaSd.h` | System setup code using sequenceId SD | `SolidSyslogMetaSd_Create`, `_Destroy` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(SOLIDSYSLOG_WINSOCK "Include Winsock UDP sender" ${HAVE_WINSOCK})
 include(CheckIncludeFile)
 check_include_file(stdatomic.h HAVE_STDATOMIC_H)
 check_symbol_exists(InterlockedIncrement "windows.h" HAVE_WINDOWS_INTERLOCKED)
+check_symbol_exists(GetSystemTimeAsFileTime "windows.h" HAVE_WINDOWS_PLATFORM)
 
 if(HAVE_STDATOMIC_H OR HAVE_WINDOWS_INTERLOCKED)
     set(HAVE_ATOMIC_COUNTER TRUE)
@@ -87,7 +88,7 @@ if(SOLIDSYSLOG_POSIX)
     add_subdirectory(Platform/Posix)
 endif()
 
-if(HAVE_WINDOWS_INTERLOCKED OR SOLIDSYSLOG_WINSOCK)
+if(HAVE_WINDOWS_INTERLOCKED OR HAVE_WINDOWS_PLATFORM OR SOLIDSYSLOG_WINSOCK)
     add_subdirectory(Platform/Windows)
 endif()
 

--- a/Platform/Windows/CMakeLists.txt
+++ b/Platform/Windows/CMakeLists.txt
@@ -4,6 +4,22 @@ if(HAVE_WINDOWS_INTERLOCKED)
     )
 endif()
 
+if(HAVE_WINDOWS_PLATFORM)
+    target_sources(${PROJECT_NAME} PRIVATE
+        Source/SolidSyslogWindowsClock.c
+        Source/SolidSyslogWindowsHostname.c
+        Source/SolidSyslogWindowsProcessId.c
+    )
+endif()
+
+if(HAVE_WINDOWS_INTERLOCKED OR HAVE_WINDOWS_PLATFORM OR SOLIDSYSLOG_WINSOCK)
+    target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Interface)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+    )
+endif()
+
 if(SOLIDSYSLOG_WINSOCK)
     target_sources(${PROJECT_NAME} PRIVATE
         Source/SolidSyslogAddress.c
@@ -11,9 +27,4 @@ if(SOLIDSYSLOG_WINSOCK)
         Source/SolidSyslogWinsockDatagram.c
     )
     target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32)
-    target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Interface)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        FILES_MATCHING PATTERN "*.h"
-    )
 endif()

--- a/Platform/Windows/Interface/SolidSyslogWindowsClock.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsClock.h
@@ -1,0 +1,12 @@
+#ifndef SOLIDSYSLOGWINDOWSCLOCK_H
+#define SOLIDSYSLOGWINDOWSCLOCK_H
+
+#include "SolidSyslogTimestamp.h"
+
+EXTERN_C_BEGIN
+
+    void SolidSyslogWindowsClock_GetTimestamp(struct SolidSyslogTimestamp * timestamp);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSCLOCK_H */

--- a/Platform/Windows/Interface/SolidSyslogWindowsHostname.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsHostname.h
@@ -1,0 +1,12 @@
+#ifndef SOLIDSYSLOGWINDOWSHOSTNAME_H
+#define SOLIDSYSLOGWINDOWSHOSTNAME_H
+
+#include "SolidSyslogConfig.h"
+
+EXTERN_C_BEGIN
+
+    void SolidSyslogWindowsHostname_Get(struct SolidSyslogFormatter * formatter);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSHOSTNAME_H */

--- a/Platform/Windows/Interface/SolidSyslogWindowsProcessId.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsProcessId.h
@@ -1,0 +1,12 @@
+#ifndef SOLIDSYSLOGWINDOWSPROCESSID_H
+#define SOLIDSYSLOGWINDOWSPROCESSID_H
+
+#include "SolidSyslogConfig.h"
+
+EXTERN_C_BEGIN
+
+    void SolidSyslogWindowsProcessId_Get(struct SolidSyslogFormatter * formatter);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSPROCESSID_H */

--- a/Platform/Windows/Source/SolidSyslogWindowsClock.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsClock.c
@@ -1,0 +1,65 @@
+#include "SolidSyslogWindowsClock.h"
+#include "SolidSyslogWindowsClockInternal.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* File-local forwarder. Taking the address of an imported Windows API
+   for static initialisation may trigger MSVC C4232 in some configurations;
+   forwarding through a static function whose address IS a compile-time
+   constant avoids the warning without a suppression. */
+static void WINAPI CallGetSystemTimeAsFileTime(LPFILETIME fileTime);
+
+WindowsGetSystemTimeAsFileTimeFn WindowsClock_GetSystemTimeAsFileTime = CallGetSystemTimeAsFileTime;
+
+static void WINAPI CallGetSystemTimeAsFileTime(LPFILETIME fileTime)
+{
+    GetSystemTimeAsFileTime(fileTime);
+}
+
+enum
+{
+    HUNDRED_NS_PER_MICROSECOND = 10,
+    HUNDRED_NS_PER_SECOND      = 10000000
+};
+
+static inline bool     BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown);
+static inline uint32_t MicrosecondsFromFileTime(const FILETIME* fileTime);
+static inline void     PopulateTimestamp(struct SolidSyslogTimestamp* timestamp, const SYSTEMTIME* breakdown, uint32_t microseconds);
+
+void SolidSyslogWindowsClock_GetTimestamp(struct SolidSyslogTimestamp* timestamp)
+{
+    FILETIME   fileTime;
+    SYSTEMTIME breakdown;
+
+    *timestamp = (struct SolidSyslogTimestamp) {0};
+
+    WindowsClock_GetSystemTimeAsFileTime(&fileTime);
+
+    if (BreakDownFileTime(&fileTime, &breakdown))
+    {
+        PopulateTimestamp(timestamp, &breakdown, MicrosecondsFromFileTime(&fileTime));
+    }
+}
+
+static inline bool BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown)
+{
+    return FileTimeToSystemTime(fileTime, breakdown) != 0;
+}
+
+static inline uint32_t MicrosecondsFromFileTime(const FILETIME* fileTime)
+{
+    uint64_t hundredNs = ((uint64_t) fileTime->dwHighDateTime << 32) | (uint64_t) fileTime->dwLowDateTime;
+    return (uint32_t) ((hundredNs % HUNDRED_NS_PER_SECOND) / HUNDRED_NS_PER_MICROSECOND);
+}
+
+static inline void PopulateTimestamp(struct SolidSyslogTimestamp* timestamp, const SYSTEMTIME* breakdown, uint32_t microseconds)
+{
+    timestamp->year        = breakdown->wYear;
+    timestamp->month       = (uint8_t) breakdown->wMonth;
+    timestamp->day         = (uint8_t) breakdown->wDay;
+    timestamp->hour        = (uint8_t) breakdown->wHour;
+    timestamp->minute      = (uint8_t) breakdown->wMinute;
+    timestamp->second      = (uint8_t) breakdown->wSecond;
+    timestamp->microsecond = microseconds;
+}

--- a/Platform/Windows/Source/SolidSyslogWindowsClockInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWindowsClockInternal.h
@@ -1,0 +1,20 @@
+#ifndef SOLIDSYSLOGWINDOWSCLOCKINTERNAL_H
+#define SOLIDSYSLOGWINDOWSCLOCKINTERNAL_H
+
+/* Library-internal test seam. Tests replace this function pointer via
+   CppUTest's UT_PTR_SET to inject a fake FILETIME source (MSVC does not
+   support GCC's weak/strong symbol override trick used by the POSIX fakes). */
+
+#include "ExternC.h"
+
+#include <windows.h>
+
+EXTERN_C_BEGIN
+
+    typedef void(WINAPI * WindowsGetSystemTimeAsFileTimeFn)(LPFILETIME);
+
+    extern WindowsGetSystemTimeAsFileTimeFn WindowsClock_GetSystemTimeAsFileTime;
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSCLOCKINTERNAL_H */

--- a/Platform/Windows/Source/SolidSyslogWindowsHostname.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsHostname.c
@@ -1,0 +1,33 @@
+#include "SolidSyslogWindowsHostname.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogWindowsHostnameInternal.h"
+
+/* File-local forwarder. Taking the address of an imported Windows API
+   for static initialisation may trigger MSVC C4232 in some configurations;
+   forwarding through a static function whose address IS a compile-time
+   constant avoids the warning without a suppression. */
+static BOOL WINAPI CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size);
+
+WindowsGetComputerNameExAFn WindowsHostname_GetComputerNameExA = CallGetComputerNameExA;
+
+static BOOL WINAPI CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size)
+{
+    return GetComputerNameExA(nameType, buffer, size);
+}
+
+enum
+{
+    MAX_HOSTNAME_SIZE = 256
+};
+
+void SolidSyslogWindowsHostname_Get(struct SolidSyslogFormatter* formatter)
+{
+    char  hostname[MAX_HOSTNAME_SIZE];
+    DWORD size = sizeof(hostname);
+
+    if (WindowsHostname_GetComputerNameExA(ComputerNamePhysicalDnsHostname, hostname, &size))
+    {
+        hostname[sizeof(hostname) - 1] = '\0';
+        SolidSyslogFormatter_BoundedString(formatter, hostname, sizeof(hostname));
+    }
+}

--- a/Platform/Windows/Source/SolidSyslogWindowsHostnameInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWindowsHostnameInternal.h
@@ -1,0 +1,20 @@
+#ifndef SOLIDSYSLOGWINDOWSHOSTNAMEINTERNAL_H
+#define SOLIDSYSLOGWINDOWSHOSTNAMEINTERNAL_H
+
+/* Library-internal test seam. Tests replace this function pointer via
+   CppUTest's UT_PTR_SET to inject a fake hostname source (MSVC does not
+   support GCC's weak/strong symbol override trick used by the POSIX fakes). */
+
+#include "ExternC.h"
+
+#include <windows.h>
+
+EXTERN_C_BEGIN
+
+    typedef BOOL(WINAPI * WindowsGetComputerNameExAFn)(COMPUTER_NAME_FORMAT, LPSTR, LPDWORD);
+
+    extern WindowsGetComputerNameExAFn WindowsHostname_GetComputerNameExA;
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSHOSTNAMEINTERNAL_H */

--- a/Platform/Windows/Source/SolidSyslogWindowsProcessId.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsProcessId.c
@@ -1,0 +1,23 @@
+#include "SolidSyslogWindowsProcessId.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogWindowsProcessIdInternal.h"
+
+#include <stdint.h>
+
+/* File-local forwarder. Taking the address of an imported Windows API
+   for static initialisation may trigger MSVC C4232 in some configurations;
+   forwarding through a static function whose address IS a compile-time
+   constant avoids the warning without a suppression. */
+static DWORD WINAPI CallGetCurrentProcessId(void);
+
+WindowsGetCurrentProcessIdFn WindowsProcessId_GetCurrentProcessId = CallGetCurrentProcessId;
+
+static DWORD WINAPI CallGetCurrentProcessId(void)
+{
+    return GetCurrentProcessId();
+}
+
+void SolidSyslogWindowsProcessId_Get(struct SolidSyslogFormatter* formatter)
+{
+    SolidSyslogFormatter_Uint32(formatter, (uint32_t) WindowsProcessId_GetCurrentProcessId());
+}

--- a/Platform/Windows/Source/SolidSyslogWindowsProcessIdInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWindowsProcessIdInternal.h
@@ -1,0 +1,20 @@
+#ifndef SOLIDSYSLOGWINDOWSPROCESSIDINTERNAL_H
+#define SOLIDSYSLOGWINDOWSPROCESSIDINTERNAL_H
+
+/* Library-internal test seam. Tests replace this function pointer via
+   CppUTest's UT_PTR_SET to inject a deterministic PID (MSVC does not
+   support GCC's weak/strong symbol override trick used by the POSIX fakes). */
+
+#include "ExternC.h"
+
+#include <windows.h>
+
+EXTERN_C_BEGIN
+
+    typedef DWORD(WINAPI * WindowsGetCurrentProcessIdFn)(void);
+
+    extern WindowsGetCurrentProcessIdFn WindowsProcessId_GetCurrentProcessId;
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSPROCESSIDINTERNAL_H */

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -64,6 +64,14 @@ if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
     list(APPEND TEST_SOURCES SolidSyslogAddressTest.cpp)
 endif()
 
+if(HAVE_WINDOWS_PLATFORM)
+    list(APPEND TEST_SOURCES
+        SolidSyslogWindowsClockTest.cpp
+        SolidSyslogWindowsHostnameTest.cpp
+        SolidSyslogWindowsProcessIdTest.cpp
+    )
+endif()
+
 if(SOLIDSYSLOG_WINSOCK)
     list(APPEND TEST_SOURCES
         WinsockFakeTest.cpp
@@ -81,9 +89,12 @@ if(SOLIDSYSLOG_POSIX)
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE PosixFakes)
 endif()
 
+if(HAVE_WINDOWS_PLATFORM OR SOLIDSYSLOG_WINSOCK)
+    target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Platform/Windows/Source)
+endif()
+
 if(SOLIDSYSLOG_WINSOCK)
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE WinsockFakes)
-    target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Platform/Windows/Source)
 endif()
 
 # Standard CppUTest console output via ctest -V

--- a/Tests/SolidSyslogWindowsClockTest.cpp
+++ b/Tests/SolidSyslogWindowsClockTest.cpp
@@ -60,6 +60,7 @@ TEST_GROUP(SolidSyslogWindowsClock)
 
     static void setFileTimeFromSystemTime(WORD year, WORD month, WORD day, WORD hour, WORD minute, WORD second)
     {
+        useRawFileTime               = false;
         fakeSystemTime.wYear         = year;
         fakeSystemTime.wMonth        = month;
         fakeSystemTime.wDay          = day;

--- a/Tests/SolidSyslogWindowsClockTest.cpp
+++ b/Tests/SolidSyslogWindowsClockTest.cpp
@@ -1,0 +1,185 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogWindowsClock.h"
+#include "SolidSyslogWindowsClockInternal.h"
+
+#include <windows.h>
+
+// 2025-04-02T00:00:00Z — matches the POSIX clock test default so timestamps
+// behave identically across platforms when the same wall-clock value is faked.
+static SYSTEMTIME fakeSystemTime;
+static FILETIME   fakeFileTime;
+static bool       useRawFileTime;
+
+static void WINAPI FakeGetSystemTimeAsFileTime(LPFILETIME fileTime)
+{
+    if (useRawFileTime)
+    {
+        *fileTime = fakeFileTime;
+        return;
+    }
+    SystemTimeToFileTime(&fakeSystemTime, fileTime);
+}
+
+// clang-format off
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
+#define GET_TIMESTAMP()              getTimestamp()
+#define CHECK_YEAR(expected)         LONGS_EQUAL(expected, GET_TIMESTAMP().year)
+#define CHECK_MONTH(expected)        LONGS_EQUAL(expected, GET_TIMESTAMP().month)
+#define CHECK_DAY(expected)          LONGS_EQUAL(expected, GET_TIMESTAMP().day)
+#define CHECK_HOUR(expected)         LONGS_EQUAL(expected, GET_TIMESTAMP().hour)
+#define CHECK_MINUTE(expected)       LONGS_EQUAL(expected, GET_TIMESTAMP().minute)
+#define CHECK_SECOND(expected)       LONGS_EQUAL(expected, GET_TIMESTAMP().second)
+#define CHECK_MICROSECOND(expected)  LONGS_EQUAL(expected, GET_TIMESTAMP().microsecond)
+#define CHECK_UTC_OFFSET(expected)   LONGS_EQUAL(expected, GET_TIMESTAMP().utcOffsetMinutes)
+#define CHECK_MONTH_IS_INVALID()     LONGS_EQUAL(0, GET_TIMESTAMP().month)
+// NOLINTEND(cppcoreguidelines-macro-usage)
+// clang-format on
+
+// clang-format off
+TEST_GROUP(SolidSyslogWindowsClock)
+{
+    void setup() override
+    {
+        useRawFileTime = false;
+        fakeSystemTime = SYSTEMTIME{};
+        fakeSystemTime.wYear   = 2025;
+        fakeSystemTime.wMonth  = 4;
+        fakeSystemTime.wDay    = 2;
+        fakeSystemTime.wHour   = 0;
+        fakeSystemTime.wMinute = 0;
+        fakeSystemTime.wSecond = 0;
+        UT_PTR_SET(WindowsClock_GetSystemTimeAsFileTime, FakeGetSystemTimeAsFileTime);
+    }
+
+    static struct SolidSyslogTimestamp getTimestamp()
+    {
+        struct SolidSyslogTimestamp ts = {};
+        SolidSyslogWindowsClock_GetTimestamp(&ts);
+        return ts;
+    }
+
+    static void setFileTimeFromSystemTime(WORD year, WORD month, WORD day, WORD hour, WORD minute, WORD second)
+    {
+        fakeSystemTime.wYear         = year;
+        fakeSystemTime.wMonth        = month;
+        fakeSystemTime.wDay          = day;
+        fakeSystemTime.wHour         = hour;
+        fakeSystemTime.wMinute       = minute;
+        fakeSystemTime.wSecond       = second;
+        fakeSystemTime.wMilliseconds = 0;
+    }
+
+    static void setRawFileTime(DWORD low, DWORD high)
+    {
+        useRawFileTime           = true;
+        fakeFileTime.dwLowDateTime  = low;
+        fakeFileTime.dwHighDateTime = high;
+    }
+};
+// clang-format on
+
+TEST(SolidSyslogWindowsClock, YearMatchesKnownTime)
+{
+    CHECK_YEAR(2025);
+}
+
+TEST(SolidSyslogWindowsClock, MonthMatchesKnownTime)
+{
+    CHECK_MONTH(4);
+}
+
+TEST(SolidSyslogWindowsClock, DayMatchesKnownTime)
+{
+    CHECK_DAY(2);
+}
+
+TEST(SolidSyslogWindowsClock, HourMatchesKnownTime)
+{
+    CHECK_HOUR(0);
+}
+
+TEST(SolidSyslogWindowsClock, MinuteMatchesKnownTime)
+{
+    CHECK_MINUTE(0);
+}
+
+TEST(SolidSyslogWindowsClock, SecondMatchesKnownTime)
+{
+    CHECK_SECOND(0);
+}
+
+TEST(SolidSyslogWindowsClock, UtcOffsetIsAlwaysZero)
+{
+    CHECK_UTC_OFFSET(0);
+}
+
+TEST(SolidSyslogWindowsClock, ZeroMicrosecondsProducesZeroMicroseconds)
+{
+    CHECK_MICROSECOND(0);
+}
+
+// FILETIME granularity is 100-ns; microsecond = (filetime % 10_000_000) / 10
+TEST(SolidSyslogWindowsClock, MicrosecondFromHundredNanosecondRemainder)
+{
+    // One second after FILETIME epoch (1601-01-01) + 123_456 microseconds.
+    // In 100-ns units: 10_000_000 + 1_234_560 = 11_234_560.
+    setRawFileTime(11234560, 0);
+    CHECK_MICROSECOND(123456);
+}
+
+TEST(SolidSyslogWindowsClock, MaxMicrosecondsFromRemainder)
+{
+    // 9_999_990 100-ns units → 999_999 microseconds.
+    setRawFileTime(9999990, 0);
+    CHECK_MICROSECOND(999999);
+}
+
+TEST(SolidSyslogWindowsClock, FileTimeToSystemTimeFailureReturnsInvalidTimestamp)
+{
+    // dwHighDateTime > 0x7FFFFFFF causes FileTimeToSystemTime to fail.
+    setRawFileTime(0, 0x80000000);
+    CHECK_MONTH_IS_INVALID();
+}
+
+TEST(SolidSyslogWindowsClock, Month1FromJanuary)
+{
+    setFileTimeFromSystemTime(2025, 1, 1, 0, 0, 0);
+    CHECK_MONTH(1);
+}
+
+TEST(SolidSyslogWindowsClock, Month12Day31FromDecember)
+{
+    setFileTimeFromSystemTime(2025, 12, 31, 0, 0, 0);
+    CHECK_MONTH(12);
+    CHECK_DAY(31);
+}
+
+TEST(SolidSyslogWindowsClock, Hour23Minute59Second59)
+{
+    setFileTimeFromSystemTime(2025, 4, 2, 23, 59, 59);
+    CHECK_HOUR(23);
+    CHECK_MINUTE(59);
+    CHECK_SECOND(59);
+}
+
+// FILETIME epoch is 1601-01-01 — all zeroes map to year 1601.
+TEST(SolidSyslogWindowsClock, ZeroFileTimeProduces1601)
+{
+    setRawFileTime(0, 0);
+    CHECK_YEAR(1601);
+    CHECK_MONTH(1);
+    CHECK_DAY(1);
+}
+
+TEST(SolidSyslogWindowsClock, AllFieldsInValidRanges)
+{
+    struct SolidSyslogTimestamp ts = getTimestamp();
+    CHECK(ts.year > 0);
+    CHECK((ts.month >= 1) && (ts.month <= 12));
+    CHECK((ts.day >= 1) && (ts.day <= 31));
+    CHECK(ts.hour <= 23);
+    CHECK(ts.minute <= 59);
+    CHECK(ts.second <= 59);
+    CHECK(ts.microsecond <= 999999);
+    LONGS_EQUAL(0, ts.utcOffsetMinutes);
+}

--- a/Tests/SolidSyslogWindowsHostnameTest.cpp
+++ b/Tests/SolidSyslogWindowsHostnameTest.cpp
@@ -1,0 +1,90 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogWindowsHostname.h"
+#include "SolidSyslogWindowsHostnameInternal.h"
+
+#include <string.h>
+#include <windows.h>
+
+enum
+{
+    FORMATTER_BUFFER_SIZE = 256
+};
+
+static const char* fakeHostname;
+static BOOL        fakeReturnValue;
+
+static BOOL WINAPI FakeGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size)
+{
+    (void) nameType;
+    if (!fakeReturnValue)
+    {
+        return FALSE;
+    }
+    const size_t length = strlen(fakeHostname);
+    if ((length + 1U) > *size)
+    {
+        *size = (DWORD) (length + 1U);
+        return FALSE;
+    }
+    memcpy(buffer, fakeHostname, length);
+    buffer[length] = '\0';
+    *size          = (DWORD) length;
+    return TRUE;
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogWindowsHostname)
+{
+    SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogFormatter* formatter = nullptr;
+
+    void setup() override
+    {
+        fakeHostname    = "winhost";
+        fakeReturnValue = TRUE;
+        UT_PTR_SET(WindowsHostname_GetComputerNameExA, FakeGetComputerNameExA);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
+    }
+
+    const char* formatted() const
+    {
+        return SolidSyslogFormatter_AsString(formatter);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWindowsHostname, WritesFakeHostnameIntoFormatter)
+{
+    SolidSyslogWindowsHostname_Get(formatter);
+    STRCMP_EQUAL("winhost", formatted());
+}
+
+TEST(SolidSyslogWindowsHostname, WritesNothingWhenApiFails)
+{
+    fakeReturnValue = FALSE;
+    SolidSyslogWindowsHostname_Get(formatter);
+    STRCMP_EQUAL("", formatted());
+}
+
+TEST(SolidSyslogWindowsHostname, EmptyHostnameProducesEmptyString)
+{
+    fakeHostname = "";
+    SolidSyslogWindowsHostname_Get(formatter);
+    STRCMP_EQUAL("", formatted());
+}
+
+TEST(SolidSyslogWindowsHostname, HostnameTooLongForBufferProducesEmptyString)
+{
+    // 260-char hostname exceeds the internal 256-char buffer. GetComputerNameExA
+    // reports ERROR_MORE_DATA → the helper treats this as failure → nothing written.
+    static char longName[261];
+    memset(longName, 'x', 260);
+    longName[260] = '\0';
+    fakeHostname  = longName;
+    SolidSyslogWindowsHostname_Get(formatter);
+    STRCMP_EQUAL("", formatted());
+}

--- a/Tests/SolidSyslogWindowsProcessIdTest.cpp
+++ b/Tests/SolidSyslogWindowsProcessIdTest.cpp
@@ -1,0 +1,61 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogWindowsProcessId.h"
+#include "SolidSyslogWindowsProcessIdInternal.h"
+
+#include <windows.h>
+
+enum
+{
+    FORMATTER_BUFFER_SIZE = 16
+};
+
+static DWORD fakePid;
+
+static DWORD WINAPI FakeGetCurrentProcessId(void)
+{
+    return fakePid;
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogWindowsProcessId)
+{
+    SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogFormatter* formatter = nullptr;
+
+    void setup() override
+    {
+        fakePid = 4321;
+        UT_PTR_SET(WindowsProcessId_GetCurrentProcessId, FakeGetCurrentProcessId);
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
+    }
+
+    const char* formatted() const
+    {
+        return SolidSyslogFormatter_AsString(formatter);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWindowsProcessId, WritesFakePidAsDecimal)
+{
+    SolidSyslogWindowsProcessId_Get(formatter);
+    STRCMP_EQUAL("4321", formatted());
+}
+
+TEST(SolidSyslogWindowsProcessId, WritesZeroWhenPidIsZero)
+{
+    fakePid = 0;
+    SolidSyslogWindowsProcessId_Get(formatter);
+    STRCMP_EQUAL("0", formatted());
+}
+
+TEST(SolidSyslogWindowsProcessId, WritesMaxDwordValueAsDecimal)
+{
+    fakePid = 0xFFFFFFFFU;
+    SolidSyslogWindowsProcessId_Get(formatter);
+    STRCMP_EQUAL("4294967295", formatted());
+}


### PR DESCRIPTION
## Summary

Adds Windows implementations mirroring the POSIX helpers for the three `SolidSyslogConfig` callbacks the example apps need on Windows.

- **S13.13**: `SolidSyslogWindowsClock` — `GetSystemTimeAsFileTime` + `FileTimeToSystemTime` → `SolidSyslogTimestamp`
- **S13.14**: `SolidSyslogWindowsHostname` — `GetComputerNameExA(ComputerNamePhysicalDnsHostname, ...)` → formatter (no `WSAStartup` dependency)
- **S13.15**: `SolidSyslogWindowsProcessId` — `GetCurrentProcessId()` → formatter

Each helper uses a function-pointer test seam in a `Source/*Internal.h` header driven by CppUTest `UT_PTR_SET`, because MSVC does not support the weak/strong symbol override trick used by the POSIX fakes.

Gated on a new `HAVE_WINDOWS_PLATFORM` feature check (`GetSystemTimeAsFileTime` in `windows.h`). Linux builds skip them cleanly — the feature check evaluates false and the CMake subdirectory/target lists degrade to the existing POSIX-only set.

Closes #146, #147, #148.

## Test plan

- [x] `cmake --preset msvc-debug && cmake --build --preset msvc-debug --target SolidSyslogTests && ctest --preset msvc-debug` — green on native Windows (427 tests)
- [x] `cmake --preset debug && cmake --build --preset debug --target SolidSyslogTests && ctest --preset debug` — green in gcc devcontainer
- [x] `cmake --preset clang-debug && cmake --build --preset clang-debug --target SolidSyslogTests && ctest --preset clang-debug` — green in clang devcontainer
- [x] `cmake --preset tidy && cmake --build --preset tidy` — green
- [x] `cmake --preset cppcheck && cmake --build --preset cppcheck` — green
- [x] `cmake --preset coverage && cmake --build --preset coverage --target coverage` — 99.9% lines, 100% functions
- [x] `clang-format --dry-run --Werror` on `Interface Source Tests Example` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Windows support: timestamp generation, hostname resolution, and process-ID retrieval for syslog formatting.

* **Tests**
  * Added unit tests covering Windows timestamp, hostname, and process ID behavior, including edge cases.

* **Documentation**
  * Public documentation updated to list the new Windows-specific platform APIs/headers.

* **Chores**
  * Build configuration updated to detect and enable Windows platform capability during configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->