### PR TITLE
docs: document SolidSyslogTimestamp field ranges and UTC contract

### DIFF
--- a/Interface/SolidSyslogTimestamp.h
+++ b/Interface/SolidSyslogTimestamp.h
@@ -12,18 +12,20 @@ EXTERN_C_BEGIN
        utcOffsetMinutes — the built-in POSIX and Windows clocks both produce
        UTC (utcOffsetMinutes == 0).
 
-       A clock may leave the struct zeroed to signal "no usable timestamp";
-       the formatter treats month == 0 as invalid. */
+       A clock may leave the struct zeroed to signal "no usable timestamp".
+       The library validates each field before formatting; the ranges below
+       are the ones enforced by the internal TimestampIsValid check. A
+       zeroed struct fails validation because month == 0 is out of range. */
     struct SolidSyslogTimestamp
     {
-        uint16_t year;             /* Gregorian year, e.g. 2026. 0 means invalid. */
-        uint8_t  month;            /* 1-12. 0 means invalid. */
+        uint16_t year;             /* Gregorian year, e.g. 2026. Not independently validated — clocks are trusted to produce a sensible value. */
+        uint8_t  month;            /* 1-12. */
         uint8_t  day;              /* 1-31. */
         uint8_t  hour;             /* 0-23. */
         uint8_t  minute;           /* 0-59. */
         uint8_t  second;           /* 0-59. Leap seconds are not represented. */
         uint32_t microsecond;      /* 0-999999. */
-        int16_t  utcOffsetMinutes; /* Offset from UTC in minutes; 0 for UTC. */
+        int16_t  utcOffsetMinutes; /* Offset from UTC in minutes; 0 for UTC. Must be -720..840 (UTC-12:00 to UTC+14:00). */
     };
 
     typedef void (*SolidSyslogClockFunction)(struct SolidSyslogTimestamp* timestamp);

--- a/Interface/SolidSyslogTimestamp.h
+++ b/Interface/SolidSyslogTimestamp.h
@@ -7,16 +7,23 @@
 
 EXTERN_C_BEGIN
 
+    /* Broken-down timestamp as emitted by a SolidSyslogClockFunction.
+       All calendar/time fields are expressed in the timezone indicated by
+       utcOffsetMinutes — the built-in POSIX and Windows clocks both produce
+       UTC (utcOffsetMinutes == 0).
+
+       A clock may leave the struct zeroed to signal "no usable timestamp";
+       the formatter treats month == 0 as invalid. */
     struct SolidSyslogTimestamp
     {
-        uint16_t year;
-        uint8_t  month;
-        uint8_t  day;
-        uint8_t  hour;
-        uint8_t  minute;
-        uint8_t  second;
-        uint32_t microsecond;
-        int16_t  utcOffsetMinutes;
+        uint16_t year;             /* Gregorian year, e.g. 2026. 0 means invalid. */
+        uint8_t  month;            /* 1-12. 0 means invalid. */
+        uint8_t  day;              /* 1-31. */
+        uint8_t  hour;             /* 0-23. */
+        uint8_t  minute;           /* 0-59. */
+        uint8_t  second;           /* 0-59. Leap seconds are not represented. */
+        uint32_t microsecond;      /* 0-999999. */
+        int16_t  utcOffsetMinutes; /* Offset from UTC in minutes; 0 for UTC. */
     };
 
     typedef void (*SolidSyslogClockFunction)(struct SolidSyslogTimestamp* timestamp);


### PR DESCRIPTION
## Summary

Adds field-level comments to `SolidSyslogTimestamp` capturing the contract that was previously only observable by reading the POSIX and Windows clock implementations and their "AllFieldsInValidRanges" tests.

- `month` is **1-12** (not 0-11 like `struct tm`)
- `day` 1-31, `hour` 0-23, `minute`/`second` 0-59, `microsecond` 0-999999
- Built-in POSIX (`gmtime_r`) and Windows (`FileTimeToSystemTime`) clocks produce **UTC** with `utcOffsetMinutes == 0`
- `month == 0` (or a zeroed struct) signals "no usable timestamp" — matches what the formatter already treats as invalid

No behaviour change — this is purely a docs tightening to steer future `SolidSyslogClockFunction` implementors toward the right conventions.

## Test plan

- [x] `cmake --build --preset debug --target SolidSyslogTests && ctest --preset debug` — green
- [x] `clang-format --dry-run --Werror Interface/SolidSyslogTimestamp.h` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded timestamp docs to clarify timezone interpretation (fields apply with a UTC offset; platform clocks emit UTC), define how “no usable timestamp” is signaled (zeroed/invalid timestamps are rejected), specify valid ranges for calendar/time fields (including microsecond bounds), and note there are no leap seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->