### PR TITLE
feat: S13.5 tag BDD features by capability for cross-platform runners

### DIFF
--- a/Bdd/features/buffered.feature
+++ b/Bdd/features/buffered.feature
@@ -1,3 +1,4 @@
+@udp @buffered
 Feature: Buffered message delivery
   The threaded example sends messages via a PosixMessageQueueBuffer.
   A service thread drains the buffer and sends via UDP to syslog-ng.

--- a/Bdd/features/header_fields.feature
+++ b/Bdd/features/header_fields.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Message header fields
   The library includes hostname, app-name, and process ID in the
   RFC 5424 message header.

--- a/Bdd/features/message_fields.feature
+++ b/Bdd/features/message_fields.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Message ID and message body
   The library includes message ID and message body in the RFC 5424 message.
 

--- a/Bdd/features/origin.feature
+++ b/Bdd/features/origin.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Structured data — origin
   The library includes origin metadata identifying the software component.
 

--- a/Bdd/features/power_cycle_replay.feature
+++ b/Bdd/features/power_cycle_replay.feature
@@ -1,3 +1,4 @@
+@tcp @buffered
 Feature: Power cycle replay from file store
   After a power cycle, unsent messages persisted in the file store
   are replayed before new messages. The collector sees old-session

--- a/Bdd/features/prival.feature
+++ b/Bdd/features/prival.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: PRIVAL encoding
   The library calculates RFC 5424 PRIVAL from facility and severity.
   The example program accepts --facility and --severity flags,

--- a/Bdd/features/store_and_forward.feature
+++ b/Bdd/features/store_and_forward.feature
@@ -1,3 +1,4 @@
+@tcp @buffered
 Feature: Store and forward during sender outage
   When the syslog server goes down, messages accumulate in the
   file-based store. Once the server recovers, the service loop

--- a/Bdd/features/store_capacity.feature
+++ b/Bdd/features/store_capacity.feature
@@ -1,3 +1,4 @@
+@tcp @buffered
 Feature: Store capacity limit and discard policy
   The file store uses rotating files with a configurable capacity.
   When the store is full, the discard policy determines whether

--- a/Bdd/features/structured_data.feature
+++ b/Bdd/features/structured_data.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Structured data — sequence ID
   The library includes an auto-incrementing sequence ID in structured data.
 

--- a/Bdd/features/syslog.feature
+++ b/Bdd/features/syslog.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Walking skeleton end-to-end
   The example program sends an RFC 5424 message via UDP.
   syslog-ng receives it and writes the parsed fields to a log file.

--- a/Bdd/features/tcp_reconnect.feature
+++ b/Bdd/features/tcp_reconnect.feature
@@ -1,3 +1,4 @@
+@tcp @buffered
 Feature: TCP reconnection after server outage
   The TCP sender detects connection failure and reconnects when the
   server recovers. Messages sent during the outage are lost (store

--- a/Bdd/features/tcp_transport.feature
+++ b/Bdd/features/tcp_transport.feature
@@ -1,3 +1,4 @@
+@tcp @buffered
 Feature: TCP message delivery
   The threaded example sends messages via TCP transport with
   RFC 6587 octet-counting framing to syslog-ng.

--- a/Bdd/features/time_quality.feature
+++ b/Bdd/features/time_quality.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Structured data — time quality
   The library includes time quality metadata in structured data.
 

--- a/Bdd/features/timestamp.feature
+++ b/Bdd/features/timestamp.feature
@@ -1,3 +1,4 @@
+@udp @windows_wip
 Feature: Timestamp encoding
   The library captures the timestamp at raise-time via an injected clock
   and formats it as RFC 5424 FULL-DATE "T" FULL-TIME.

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -106,6 +106,33 @@ sock.close()
 This will be needed when BDD scenarios require different syslog-ng source configurations —
 for example, switching from UDP to TLS transport in E3.
 
+## Feature tags
+
+Features are tagged by **capability** — what the system under test must provide for the
+scenario to be meaningful. Runners declare which capabilities they have by excluding the
+tags they lack. This lets us add new runners (Windows, bare-metal RTOS, TLS-only client,
+etc.) without rewriting feature tags.
+
+| Tag | Meaning |
+| --- | --- |
+| `@udp` | Needs UDP transport |
+| `@tcp` | Needs TCP transport (RFC 6587 framing) |
+| `@buffered` | Drives the long-running threaded example (interactive process protocol — buffer + service thread; transitively covers store-and-forward, oracle reload, signal-kill scenarios) |
+
+Two rollout markers are also used (temporary; remove once the scenario passes):
+
+| Tag | Meaning |
+| --- | --- |
+| `@wip` | Skip everywhere — work in progress |
+| `@windows_wip` | Skip on Windows only — should work but not yet verified |
+
+Runner tag filters:
+
+| Runner | Filter |
+| --- | --- |
+| Linux (syslog-ng) | `not @wip` |
+| Windows (planned) | `not @wip and not @windows_wip and not @buffered` |
+
 ## Test isolation
 
 Behave uses line-count tracking for test isolation. The `Given` step records the current line


### PR DESCRIPTION
## Summary

- Tag every BDD feature with the SUT capabilities it requires (`@udp`, `@tcp`, `@buffered`) so future runners (Windows, bare-metal RTOS, TLS-only client) declare their capability set as exclusions rather than per-feature platform tags.
- Tag every UDP fire-and-forget feature with `@windows_wip` as a temporary rollout marker — removed scenario-by-scenario as they're proven on Windows.
- Document the tag taxonomy and runner filters in [docs/bdd.md](docs/bdd.md).

No behavioural change on Linux — the existing `not @wip` filter on the behave service is unaffected by the new tags.

## Tag mapping

| Feature | Tags |
| --- | --- |
| `syslog`, `header_fields`, `prival`, `timestamp`, `message_fields`, `structured_data`, `origin`, `time_quality` | `@udp @windows_wip` |
| `buffered` | `@udp @buffered` |
| `tcp_transport`, `tcp_reconnect`, `store_and_forward`, `store_capacity`, `power_cycle_replay` | `@tcp @buffered` |

The `@buffered` tag transitively covers store-and-forward, oracle-reload, and signal-kill scenarios — they all drive the long-running threaded example. Windows runner will exclude `@buffered` so threaded scenarios stay POSIX-only by deliberate scope decision.

## Why capability tags rather than `@windows`/`@posix`

A scenario should declare what it *needs*, not what platform it runs on. Adding a third runner (a bare-metal UDP target, say) shouldn't require touching every feature file — only the runner config. See [docs/bdd.md#feature-tags](docs/bdd.md#feature-tags) for the full rationale and runner-filter table.

## First slice of S13.5

This is the first of several PRs for [#129](https://github.com/DavidCozens/solid-syslog/issues/129). It deliberately doesn't close the issue — subsequent PRs will add the Windows example target, oracle abstraction, local tooling, and the `bdd-windows` CI job.

Refs #129

## Test plan

- [ ] Linux BDD job (`bdd`) still runs every feature it ran before — `not @wip` filter ignores the new capability tags
- [ ] All other CI gates pass (build-and-test, clang, sanitize, coverage, tidy, cppcheck, format, windows-build-and-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added organizational tags to test features across UDP, TCP, and buffering capabilities to improve test categorization.

* **Documentation**
  * Updated test documentation with feature tag definitions and platform-specific test filtering rules for different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->