### PR TITLE
ci: S13.5 bdd-windows job running walking-skeleton on windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,14 +394,41 @@ jobs:
       - name: Start OTel Collector
         shell: pwsh
         run: |
-          Start-Process -FilePath ./Bdd/otel/bin/otelcol-contrib.exe `
-                        -ArgumentList "--config=Bdd/otel/config.yaml" `
-                        -RedirectStandardOutput Bdd/output/otelcol.out `
-                        -RedirectStandardError  Bdd/output/otelcol.err `
+          # Use absolute paths for everything — Start-Process on pwsh does not
+          # reliably propagate $PWD to the child's cwd or to the redirect file
+          # resolution, so relative paths here caused the collector's config
+          # lookup and redirects to land unpredictably on windows-2025.
+          $repo   = (Get-Location).Path
+          $exe    = Join-Path $repo 'Bdd/otel/bin/otelcol-contrib.exe'
+          $config = Join-Path $repo 'Bdd/otel/config.yaml'
+          $outLog = Join-Path $repo 'Bdd/output/otelcol.out'
+          $errLog = Join-Path $repo 'Bdd/output/otelcol.err'
+          Start-Process -FilePath $exe `
+                        -ArgumentList "--config=$config" `
+                        -WorkingDirectory $repo `
+                        -RedirectStandardOutput $outLog `
+                        -RedirectStandardError  $errLog `
                         -WindowStyle Hidden
 
       - name: Wait for oracle to bind UDP 5514
-        run: sleep 3
+        shell: pwsh
+        run: |
+          # Poll until otelcol is listening on UDP 5514, instead of blind-sleeping.
+          # Dumps collector logs on timeout so a silent start failure surfaces.
+          $deadline = (Get-Date).AddSeconds(30)
+          while ((Get-Date) -lt $deadline) {
+              if (Get-NetUDPEndpoint -LocalPort 5514 -ErrorAction SilentlyContinue) {
+                  Write-Host "otelcol is listening on UDP 5514"
+                  exit 0
+              }
+              Start-Sleep -Milliseconds 500
+          }
+          Write-Host "otelcol did not bind UDP 5514 within 30 seconds"
+          Write-Host "--- otelcol.out ---"
+          Get-Content Bdd/output/otelcol.out -ErrorAction SilentlyContinue
+          Write-Host "--- otelcol.err ---"
+          Get-Content Bdd/output/otelcol.err -ErrorAction SilentlyContinue
+          exit 1
 
       - name: Run BDD tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
         run: cmake --preset msvc-debug
 
       - name: Build and test
-        run: cmake --build --preset msvc-debug --target junit
+        run: cmake --build --preset msvc-debug --target junit SolidSyslogWindowsExample
 
       - name: Test Report
         uses: dorny/test-reporter@v3
@@ -349,6 +349,93 @@ jobs:
           name: junit-msvc
           path: build/msvc-debug/cpputest_*.xml
           retention-days: 1
+
+      - name: Upload Windows example binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: solid-syslog-windows-example
+          path: build/msvc-debug/Example/Debug/SolidSyslogExample.exe
+          retention-days: 1
+          compression-level: 0
+
+  bdd-windows:
+    needs: windows-build-and-test
+    runs-on: windows-2025
+    permissions:
+      contents: read
+      checks: write
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: solid-syslog-windows-example
+          path: build/msvc-debug/Example/Debug/
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install behave
+        run: pip install -r Bdd/requirements.txt
+
+      - name: Install otelcol-contrib
+        shell: pwsh
+        run: ./Bdd/otel/Install-OtelCollector.ps1
+
+      - name: Prepare BDD directories
+        run: mkdir -p Bdd/output Bdd/junit
+
+      - name: Start OTel Collector
+        shell: pwsh
+        run: |
+          Start-Process -FilePath ./Bdd/otel/bin/otelcol-contrib.exe `
+                        -ArgumentList "--config=Bdd/otel/config.yaml" `
+                        -RedirectStandardOutput Bdd/output/otelcol.out `
+                        -RedirectStandardError  Bdd/output/otelcol.err `
+                        -WindowStyle Hidden
+
+      - name: Wait for oracle to bind UDP 5514
+        run: sleep 3
+
+      - name: Run BDD tests
+        env:
+          EXAMPLE_BINARY: build/msvc-debug/Example/Debug/SolidSyslogExample.exe
+          RECEIVED_LOG: Bdd/output/received.jsonl
+          ORACLE_FORMAT: otel-jsonl
+        run: >
+          behave --junit --junit-directory Bdd/junit
+          --tags='not @wip and not @windows_wip and not @buffered'
+          Bdd/features/
+
+      - name: BDD Test Report (Windows)
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: Test Results (BDD Windows)
+          path: Bdd/junit/TESTS-*.xml
+          reporter: java-junit
+
+      - name: Upload JUnit XML
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-bdd-windows
+          path: Bdd/junit/TESTS-*.xml
+          retention-days: 1
+
+      - name: OTel collector logs on failure
+        if: failure()
+        run: |
+          echo "--- otelcol.out ---"
+          cat Bdd/output/otelcol.out || true
+          echo "--- otelcol.err ---"
+          cat Bdd/output/otelcol.err || true
 
   bdd:
     needs: build-and-test
@@ -398,7 +485,7 @@ jobs:
 
   quality-summary:
     if: always() && github.event_name == 'pull_request'
-    needs: [build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test]
+    needs: [build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test, bdd-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -455,8 +542,13 @@ jobs:
                   },
                   {
                     "id": "junit",
-                    "name": "BDD Tests",
+                    "name": "BDD Tests (Linux)",
                     "pattern": "**/junit-bdd/TESTS-*.xml"
+                  },
+                  {
+                    "id": "junit",
+                    "name": "BDD Tests (Windows)",
+                    "pattern": "**/junit-bdd-windows/TESTS-*.xml"
                   },
                   {
                     "id": "junit",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,29 +392,19 @@ jobs:
         run: mkdir -p Bdd/output Bdd/junit
 
       - name: Start OTel Collector
-        shell: pwsh
+        # Use bash `&` backgrounding (what works locally) rather than pwsh
+        # Start-Process — the latter launched silently on windows-2025 with
+        # empty redirect files and no UDP bind, suggesting the child was
+        # either killed with the parent console or never actually executed.
         run: |
-          # Use absolute paths for everything — Start-Process on pwsh does not
-          # reliably propagate $PWD to the child's cwd or to the redirect file
-          # resolution, so relative paths here caused the collector's config
-          # lookup and redirects to land unpredictably on windows-2025.
-          $repo   = (Get-Location).Path
-          $exe    = Join-Path $repo 'Bdd/otel/bin/otelcol-contrib.exe'
-          $config = Join-Path $repo 'Bdd/otel/config.yaml'
-          $outLog = Join-Path $repo 'Bdd/output/otelcol.out'
-          $errLog = Join-Path $repo 'Bdd/output/otelcol.err'
-          Start-Process -FilePath $exe `
-                        -ArgumentList "--config=$config" `
-                        -WorkingDirectory $repo `
-                        -RedirectStandardOutput $outLog `
-                        -RedirectStandardError  $errLog `
-                        -WindowStyle Hidden
+          nohup ./Bdd/otel/bin/otelcol-contrib.exe \
+            --config=Bdd/otel/config.yaml \
+            > Bdd/output/otelcol.out 2> Bdd/output/otelcol.err &
+          echo "otelcol backgrounded with PID $!"
 
       - name: Wait for oracle to bind UDP 5514
         shell: pwsh
         run: |
-          # Poll until otelcol is listening on UDP 5514, instead of blind-sleeping.
-          # Dumps collector logs on timeout so a silent start failure surfaces.
           $deadline = (Get-Date).AddSeconds(30)
           while ((Get-Date) -lt $deadline) {
               if (Get-NetUDPEndpoint -LocalPort 5514 -ErrorAction SilentlyContinue) {
@@ -424,6 +414,12 @@ jobs:
               Start-Sleep -Milliseconds 500
           }
           Write-Host "otelcol did not bind UDP 5514 within 30 seconds"
+          Write-Host "--- tasklist otelcol-contrib ---"
+          tasklist /FI "IMAGENAME eq otelcol-contrib.exe"
+          Write-Host "--- UDP endpoints (top 20) ---"
+          Get-NetUDPEndpoint | Select-Object -First 20 | Format-Table -AutoSize
+          Write-Host "--- Bdd/output contents ---"
+          Get-ChildItem Bdd/output -ErrorAction SilentlyContinue | Format-Table
           Write-Host "--- otelcol.out ---"
           Get-Content Bdd/output/otelcol.out -ErrorAction SilentlyContinue
           Write-Host "--- otelcol.err ---"


### PR DESCRIPTION
## Summary

Packages the now-known-good local recipe from #154 into a CI job.

- **Extends `windows-build-and-test`** to build the `SolidSyslogWindowsExample` target and upload `SolidSyslogExample.exe` as the `solid-syslog-windows-example` artefact.
- **Adds `bdd-windows` job** on pinned `windows-2025` that:
  - downloads the artefact to `build/msvc-debug/Example/Debug/`,
  - installs Python 3.13 via `actions/setup-python@v6.2.0` (pinned SHA),
  - installs `behave==1.3.3` via `Bdd/requirements.txt` (same version as the Linux container image),
  - installs `otelcol-contrib v0.150.1` via `Bdd/otel/Install-OtelCollector.ps1` (SHA-256 pinned),
  - starts the OTel Collector as a hidden `Start-Process` so it persists across steps and writes `stdout`/`stderr` to files for failure diagnosis,
  - runs `behave --tags='not @wip and not @windows_wip and not @buffered'` — today that's just the walking-skeleton scenario,
  - publishes JUnit XML via `dorny/test-reporter` and uploads `junit-bdd-windows` for the Quality Monitor summary.
- **`quality-summary` wired**: adds `bdd-windows` to `needs:` and a new `BDD Tests (Windows)` entry to the quality-monitor config. Existing `BDD Tests` entry renamed to `BDD Tests (Linux)` for symmetry.

As more `@udp` features are promoted out of `@windows_wip` in subsequent PRs, they'll automatically start running on this Windows CI job — no yaml change needed.

## Why `windows-2025` not `windows-latest`

`windows-latest` still maps to `windows-2022` for many accounts; pinning to `windows-2025` captures intent and avoids silent drift when GitHub eventually re-tags. The unit-test job (`windows-build-and-test`) stays on `windows-latest` — it doesn't care, and the artefact is forward-compatible.

## Design notes

Pattern choice is straightforward serial (`needs: windows-build-and-test`). I considered parallel rebuilds or splitting the build job to let tests and BDD run concurrently, but the wall-clock gain vs current CI times is ~5 s — build dominates either way. Can revisit if unit-test runtime grows past a minute or two.

Default shell for the new job is `bash`, matching the local Git-Bash recipe documented in `docs/bdd.md` (inline `VAR=value command` invocation works natively). PowerShell is used only for PowerShell-native steps (the install script and `Start-Process`).

## Verified locally

- `actionlint` (Docker): no new warnings introduced. Pre-existing shellcheck advisories on the unchanged `format` and `cppcheck` jobs remain.
- Local dry-run of the CI tag filter against the walking-skeleton:
  ```
  behave --tags='not @wip and not @windows_wip and not @buffered' Bdd/features/
  → 1 feature passed, 0 failed, 13 skipped
  → 1 scenario passed, 0 failed, 30 skipped
  → 7 steps passed, 0 failed, 153 skipped
  ```

## Refs

Refs #129

## Test plan

- [ ] `windows-build-and-test` still passes and now uploads `solid-syslog-windows-example` artefact
- [ ] New `bdd-windows` status check appears and passes
- [ ] Quality Summary shows a new `BDD Tests (Windows)` row with 1 passed / 0 failed
- [ ] Other CI checks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows CI to build and publish the example executable as an artifact.
  * Added a dedicated Windows BDD workflow: prepares the environment, starts the collector service, waits for readiness, runs end-to-end BDD tests with tag exclusions, captures logs on failure, and uploads JUnit results.
  * Updated quality reporting to publish BDD results separately for Linux and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->