### PR TITLE
feat: S13.5 promote timestamp and header_fields to Windows runner

### DIFF
--- a/Bdd/features/header_fields.feature
+++ b/Bdd/features/header_fields.feature
@@ -1,4 +1,4 @@
-@udp @windows_wip
+@udp
 Feature: Message header fields
   The library includes hostname, app-name, and process ID in the
   RFC 5424 message header.

--- a/Bdd/features/timestamp.feature
+++ b/Bdd/features/timestamp.feature
@@ -1,4 +1,4 @@
-@udp @windows_wip
+@udp
 Feature: Timestamp encoding
   The library captures the timestamp at raise-time via an injected clock
   and formats it as RFC 5424 FULL-DATE "T" FULL-TIME.


### PR DESCRIPTION
## Summary

Removes \`@windows_wip\` from two features that already passed end-to-end via the existing step framework:

- \`timestamp.feature\` — the \`within-5-seconds-of-now\` assertion reads \`context.fields[\"TIMESTAMP\"]\`, which \`parse_otel_jsonl_line\` already populates from \`timeUnixNano\`.
- \`header_fields.feature\` — hostname / app-name / PID checks all read attributes that \`parse_otel_jsonl_line\` already maps (\`hostname\`, \`appname\`, \`proc_id\`).

No code change — just tag removal. This is the smallest possible promotion PR, exercised purely to derisk the framework before the two CLI-flag and SD-rendering PRs that follow.

## Verified locally

| Runner | Result |
| --- | --- |
| Windows via otelcol-contrib oracle | ✅ 3 features / 5 scenarios / 19 steps |
| Linux via ci/docker-compose.bdd.yml | ✅ 14 features / 31 scenarios / 160 steps (no regressions) |

## Batches remaining

- **Batch B**: \`prival\` + \`message_fields\` — add CLI arg parsing to the Windows example (\`--facility\`, \`--severity\`, \`--msgid\`, \`--message\`) and extend the parser to read OTel's \`message\` / \`msg_id\` attributes.
- **Batch C**: \`structured_data\` + \`origin\` + \`time_quality\` — render OTel's nested structured-data kvlist back into the \`[name key=\"value\"]\` text form so the regex assertions work unchanged.

Refs #129

## Test plan

- [ ] Windows \`bdd-windows\` CI job reports 3 scenarios passed (up from 1)
- [ ] Linux \`bdd\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated BDD feature tag configurations to refine test filtering for header fields and timestamp validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->