### PR TITLE
feat: S13.5 promote prival and message_fields to Windows runner

### DIFF
--- a/Bdd/features/message_fields.feature
+++ b/Bdd/features/message_fields.feature
@@ -1,4 +1,4 @@
-@udp @windows_wip
+@udp
 Feature: Message ID and message body
   The library includes message ID and message body in the RFC 5424 message.
 

--- a/Bdd/features/prival.feature
+++ b/Bdd/features/prival.feature
@@ -1,4 +1,4 @@
-@udp @windows_wip
+@udp
 Feature: PRIVAL encoding
   The library calculates RFC 5424 PRIVAL from facility and severity.
   The example program accepts --facility and --severity flags,

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -89,12 +89,10 @@ def parse_otel_jsonl_line(line):
     """Parse one JSON line from the OTel Collector file exporter into the
     same flat dict shape as parse_syslog_ng_line.
 
-    Walking-skeleton scope only: PRIORITY/TIMESTAMP/HOSTNAME/APP_NAME/PROCID.
-    MSG and STRUCTURED_DATA are not yet extracted — added when the
-    message_fields and structured_data scenarios are promoted out of
-    @windows_wip (OTel's body field carries the whole raw RFC 5424 line for
-    message-less records, so MSG extraction needs verifying against a real
-    bodied message).
+    Maps OTel's parsed RFC 5424 attributes (independent oracle, same role
+    syslog-ng plays on Linux) into the flat field dict. STRUCTURED_DATA
+    re-rendering is added when the structured_data / origin / time_quality
+    scenarios are promoted out of @windows_wip.
     """
     record = json.loads(line)
     log = record["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
@@ -113,6 +111,12 @@ def parse_otel_jsonl_line(line):
     proc_id = _otel_attribute(attrs, "proc_id")
     if proc_id is not None:
         fields["PROCID"] = proc_id
+    msg_id = _otel_attribute(attrs, "msg_id")
+    if msg_id is not None:
+        fields["MSGID"] = msg_id
+    msg = _otel_attribute(attrs, "message")
+    if msg is not None:
+        fields["MSG"] = msg
 
     # timeUnixNano → ISO 8601 string compatible with datetime.fromisoformat
     time_ns = log.get("timeUnixNano")

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -28,6 +28,7 @@ elseif(SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM)
     add_executable(SolidSyslogWindowsExample
         Windows/main.c
         Windows/SolidSyslogWindowsExample.c
+        Windows/ExampleWindowsCommandLine.c
         Common/ExampleAppName.c
         Common/ExampleInteractive.c
     )

--- a/Example/Windows/ExampleWindowsCommandLine.c
+++ b/Example/Windows/ExampleWindowsCommandLine.c
@@ -1,0 +1,32 @@
+#include "ExampleWindowsCommandLine.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void ExampleWindowsCommandLine_Parse(int argc, char* argv[], struct WindowsExampleOptions* options)
+{
+    options->facility  = SOLIDSYSLOG_FACILITY_LOCAL0;
+    options->severity  = SOLIDSYSLOG_SEVERITY_INFO;
+    options->messageId = NULL;
+    options->msg       = NULL;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (((i + 1) < argc) && (strcmp(argv[i], "--facility") == 0))
+        {
+            options->facility = (enum SolidSyslog_Facility) atoi(argv[++i]);
+        }
+        else if (((i + 1) < argc) && (strcmp(argv[i], "--severity") == 0))
+        {
+            options->severity = (enum SolidSyslog_Severity) atoi(argv[++i]);
+        }
+        else if (((i + 1) < argc) && (strcmp(argv[i], "--msgid") == 0))
+        {
+            options->messageId = argv[++i];
+        }
+        else if (((i + 1) < argc) && (strcmp(argv[i], "--message") == 0))
+        {
+            options->msg = argv[++i];
+        }
+    }
+}

--- a/Example/Windows/ExampleWindowsCommandLine.h
+++ b/Example/Windows/ExampleWindowsCommandLine.h
@@ -1,0 +1,26 @@
+#ifndef EXAMPLEWINDOWSCOMMANDLINE_H
+#define EXAMPLEWINDOWSCOMMANDLINE_H
+
+#include "ExternC.h"
+#include "SolidSyslogPrival.h"
+
+EXTERN_C_BEGIN
+
+    struct WindowsExampleOptions
+    {
+        enum SolidSyslog_Facility facility;
+        enum SolidSyslog_Severity severity;
+        const char*               messageId;
+        const char*               msg;
+    };
+
+    /* Minimal CLI parser — recognises --facility N, --severity N, --msgid X,
+       --message X, all optional. Unknown flags and flags missing their
+       argument are silently ignored. Defaults match the SingleTask example:
+       local0 / info / no msgid / no body. getopt is not available on MSVC
+       and pulling in a vcpkg getopt for four flags would be overkill. */
+    void ExampleWindowsCommandLine_Parse(int argc, char* argv[], struct WindowsExampleOptions* options);
+
+EXTERN_C_END
+
+#endif /* EXAMPLEWINDOWSCOMMANDLINE_H */

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -1,6 +1,7 @@
 #include "SolidSyslogWindowsExample.h"
 #include "ExampleAppName.h"
 #include "ExampleInteractive.h"
+#include "ExampleWindowsCommandLine.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
@@ -8,7 +9,6 @@
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogNullStore.h"
 #include "SolidSyslogOriginSd.h"
-#include "SolidSyslogPrival.h"
 #include "SolidSyslogTimeQualitySd.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogWindowsClock.h"
@@ -44,8 +44,6 @@ static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 
 int SolidSyslogWindowsExample_Run(int argc, char* argv[])
 {
-    (void) argc;
-
     WSADATA wsaData;
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
     {
@@ -53,6 +51,9 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     }
 
     ExampleAppName_Set(argv[0]);
+
+    struct WindowsExampleOptions options;
+    ExampleWindowsCommandLine_Parse(argc, argv, &options);
 
     struct SolidSyslogResolver*       resolver    = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
     struct SolidSyslogDatagram*       datagram    = SolidSyslogWinsockDatagram_Create();
@@ -81,10 +82,10 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     SolidSyslog_Create(&config);
 
     struct SolidSyslogMessage message = {
-        .facility  = SOLIDSYSLOG_FACILITY_LOCAL0,
-        .severity  = SOLIDSYSLOG_SEVERITY_INFO,
-        .messageId = NULL,
-        .msg       = NULL,
+        .facility  = options.facility,
+        .severity  = options.severity,
+        .messageId = options.messageId,
+        .msg       = options.msg,
     };
 
     ExampleInteractive_Run(&message, stdin);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2,7 +2,7 @@ if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
     add_subdirectory(Support)
 endif()
 
-if(SOLIDSYSLOG_POSIX)
+if(SOLIDSYSLOG_POSIX OR (SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM))
     add_subdirectory(Example)
 endif()
 

--- a/Tests/Example/CMakeLists.txt
+++ b/Tests/Example/CMakeLists.txt
@@ -1,25 +1,55 @@
+# Platform-agnostic tests always included.
 set(EXAMPLE_TEST_SOURCES
     ExampleAppNameTest.cpp
-    ExampleCommandLineTest.cpp
-    SolidSyslogExampleTest.cpp
-    ExampleServiceThreadTest.cpp
     main.cpp
 )
 
-add_executable(ExampleTests ${EXAMPLE_TEST_SOURCES})
+set(EXAMPLE_PRODUCTION_SOURCES
+    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleAppName.c
+)
 
-target_link_libraries(ExampleTests PRIVATE ${PROJECT_NAME} PosixFakes CppUTest CppUTestExt Threads::Threads)
-
-target_include_directories(ExampleTests PRIVATE
-    ${CMAKE_SOURCE_DIR}/Example/SingleTask
+set(EXAMPLE_TEST_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/Example/Common
 )
 
-target_sources(ExampleTests PRIVATE
-    ${CMAKE_SOURCE_DIR}/Example/SingleTask/SolidSyslogExample.c
-    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleAppName.c
-    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleCommandLine.c
-    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleServiceThread.c
-    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleUdpConfig.c
-    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleInteractive.c
-)
+if(SOLIDSYSLOG_POSIX)
+    list(APPEND EXAMPLE_TEST_SOURCES
+        ExampleCommandLineTest.cpp
+        SolidSyslogExampleTest.cpp
+        ExampleServiceThreadTest.cpp
+    )
+    list(APPEND EXAMPLE_PRODUCTION_SOURCES
+        ${CMAKE_SOURCE_DIR}/Example/SingleTask/SolidSyslogExample.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleCommandLine.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleServiceThread.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleUdpConfig.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleInteractive.c
+    )
+    list(APPEND EXAMPLE_TEST_INCLUDE_DIRS
+        ${CMAKE_SOURCE_DIR}/Example/SingleTask
+    )
+endif()
+
+if(SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM)
+    list(APPEND EXAMPLE_TEST_SOURCES
+        ExampleWindowsCommandLineTest.cpp
+    )
+    list(APPEND EXAMPLE_PRODUCTION_SOURCES
+        ${CMAKE_SOURCE_DIR}/Example/Windows/ExampleWindowsCommandLine.c
+    )
+    list(APPEND EXAMPLE_TEST_INCLUDE_DIRS
+        ${CMAKE_SOURCE_DIR}/Example/Windows
+    )
+endif()
+
+add_executable(ExampleTests ${EXAMPLE_TEST_SOURCES})
+
+target_link_libraries(ExampleTests PRIVATE ${PROJECT_NAME} CppUTest CppUTestExt Threads::Threads)
+
+if(SOLIDSYSLOG_POSIX)
+    target_link_libraries(ExampleTests PRIVATE PosixFakes)
+endif()
+
+target_include_directories(ExampleTests PRIVATE ${EXAMPLE_TEST_INCLUDE_DIRS})
+
+target_sources(ExampleTests PRIVATE ${EXAMPLE_PRODUCTION_SOURCES})

--- a/Tests/Example/ExampleWindowsCommandLineTest.cpp
+++ b/Tests/Example/ExampleWindowsCommandLineTest.cpp
@@ -1,0 +1,126 @@
+#include "CppUTest/TestHarness.h"
+#include "ExampleWindowsCommandLine.h"
+
+// clang-format off
+TEST_GROUP(ExampleWindowsCommandLine)
+{
+    struct WindowsExampleOptions options = {};
+
+    void Parse(int argc, char* argv[])
+    {
+        ExampleWindowsCommandLine_Parse(argc, argv, &options);
+    }
+};
+
+// clang-format on
+
+TEST(ExampleWindowsCommandLine, DefaultFacilityIsLocal0)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_FACILITY_LOCAL0, options.facility);
+}
+
+TEST(ExampleWindowsCommandLine, DefaultSeverityIsInfo)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_INFO, options.severity);
+}
+
+TEST(ExampleWindowsCommandLine, DefaultMessageIdIsNull)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    POINTERS_EQUAL(nullptr, options.messageId);
+}
+
+TEST(ExampleWindowsCommandLine, DefaultMsgIsNull)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    POINTERS_EQUAL(nullptr, options.msg);
+}
+
+TEST(ExampleWindowsCommandLine, FacilityFlagSetsFacility)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--facility";
+    char  arg2[] = "23";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    LONGS_EQUAL(23, options.facility);
+}
+
+TEST(ExampleWindowsCommandLine, SeverityFlagSetsSeverity)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--severity";
+    char  arg2[] = "7";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    LONGS_EQUAL(7, options.severity);
+}
+
+TEST(ExampleWindowsCommandLine, MsgidFlagSetsMessageId)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--msgid";
+    char  arg2[] = "ID47";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    STRCMP_EQUAL("ID47", options.messageId);
+}
+
+TEST(ExampleWindowsCommandLine, MessageFlagSetsMsg)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--message";
+    char  arg2[] = "system started";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    STRCMP_EQUAL("system started", options.msg);
+}
+
+TEST(ExampleWindowsCommandLine, AllFlagsTogether)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--facility";
+    char  arg2[] = "16";
+    char  arg3[] = "--severity";
+    char  arg4[] = "6";
+    char  arg5[] = "--msgid";
+    char  arg6[] = "CONN";
+    char  arg7[] = "--message";
+    char  arg8[] = "session opened";
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, nullptr};
+    Parse(9, argv);
+    LONGS_EQUAL(16, options.facility);
+    LONGS_EQUAL(6, options.severity);
+    STRCMP_EQUAL("CONN", options.messageId);
+    STRCMP_EQUAL("session opened", options.msg);
+}
+
+TEST(ExampleWindowsCommandLine, UnknownFlagIsIgnored)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--unknown";
+    char  arg2[] = "value";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_FACILITY_LOCAL0, options.facility);
+    POINTERS_EQUAL(nullptr, options.messageId);
+}
+
+TEST(ExampleWindowsCommandLine, FacilityFlagWithoutValueIsIgnored)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--facility";
+    char* argv[] = {arg0, arg1, nullptr};
+    Parse(2, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_FACILITY_LOCAL0, options.facility);
+}


### PR DESCRIPTION
## Summary

The Windows example now accepts \`--facility\` / \`--severity\` / \`--msgid\` / \`--message\`, and the OTel parser reads OTel's \`message\` / \`msg_id\` attributes — enough to promote two more features out of \`@windows_wip\`.

**Discipline note:** my first attempt put the CLI parser inline in \`SolidSyslogWindowsExample.c\` with no unit tests — caught in review against the POSIX \`ExampleCommandLine\` precedent which has [\`ExampleCommandLineTest.cpp\`](Tests/Example/ExampleCommandLineTest.cpp) covering every flag. This commit extracts the parser into its own TU and adds the matching unit-test file.

## What's new

- \`Example/Windows/ExampleWindowsCommandLine.{h,c}\` — minimal four-flag parser (\`--facility N\`, \`--severity N\`, \`--msgid X\`, \`--message X\`), unknown flags and missing values silently ignored. Defaults match the SingleTask example.
- \`Tests/Example/ExampleWindowsCommandLineTest.cpp\` — 11 CppUTest cases: each default, each flag, all-together, unknown-flag, missing-value.
- \`parse_otel_jsonl_line\` extended: maps OTel's \`message\` → \`MSG\`, \`msg_id\` → \`MSGID\`. Confirmed by the parsing experiment in [#156's discussion](https://github.com/DavidCozens/solid-syslog/pull/156) — OTel populates these attributes as part of its independent RFC 5424 parse, just like syslog-ng.
- Removed \`@windows_wip\` from \`prival.feature\` and \`message_fields.feature\`.

## Test infra changes

\`Tests/CMakeLists.txt\` previously gated \`Tests/Example/\` on \`SOLIDSYSLOG_POSIX\` only — meaning \`ExampleTests.exe\` didn't build on the windows-build-and-test job at all. Now gates on \`SOLIDSYSLOG_POSIX OR (SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM)\`, and \`Tests/Example/CMakeLists.txt\` conditionally pulls in the right test files and production sources per platform. \`ExampleAppNameTest\` is now part of the test suite on both platforms; the existing POSIX-only tests remain POSIX-only.

## Local verification

| Gate | Result |
| --- | --- |
| ExampleWindowsCommandLine unit tests on MSVC | ✅ 11 / 11 |
| ExampleTests on Linux gcc | ✅ 41 / 41 (unchanged) |
| BDD on Windows via otelcol | ✅ 5 features / 14 scenarios / 52 steps (up from 3 / 5 / 19) |
| BDD on Linux via docker-compose | ✅ 14 features / 31 scenarios / 160 steps (no regressions) |
| tidy, cppcheck, sanitize, format | ✅ all green |

## Remaining @windows_wip features

After this PR: \`structured_data\`, \`origin\`, \`time_quality\`. All three need OTel's nested SD kvlist re-rendered into \`[name key=\"value\"]\` text form so the existing regex \`Then\` steps work unchanged. Single follow-up PR (Batch C).

Refs #129

## Test plan

- [ ] All CI checks pass: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test, bdd-windows
- [ ] \`bdd-windows\` reports 5 scenarios passed (up from 3)
- [ ] \`windows-build-and-test\` Test Results show \`ExampleWindowsCommandLine\` group with 11 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)