### PR TITLE
feat: S3.4 lazy initialisation and reconnection on UdpSender and TcpSender

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogEndpoint.h` | System setup code that supplies destination host/port (and version on changes) | `SolidSyslogEndpoint`, `SolidSyslogEndpointFunction`, `SolidSyslogEndpointVersionFunction`, `SOLIDSYSLOG_MAX_HOST_SIZE` |
 | `SolidSyslogSender.h` | Any code holding a sender handle | `SolidSyslogSender_Send`, `SolidSyslogSender_Disconnect` |
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct (`Send`, `Disconnect`) |
-| `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(transport, host, port, *out)` |
+| `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(resolver, transport, host, port, *out)` |
 | `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
 | `SolidSyslogTcpSender.h` | System setup code using TCP transport (RFC 6587) | `SolidSyslogTcpSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogTcpSender_Create`, `_Destroy`, `SOLIDSYSLOG_TCP_DEFAULT_PORT` |
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,12 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsString`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
-| `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct |
-| `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
-| `SolidSyslogTcpSender.h` | System setup code using TCP transport (RFC 6587) | `SolidSyslogTcpSender_Create`, `_Destroy`, `SOLIDSYSLOG_TCP_DEFAULT_PORT` |
+| `SolidSyslogEndpoint.h` | System setup code that supplies destination host/port (and version on changes) | `SolidSyslogEndpoint`, `SolidSyslogEndpointFunction`, `SolidSyslogEndpointVersionFunction`, `SOLIDSYSLOG_MAX_HOST_SIZE` |
+| `SolidSyslogSender.h` | Any code holding a sender handle | `SolidSyslogSender_Send`, `SolidSyslogSender_Disconnect` |
+| `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct (`Send`, `Disconnect`) |
+| `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(transport, host, port, *out)` |
+| `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
+| `SolidSyslogTcpSender.h` | System setup code using TCP transport (RFC 6587) | `SolidSyslogTcpSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogTcpSender_Create`, `_Destroy`, `SOLIDSYSLOG_TCP_DEFAULT_PORT` |
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |

--- a/Example/Common/ExampleTcpConfig.c
+++ b/Example/Common/ExampleTcpConfig.c
@@ -2,7 +2,6 @@
 #include "SolidSyslogFormatter.h"
 
 #include <stdint.h>
-#include <string.h>
 
 /* Unprivileged mirror of SOLIDSYSLOG_TCP_DEFAULT_PORT (514) for BDD containers */
 enum
@@ -22,8 +21,7 @@ int ExampleTcpConfig_GetPort(void)
 
 void ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = ExampleTcpConfig_GetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, ExampleTcpConfig_GetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) ExampleTcpConfig_GetPort();
 }
 

--- a/Example/Common/ExampleTcpConfig.c
+++ b/Example/Common/ExampleTcpConfig.c
@@ -24,6 +24,5 @@ void ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = ExampleTcpConfig_GetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) ExampleTcpConfig_GetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) ExampleTcpConfig_GetPort();
 }

--- a/Example/Common/ExampleTcpConfig.c
+++ b/Example/Common/ExampleTcpConfig.c
@@ -1,4 +1,8 @@
 #include "ExampleTcpConfig.h"
+#include "SolidSyslogFormatter.h"
+
+#include <stdint.h>
+#include <string.h>
 
 /* Unprivileged mirror of SOLIDSYSLOG_TCP_DEFAULT_PORT (514) for BDD containers */
 enum
@@ -14,4 +18,12 @@ const char* ExampleTcpConfig_GetHost(void)
 int ExampleTcpConfig_GetPort(void)
 {
     return EXAMPLE_TCP_PORT;
+}
+
+void ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = ExampleTcpConfig_GetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) ExampleTcpConfig_GetPort();
+    endpoint->version = 0;
 }

--- a/Example/Common/ExampleTcpConfig.c
+++ b/Example/Common/ExampleTcpConfig.c
@@ -26,3 +26,10 @@ void ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
     endpoint->port = (uint16_t) ExampleTcpConfig_GetPort();
 }
+
+/* Static config — host/port never change, so version stays 0 forever and the
+   sender connects exactly once. */
+uint32_t ExampleTcpConfig_GetEndpointVersion(void)
+{
+    return 0;
+}

--- a/Example/Common/ExampleTcpConfig.h
+++ b/Example/Common/ExampleTcpConfig.h
@@ -2,11 +2,13 @@
 #define EXAMPLETCPCONFIG_H
 
 #include "ExternC.h"
+#include "SolidSyslogEndpoint.h"
 
 EXTERN_C_BEGIN
 
     const char* ExampleTcpConfig_GetHost(void);
     int         ExampleTcpConfig_GetPort(void);
+    void        ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint * endpoint);
 
 EXTERN_C_END
 

--- a/Example/Common/ExampleTcpConfig.h
+++ b/Example/Common/ExampleTcpConfig.h
@@ -4,11 +4,14 @@
 #include "ExternC.h"
 #include "SolidSyslogEndpoint.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
 
     const char* ExampleTcpConfig_GetHost(void);
     int         ExampleTcpConfig_GetPort(void);
     void        ExampleTcpConfig_GetEndpoint(struct SolidSyslogEndpoint * endpoint);
+    uint32_t    ExampleTcpConfig_GetEndpointVersion(void);
 
 EXTERN_C_END
 

--- a/Example/Common/ExampleUdpConfig.c
+++ b/Example/Common/ExampleUdpConfig.c
@@ -24,6 +24,12 @@ void ExampleUdpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = ExampleUdpConfig_GetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) ExampleUdpConfig_GetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) ExampleUdpConfig_GetPort();
+}
+
+/* Static config — host/port never change, so version stays 0 forever and the
+   sender connects exactly once. */
+uint32_t ExampleUdpConfig_GetEndpointVersion(void)
+{
+    return 0;
 }

--- a/Example/Common/ExampleUdpConfig.c
+++ b/Example/Common/ExampleUdpConfig.c
@@ -1,4 +1,8 @@
 #include "ExampleUdpConfig.h"
+#include "SolidSyslogFormatter.h"
+
+#include <stdint.h>
+#include <string.h>
 
 /* Unprivileged mirror of SOLIDSYSLOG_UDP_DEFAULT_PORT (514) for BDD containers */
 enum
@@ -14,4 +18,12 @@ const char* ExampleUdpConfig_GetHost(void)
 int ExampleUdpConfig_GetPort(void)
 {
     return EXAMPLE_UDP_PORT;
+}
+
+void ExampleUdpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = ExampleUdpConfig_GetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) ExampleUdpConfig_GetPort();
+    endpoint->version = 0;
 }

--- a/Example/Common/ExampleUdpConfig.c
+++ b/Example/Common/ExampleUdpConfig.c
@@ -2,7 +2,6 @@
 #include "SolidSyslogFormatter.h"
 
 #include <stdint.h>
-#include <string.h>
 
 /* Unprivileged mirror of SOLIDSYSLOG_UDP_DEFAULT_PORT (514) for BDD containers */
 enum
@@ -22,8 +21,7 @@ int ExampleUdpConfig_GetPort(void)
 
 void ExampleUdpConfig_GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = ExampleUdpConfig_GetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, ExampleUdpConfig_GetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) ExampleUdpConfig_GetPort();
 }
 

--- a/Example/Common/ExampleUdpConfig.h
+++ b/Example/Common/ExampleUdpConfig.h
@@ -4,11 +4,14 @@
 #include "ExternC.h"
 #include "SolidSyslogEndpoint.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
 
     const char* ExampleUdpConfig_GetHost(void);
     int         ExampleUdpConfig_GetPort(void);
     void        ExampleUdpConfig_GetEndpoint(struct SolidSyslogEndpoint * endpoint);
+    uint32_t    ExampleUdpConfig_GetEndpointVersion(void);
 
 EXTERN_C_END
 

--- a/Example/Common/ExampleUdpConfig.h
+++ b/Example/Common/ExampleUdpConfig.h
@@ -2,11 +2,13 @@
 #define EXAMPLEUDPCONFIG_H
 
 #include "ExternC.h"
+#include "SolidSyslogEndpoint.h"
 
 EXTERN_C_BEGIN
 
     const char* ExampleUdpConfig_GetHost(void);
     int         ExampleUdpConfig_GetPort(void);
+    void        ExampleUdpConfig_GetEndpoint(struct SolidSyslogEndpoint * endpoint);
 
 EXTERN_C_END
 

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -35,7 +35,7 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         return 1;
     }
 
-    struct SolidSyslogResolver*       resolver    = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
+    struct SolidSyslogResolver*       resolver    = SolidSyslogGetAddrInfoResolver_Create();
     struct SolidSyslogDatagram*       datagram    = SolidSyslogPosixDatagram_Create();
     struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = ExampleUdpConfig_GetEndpoint};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -37,7 +37,7 @@ int SolidSyslogExample_Run(int argc, char* argv[])
 
     struct SolidSyslogResolver*       resolver    = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
     struct SolidSyslogDatagram*       datagram    = SolidSyslogPosixDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram};
+    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = ExampleUdpConfig_GetEndpoint};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
     struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -35,9 +35,10 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         return 1;
     }
 
-    struct SolidSyslogResolver*       resolver    = SolidSyslogGetAddrInfoResolver_Create();
-    struct SolidSyslogDatagram*       datagram    = SolidSyslogPosixDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = ExampleUdpConfig_GetEndpoint};
+    struct SolidSyslogResolver*       resolver  = SolidSyslogGetAddrInfoResolver_Create();
+    struct SolidSyslogDatagram*       datagram  = SolidSyslogPosixDatagram_Create();
+    struct SolidSyslogUdpSenderConfig udpConfig = {
+        .resolver = resolver, .datagram = datagram, .endpoint = ExampleUdpConfig_GetEndpoint, .endpointVersion = ExampleUdpConfig_GetEndpointVersion};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
     struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -57,6 +57,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
         static struct SolidSyslogTcpSenderConfig tcpConfig = {0};
         tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleTcpConfig_GetHost, ExampleTcpConfig_GetPort);
         tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
+        tcpConfig.endpoint                                 = ExampleTcpConfig_GetEndpoint;
         return SolidSyslogTcpSender_Create(&tcpConfig);
     }
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -65,6 +65,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
     udpConfig.datagram                                 = SolidSyslogPosixDatagram_Create();
     udpConfig.endpoint                                 = ExampleUdpConfig_GetEndpoint;
+    udpConfig.endpointVersion                          = ExampleUdpConfig_GetEndpointVersion;
     return SolidSyslogUdpSender_Create(&udpConfig);
 }
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -55,14 +55,14 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     if (useTcp)
     {
         static struct SolidSyslogTcpSenderConfig tcpConfig = {0};
-        tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleTcpConfig_GetHost, ExampleTcpConfig_GetPort);
+        tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
         tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
         tcpConfig.endpoint                                 = ExampleTcpConfig_GetEndpoint;
         return SolidSyslogTcpSender_Create(&tcpConfig);
     }
 
     static struct SolidSyslogUdpSenderConfig udpConfig = {0};
-    udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
+    udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
     udpConfig.datagram                                 = SolidSyslogPosixDatagram_Create();
     udpConfig.endpoint                                 = ExampleUdpConfig_GetEndpoint;
     return SolidSyslogUdpSender_Create(&udpConfig);

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -58,6 +58,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
         tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
         tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
         tcpConfig.endpoint                                 = ExampleTcpConfig_GetEndpoint;
+        tcpConfig.endpointVersion                          = ExampleTcpConfig_GetEndpointVersion;
         return SolidSyslogTcpSender_Create(&tcpConfig);
     }
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -63,6 +63,7 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     static struct SolidSyslogUdpSenderConfig udpConfig = {0};
     udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort);
     udpConfig.datagram                                 = SolidSyslogPosixDatagram_Create();
+    udpConfig.endpoint                                 = ExampleUdpConfig_GetEndpoint;
     return SolidSyslogUdpSender_Create(&udpConfig);
 }
 

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -21,7 +21,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <winsock2.h>
 
 enum
@@ -41,8 +40,7 @@ static int GetPort(void)
 
 static void GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = GetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, GetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) GetPort();
 }
 

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -43,8 +43,12 @@ static void GetEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = GetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) GetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) GetPort();
+}
+
+static uint32_t GetEndpointVersion(void)
+{
+    return 0;
 }
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
@@ -67,14 +71,14 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     struct WindowsExampleOptions options;
     ExampleWindowsCommandLine_Parse(argc, argv, &options);
 
-    struct SolidSyslogResolver*       resolver    = SolidSyslogWinsockResolver_Create();
-    struct SolidSyslogDatagram*       datagram    = SolidSyslogWinsockDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint};
-    struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
-    struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
-    struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();
-    struct SolidSyslogAtomicCounter*  counter     = SolidSyslogAtomicCounter_Create();
-    struct SolidSyslogStructuredData* metaSd      = SolidSyslogMetaSd_Create(counter);
+    struct SolidSyslogResolver*       resolver  = SolidSyslogWinsockResolver_Create();
+    struct SolidSyslogDatagram*       datagram  = SolidSyslogWinsockDatagram_Create();
+    struct SolidSyslogUdpSenderConfig udpConfig = {.resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint, .endpointVersion = GetEndpointVersion};
+    struct SolidSyslogSender*         sender    = SolidSyslogUdpSender_Create(&udpConfig);
+    struct SolidSyslogBuffer*         buffer    = SolidSyslogNullBuffer_Create(sender);
+    struct SolidSyslogStore*          store     = SolidSyslogNullStore_Create();
+    struct SolidSyslogAtomicCounter*  counter   = SolidSyslogAtomicCounter_Create();
+    struct SolidSyslogStructuredData* metaSd    = SolidSyslogMetaSd_Create(counter);
     struct SolidSyslogStructuredData* timeQuality = SolidSyslogTimeQualitySd_Create(GetTimeQuality);
     struct SolidSyslogStructuredData* originSd    = SolidSyslogOriginSd_Create("SolidSyslogExample", "0.7.0");
 

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -67,7 +67,7 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     struct WindowsExampleOptions options;
     ExampleWindowsCommandLine_Parse(argc, argv, &options);
 
-    struct SolidSyslogResolver*       resolver    = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
+    struct SolidSyslogResolver*       resolver    = SolidSyslogWinsockResolver_Create();
     struct SolidSyslogDatagram*       datagram    = SolidSyslogWinsockDatagram_Create();
     struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -5,6 +5,8 @@
 #include "SolidSyslog.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogEndpoint.h"
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogMetaSd.h"
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogNullStore.h"
@@ -17,7 +19,9 @@
 #include "SolidSyslogWinsockDatagram.h"
 #include "SolidSyslogWinsockResolver.h"
 
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <winsock2.h>
 
 enum
@@ -33,6 +37,14 @@ static const char* GetHost(void)
 static int GetPort(void)
 {
     return EXAMPLE_UDP_PORT;
+}
+
+static void GetEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = GetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) GetPort();
+    endpoint->version = 0;
 }
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
@@ -57,7 +69,7 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
 
     struct SolidSyslogResolver*       resolver    = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
     struct SolidSyslogDatagram*       datagram    = SolidSyslogWinsockDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram};
+    struct SolidSyslogUdpSenderConfig udpConfig   = {.resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint};
     struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
     struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();

--- a/Interface/SolidSyslogEndpoint.h
+++ b/Interface/SolidSyslogEndpoint.h
@@ -1,0 +1,27 @@
+#ifndef SOLIDSYSLOGENDPOINT_H
+#define SOLIDSYSLOGENDPOINT_H
+
+#include "ExternC.h"
+#include "SolidSyslogFormatter.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    enum
+    {
+        SOLIDSYSLOG_MAX_HOST_SIZE = 256
+    };
+
+    struct SolidSyslogEndpoint
+    {
+        struct SolidSyslogFormatter* host;    /* library-provided; user writes destination host into it */
+        uint16_t                     port;    /* user assigns destination port */
+        uint32_t                     version; /* user bumps on any change to host or port */
+    };
+
+    typedef void (*SolidSyslogEndpointFunction)(struct SolidSyslogEndpoint* endpoint);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGENDPOINT_H */

--- a/Interface/SolidSyslogEndpoint.h
+++ b/Interface/SolidSyslogEndpoint.h
@@ -15,12 +15,16 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogEndpoint
     {
-        struct SolidSyslogFormatter* host;    /* library-provided; user writes destination host into it */
-        uint16_t                     port;    /* user assigns destination port */
-        uint32_t                     version; /* user bumps on any change to host or port */
+        struct SolidSyslogFormatter* host; /* library-provided; user writes destination host into it */
+        uint16_t                     port; /* user assigns destination port */
     };
 
     typedef void (*SolidSyslogEndpointFunction)(struct SolidSyslogEndpoint* endpoint);
+
+    /* Cheap pure function returning a monotonic version counter the user bumps on any change to host or port.
+       The sender polls this on every Send and only re-pulls the endpoint when the version differs from the
+       last value it acted on. */
+    typedef uint32_t (*SolidSyslogEndpointVersionFunction)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogResolver.h
+++ b/Interface/SolidSyslogResolver.h
@@ -11,9 +11,8 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogResolver;
 
-    bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct SolidSyslogAddress * result);
-    bool SolidSyslogResolver_ResolveAt(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
-                                       struct SolidSyslogAddress* result);
+    bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                     struct SolidSyslogAddress* result);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogResolver.h
+++ b/Interface/SolidSyslogResolver.h
@@ -5,12 +5,15 @@
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogTransport.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 EXTERN_C_BEGIN
 
     struct SolidSyslogResolver;
 
     bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, struct SolidSyslogAddress * result);
+    bool SolidSyslogResolver_ResolveAt(struct SolidSyslogResolver * resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                       struct SolidSyslogAddress* result);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogResolverDefinition.h
+++ b/Interface/SolidSyslogResolverDefinition.h
@@ -4,11 +4,15 @@
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogTransport.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
 
     struct SolidSyslogResolver
     {
         bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
+        bool (*ResolveAt)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                          struct SolidSyslogAddress* result);
     };
 
 EXTERN_C_END

--- a/Interface/SolidSyslogResolverDefinition.h
+++ b/Interface/SolidSyslogResolverDefinition.h
@@ -10,9 +10,8 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogResolver
     {
-        bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
-        bool (*ResolveAt)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
-                          struct SolidSyslogAddress* result);
+        bool (*Resolve)(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                        struct SolidSyslogAddress* result);
     };
 
 EXTERN_C_END

--- a/Interface/SolidSyslogSender.h
+++ b/Interface/SolidSyslogSender.h
@@ -10,6 +10,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogSender;
 
     bool SolidSyslogSender_Send(struct SolidSyslogSender * sender, const void* buffer, size_t size);
+    void SolidSyslogSender_Disconnect(struct SolidSyslogSender * sender);
 
 EXTERN_C_END
 

--- a/Interface/SolidSyslogSenderDefinition.h
+++ b/Interface/SolidSyslogSenderDefinition.h
@@ -8,6 +8,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogSender
     {
         bool (*Send)(struct SolidSyslogSender* sender, const void* buffer, size_t size);
+        void (*Disconnect)(struct SolidSyslogSender* sender);
     };
 
 EXTERN_C_END

--- a/Interface/SolidSyslogTcpSender.h
+++ b/Interface/SolidSyslogTcpSender.h
@@ -1,6 +1,7 @@
 #ifndef SOLIDSYSLOG_TCP_SENDER_H
 #define SOLIDSYSLOG_TCP_SENDER_H
 
+#include "SolidSyslogEndpoint.h"
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogStream.h"
 
@@ -15,6 +16,7 @@ struct SolidSyslogTcpSenderConfig
 {
     struct SolidSyslogResolver* resolver;
     struct SolidSyslogStream*   stream;
+    SolidSyslogEndpointFunction endpoint; /* optional during cut-over; NULL falls back to legacy resolver path */
 };
 
 EXTERN_C_BEGIN

--- a/Interface/SolidSyslogTcpSender.h
+++ b/Interface/SolidSyslogTcpSender.h
@@ -14,9 +14,10 @@ enum
 
 struct SolidSyslogTcpSenderConfig
 {
-    struct SolidSyslogResolver* resolver;
-    struct SolidSyslogStream*   stream;
-    SolidSyslogEndpointFunction endpoint; /* optional during cut-over; NULL falls back to legacy resolver path */
+    struct SolidSyslogResolver*        resolver;
+    struct SolidSyslogStream*          stream;
+    SolidSyslogEndpointFunction        endpoint;        /* fills host/port; called only on (re)connect */
+    SolidSyslogEndpointVersionFunction endpointVersion; /* polled cheaply on every Send for stale check */
 };
 
 EXTERN_C_BEGIN

--- a/Interface/SolidSyslogTcpSender.h
+++ b/Interface/SolidSyslogTcpSender.h
@@ -5,22 +5,22 @@
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogStream.h"
 
-struct SolidSyslogSender;
-
-enum
-{
-    SOLIDSYSLOG_TCP_DEFAULT_PORT = 514 /* RFC 6587 convention — same as UDP; no IANA assignment for plain TCP syslog */
-};
-
-struct SolidSyslogTcpSenderConfig
-{
-    struct SolidSyslogResolver*        resolver;
-    struct SolidSyslogStream*          stream;
-    SolidSyslogEndpointFunction        endpoint;        /* fills host/port; called only on (re)connect */
-    SolidSyslogEndpointVersionFunction endpointVersion; /* polled cheaply on every Send for stale check */
-};
-
 EXTERN_C_BEGIN
+
+    struct SolidSyslogSender;
+
+    enum
+    {
+        SOLIDSYSLOG_TCP_DEFAULT_PORT = 514 /* RFC 6587 convention — same as UDP; no IANA assignment for plain TCP syslog */
+    };
+
+    struct SolidSyslogTcpSenderConfig
+    {
+        struct SolidSyslogResolver*        resolver;
+        struct SolidSyslogStream*          stream;
+        SolidSyslogEndpointFunction        endpoint;        /* fills host/port; called only on (re)connect */
+        SolidSyslogEndpointVersionFunction endpointVersion; /* polled cheaply on every Send for stale check */
+    };
 
     struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTcpSenderConfig* config);
     void                      SolidSyslogTcpSender_Destroy(void);

--- a/Interface/SolidSyslogUdpSender.h
+++ b/Interface/SolidSyslogUdpSender.h
@@ -2,6 +2,7 @@
 #define SOLIDSYSLOGUDPSENDER_H
 
 #include "SolidSyslogDatagram.h"
+#include "SolidSyslogEndpoint.h"
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogSender.h"
 
@@ -16,6 +17,7 @@ EXTERN_C_BEGIN
     {
         struct SolidSyslogResolver* resolver;
         struct SolidSyslogDatagram* datagram;
+        SolidSyslogEndpointFunction endpoint; /* optional during cut-over; NULL falls back to legacy resolver path */
     };
 
     struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config);

--- a/Interface/SolidSyslogUdpSender.h
+++ b/Interface/SolidSyslogUdpSender.h
@@ -15,9 +15,10 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogUdpSenderConfig
     {
-        struct SolidSyslogResolver* resolver;
-        struct SolidSyslogDatagram* datagram;
-        SolidSyslogEndpointFunction endpoint; /* optional during cut-over; NULL falls back to legacy resolver path */
+        struct SolidSyslogResolver*        resolver;
+        struct SolidSyslogDatagram*        datagram;
+        SolidSyslogEndpointFunction        endpoint;        /* fills host/port; called only on (re)connect */
+        SolidSyslogEndpointVersionFunction endpointVersion; /* polled cheaply on every Send for stale check */
     };
 
     struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config);

--- a/Platform/Posix/Interface/SolidSyslogGetAddrInfoResolver.h
+++ b/Platform/Posix/Interface/SolidSyslogGetAddrInfoResolver.h
@@ -5,8 +5,7 @@
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(const char* (*getHost)(void), // NOLINT(modernize-redundant-void-arg) -- C idiom
-                                                                      int (*getPort)(void));        // NOLINT(modernize-redundant-void-arg) -- C idiom
+    struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(void);
     void                        SolidSyslogGetAddrInfoResolver_Destroy(void);
 
 EXTERN_C_END

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
@@ -12,37 +12,28 @@ enum
     GETADDRINFO_SUCCESS = 0
 };
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
-static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
-                      struct SolidSyslogAddress* result);
-
-static int MapTransport(enum SolidSyslogTransport transport);
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result);
+static int  MapTransport(enum SolidSyslogTransport transport);
 
 struct SolidSyslogGetAddrInfoResolver
 {
     struct SolidSyslogResolver base;
-    const char* (*getHost)(void);
-    int (*getPort)(void);
 };
 
 static struct SolidSyslogGetAddrInfoResolver instance;
 
-struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(const char* (*getHost)(void), int (*getPort)(void))
+struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(void)
 {
-    instance.base.Resolve   = Resolve;
-    instance.base.ResolveAt = ResolveAt;
-    instance.getHost        = getHost;
-    instance.getPort        = getPort;
+    instance.base.Resolve = Resolve;
     return &instance.base;
 }
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
+void SolidSyslogGetAddrInfoResolver_Destroy(void)
 {
-    struct SolidSyslogGetAddrInfoResolver* resolver = (struct SolidSyslogGetAddrInfoResolver*) self;
-    return ResolveAt(self, transport, resolver->getHost(), (uint16_t) resolver->getPort(), result);
+    instance.base.Resolve = NULL;
 }
 
-static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
 {
     (void) self;
 
@@ -75,12 +66,4 @@ static int MapTransport(enum SolidSyslogTransport transport)
     }
 
     return socktype;
-}
-
-void SolidSyslogGetAddrInfoResolver_Destroy(void)
-{
-    instance.base.Resolve   = NULL;
-    instance.base.ResolveAt = NULL;
-    instance.getHost        = NULL;
-    instance.getPort        = NULL;
 }

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
@@ -13,6 +13,8 @@ enum
 };
 
 static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
+static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                      struct SolidSyslogAddress* result);
 
 static int MapTransport(enum SolidSyslogTransport transport);
 
@@ -27,15 +29,22 @@ static struct SolidSyslogGetAddrInfoResolver instance;
 
 struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(const char* (*getHost)(void), int (*getPort)(void))
 {
-    instance.base.Resolve = Resolve;
-    instance.getHost      = getHost;
-    instance.getPort      = getPort;
+    instance.base.Resolve   = Resolve;
+    instance.base.ResolveAt = ResolveAt;
+    instance.getHost        = getHost;
+    instance.getPort        = getPort;
     return &instance.base;
 }
 
 static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
 {
     struct SolidSyslogGetAddrInfoResolver* resolver = (struct SolidSyslogGetAddrInfoResolver*) self;
+    return ResolveAt(self, transport, resolver->getHost(), (uint16_t) resolver->getPort(), result);
+}
+
+static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
+{
+    (void) self;
 
     struct addrinfo hints = {0};
     hints.ai_family       = AF_INET;
@@ -44,11 +53,11 @@ static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport 
     struct addrinfo* info     = NULL;
     bool             resolved = false;
 
-    if (getaddrinfo(resolver->getHost(), NULL, &hints, &info) == GETADDRINFO_SUCCESS)
+    if (getaddrinfo(host, NULL, &hints, &info) == GETADDRINFO_SUCCESS)
     {
         struct sockaddr_in* sin = SolidSyslogAddress_AsSockaddrIn(result);
         *sin                    = *(struct sockaddr_in*) info->ai_addr;
-        sin->sin_port           = htons((uint16_t) resolver->getPort());
+        sin->sin_port           = htons(port);
         freeaddrinfo(info);
         resolved = true;
     }
@@ -70,7 +79,8 @@ static int MapTransport(enum SolidSyslogTransport transport)
 
 void SolidSyslogGetAddrInfoResolver_Destroy(void)
 {
-    instance.base.Resolve = NULL;
-    instance.getHost      = NULL;
-    instance.getPort      = NULL;
+    instance.base.Resolve   = NULL;
+    instance.base.ResolveAt = NULL;
+    instance.getHost        = NULL;
+    instance.getPort        = NULL;
 }

--- a/Platform/Windows/Interface/SolidSyslogWinsockResolver.h
+++ b/Platform/Windows/Interface/SolidSyslogWinsockResolver.h
@@ -8,8 +8,7 @@ EXTERN_C_BEGIN
     /* Precondition: caller has invoked WSAStartup() before using the resolver,
        and will call WSACleanup() on shutdown. The library does not manage
        Winsock lifecycle. */
-    struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(const char* (*getHost)(void), // NOLINT(modernize-redundant-void-arg) -- C idiom
-                                                                  int (*getPort)(void));        // NOLINT(modernize-redundant-void-arg) -- C idiom
+    struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(void);
     void                        SolidSyslogWinsockResolver_Destroy(void);
 
 EXTERN_C_END

--- a/Platform/Windows/Source/SolidSyslogWinsockResolver.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolver.c
@@ -32,37 +32,28 @@ enum
     GETADDRINFO_SUCCESS = 0
 };
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
-static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
-                      struct SolidSyslogAddress* result);
-
-static int MapTransport(enum SolidSyslogTransport transport);
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result);
+static int  MapTransport(enum SolidSyslogTransport transport);
 
 struct SolidSyslogWinsockResolver
 {
     struct SolidSyslogResolver base;
-    const char* (*getHost)(void);
-    int (*getPort)(void);
 };
 
 static struct SolidSyslogWinsockResolver instance;
 
-struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(const char* (*getHost)(void), int (*getPort)(void))
+struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(void)
 {
-    instance.base.Resolve   = Resolve;
-    instance.base.ResolveAt = ResolveAt;
-    instance.getHost        = getHost;
-    instance.getPort        = getPort;
+    instance.base.Resolve = Resolve;
     return &instance.base;
 }
 
-static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
+void SolidSyslogWinsockResolver_Destroy(void)
 {
-    struct SolidSyslogWinsockResolver* resolver = (struct SolidSyslogWinsockResolver*) self;
-    return ResolveAt(self, transport, resolver->getHost(), (uint16_t) resolver->getPort(), result);
+    instance.base.Resolve = NULL;
 }
 
-static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
+static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
 {
     (void) self;
 
@@ -95,12 +86,4 @@ static int MapTransport(enum SolidSyslogTransport transport)
     }
 
     return socktype;
-}
-
-void SolidSyslogWinsockResolver_Destroy(void)
-{
-    instance.base.Resolve   = NULL;
-    instance.base.ResolveAt = NULL;
-    instance.getHost        = NULL;
-    instance.getPort        = NULL;
 }

--- a/Platform/Windows/Source/SolidSyslogWinsockResolver.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolver.c
@@ -33,6 +33,8 @@ enum
 };
 
 static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result);
+static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                      struct SolidSyslogAddress* result);
 
 static int MapTransport(enum SolidSyslogTransport transport);
 
@@ -47,15 +49,22 @@ static struct SolidSyslogWinsockResolver instance;
 
 struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(const char* (*getHost)(void), int (*getPort)(void))
 {
-    instance.base.Resolve = Resolve;
-    instance.getHost      = getHost;
-    instance.getPort      = getPort;
+    instance.base.Resolve   = Resolve;
+    instance.base.ResolveAt = ResolveAt;
+    instance.getHost        = getHost;
+    instance.getPort        = getPort;
     return &instance.base;
 }
 
 static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
 {
     struct SolidSyslogWinsockResolver* resolver = (struct SolidSyslogWinsockResolver*) self;
+    return ResolveAt(self, transport, resolver->getHost(), (uint16_t) resolver->getPort(), result);
+}
+
+static bool ResolveAt(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port, struct SolidSyslogAddress* result)
+{
+    (void) self;
 
     struct addrinfo hints = {0};
     hints.ai_family       = AF_INET;
@@ -64,11 +73,11 @@ static bool Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport 
     struct addrinfo* info     = NULL;
     bool             resolved = false;
 
-    if (Winsock_getaddrinfo(resolver->getHost(), NULL, &hints, &info) == GETADDRINFO_SUCCESS)
+    if (Winsock_getaddrinfo(host, NULL, &hints, &info) == GETADDRINFO_SUCCESS)
     {
         struct sockaddr_in* sin = SolidSyslogAddress_AsSockaddrIn(result);
         *sin                    = *(struct sockaddr_in*) info->ai_addr;
-        sin->sin_port           = htons((uint16_t) resolver->getPort());
+        sin->sin_port           = htons(port);
         Winsock_freeaddrinfo(info);
         resolved = true;
     }
@@ -90,7 +99,8 @@ static int MapTransport(enum SolidSyslogTransport transport)
 
 void SolidSyslogWinsockResolver_Destroy(void)
 {
-    instance.base.Resolve = NULL;
-    instance.getHost      = NULL;
-    instance.getPort      = NULL;
+    instance.base.Resolve   = NULL;
+    instance.base.ResolveAt = NULL;
+    instance.getHost        = NULL;
+    instance.getPort        = NULL;
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Public headers are split by audience (Interface Segregation Principle):
 - **`SolidSyslogTcpSender.h`** — TCP transport with RFC 6587 octet-counting framing. Note: RFC 6587
   is a Historic RFC — the IESG recommends TLS (RFC 5425) over plain TCP for new deployments.
   TCP is provided for interoperability with existing infrastructure
+- **`SolidSyslogEndpoint.h`** — destination spec for senders. Application supplies `endpoint`
+  (fills host/port on (re)connect) and `endpointVersion` (cheap polled fingerprint); senders
+  Disconnect and lazily reopen when the version changes — supports runtime address rotation
 - **`SolidSyslogStoreDefinition.h`** / **`SolidSyslogFileStore.h`** — file-based store-and-forward with rotating files
 - **`SolidSyslogSecurityPolicyDefinition.h`** — extension point for record integrity policies
 - **`SolidSyslogCrc16Policy.h`** — CRC-16/CCITT-FALSE integrity policy

--- a/Source/SolidSyslogResolver.c
+++ b/Source/SolidSyslogResolver.c
@@ -4,3 +4,9 @@ bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum Soli
 {
     return resolver->Resolve(resolver, transport, result);
 }
+
+bool SolidSyslogResolver_ResolveAt(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                   struct SolidSyslogAddress* result)
+{
+    return resolver->ResolveAt(resolver, transport, host, port, result);
+}

--- a/Source/SolidSyslogResolver.c
+++ b/Source/SolidSyslogResolver.c
@@ -1,12 +1,7 @@
 #include "SolidSyslogResolverDefinition.h"
 
-bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, struct SolidSyslogAddress* result)
+bool SolidSyslogResolver_Resolve(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                 struct SolidSyslogAddress* result)
 {
-    return resolver->Resolve(resolver, transport, result);
-}
-
-bool SolidSyslogResolver_ResolveAt(struct SolidSyslogResolver* resolver, enum SolidSyslogTransport transport, const char* host, uint16_t port,
-                                   struct SolidSyslogAddress* result)
-{
-    return resolver->ResolveAt(resolver, transport, host, port, result);
+    return resolver->Resolve(resolver, transport, host, port, result);
 }

--- a/Source/SolidSyslogSender.c
+++ b/Source/SolidSyslogSender.c
@@ -4,3 +4,8 @@ bool SolidSyslogSender_Send(struct SolidSyslogSender* sender, const void* buffer
 {
     return sender->Send(sender, buffer, size);
 }
+
+void SolidSyslogSender_Disconnect(struct SolidSyslogSender* sender)
+{
+    sender->Disconnect(sender);
+}

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogTcpSender.h"
+#include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogSenderDefinition.h"
 
@@ -24,6 +25,8 @@ static bool                         Send(struct SolidSyslogSender* self, const v
 static inline bool                  EnsureConnected(struct SolidSyslogTcpSender* tcp);
 static inline bool                  Connected(struct SolidSyslogTcpSender* tcp);
 static bool                         Connect(struct SolidSyslogTcpSender* tcp);
+static inline bool                  ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr);
+static bool                         ResolveAtEndpoint(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr);
 static void                         Disconnect(struct SolidSyslogSender* self);
 static inline void                  CloseStream(struct SolidSyslogTcpSender* tcp);
 static bool                         TransmitFramed(struct SolidSyslogTcpSender* tcp, const void* buffer, size_t size);
@@ -69,12 +72,32 @@ static bool Connect(struct SolidSyslogTcpSender* tcp)
     SolidSyslogAddressStorage  addrStorage = {0};
     struct SolidSyslogAddress* addr        = SolidSyslogAddress_FromStorage(&addrStorage);
 
-    if (SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, addr))
+    if (ResolveDestination(tcp, addr))
     {
         tcp->connected = SolidSyslogStream_Open(tcp->config.stream, addr);
     }
 
     return Connected(tcp);
+}
+
+static inline bool ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr)
+{
+    if (tcp->config.endpoint != NULL)
+    {
+        return ResolveAtEndpoint(tcp, addr);
+    }
+    return SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, addr);
+}
+
+static bool ResolveAtEndpoint(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr)
+{
+    SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
+    struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
+    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0, .version = 0};
+
+    tcp->config.endpoint(&endpoint);
+
+    return SolidSyslogResolver_ResolveAt(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port, addr);
 }
 
 static void Disconnect(struct SolidSyslogSender* self)

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -87,7 +87,7 @@ static bool ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSys
 {
     SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
-    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0, .version = 0};
+    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0};
 
     tcp->config.endpoint(&endpoint);
 
@@ -141,6 +141,5 @@ static bool SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t
 static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
-    endpoint->port    = 0;
-    endpoint->version = 0;
+    endpoint->port = 0;
 }

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -12,8 +12,6 @@ struct SolidSyslogTcpSender
     bool                              connected;
 };
 
-static struct SolidSyslogTcpSender instance;
-
 enum
 {
     UINT32_MAX_DECIMAL_DIGITS      = 10,
@@ -22,57 +20,48 @@ enum
     OCTET_COUNTING_PREFIX_CAPACITY = UINT32_MAX_DECIMAL_DIGITS + OCTET_COUNTING_SEPARATOR + OCTET_COUNTING_NULL_TERMINATOR
 };
 
-static bool                         Connect(struct SolidSyslogTcpSender* tcp);
-static bool                         EnsureConnected(struct SolidSyslogTcpSender* tcp);
-static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
 static bool                         Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
-static bool                         SendData(struct SolidSyslogTcpSender* tcp, const void* data, size_t len);
+static inline bool                  EnsureConnected(struct SolidSyslogTcpSender* tcp);
+static inline bool                  Connected(struct SolidSyslogTcpSender* tcp);
+static bool                         Connect(struct SolidSyslogTcpSender* tcp);
+static void                         Disconnect(struct SolidSyslogSender* self);
+static inline void                  CloseStream(struct SolidSyslogTcpSender* tcp);
+static bool                         TransmitFramed(struct SolidSyslogTcpSender* tcp, const void* buffer, size_t size);
+static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
+static bool                         SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t len);
+
+static const struct SolidSyslogTcpSender DEFAULT_INSTANCE = {0};
+static struct SolidSyslogTcpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTcpSenderConfig* config)
 {
-    instance.config    = *config;
-    instance.base.Send = Send;
-    instance.connected = false;
+    instance                 = DEFAULT_INSTANCE;
+    instance.config          = *config;
+    instance.base.Send       = Send;
+    instance.base.Disconnect = Disconnect;
     return &instance.base;
 }
 
 void SolidSyslogTcpSender_Destroy(void)
 {
-    if (instance.connected && instance.config.stream != NULL)
-    {
-        SolidSyslogStream_Close(instance.config.stream);
-    }
-    instance.base.Send = NULL;
-    instance.connected = false;
-    instance.config    = (struct SolidSyslogTcpSenderConfig) {0};
+    Disconnect(&instance.base);
+    instance = DEFAULT_INSTANCE;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
-    struct SolidSyslogTcpSender* tcp  = (struct SolidSyslogTcpSender*) self;
-    bool                         sent = false;
-
-    if (EnsureConnected(tcp))
-    {
-        SolidSyslogFormatterStorage  prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
-        struct SolidSyslogFormatter* prefix = FormatOctetCountingPrefix(prefixStorage, size);
-
-        sent = SendData(tcp, SolidSyslogFormatter_AsString(prefix), SolidSyslogFormatter_Length(prefix)) && SendData(tcp, buffer, size);
-    }
-
-    return sent;
+    struct SolidSyslogTcpSender* tcp = (struct SolidSyslogTcpSender*) self;
+    return EnsureConnected(tcp) && TransmitFramed(tcp, buffer, size);
 }
 
-static bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
+static inline bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
 {
-    bool connected = tcp->connected;
+    return Connected(tcp) || Connect(tcp);
+}
 
-    if (!connected)
-    {
-        connected = Connect(tcp);
-    }
-
-    return connected;
+static inline bool Connected(struct SolidSyslogTcpSender* tcp)
+{
+    return tcp->connected;
 }
 
 static bool Connect(struct SolidSyslogTcpSender* tcp)
@@ -85,7 +74,31 @@ static bool Connect(struct SolidSyslogTcpSender* tcp)
         tcp->connected = SolidSyslogStream_Open(tcp->config.stream, addr);
     }
 
-    return tcp->connected;
+    return Connected(tcp);
+}
+
+static void Disconnect(struct SolidSyslogSender* self)
+{
+    struct SolidSyslogTcpSender* tcp = (struct SolidSyslogTcpSender*) self;
+
+    if (Connected(tcp))
+    {
+        CloseStream(tcp);
+    }
+}
+
+static inline void CloseStream(struct SolidSyslogTcpSender* tcp)
+{
+    SolidSyslogStream_Close(tcp->config.stream);
+    tcp->connected = false;
+}
+
+static bool TransmitFramed(struct SolidSyslogTcpSender* tcp, const void* buffer, size_t size)
+{
+    SolidSyslogFormatterStorage  prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
+    struct SolidSyslogFormatter* prefix = FormatOctetCountingPrefix(prefixStorage, size);
+
+    return SendBytes(tcp, SolidSyslogFormatter_AsString(prefix), SolidSyslogFormatter_Length(prefix)) && SendBytes(tcp, buffer, size);
 }
 
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)
@@ -96,14 +109,13 @@ static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatt
     return f;
 }
 
-static bool SendData(struct SolidSyslogTcpSender* tcp, const void* data, size_t len)
+static bool SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t len)
 {
     bool sent = SolidSyslogStream_Send(tcp->config.stream, data, len);
 
     if (!sent)
     {
-        SolidSyslogStream_Close(tcp->config.stream);
-        tcp->connected = false;
+        CloseStream(tcp);
     }
 
     return sent;

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -6,12 +6,14 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 struct SolidSyslogTcpSender
 {
     struct SolidSyslogSender          base;
     struct SolidSyslogTcpSenderConfig config;
     bool                              connected;
+    uint32_t                          lastEndpointVersion;
 };
 
 enum
@@ -23,6 +25,8 @@ enum
 };
 
 static bool                         Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static inline bool                  Reconcile(struct SolidSyslogTcpSender* tcp);
+static inline void                  DisconnectIfStale(struct SolidSyslogTcpSender* tcp);
 static inline bool                  EnsureConnected(struct SolidSyslogTcpSender* tcp);
 static inline bool                  Connected(struct SolidSyslogTcpSender* tcp);
 static bool                         Connect(struct SolidSyslogTcpSender* tcp);
@@ -33,8 +37,9 @@ static bool                         TransmitFramed(struct SolidSyslogTcpSender* 
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
 static bool                         SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t len);
 static void                         NilEndpoint(struct SolidSyslogEndpoint* endpoint);
+static uint32_t                     NilEndpointVersion(void);
 
-static const struct SolidSyslogTcpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint}};
+static const struct SolidSyslogTcpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
 static struct SolidSyslogTcpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTcpSenderConfig* config)
@@ -43,6 +48,7 @@ struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTc
     instance.config.resolver = config->resolver;
     instance.config.stream   = config->stream;
     ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
+    ASSIGN_IF_NON_NULL(instance.config.endpointVersion, config->endpointVersion);
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;
     return &instance.base;
@@ -57,7 +63,24 @@ void SolidSyslogTcpSender_Destroy(void)
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     struct SolidSyslogTcpSender* tcp = (struct SolidSyslogTcpSender*) self;
-    return EnsureConnected(tcp) && TransmitFramed(tcp, buffer, size);
+    return Reconcile(tcp) && TransmitFramed(tcp, buffer, size);
+}
+
+static inline bool Reconcile(struct SolidSyslogTcpSender* tcp)
+{
+    DisconnectIfStale(tcp);
+    return EnsureConnected(tcp);
+}
+
+static inline void DisconnectIfStale(struct SolidSyslogTcpSender* tcp)
+{
+    uint32_t version = tcp->config.endpointVersion();
+
+    if (version != tcp->lastEndpointVersion)
+    {
+        Disconnect(&tcp->base);
+        tcp->lastEndpointVersion = version;
+    }
 }
 
 static inline bool EnsureConnected(struct SolidSyslogTcpSender* tcp)
@@ -142,4 +165,9 @@ static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
     endpoint->port = 0;
+}
+
+static uint32_t NilEndpointVersion(void)
+{
+    return 0;
 }

--- a/Source/SolidSyslogTcpSender.c
+++ b/Source/SolidSyslogTcpSender.c
@@ -1,6 +1,7 @@
 #include "SolidSyslogTcpSender.h"
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogMacros.h"
 #include "SolidSyslogSenderDefinition.h"
 
 #include <stdbool.h>
@@ -25,21 +26,23 @@ static bool                         Send(struct SolidSyslogSender* self, const v
 static inline bool                  EnsureConnected(struct SolidSyslogTcpSender* tcp);
 static inline bool                  Connected(struct SolidSyslogTcpSender* tcp);
 static bool                         Connect(struct SolidSyslogTcpSender* tcp);
-static inline bool                  ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr);
-static bool                         ResolveAtEndpoint(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr);
+static bool                         ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr);
 static void                         Disconnect(struct SolidSyslogSender* self);
 static inline void                  CloseStream(struct SolidSyslogTcpSender* tcp);
 static bool                         TransmitFramed(struct SolidSyslogTcpSender* tcp, const void* buffer, size_t size);
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
 static bool                         SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t len);
+static void                         NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 
-static const struct SolidSyslogTcpSender DEFAULT_INSTANCE = {0};
+static const struct SolidSyslogTcpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint}};
 static struct SolidSyslogTcpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogTcpSender_Create(const struct SolidSyslogTcpSenderConfig* config)
 {
     instance                 = DEFAULT_INSTANCE;
-    instance.config          = *config;
+    instance.config.resolver = config->resolver;
+    instance.config.stream   = config->stream;
+    ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;
     return &instance.base;
@@ -80,16 +83,7 @@ static bool Connect(struct SolidSyslogTcpSender* tcp)
     return Connected(tcp);
 }
 
-static inline bool ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr)
-{
-    if (tcp->config.endpoint != NULL)
-    {
-        return ResolveAtEndpoint(tcp, addr);
-    }
-    return SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, addr);
-}
-
-static bool ResolveAtEndpoint(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr)
+static bool ResolveDestination(struct SolidSyslogTcpSender* tcp, struct SolidSyslogAddress* addr)
 {
     SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
@@ -97,7 +91,7 @@ static bool ResolveAtEndpoint(struct SolidSyslogTcpSender* tcp, struct SolidSysl
 
     tcp->config.endpoint(&endpoint);
 
-    return SolidSyslogResolver_ResolveAt(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port, addr);
+    return SolidSyslogResolver_Resolve(tcp->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port, addr);
 }
 
 static void Disconnect(struct SolidSyslogSender* self)
@@ -142,4 +136,11 @@ static bool SendBytes(struct SolidSyslogTcpSender* tcp, const void* data, size_t
     }
 
     return sent;
+}
+
+static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
+    endpoint->port    = 0;
+    endpoint->version = 0;
 }

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -1,5 +1,6 @@
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogMacros.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
 
@@ -19,19 +20,21 @@ static inline bool                       Connected(struct SolidSyslogUdpSender* 
 static bool                              Connect(struct SolidSyslogUdpSender* udp);
 static void                              Disconnect(struct SolidSyslogSender* self);
 static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
-static inline bool                       ResolveDestination(struct SolidSyslogUdpSender* udp);
-static bool                              ResolveAtEndpoint(struct SolidSyslogUdpSender* udp);
+static bool                              ResolveDestination(struct SolidSyslogUdpSender* udp);
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
 static inline void                       CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                       TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
+static void                              NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {0};
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint}};
 static struct SolidSyslogUdpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
     instance                 = DEFAULT_INSTANCE;
-    instance.config          = *config;
+    instance.config.resolver = config->resolver;
+    instance.config.datagram = config->datagram;
+    ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;
     return &instance.base;
@@ -86,16 +89,7 @@ static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
     return SolidSyslogDatagram_Open(udp->config.datagram);
 }
 
-static inline bool ResolveDestination(struct SolidSyslogUdpSender* udp)
-{
-    if (udp->config.endpoint != NULL)
-    {
-        return ResolveAtEndpoint(udp);
-    }
-    return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, Address(udp));
-}
-
-static bool ResolveAtEndpoint(struct SolidSyslogUdpSender* udp)
+static bool ResolveDestination(struct SolidSyslogUdpSender* udp)
 {
     SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
@@ -103,8 +97,8 @@ static bool ResolveAtEndpoint(struct SolidSyslogUdpSender* udp)
 
     udp->config.endpoint(&endpoint);
 
-    return SolidSyslogResolver_ResolveAt(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port,
-                                         Address(udp));
+    return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port,
+                                       Address(udp));
 }
 
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp)
@@ -121,4 +115,11 @@ static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
     return SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
+}
+
+static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
+    endpoint->port    = 0;
+    endpoint->version = 0;
 }

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -1,3 +1,5 @@
+#include "SolidSyslogEndpoint.h"
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
 
@@ -18,6 +20,7 @@ static bool                              Connect(struct SolidSyslogUdpSender* ud
 static void                              Disconnect(struct SolidSyslogSender* self);
 static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                       ResolveDestination(struct SolidSyslogUdpSender* udp);
+static bool                              ResolveAtEndpoint(struct SolidSyslogUdpSender* udp);
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
 static inline void                       CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                       TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
@@ -85,7 +88,23 @@ static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
 
 static inline bool ResolveDestination(struct SolidSyslogUdpSender* udp)
 {
+    if (udp->config.endpoint != NULL)
+    {
+        return ResolveAtEndpoint(udp);
+    }
     return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, Address(udp));
+}
+
+static bool ResolveAtEndpoint(struct SolidSyslogUdpSender* udp)
+{
+    SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
+    struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
+    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0, .version = 0};
+
+    udp->config.endpoint(&endpoint);
+
+    return SolidSyslogResolver_ResolveAt(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port,
+                                         Address(udp));
 }
 
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp)

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -3,60 +3,93 @@
 
 #include <stddef.h>
 
-static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
-
 struct SolidSyslogUdpSender
 {
     struct SolidSyslogSender          base;
     struct SolidSyslogUdpSenderConfig config;
     SolidSyslogAddressStorage         addrStorage;
-    bool                              ready;
+    bool                              connected;
 };
 
-static struct SolidSyslogUdpSender instance;
+static bool                              Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static inline bool                       EnsureConnected(struct SolidSyslogUdpSender* udp);
+static inline bool                       Connected(struct SolidSyslogUdpSender* udp);
+static bool                              Connect(struct SolidSyslogUdpSender* udp);
+static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
+static inline bool                       ResolveDestination(struct SolidSyslogUdpSender* udp);
+static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
+static inline void                       CloseSocket(struct SolidSyslogUdpSender* udp);
+static inline bool                       TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
+
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {0};
+static struct SolidSyslogUdpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
+    instance           = DEFAULT_INSTANCE;
     instance.config    = *config;
     instance.base.Send = Send;
-
-    struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&instance.addrStorage);
-
-    bool opened   = SolidSyslogDatagram_Open(config->datagram);
-    bool resolved = false;
-
-    if (opened)
-    {
-        resolved = SolidSyslogResolver_Resolve(config->resolver, SOLIDSYSLOG_TRANSPORT_UDP, addr);
-    }
-
-    instance.ready = opened && resolved;
-
     return &instance.base;
 }
 
 void SolidSyslogUdpSender_Destroy(void)
 {
-    if (instance.config.datagram != NULL)
+    if (Connected(&instance))
     {
         SolidSyslogDatagram_Close(instance.config.datagram);
     }
-    instance.base.Send   = NULL;
-    instance.addrStorage = (SolidSyslogAddressStorage) {0};
-    instance.config      = (struct SolidSyslogUdpSenderConfig) {0};
-    instance.ready       = false;
+    instance = DEFAULT_INSTANCE;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
-    struct SolidSyslogUdpSender* udpSender = (struct SolidSyslogUdpSender*) self;
-    bool                         sent      = false;
+    struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
+    return EnsureConnected(udp) && TransmitDatagram(udp, buffer, size);
+}
 
-    if (udpSender->ready)
+static inline bool EnsureConnected(struct SolidSyslogUdpSender* udp)
+{
+    return Connected(udp) || Connect(udp);
+}
+
+static inline bool Connected(struct SolidSyslogUdpSender* udp)
+{
+    return udp->connected;
+}
+
+static bool Connect(struct SolidSyslogUdpSender* udp)
+{
+    udp->connected = OpenSocket(udp) && ResolveDestination(udp);
+
+    if (!Connected(udp))
     {
-        struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&udpSender->addrStorage);
-        sent                            = SolidSyslogDatagram_SendTo(udpSender->config.datagram, buffer, size, addr);
+        CloseSocket(udp);
     }
 
-    return sent;
+    return Connected(udp);
+}
+
+static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
+{
+    return SolidSyslogDatagram_Open(udp->config.datagram);
+}
+
+static inline bool ResolveDestination(struct SolidSyslogUdpSender* udp)
+{
+    return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, Address(udp));
+}
+
+static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp)
+{
+    return SolidSyslogAddress_FromStorage(&udp->addrStorage);
+}
+
+static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
+{
+    SolidSyslogDatagram_Close(udp->config.datagram);
+}
+
+static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
+{
+    return SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
 }

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -5,6 +5,7 @@
 #include "SolidSyslogSenderDefinition.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct SolidSyslogUdpSender
 {
@@ -12,21 +13,25 @@ struct SolidSyslogUdpSender
     struct SolidSyslogUdpSenderConfig config;
     SolidSyslogAddressStorage         addrStorage;
     bool                              connected;
+    uint32_t                          lastEndpointVersion;
 };
 
 static bool                              Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static inline bool                       Reconcile(struct SolidSyslogUdpSender* udp);
+static inline void                       DisconnectIfStale(struct SolidSyslogUdpSender* udp);
 static inline bool                       EnsureConnected(struct SolidSyslogUdpSender* udp);
 static inline bool                       Connected(struct SolidSyslogUdpSender* udp);
 static bool                              Connect(struct SolidSyslogUdpSender* udp);
 static void                              Disconnect(struct SolidSyslogSender* self);
 static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
-static bool                              ResolveDestination(struct SolidSyslogUdpSender* udp);
+static bool                              ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
 static inline void                       CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                       TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
 static void                              NilEndpoint(struct SolidSyslogEndpoint* endpoint);
+static uint32_t                          NilEndpointVersion(void);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint}};
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
 static struct SolidSyslogUdpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
@@ -35,6 +40,7 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     instance.config.resolver = config->resolver;
     instance.config.datagram = config->datagram;
     ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
+    ASSIGN_IF_NON_NULL(instance.config.endpointVersion, config->endpointVersion);
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;
     return &instance.base;
@@ -49,7 +55,24 @@ void SolidSyslogUdpSender_Destroy(void)
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
-    return EnsureConnected(udp) && TransmitDatagram(udp, buffer, size);
+    return Reconcile(udp) && TransmitDatagram(udp, buffer, size);
+}
+
+static inline bool Reconcile(struct SolidSyslogUdpSender* udp)
+{
+    DisconnectIfStale(udp);
+    return EnsureConnected(udp);
+}
+
+static inline void DisconnectIfStale(struct SolidSyslogUdpSender* udp)
+{
+    uint32_t version = udp->config.endpointVersion();
+
+    if (version != udp->lastEndpointVersion)
+    {
+        Disconnect(&udp->base);
+        udp->lastEndpointVersion = version;
+    }
 }
 
 static inline bool EnsureConnected(struct SolidSyslogUdpSender* udp)
@@ -64,7 +87,13 @@ static inline bool Connected(struct SolidSyslogUdpSender* udp)
 
 static bool Connect(struct SolidSyslogUdpSender* udp)
 {
-    udp->connected = OpenSocket(udp) && ResolveDestination(udp);
+    SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
+    struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
+    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0};
+
+    udp->config.endpoint(&endpoint);
+
+    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port);
 
     if (!Connected(udp))
     {
@@ -89,16 +118,9 @@ static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
     return SolidSyslogDatagram_Open(udp->config.datagram);
 }
 
-static bool ResolveDestination(struct SolidSyslogUdpSender* udp)
+static bool ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port)
 {
-    SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
-    struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
-    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0, .version = 0};
-
-    udp->config.endpoint(&endpoint);
-
-    return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port,
-                                       Address(udp));
+    return SolidSyslogResolver_Resolve(udp->config.resolver, SOLIDSYSLOG_TRANSPORT_UDP, host, port, Address(udp));
 }
 
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp)
@@ -120,6 +142,10 @@ static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void
 static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
-    endpoint->port    = 0;
-    endpoint->version = 0;
+    endpoint->port = 0;
+}
+
+static uint32_t NilEndpointVersion(void)
+{
+    return 0;
 }

--- a/Source/SolidSyslogUdpSender.c
+++ b/Source/SolidSyslogUdpSender.c
@@ -15,6 +15,7 @@ static bool                              Send(struct SolidSyslogSender* self, co
 static inline bool                       EnsureConnected(struct SolidSyslogUdpSender* udp);
 static inline bool                       Connected(struct SolidSyslogUdpSender* udp);
 static bool                              Connect(struct SolidSyslogUdpSender* udp);
+static void                              Disconnect(struct SolidSyslogSender* self);
 static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                       ResolveDestination(struct SolidSyslogUdpSender* udp);
 static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
@@ -26,18 +27,16 @@ static struct SolidSyslogUdpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
-    instance           = DEFAULT_INSTANCE;
-    instance.config    = *config;
-    instance.base.Send = Send;
+    instance                 = DEFAULT_INSTANCE;
+    instance.config          = *config;
+    instance.base.Send       = Send;
+    instance.base.Disconnect = Disconnect;
     return &instance.base;
 }
 
 void SolidSyslogUdpSender_Destroy(void)
 {
-    if (Connected(&instance))
-    {
-        SolidSyslogDatagram_Close(instance.config.datagram);
-    }
+    Disconnect(&instance.base);
     instance = DEFAULT_INSTANCE;
 }
 
@@ -69,6 +68,16 @@ static bool Connect(struct SolidSyslogUdpSender* udp)
     return Connected(udp);
 }
 
+static void Disconnect(struct SolidSyslogSender* self)
+{
+    struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
+
+    if (Connected(udp))
+    {
+        CloseSocket(udp);
+    }
+}
+
 static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
 {
     return SolidSyslogDatagram_Open(udp->config.datagram);
@@ -87,6 +96,7 @@ static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* ud
 static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
 {
     SolidSyslogDatagram_Close(udp->config.datagram);
+    udp->connected = false;
 }
 
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -38,7 +38,7 @@ TEST_GROUP(ExampleServiceThread)
         ClockFake_SetTime(1743768600, 0);
         shutdown = true;
 
-        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort), SolidSyslogPosixDatagram_Create(), ExampleEndpoint};
+        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(), SolidSyslogPosixDatagram_Create(), ExampleEndpoint};
         sender = SolidSyslogUdpSender_Create(&udpConfig);
         buffer = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
         store  = SolidSyslogNullStore_Create();

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -12,12 +12,10 @@
 #include "SolidSyslogNullStore.h"
 #include "SocketFake.h"
 #include "ClockFake.h"
-#include <cstring>
 
 static void ExampleEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = ExampleUdpConfig_GetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, ExampleUdpConfig_GetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) ExampleUdpConfig_GetPort();
 }
 

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -3,6 +3,8 @@
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogEndpoint.h"
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogPosixMessageQueueBuffer.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixDatagram.h"
@@ -10,6 +12,15 @@
 #include "SolidSyslogNullStore.h"
 #include "SocketFake.h"
 #include "ClockFake.h"
+#include <cstring>
+
+static void ExampleEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = ExampleUdpConfig_GetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) ExampleUdpConfig_GetPort();
+    endpoint->version = 0;
+}
 
 // clang-format off
 TEST_GROUP(ExampleServiceThread)
@@ -27,7 +38,7 @@ TEST_GROUP(ExampleServiceThread)
         ClockFake_SetTime(1743768600, 0);
         shutdown = true;
 
-        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort), SolidSyslogPosixDatagram_Create()};
+        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(ExampleUdpConfig_GetHost, ExampleUdpConfig_GetPort), SolidSyslogPosixDatagram_Create(), ExampleEndpoint};
         sender = SolidSyslogUdpSender_Create(&udpConfig);
         buffer = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
         store  = SolidSyslogNullStore_Create();

--- a/Tests/Example/ExampleServiceThreadTest.cpp
+++ b/Tests/Example/ExampleServiceThreadTest.cpp
@@ -18,8 +18,12 @@ static void ExampleEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = ExampleUdpConfig_GetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) ExampleUdpConfig_GetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) ExampleUdpConfig_GetPort();
+}
+
+static uint32_t ExampleEndpointVersion() // NOLINT(modernize-use-trailing-return-type)
+{
+    return 0;
 }
 
 // clang-format off
@@ -38,7 +42,7 @@ TEST_GROUP(ExampleServiceThread)
         ClockFake_SetTime(1743768600, 0);
         shutdown = true;
 
-        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(), SolidSyslogPosixDatagram_Create(), ExampleEndpoint};
+        SolidSyslogUdpSenderConfig udpConfig = {SolidSyslogGetAddrInfoResolver_Create(), SolidSyslogPosixDatagram_Create(), ExampleEndpoint, ExampleEndpointVersion};
         sender = SolidSyslogUdpSender_Create(&udpConfig);
         buffer = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
         store  = SolidSyslogNullStore_Create();

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -2,7 +2,6 @@
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogResolver.h"
-#include "SolidSyslogResolverDefinition.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
 #include <cstdint>
@@ -11,30 +10,10 @@
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";
-static const int         TEST_PORT           = 514;
+static const uint16_t    TEST_PORT           = 514;
 static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";
-static const int         TEST_ALTERNATE_PORT = 9999;
+static const uint16_t    TEST_ALTERNATE_PORT = 9999;
 // clang-format on
-
-static const char* GetHost()
-{
-    return TEST_HOST;
-}
-
-static int GetPort()
-{
-    return TEST_PORT;
-}
-
-static const char* GetAlternateHost()
-{
-    return TEST_ALTERNATE_HOST;
-}
-
-static int GetAlternatePort()
-{
-    return TEST_ALTERNATE_PORT;
-}
 
 // clang-format off
 TEST_GROUP(SolidSyslogGetAddrInfoResolver)
@@ -45,7 +24,7 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolver)
     void setup() override
     {
         SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
     }
 
     void teardown() override
@@ -53,14 +32,13 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolver)
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
-    bool Resolve(enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    bool Resolve(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
     {
         struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
-        return resolver->Resolve(resolver, transport, address);
+        return SolidSyslogResolver_Resolve(resolver, transport, host, port, address);
     }
 
-    // Test-only peek: the resolver fills the storage per the POSIX sockaddr_in layout.
-    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through the accessor syntax in tests
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
     const struct sockaddr_in* Result() const
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
@@ -76,176 +54,65 @@ TEST(SolidSyslogGetAddrInfoResolver, CreateDestroyWorksWithoutCrashing)
 {
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesAddressFamily)
+TEST(SolidSyslogGetAddrInfoResolver, ReturnsTrueOnSuccess)
 {
-    Resolve();
+    CHECK_TRUE(Resolve(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogGetAddrInfoResolver, PopulatesAddressFamily)
+{
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(AF_INET, Result()->sin_family);
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesResolvedAddress)
+TEST(SolidSyslogGetAddrInfoResolver, PopulatesResolvedAddressFromHostArgument)
 {
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     char addrString[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
     STRCMP_EQUAL(TEST_HOST, addrString);
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolvePopulatesPort)
+TEST(SolidSyslogGetAddrInfoResolver, PopulatesPortFromPortArgument)
 {
-    Resolve();
-    LONGS_EQUAL(TEST_PORT, ntohs(Result()->sin_port));
-}
-
-TEST(SolidSyslogGetAddrInfoResolver, GetAddrInfoCalledWithHostname)
-{
-    Resolve();
-    LONGS_EQUAL(1, SocketFake_GetAddrInfoCallCount());
-    STRCMP_EQUAL(TEST_HOST, SocketFake_LastGetAddrInfoHostname());
-}
-
-TEST(SolidSyslogGetAddrInfoResolver, AlternateHostResolvesCorrectly)
-{
-    resolver = SolidSyslogGetAddrInfoResolver_Create(GetAlternateHost, GetPort);
-    Resolve();
-    STRCMP_EQUAL(TEST_ALTERNATE_HOST, SocketFake_LastGetAddrInfoHostname());
-}
-
-TEST(SolidSyslogGetAddrInfoResolver, AlternatePortResolvesCorrectly)
-{
-    resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetAlternatePort);
-    Resolve();
+    Resolve(TEST_HOST, TEST_ALTERNATE_PORT);
     LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogGetAddrInfoResolver, GetAddrInfoCalledWithHostArgument)
+{
+    Resolve(TEST_ALTERNATE_HOST, TEST_PORT);
+    LONGS_EQUAL(1, SocketFake_GetAddrInfoCallCount());
+    STRCMP_EQUAL(TEST_ALTERNATE_HOST, SocketFake_LastGetAddrInfoHostname());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, UdpTransportPassesDatagramSocktype)
 {
-    Resolve(SOLIDSYSLOG_TRANSPORT_UDP);
+    Resolve(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
     LONGS_EQUAL(SOCK_DGRAM, SocketFake_LastGetAddrInfoSocktype());
 }
 
 TEST(SolidSyslogGetAddrInfoResolver, TcpTransportPassesStreamSocktype)
 {
-    Resolve(SOLIDSYSLOG_TRANSPORT_TCP);
+    Resolve(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
     LONGS_EQUAL(SOCK_STREAM, SocketFake_LastGetAddrInfoSocktype());
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsFalseWhenGetAddrInfoFails)
+TEST(SolidSyslogGetAddrInfoResolver, ReturnsFalseWhenGetAddrInfoFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
-    CHECK_FALSE(Resolve());
+    CHECK_FALSE(Resolve(TEST_HOST, TEST_PORT));
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolveReturnsTrueOnSuccess)
-{
-    CHECK_TRUE(Resolve());
-}
-
-TEST(SolidSyslogGetAddrInfoResolver, ResolveDoesNotFreeAddrInfoWhenGetAddrInfoFails)
+TEST(SolidSyslogGetAddrInfoResolver, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(0, SocketFake_FreeAddrInfoCallCount());
 }
 
-TEST(SolidSyslogGetAddrInfoResolver, ResolveFreesAddrInfoOnSuccess)
+TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
 {
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
-}
-
-// clang-format off
-TEST_GROUP(SolidSyslogGetAddrInfoResolverResolveAt)
-{
-    struct SolidSyslogResolver* resolver = nullptr;
-    SolidSyslogAddressStorage   resultStorage{};
-
-    void setup() override
-    {
-        SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-    }
-
-    void teardown() override
-    {
-        SolidSyslogGetAddrInfoResolver_Destroy();
-    }
-
-    bool ResolveAt(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
-    {
-        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
-        return SolidSyslogResolver_ResolveAt(resolver, transport, host, port, address);
-    }
-
-    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
-    const struct sockaddr_in* Result() const
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
-        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
-        return reinterpret_cast<const struct sockaddr_in*>(bytes);
-    }
-};
-
-// clang-format on
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, ReturnsTrueOnSuccess)
-{
-    CHECK_TRUE(ResolveAt(TEST_HOST, TEST_PORT));
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesAddressFamily)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(AF_INET, Result()->sin_family);
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesResolvedAddressFromHostArgument)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    char addrString[INET_ADDRSTRLEN];
-    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
-    STRCMP_EQUAL(TEST_HOST, addrString);
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesPortFromPortArgument)
-{
-    ResolveAt(TEST_HOST, TEST_ALTERNATE_PORT);
-    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, TcpTransportPassesStreamSocktype)
-{
-    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
-    LONGS_EQUAL(SOCK_STREAM, SocketFake_LastGetAddrInfoSocktype());
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, ReturnsFalseWhenGetAddrInfoFails)
-{
-    SocketFake_SetGetAddrInfoFails(true);
-    CHECK_FALSE(ResolveAt(TEST_HOST, TEST_PORT));
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
-{
-    SocketFake_SetGetAddrInfoFails(true);
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(0, SocketFake_FreeAddrInfoCallCount());
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, FreesAddrInfoOnSuccess)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, UdpTransportPassesDatagramSocktype)
-{
-    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
-    LONGS_EQUAL(SOCK_DGRAM, SocketFake_LastGetAddrInfoSocktype());
-}
-
-TEST(SolidSyslogGetAddrInfoResolverResolveAt, IgnoresResolverGetHostCallback)
-{
-    ResolveAt(TEST_ALTERNATE_HOST, TEST_PORT);
-    STRCMP_EQUAL(TEST_ALTERNATE_HOST, SocketFake_LastGetAddrInfoHostname());
 }

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -1,6 +1,7 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
+#include "SolidSyslogResolver.h"
 #include "SolidSyslogResolverDefinition.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
@@ -150,4 +151,101 @@ TEST(SolidSyslogGetAddrInfoResolver, ResolveFreesAddrInfoOnSuccess)
 {
     Resolve();
     LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogGetAddrInfoResolverResolveAt)
+{
+    struct SolidSyslogResolver* resolver = nullptr;
+    SolidSyslogAddressStorage   resultStorage{};
+
+    void setup() override
+    {
+        SocketFake_Reset();
+        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogGetAddrInfoResolver_Destroy();
+    }
+
+    bool ResolveAt(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    {
+        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
+        return SolidSyslogResolver_ResolveAt(resolver, transport, host, port, address);
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
+    const struct sockaddr_in* Result() const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
+        return reinterpret_cast<const struct sockaddr_in*>(bytes);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, ReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(ResolveAt(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesAddressFamily)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(AF_INET, Result()->sin_family);
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesResolvedAddressFromHostArgument)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    char addrString[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
+    STRCMP_EQUAL(TEST_HOST, addrString);
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, PopulatesPortFromPortArgument)
+{
+    ResolveAt(TEST_HOST, TEST_ALTERNATE_PORT);
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, TcpTransportPassesStreamSocktype)
+{
+    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
+    LONGS_EQUAL(SOCK_STREAM, SocketFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, ReturnsFalseWhenGetAddrInfoFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(ResolveAt(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(0, SocketFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, FreesAddrInfoOnSuccess)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(1, SocketFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, UdpTransportPassesDatagramSocktype)
+{
+    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
+    LONGS_EQUAL(SOCK_DGRAM, SocketFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogGetAddrInfoResolverResolveAt, IgnoresResolverGetHostCallback)
+{
+    ResolveAt(TEST_ALTERNATE_HOST, TEST_PORT);
+    STRCMP_EQUAL(TEST_ALTERNATE_HOST, SocketFake_LastGetAddrInfoHostname());
 }

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -55,17 +55,25 @@ static const char* SpyGetHost()
     return TEST_HOST;
 }
 
-// Endpoint stub — delegates to per-test function pointers so existing
+// Endpoint stubs — delegate to per-test function pointers so existing
 // callback-spy tests in TEST_GROUP(SolidSyslogTcpSenderConfig) keep counting
-// callback invocations through the new endpoint path.
+// callback invocations through the new endpoint path. endpointVersion is the
+// per-test version reported by TestEndpointVersion; bump it between Sends to
+// drive fingerprint-reconnection tests.
 static const char* (*endpointGetHost)() = GetHost;
 static int (*endpointGetPort)()         = GetPort;
+static uint32_t endpointVersion         = 0;
 
 static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = endpointGetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
     endpoint->port = (uint16_t) endpointGetPort();
+}
+
+static uint32_t TestEndpointVersion() // NOLINT(modernize-use-trailing-return-type)
+{
+    return endpointVersion;
 }
 
 // clang-format off
@@ -82,10 +90,11 @@ TEST_GROUP(SolidSyslogTcpSender)
     {
         SocketFake_Reset();
         endpointGetHost = GetHost;
+        endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
-        config          = {resolver, stream, TestEndpoint};
+        config          = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -142,11 +151,12 @@ TEST_GROUP(SolidSyslogTcpSenderDestroy)
     {
         SocketFake_Reset();
         endpointGetHost = GetHost;
+        endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver, stream, TestEndpoint};
+        config = {resolver, stream, TestEndpoint, TestEndpointVersion};
     }
 
     void teardown() override
@@ -285,6 +295,23 @@ TEST(SolidSyslogTcpSender, DisconnectWithoutSendDoesNotClose)
     LONGS_EQUAL(0, SocketFake_CloseCallCount());
 }
 
+TEST(SolidSyslogTcpSender, EndpointVersionChangeBetweenSendsTriggersReconnect)
+{
+    Send();
+    endpointVersion = 1;
+    Send();
+    LONGS_EQUAL(2, SocketFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogTcpSender, EndpointVersionChangeUsesNewPortOnReconnect)
+{
+    Send();
+    endpointVersion = 1;
+    endpointGetPort = GetAlternatePort;
+    Send();
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketFake_LastConnectPort());
+}
+
 // clang-format off
 TEST_GROUP(SolidSyslogTcpSenderConfig)
 {
@@ -302,6 +329,7 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
         getPortCallCount = 0;
         getHostCallCount = 0;
         endpointGetHost  = GetHost;
+        endpointVersion  = 0;
         endpointGetPort  = GetPort;
     }
 
@@ -318,7 +346,7 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
         endpointGetPort = getPortFn;
         struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
         struct SolidSyslogStream*         stream   = SolidSyslogPosixTcpStream_Create();
-        struct SolidSyslogTcpSenderConfig config   = {resolver, stream, TestEndpoint};
+        struct SolidSyslogTcpSenderConfig config   = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -405,10 +433,11 @@ TEST_GROUP(SolidSyslogTcpSenderFailure)
     {
         SocketFake_Reset();
         endpointGetHost = GetHost;
+        endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
-        config          = {resolver, stream, TestEndpoint};
+        config          = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -568,7 +597,7 @@ TEST(SolidSyslogTcpSenderFailure, SendReturnsTrueWhenResolverSucceeds)
 TEST(SolidSyslogTcpSenderFailure, NoEndpointConfiguredConnectsToPortZero)
 {
     SolidSyslogTcpSender_Destroy();
-    struct SolidSyslogTcpSenderConfig configNoEndpoint = {resolver, stream, nullptr};
+    struct SolidSyslogTcpSenderConfig configNoEndpoint = {resolver, stream, nullptr, nullptr};
     struct SolidSyslogSender*         senderNoEndpoint = SolidSyslogTcpSender_Create(&configNoEndpoint);
     SolidSyslogSender_Send(senderNoEndpoint, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(0, SocketFake_LastConnectPort());

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -592,6 +592,14 @@ TEST(SolidSyslogTcpSenderFailure, SendReturnsTrueWhenResolverSucceeds)
     CHECK_TRUE(Send());
 }
 
+TEST(SolidSyslogTcpSenderFailure, SendRecoversAfterTransientResolveFailure)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(Send());
+    SocketFake_SetGetAddrInfoFails(false);
+    CHECK_TRUE(Send());
+}
+
 TEST(SolidSyslogTcpSenderFailure, NoEndpointConfiguredConnectsToPortZero)
 {
     SolidSyslogTcpSender_Destroy();

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -65,8 +65,7 @@ static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = endpointGetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) endpointGetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) endpointGetPort();
 }
 
 // clang-format off

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -1,9 +1,12 @@
 #include "CppUTest/TestHarness.h"
+#include "SolidSyslogEndpoint.h"
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixTcpStream.h"
 #include "SolidSyslogSender.h"
 #include "SolidSyslogTcpSender.h"
 #include "SocketFake.h"
+#include <cstring>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
@@ -52,6 +55,20 @@ static const char* SpyGetHost()
     return TEST_HOST;
 }
 
+// Endpoint stub — delegates to per-test function pointers so existing
+// callback-spy tests in TEST_GROUP(SolidSyslogTcpSenderConfig) keep counting
+// callback invocations through the new endpoint path.
+static const char* (*endpointGetHost)() = GetHost;
+static int (*endpointGetPort)()         = GetPort;
+
+static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = endpointGetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) endpointGetPort();
+    endpoint->version = 0;
+}
+
 // clang-format off
 TEST_GROUP(SolidSyslogTcpSender)
 {
@@ -65,9 +82,11 @@ TEST_GROUP(SolidSyslogTcpSender)
     void setup() override
     {
         SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-        stream   = SolidSyslogPosixTcpStream_Create();
-        config = {resolver, stream};
+        endpointGetHost = GetHost;
+        endpointGetPort = GetPort;
+        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        stream          = SolidSyslogPosixTcpStream_Create();
+        config          = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -123,10 +142,12 @@ TEST_GROUP(SolidSyslogTcpSenderDestroy)
     void setup() override
     {
         SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-        stream   = SolidSyslogPosixTcpStream_Create();
+        endpointGetHost = GetHost;
+        endpointGetPort = GetPort;
+        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        stream          = SolidSyslogPosixTcpStream_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver, stream};
+        config = {resolver, stream, TestEndpoint};
     }
 
     void teardown() override
@@ -281,6 +302,8 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
         SocketFake_Reset();
         getPortCallCount = 0;
         getHostCallCount = 0;
+        endpointGetHost  = GetHost;
+        endpointGetPort  = GetPort;
     }
 
     void teardown() override
@@ -292,9 +315,11 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
 
     void CreateSender()
     {
-        struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
-        struct SolidSyslogStream*   stream   = SolidSyslogPosixTcpStream_Create();
-        struct SolidSyslogTcpSenderConfig config = {resolver, stream};
+        endpointGetHost = getHostFn;
+        endpointGetPort = getPortFn;
+        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
+        struct SolidSyslogStream*         stream   = SolidSyslogPosixTcpStream_Create();
+        struct SolidSyslogTcpSenderConfig config   = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }
@@ -380,9 +405,11 @@ TEST_GROUP(SolidSyslogTcpSenderFailure)
     void setup() override
     {
         SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
-        stream   = SolidSyslogPosixTcpStream_Create();
-        config = {resolver, stream};
+        endpointGetHost = GetHost;
+        endpointGetPort = GetPort;
+        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        stream          = SolidSyslogPosixTcpStream_Create();
+        config          = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogTcpSender_Create(&config);
     }

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -6,7 +6,6 @@
 #include "SolidSyslogSender.h"
 #include "SolidSyslogTcpSender.h"
 #include "SocketFake.h"
-#include <cstring>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
@@ -66,8 +65,7 @@ static uint32_t endpointVersion         = 0;
 
 static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = endpointGetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, endpointGetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) endpointGetPort();
 }
 
@@ -600,5 +598,6 @@ TEST(SolidSyslogTcpSenderFailure, NoEndpointConfiguredConnectsToPortZero)
     struct SolidSyslogTcpSenderConfig configNoEndpoint = {resolver, stream, nullptr, nullptr};
     struct SolidSyslogSender*         senderNoEndpoint = SolidSyslogTcpSender_Create(&configNoEndpoint);
     SolidSyslogSender_Send(senderNoEndpoint, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, SocketFake_ConnectCallCount());
     LONGS_EQUAL(0, SocketFake_LastConnectPort());
 }

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -84,7 +84,7 @@ TEST_GROUP(SolidSyslogTcpSender)
         SocketFake_Reset();
         endpointGetHost = GetHost;
         endpointGetPort = GetPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
         config          = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
@@ -144,7 +144,7 @@ TEST_GROUP(SolidSyslogTcpSenderDestroy)
         SocketFake_Reset();
         endpointGetHost = GetHost;
         endpointGetPort = GetPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
         config = {resolver, stream, TestEndpoint};
@@ -317,7 +317,7 @@ TEST_GROUP(SolidSyslogTcpSenderConfig)
     {
         endpointGetHost = getHostFn;
         endpointGetPort = getPortFn;
-        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
+        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
         struct SolidSyslogStream*         stream   = SolidSyslogPosixTcpStream_Create();
         struct SolidSyslogTcpSenderConfig config   = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
@@ -407,7 +407,7 @@ TEST_GROUP(SolidSyslogTcpSenderFailure)
         SocketFake_Reset();
         endpointGetHost = GetHost;
         endpointGetPort = GetPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetHost, GetPort);
+        resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create();
         config          = {resolver, stream, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
@@ -564,4 +564,13 @@ TEST(SolidSyslogTcpSenderFailure, SendDoesNotOpenStreamWhenResolverFails)
 TEST(SolidSyslogTcpSenderFailure, SendReturnsTrueWhenResolverSucceeds)
 {
     CHECK_TRUE(Send());
+}
+
+TEST(SolidSyslogTcpSenderFailure, NoEndpointConfiguredConnectsToPortZero)
+{
+    SolidSyslogTcpSender_Destroy();
+    struct SolidSyslogTcpSenderConfig configNoEndpoint = {resolver, stream, nullptr};
+    struct SolidSyslogSender*         senderNoEndpoint = SolidSyslogTcpSender_Create(&configNoEndpoint);
+    SolidSyslogSender_Send(senderNoEndpoint, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(0, SocketFake_LastConnectPort());
 }

--- a/Tests/SolidSyslogTcpSenderTest.cpp
+++ b/Tests/SolidSyslogTcpSenderTest.cpp
@@ -159,6 +159,15 @@ TEST(SolidSyslogTcpSenderDestroy, DestroyAfterSendClosesSocket)
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
 
+TEST(SolidSyslogTcpSenderDestroy, DestroyAfterDisconnectDoesNotDoubleClose)
+{
+    struct SolidSyslogSender* sender = SolidSyslogTcpSender_Create(&config);
+    SolidSyslogSender_Send(sender, "x", 1);
+    SolidSyslogSender_Disconnect(sender);
+    SolidSyslogTcpSender_Destroy();
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
 TEST(SolidSyslogTcpSender, SendConnectsOnFirstCall)
 {
     Send();
@@ -217,6 +226,43 @@ TEST(SolidSyslogTcpSender, SendUsesSocketFd)
 TEST(SolidSyslogTcpSender, SendReturnsTrueOnSuccess)
 {
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogTcpSender, DisconnectAfterSendClosesSocket)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogTcpSender, DisconnectIsIdempotent)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogTcpSender, SendAfterDisconnectReopensSocket)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    Send();
+    LONGS_EQUAL(2, SocketFake_SocketCallCount());
+}
+
+TEST(SolidSyslogTcpSender, SendAfterDisconnectResolves)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    Send();
+    LONGS_EQUAL(2, SocketFake_GetAddrInfoCallCount());
+}
+
+TEST(SolidSyslogTcpSender, DisconnectWithoutSendDoesNotClose)
+{
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(0, SocketFake_CloseCallCount());
 }
 
 // clang-format off

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -193,6 +193,43 @@ TEST(SolidSyslogUdpSender, SendtoCalledWithSocketFd)
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastSendtoFd());
 }
 
+TEST(SolidSyslogUdpSender, DisconnectAfterSendClosesSocket)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogUdpSender, DisconnectIsIdempotent)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+}
+
+TEST(SolidSyslogUdpSender, SendAfterDisconnectReopensSocket)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    Send();
+    LONGS_EQUAL(2, SocketFake_SocketCallCount());
+}
+
+TEST(SolidSyslogUdpSender, SendAfterDisconnectResolves)
+{
+    Send();
+    SolidSyslogSender_Disconnect(sender);
+    Send();
+    LONGS_EQUAL(2, SocketFake_GetAddrInfoCallCount());
+}
+
+TEST(SolidSyslogUdpSender, DisconnectWithoutSendDoesNotClose)
+{
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(0, SocketFake_CloseCallCount());
+}
+
 IGNORE_TEST(SolidSyslogUdpSender, HappyPathOnly)
 {
     // Error handling not yet implemented — see Epic #31
@@ -252,6 +289,15 @@ TEST(SolidSyslogUdpSenderDestroy, DestroyAfterSendClosesSocket)
     SolidSyslogUdpSender_Destroy();
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
+}
+
+TEST(SolidSyslogUdpSenderDestroy, DestroyAfterDisconnectDoesNotDoubleClose)
+{
+    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    SolidSyslogSender_Disconnect(sender);
+    SolidSyslogUdpSender_Destroy();
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
 
 TEST(SolidSyslogUdpSenderDestroy, SimpleScenario)

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -7,7 +7,6 @@
 #include "SolidSyslogSender.h"
 #include "SocketFake.h"
 #include <array>
-#include <cstring>
 #include <netinet/in.h>
 
 // clang-format off
@@ -61,8 +60,7 @@ static uint32_t endpointVersion         = 0;
 
 static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
-    const char* host = endpointGetHost();
-    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    SolidSyslogFormatter_BoundedString(endpoint->host, endpointGetHost(), SOLIDSYSLOG_MAX_HOST_SIZE);
     endpoint->port = (uint16_t) endpointGetPort();
 }
 
@@ -547,5 +545,6 @@ TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
     struct SolidSyslogUdpSenderConfig configNoEndpoint = {resolver, datagram, nullptr, nullptr};
     sender                                             = SolidSyslogUdpSender_Create(&configNoEndpoint);
     SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, SocketFake_SendtoCallCount());
     LONGS_EQUAL(0, SocketFake_LastPort());
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -538,6 +538,15 @@ TEST(SolidSyslogUdpSenderFailure, SendReturnsTrueWhenResolverAndSocketSucceed)
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
+TEST(SolidSyslogUdpSenderFailure, SendRecoversAfterTransientResolveFailure)
+{
+    SocketFake_SetGetAddrInfoFails(true);
+    CreateSender();
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    SocketFake_SetGetAddrInfoFails(false);
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
 TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
 {
     resolver                                           = SolidSyslogGetAddrInfoResolver_Create();

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -92,6 +92,11 @@ TEST(SolidSyslogUdpSender, CreateDestroyWorksWithoutCrashing)
 {
 }
 
+TEST(SolidSyslogUdpSender, CreateDoesNotOpenSocket)
+{
+    LONGS_EQUAL(0, SocketFake_SocketCallCount());
+}
+
 TEST(SolidSyslogUdpSender, SendReturnsTrueOnSuccess)
 {
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
@@ -154,19 +159,32 @@ TEST(SolidSyslogUdpSender, SendtoCalledWithAddrlenOfSockaddrIn)
     LONGS_EQUAL(sizeof(struct sockaddr_in), SocketFake_LastAddrLen());
 }
 
-TEST(SolidSyslogUdpSender, SocketCalledOnCreate)
+TEST(SolidSyslogUdpSender, FirstSendOpensDatagramSocket)
 {
+    Send();
+    LONGS_EQUAL(1, SocketFake_SocketCallCount());
+    LONGS_EQUAL(AF_INET, SocketFake_SocketDomain());
+    LONGS_EQUAL(SOCK_DGRAM, SocketFake_SocketType());
+}
+
+TEST(SolidSyslogUdpSender, FirstSendResolves)
+{
+    Send();
+    LONGS_EQUAL(1, SocketFake_GetAddrInfoCallCount());
+}
+
+TEST(SolidSyslogUdpSender, SecondSendDoesNotReopenSocket)
+{
+    Send();
+    Send();
     LONGS_EQUAL(1, SocketFake_SocketCallCount());
 }
 
-TEST(SolidSyslogUdpSender, SocketCalledWithAF_INET)
+TEST(SolidSyslogUdpSender, SecondSendDoesNotResolve)
 {
-    LONGS_EQUAL(AF_INET, SocketFake_SocketDomain());
-}
-
-TEST(SolidSyslogUdpSender, SocketCalledWithSOCK_DGRAM)
-{
-    LONGS_EQUAL(SOCK_DGRAM, SocketFake_SocketType());
+    Send();
+    Send();
+    LONGS_EQUAL(1, SocketFake_GetAddrInfoCallCount());
 }
 
 TEST(SolidSyslogUdpSender, SendtoCalledWithSocketFd)
@@ -221,15 +239,18 @@ TEST_GROUP(SolidSyslogUdpSenderDestroy)
 
 // clang-format on
 
-TEST(SolidSyslogUdpSenderDestroy, CloseCalledOnDestroy)
+TEST(SolidSyslogUdpSenderDestroy, DestroyWithoutSendDoesNotClose)
 {
     CreateAndDestroy();
-    LONGS_EQUAL(1, SocketFake_CloseCallCount());
+    LONGS_EQUAL(0, SocketFake_CloseCallCount());
 }
 
-TEST(SolidSyslogUdpSenderDestroy, CloseCalledWithSocketFd)
+TEST(SolidSyslogUdpSenderDestroy, DestroyAfterSendClosesSocket)
 {
-    CreateAndDestroy();
+    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    SolidSyslogUdpSender_Destroy();
+    LONGS_EQUAL(1, SocketFake_CloseCallCount());
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
 
@@ -289,11 +310,20 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
 
 // clang-format on
 
-TEST(SolidSyslogUdpSenderConfig, GetPortCalledOnCreate)
+TEST(SolidSyslogUdpSenderConfig, GetPortCalledOnFirstSend)
 {
     getPortFn = SpyGetPort;
     CreateSender();
+    LONGS_EQUAL(0, getPortCallCount);
+    Send();
     LONGS_EQUAL(1, getPortCallCount);
+}
+
+TEST(SolidSyslogUdpSenderConfig, GetPortNotCalledOnSecondSend)
+{
+    getPortFn = SpyGetPort;
+    CreateSender();
+    Send();
     Send();
     LONGS_EQUAL(1, getPortCallCount);
 }
@@ -306,11 +336,20 @@ TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithConfiguredPort)
     LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketFake_LastPort());
 }
 
-TEST(SolidSyslogUdpSenderConfig, GetHostCalledOnCreate)
+TEST(SolidSyslogUdpSenderConfig, GetHostCalledOnFirstSend)
 {
     getHostFn = SpyGetHost;
     CreateSender();
+    LONGS_EQUAL(0, getHostCallCount);
+    Send();
     LONGS_EQUAL(1, getHostCallCount);
+}
+
+TEST(SolidSyslogUdpSenderConfig, GetHostNotCalledOnSecondSend)
+{
+    getHostFn = SpyGetHost;
+    CreateSender();
+    Send();
     Send();
     LONGS_EQUAL(1, getHostCallCount);
 }
@@ -319,6 +358,7 @@ TEST(SolidSyslogUdpSenderConfig, GetAddrInfoCalledWithHostnameFromGetHost)
 {
     getHostFn = SpyGetHost;
     CreateSender();
+    Send();
     LONGS_EQUAL(1, SocketFake_GetAddrInfoCallCount());
     STRCMP_EQUAL(TEST_DEFAULT_HOST, SocketFake_LastGetAddrInfoHostname());
 }
@@ -364,24 +404,25 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
 
 // clang-format on
 
-TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenResolverFailedAtCreate)
+TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenResolverFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
     CreateSender();
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
-TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenSocketFailedAtCreate)
+TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenSocketFails)
 {
     SocketFake_SetSocketFails(true);
     CreateSender();
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
-TEST(SolidSyslogUdpSenderFailure, DoesNotResolveWhenSocketFailedAtCreate)
+TEST(SolidSyslogUdpSenderFailure, DoesNotResolveWhenSocketFails)
 {
     SocketFake_SetSocketFails(true);
     CreateSender();
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(0, SocketFake_GetAddrInfoCallCount());
 }
 

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -1,4 +1,6 @@
 #include "CppUTest/TestHarness.h"
+#include "SolidSyslogEndpoint.h"
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogUdpSender.h"
@@ -48,6 +50,20 @@ static int SpyGetPort()
     return TEST_DEFAULT_PORT;
 }
 
+// Endpoint stub — delegates to per-test function pointers so existing
+// callback-spy tests in TEST_GROUP(SolidSyslogUdpSenderConfig) keep counting
+// callback invocations through the new endpoint path.
+static const char* (*endpointGetHost)() = GetDefaultHost;
+static int (*endpointGetPort)()         = GetDefaultPort;
+
+static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
+{
+    const char* host = endpointGetHost();
+    SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
+    endpoint->port    = (uint16_t) endpointGetPort();
+    endpoint->version = 0;
+}
+
 // clang-format off
 TEST_GROUP(SolidSyslogUdpSender)
 {
@@ -61,9 +77,11 @@ TEST_GROUP(SolidSyslogUdpSender)
     void setup() override
     {
         SocketFake_Reset();
+        endpointGetHost = GetDefaultHost;
+        endpointGetPort = GetDefaultPort;
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
         datagram = SolidSyslogPosixDatagram_Create();
-        config = {resolver, datagram};
+        config = {resolver, datagram, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogUdpSender_Create(&config);
     }
@@ -255,10 +273,12 @@ TEST_GROUP(SolidSyslogUdpSenderDestroy)
     void setup() override
     {
         SocketFake_Reset();
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
-        datagram = SolidSyslogPosixDatagram_Create();
+        endpointGetHost = GetDefaultHost;
+        endpointGetPort = GetDefaultPort;
+        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        datagram        = SolidSyslogPosixDatagram_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver, datagram};
+        config = {resolver, datagram, TestEndpoint};
     }
 
     void teardown() override
@@ -331,6 +351,8 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
         SocketFake_Reset();
         getPortCallCount = 0;
         getHostCallCount = 0;
+        endpointGetHost  = GetDefaultHost;
+        endpointGetPort  = GetDefaultPort;
     }
 
     void teardown() override
@@ -342,10 +364,12 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
 
     void CreateSender()
     {
-        struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
-        struct SolidSyslogDatagram* datagram = SolidSyslogPosixDatagram_Create();
-        struct SolidSyslogUdpSenderConfig config = {resolver, datagram};
-        sender = SolidSyslogUdpSender_Create(&config);
+        endpointGetHost = getHostFn;
+        endpointGetPort = getPortFn;
+        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
+        struct SolidSyslogDatagram*       datagram = SolidSyslogPosixDatagram_Create();
+        struct SolidSyslogUdpSenderConfig config   = {resolver, datagram, TestEndpoint};
+        sender                                     = SolidSyslogUdpSender_Create(&config);
     }
 
     void Send() const
@@ -429,6 +453,8 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
     void setup() override
     {
         SocketFake_Reset();
+        endpointGetHost = GetDefaultHost;
+        endpointGetPort = GetDefaultPort;
     }
 
     void teardown() override
@@ -442,7 +468,7 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
     {
         resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
         datagram = SolidSyslogPosixDatagram_Create();
-        config   = {resolver, datagram};
+        config   = {resolver, datagram, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest macros
         sender   = SolidSyslogUdpSender_Create(&config);
     }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -50,18 +50,25 @@ static int SpyGetPort()
     return TEST_DEFAULT_PORT;
 }
 
-// Endpoint stub — delegates to per-test function pointers so existing
+// Endpoint stubs — delegate to per-test function pointers so existing
 // callback-spy tests in TEST_GROUP(SolidSyslogUdpSenderConfig) keep counting
-// callback invocations through the new endpoint path.
+// callback invocations through the new endpoint path. endpointVersion is the
+// per-test version reported by TestEndpointVersion; bump it between Sends to
+// drive fingerprint-reconnection tests.
 static const char* (*endpointGetHost)() = GetDefaultHost;
 static int (*endpointGetPort)()         = GetDefaultPort;
+static uint32_t endpointVersion         = 0;
 
 static void TestEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     const char* host = endpointGetHost();
     SolidSyslogFormatter_BoundedString(endpoint->host, host, strlen(host));
-    endpoint->port    = (uint16_t) endpointGetPort();
-    endpoint->version = 0;
+    endpoint->port = (uint16_t) endpointGetPort();
+}
+
+static uint32_t TestEndpointVersion() // NOLINT(modernize-use-trailing-return-type)
+{
+    return endpointVersion;
 }
 
 // clang-format off
@@ -78,10 +85,11 @@ TEST_GROUP(SolidSyslogUdpSender)
     {
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
+        endpointVersion = 0;
         endpointGetPort = GetDefaultPort;
         resolver = SolidSyslogGetAddrInfoResolver_Create();
         datagram = SolidSyslogPosixDatagram_Create();
-        config = {resolver, datagram, TestEndpoint};
+        config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogUdpSender_Create(&config);
     }
@@ -248,6 +256,23 @@ TEST(SolidSyslogUdpSender, DisconnectWithoutSendDoesNotClose)
     LONGS_EQUAL(0, SocketFake_CloseCallCount());
 }
 
+TEST(SolidSyslogUdpSender, EndpointVersionChangeBetweenSendsTriggersReconnect)
+{
+    Send();
+    endpointVersion = 1;
+    Send();
+    LONGS_EQUAL(2, SocketFake_SocketCallCount());
+}
+
+TEST(SolidSyslogUdpSender, EndpointVersionChangeUsesNewPortOnReconnect)
+{
+    Send();
+    endpointVersion = 1;
+    endpointGetPort = GetAlternatePort;
+    Send();
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketFake_LastPort());
+}
+
 IGNORE_TEST(SolidSyslogUdpSender, HappyPathOnly)
 {
     // Error handling not yet implemented — see Epic #31
@@ -274,11 +299,12 @@ TEST_GROUP(SolidSyslogUdpSenderDestroy)
     {
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
+        endpointVersion = 0;
         endpointGetPort = GetDefaultPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         datagram        = SolidSyslogPosixDatagram_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver, datagram, TestEndpoint};
+        config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
     }
 
     void teardown() override
@@ -352,6 +378,7 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
         getPortCallCount = 0;
         getHostCallCount = 0;
         endpointGetHost  = GetDefaultHost;
+        endpointVersion  = 0;
         endpointGetPort  = GetDefaultPort;
     }
 
@@ -368,7 +395,7 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
         endpointGetPort = getPortFn;
         struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
         struct SolidSyslogDatagram*       datagram = SolidSyslogPosixDatagram_Create();
-        struct SolidSyslogUdpSenderConfig config   = {resolver, datagram, TestEndpoint};
+        struct SolidSyslogUdpSenderConfig config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
         sender                                     = SolidSyslogUdpSender_Create(&config);
     }
 
@@ -454,6 +481,7 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
     {
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
+        endpointVersion = 0;
         endpointGetPort = GetDefaultPort;
     }
 
@@ -468,7 +496,7 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
     {
         resolver = SolidSyslogGetAddrInfoResolver_Create();
         datagram = SolidSyslogPosixDatagram_Create();
-        config   = {resolver, datagram, TestEndpoint};
+        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest macros
         sender   = SolidSyslogUdpSender_Create(&config);
     }
@@ -516,7 +544,7 @@ TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
 {
     resolver                                           = SolidSyslogGetAddrInfoResolver_Create();
     datagram                                           = SolidSyslogPosixDatagram_Create();
-    struct SolidSyslogUdpSenderConfig configNoEndpoint = {resolver, datagram, nullptr};
+    struct SolidSyslogUdpSenderConfig configNoEndpoint = {resolver, datagram, nullptr, nullptr};
     sender                                             = SolidSyslogUdpSender_Create(&configNoEndpoint);
     SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(0, SocketFake_LastPort());

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -79,7 +79,7 @@ TEST_GROUP(SolidSyslogUdpSender)
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
         endpointGetPort = GetDefaultPort;
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
         datagram = SolidSyslogPosixDatagram_Create();
         config = {resolver, datagram, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
@@ -275,7 +275,7 @@ TEST_GROUP(SolidSyslogUdpSenderDestroy)
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
         endpointGetPort = GetDefaultPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        resolver        = SolidSyslogGetAddrInfoResolver_Create();
         datagram        = SolidSyslogPosixDatagram_Create();
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
         config = {resolver, datagram, TestEndpoint};
@@ -366,7 +366,7 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
     {
         endpointGetHost = getHostFn;
         endpointGetPort = getPortFn;
-        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create(getHostFn, getPortFn);
+        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
         struct SolidSyslogDatagram*       datagram = SolidSyslogPosixDatagram_Create();
         struct SolidSyslogUdpSenderConfig config   = {resolver, datagram, TestEndpoint};
         sender                                     = SolidSyslogUdpSender_Create(&config);
@@ -466,7 +466,7 @@ TEST_GROUP(SolidSyslogUdpSenderFailure)
 
     void CreateSender()
     {
-        resolver = SolidSyslogGetAddrInfoResolver_Create(GetDefaultHost, GetDefaultPort);
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
         datagram = SolidSyslogPosixDatagram_Create();
         config   = {resolver, datagram, TestEndpoint};
         // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest macros
@@ -510,4 +510,14 @@ TEST(SolidSyslogUdpSenderFailure, SendReturnsTrueWhenResolverAndSocketSucceed)
 {
     CreateSender();
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
+{
+    resolver                                           = SolidSyslogGetAddrInfoResolver_Create();
+    datagram                                           = SolidSyslogPosixDatagram_Create();
+    struct SolidSyslogUdpSenderConfig configNoEndpoint = {resolver, datagram, nullptr};
+    sender                                             = SolidSyslogUdpSender_Create(&configNoEndpoint);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(0, SocketFake_LastPort());
 }

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -1,7 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogResolver.h"
-#include "SolidSyslogResolverDefinition.h"
 #include "SolidSyslogWinsockResolver.h"
 #include "SolidSyslogWinsockResolverInternal.h"
 #include "WinsockFake.h"
@@ -11,30 +10,10 @@
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";
-static const int         TEST_PORT           = 514;
+static const uint16_t    TEST_PORT           = 514;
 static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";
-static const int         TEST_ALTERNATE_PORT = 9999;
+static const uint16_t    TEST_ALTERNATE_PORT = 9999;
 // clang-format on
-
-static const char* GetHost()
-{
-    return TEST_HOST;
-}
-
-static int GetPort()
-{
-    return TEST_PORT;
-}
-
-static const char* GetAlternateHost()
-{
-    return TEST_ALTERNATE_HOST;
-}
-
-static int GetAlternatePort()
-{
-    return TEST_ALTERNATE_PORT;
-}
 
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockResolver)
@@ -47,7 +26,7 @@ TEST_GROUP(SolidSyslogWinsockResolver)
         WinsockFake_Reset();
         UT_PTR_SET(Winsock_getaddrinfo, WinsockFake_getaddrinfo);
         UT_PTR_SET(Winsock_freeaddrinfo, WinsockFake_freeaddrinfo);
-        resolver = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
+        resolver = SolidSyslogWinsockResolver_Create();
     }
 
     void teardown() override
@@ -55,10 +34,10 @@ TEST_GROUP(SolidSyslogWinsockResolver)
         SolidSyslogWinsockResolver_Destroy();
     }
 
-    bool Resolve(enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    bool Resolve(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
     {
         struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
-        return resolver->Resolve(resolver, transport, address);
+        return SolidSyslogResolver_Resolve(resolver, transport, host, port, address);
     }
 
     // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
@@ -77,178 +56,65 @@ TEST(SolidSyslogWinsockResolver, CreateDestroyWorksWithoutCrashing)
 {
 }
 
-TEST(SolidSyslogWinsockResolver, ResolvePopulatesAddressFamily)
+TEST(SolidSyslogWinsockResolver, ReturnsTrueOnSuccess)
 {
-    Resolve();
+    CHECK_TRUE(Resolve(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogWinsockResolver, PopulatesAddressFamily)
+{
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(AF_INET, Result()->sin_family);
 }
 
-TEST(SolidSyslogWinsockResolver, ResolvePopulatesResolvedAddress)
+TEST(SolidSyslogWinsockResolver, PopulatesResolvedAddressFromHostArgument)
 {
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     char addrString[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
     STRCMP_EQUAL(TEST_HOST, addrString);
 }
 
-TEST(SolidSyslogWinsockResolver, ResolvePopulatesPort)
+TEST(SolidSyslogWinsockResolver, PopulatesPortFromPortArgument)
 {
-    Resolve();
-    LONGS_EQUAL(TEST_PORT, ntohs(Result()->sin_port));
-}
-
-TEST(SolidSyslogWinsockResolver, GetAddrInfoCalledWithHostname)
-{
-    Resolve();
-    LONGS_EQUAL(1, WinsockFake_GetAddrInfoCallCount());
-    STRCMP_EQUAL(TEST_HOST, WinsockFake_LastGetAddrInfoHostname());
-}
-
-TEST(SolidSyslogWinsockResolver, AlternateHostResolvesCorrectly)
-{
-    resolver = SolidSyslogWinsockResolver_Create(GetAlternateHost, GetPort);
-    Resolve();
-    STRCMP_EQUAL(TEST_ALTERNATE_HOST, WinsockFake_LastGetAddrInfoHostname());
-}
-
-TEST(SolidSyslogWinsockResolver, AlternatePortResolvesCorrectly)
-{
-    resolver = SolidSyslogWinsockResolver_Create(GetHost, GetAlternatePort);
-    Resolve();
+    Resolve(TEST_HOST, TEST_ALTERNATE_PORT);
     LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogWinsockResolver, GetAddrInfoCalledWithHostArgument)
+{
+    Resolve(TEST_ALTERNATE_HOST, TEST_PORT);
+    LONGS_EQUAL(1, WinsockFake_GetAddrInfoCallCount());
+    STRCMP_EQUAL(TEST_ALTERNATE_HOST, WinsockFake_LastGetAddrInfoHostname());
 }
 
 TEST(SolidSyslogWinsockResolver, UdpTransportPassesDatagramSocktype)
 {
-    Resolve(SOLIDSYSLOG_TRANSPORT_UDP);
+    Resolve(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
     LONGS_EQUAL(SOCK_DGRAM, WinsockFake_LastGetAddrInfoSocktype());
 }
 
 TEST(SolidSyslogWinsockResolver, TcpTransportPassesStreamSocktype)
 {
-    Resolve(SOLIDSYSLOG_TRANSPORT_TCP);
+    Resolve(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
     LONGS_EQUAL(SOCK_STREAM, WinsockFake_LastGetAddrInfoSocktype());
 }
 
-TEST(SolidSyslogWinsockResolver, ResolveReturnsFalseWhenGetAddrInfoFails)
+TEST(SolidSyslogWinsockResolver, ReturnsFalseWhenGetAddrInfoFails)
 {
     WinsockFake_SetGetAddrInfoFails(true);
-    CHECK_FALSE(Resolve());
+    CHECK_FALSE(Resolve(TEST_HOST, TEST_PORT));
 }
 
-TEST(SolidSyslogWinsockResolver, ResolveReturnsTrueOnSuccess)
-{
-    CHECK_TRUE(Resolve());
-}
-
-TEST(SolidSyslogWinsockResolver, ResolveDoesNotFreeAddrInfoWhenGetAddrInfoFails)
+TEST(SolidSyslogWinsockResolver, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
 {
     WinsockFake_SetGetAddrInfoFails(true);
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(0, WinsockFake_FreeAddrInfoCallCount());
 }
 
-TEST(SolidSyslogWinsockResolver, ResolveFreesAddrInfoOnSuccess)
+TEST(SolidSyslogWinsockResolver, FreesAddrInfoOnSuccess)
 {
-    Resolve();
+    Resolve(TEST_HOST, TEST_PORT);
     LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
-}
-
-// clang-format off
-TEST_GROUP(SolidSyslogWinsockResolverResolveAt)
-{
-    struct SolidSyslogResolver* resolver = nullptr;
-    SolidSyslogAddressStorage   resultStorage{};
-
-    void setup() override
-    {
-        WinsockFake_Reset();
-        UT_PTR_SET(Winsock_getaddrinfo, WinsockFake_getaddrinfo);
-        UT_PTR_SET(Winsock_freeaddrinfo, WinsockFake_freeaddrinfo);
-        resolver = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
-    }
-
-    void teardown() override
-    {
-        SolidSyslogWinsockResolver_Destroy();
-    }
-
-    bool ResolveAt(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
-    {
-        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
-        return SolidSyslogResolver_ResolveAt(resolver, transport, host, port, address);
-    }
-
-    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
-    const struct sockaddr_in* Result() const
-    {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
-        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
-        return reinterpret_cast<const struct sockaddr_in*>(bytes);
-    }
-};
-
-// clang-format on
-
-TEST(SolidSyslogWinsockResolverResolveAt, ReturnsTrueOnSuccess)
-{
-    CHECK_TRUE(ResolveAt(TEST_HOST, TEST_PORT));
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, PopulatesAddressFamily)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(AF_INET, Result()->sin_family);
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, PopulatesResolvedAddressFromHostArgument)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    char addrString[INET_ADDRSTRLEN];
-    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
-    STRCMP_EQUAL(TEST_HOST, addrString);
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, PopulatesPortFromPortArgument)
-{
-    ResolveAt(TEST_HOST, TEST_ALTERNATE_PORT);
-    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, TcpTransportPassesStreamSocktype)
-{
-    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
-    LONGS_EQUAL(SOCK_STREAM, WinsockFake_LastGetAddrInfoSocktype());
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, ReturnsFalseWhenGetAddrInfoFails)
-{
-    WinsockFake_SetGetAddrInfoFails(true);
-    CHECK_FALSE(ResolveAt(TEST_HOST, TEST_PORT));
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
-{
-    WinsockFake_SetGetAddrInfoFails(true);
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(0, WinsockFake_FreeAddrInfoCallCount());
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, FreesAddrInfoOnSuccess)
-{
-    ResolveAt(TEST_HOST, TEST_PORT);
-    LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, UdpTransportPassesDatagramSocktype)
-{
-    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
-    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_LastGetAddrInfoSocktype());
-}
-
-TEST(SolidSyslogWinsockResolverResolveAt, IgnoresResolverGetHostCallback)
-{
-    ResolveAt(TEST_ALTERNATE_HOST, TEST_PORT);
-    STRCMP_EQUAL(TEST_ALTERNATE_HOST, WinsockFake_LastGetAddrInfoHostname());
 }

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogAddress.h"
+#include "SolidSyslogResolver.h"
 #include "SolidSyslogResolverDefinition.h"
 #include "SolidSyslogWinsockResolver.h"
 #include "SolidSyslogWinsockResolverInternal.h"
@@ -151,4 +152,103 @@ TEST(SolidSyslogWinsockResolver, ResolveFreesAddrInfoOnSuccess)
 {
     Resolve();
     LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogWinsockResolverResolveAt)
+{
+    struct SolidSyslogResolver* resolver = nullptr;
+    SolidSyslogAddressStorage   resultStorage{};
+
+    void setup() override
+    {
+        WinsockFake_Reset();
+        UT_PTR_SET(Winsock_getaddrinfo, WinsockFake_getaddrinfo);
+        UT_PTR_SET(Winsock_freeaddrinfo, WinsockFake_freeaddrinfo);
+        resolver = SolidSyslogWinsockResolver_Create(GetHost, GetPort);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogWinsockResolver_Destroy();
+    }
+
+    bool ResolveAt(const char* host, uint16_t port, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    {
+        struct SolidSyslogAddress* address = SolidSyslogAddress_FromStorage(&resultStorage);
+        return SolidSyslogResolver_ResolveAt(resolver, transport, host, port, address);
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
+    const struct sockaddr_in* Result() const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
+        const auto* bytes = reinterpret_cast<const std::uint8_t*>(&resultStorage);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
+        return reinterpret_cast<const struct sockaddr_in*>(bytes);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWinsockResolverResolveAt, ReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(ResolveAt(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, PopulatesAddressFamily)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(AF_INET, Result()->sin_family);
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, PopulatesResolvedAddressFromHostArgument)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    char addrString[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &Result()->sin_addr, addrString, sizeof(addrString));
+    STRCMP_EQUAL(TEST_HOST, addrString);
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, PopulatesPortFromPortArgument)
+{
+    ResolveAt(TEST_HOST, TEST_ALTERNATE_PORT);
+    LONGS_EQUAL(TEST_ALTERNATE_PORT, ntohs(Result()->sin_port));
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, TcpTransportPassesStreamSocktype)
+{
+    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
+    LONGS_EQUAL(SOCK_STREAM, WinsockFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, ReturnsFalseWhenGetAddrInfoFails)
+{
+    WinsockFake_SetGetAddrInfoFails(true);
+    CHECK_FALSE(ResolveAt(TEST_HOST, TEST_PORT));
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, DoesNotFreeAddrInfoWhenGetAddrInfoFails)
+{
+    WinsockFake_SetGetAddrInfoFails(true);
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(0, WinsockFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, FreesAddrInfoOnSuccess)
+{
+    ResolveAt(TEST_HOST, TEST_PORT);
+    LONGS_EQUAL(1, WinsockFake_FreeAddrInfoCallCount());
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, UdpTransportPassesDatagramSocktype)
+{
+    ResolveAt(TEST_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
+    LONGS_EQUAL(SOCK_DGRAM, WinsockFake_LastGetAddrInfoSocktype());
+}
+
+TEST(SolidSyslogWinsockResolverResolveAt, IgnoresResolverGetHostCallback)
+{
+    ResolveAt(TEST_ALTERNATE_HOST, TEST_PORT);
+    STRCMP_EQUAL(TEST_ALTERNATE_HOST, WinsockFake_LastGetAddrInfoHostname());
 }

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -142,7 +142,6 @@ for SL4 extension but some components are not yet implemented.
 | Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | PRINTUSASCII validation | — | Header field character compliance | Planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
 | UTF-8 safe truncation | — | No split multi-byte sequences | Planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
-| Sender reconnection | — | Automatic reconnect on failure | Planned — [S3.1](https://github.com/DavidCozens/solid-syslog/issues/33) |
 | Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
 
 **What SL4 will add over SL3:**
@@ -150,8 +149,6 @@ for SL4 extension but some components are not yet implemented.
 - Cryptographic integrity — HMAC or AES-CMAC replaces CRC-16, making stored
   record tampering detectable even by a local attacker (CR 2.12, CR 3.9)
 - Encryption at rest — stored records unreadable without key material (CR 3.9)
-- Automatic reconnection — sender recovers from network failures without
-  application intervention
 - Full RFC 5424 character compliance — PRINTUSASCII validation on header fields,
   UTF-8 safe truncation on message body
 

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -47,12 +47,13 @@ Status key:
 
 | Section | Requirement | Status | Notes |
 |---|---|---|---|
-| 3.2 | Sender initiates TCP connection | Supported | `SolidSyslogTcpSender` connects on first send |
+| 3.2 | Sender initiates TCP connection | Supported | `SolidSyslogTcpSender` connects lazily on first send (S3.4) |
 | 3.2 | Default port 601 | Partial | `SOLIDSYSLOG_TCP_DEFAULT_PORT` defined but defaults to 514. Should be 601 per IANA |
 | 3.4.1 | Octet counting framing | Supported | `MSG-LEN SP MSG` prefix on every send |
 | 3.4.2 | Non-transparent framing (LF trailer) | Not supported | Octet counting is the recommended method |
-| 3.5 | Session closure handling | Partial | Sender detects send failure. Reconnection planned — [S3.1](https://github.com/DavidCozens/solid-syslog/issues/33) |
-| 3.5 | Handle receiver-initiated close | Partial | Send failure detected. Automatic reconnection planned — [S3.1](https://github.com/DavidCozens/solid-syslog/issues/33) |
+| 3.5 | Session closure handling | Supported | On send failure the stream is closed; the next Send transparently reconnects (S3.4) |
+| 3.5 | Handle receiver-initiated close | Supported | Detected via send failure path — same reconnect-on-next-Send mechanism (S3.4) |
+| 3.5 | Address rotation without app restart | Supported | App bumps `endpointVersion`; sender Disconnects and reconnects on next Send (S3.4) |
 | — | Partial write handling (send returns short) | Not yet | Planned — [S12.8](https://github.com/DavidCozens/solid-syslog/issues/119) |
 
 ## RFC 5425 — TLS Transport Mapping for Syslog


### PR DESCRIPTION
## Purpose

Closes #33 (S3.4). Establishes the connection-lifecycle pattern shared by UdpSender and TcpSender: lazy socket open + DNS resolve on first Send, reversible Disconnect, and version-fingerprint reconnection driven by a cheap user-provided callback. Sets the foundations for E20 (Multi-Transport Switching) and the upcoming reconfiguration epic.

## Change Description

**New API:**
- `SolidSyslogEndpoint.h` — destination spec: `SolidSyslogEndpointFunction` fills `{host, port}` (called only on (re)connect); `SolidSyslogEndpointVersionFunction` returns `uint32_t` (polled cheaply per Send).
- `SolidSyslogSender_Disconnect` (public wrapper + vtable op) — releases network resources but stays valid; next Send re-opens lazily. Distinct from Destroy (terminal).
- Resolver becomes stateless w.r.t. destination: `Resolve(transport, host, port, *out)`. Old `Resolve(transport, *out)` and the resolver's `getHost`/`getPort` callbacks removed.

**Sender shape (UdpSender ≅ TcpSender):**
```
Send → Reconcile && Transmit
Reconcile → DisconnectIfStale; EnsureConnected
DisconnectIfStale → endpointVersion(); compare; Disconnect if changed
EnsureConnected → Connected || Connect
Connect → endpoint(); OpenSocket && Resolve
```
Steady-state cost per Send: one cheap `endpointVersion()` call + `uint32_t` compare. Endpoint with formatter setup happens only on actual (re)connect.

**Nil-object pattern:** `NilEndpoint` and `NilEndpointVersion` installed via `DEFAULT_INSTANCE`; `ASSIGN_IF_NON_NULL` in Create overrides only what the user provides. Senders never deref a NULL callback.

**TcpSender refactor:** brought into the same shape as UdpSender — `Connected(tcp)` accessor, `CloseStream` extracted as the close-and-clear helper, `Destroy` delegates to `Disconnect` (DRY), `DEFAULT_INSTANCE` for create/reset.

**Examples:** `ExampleUdpConfig` and `ExampleTcpConfig` provide `_GetEndpoint` and `_GetEndpointVersion` (returns 0 — static config). All UDP example mains (SingleTask, Threaded, Windows) and the Threaded TCP path wired through.

## Test Evidence

Per-step parallel-change discipline kept all existing tests green throughout. New tests added only when introducing new contracts (Disconnect contract, NilEndpoint behaviour, fingerprint reconnection).

**13 commits, each individually buildable + tested:**
1. Add Endpoint header (types only)
2. Add stateless `ResolveAt` parallel API to Resolver (Posix + Winsock)
3. UdpSender lazy init + cleanup (single level of abstraction, DEFAULT_INSTANCE, Connected accessor)
4. Add Disconnect vtable op + public wrapper + UdpSender impl
5. TcpSender Disconnect + cleanup; Destroy uses Disconnect (DRY)
6. UdpSender uses Endpoint; tests + ExampleServiceThreadTest cut over (no new tests)
7. ExampleUdpConfig + UDP example mains wired through Endpoint
8. TcpSender uses Endpoint with legacy fallback; tests cut over
9. ExampleTcpConfig + Threaded TCP path wired
10. Drop legacy fallback via nil-object pattern; remove `getHost`/`getPort` from Resolver_Create; rename `ResolveAt` → `Resolve`
11. UdpSender version-fingerprint reconnection via separate cheap `endpointVersion` callback
12. TcpSender version-fingerprint reconnection (mirror)
13. CLAUDE.md docs

**Tests:** 554 pass on Posix (was ~534 before this branch). New behaviours covered:
- Lazy contract: CreateDoesNotOpenSocket, FirstSendOpens..., Second... (UDP); existing TCP equivalents already there.
- Disconnect: AfterSendCloses, IsIdempotent, SendAfterDisconnectReopens/Resolves, WithoutSendDoesNotClose, DestroyAfterDisconnectDoesNotDoubleClose (both senders).
- Nil-object: NoEndpointConfiguredSendsToPortZero / ConnectsToPortZero.
- Fingerprint: EndpointVersionChangeBetweenSendsTriggersReconnect, EndpointVersionChangeUsesNewPortOnReconnect (both senders).

**Presets all green:** debug, clang-debug, sanitize, tidy, cppcheck, coverage (100% production lines + functions), format. BDD: 14 features / 31 scenarios pass.

## Areas Affected

- `Interface/`: new `SolidSyslogEndpoint.h`; `SolidSyslogResolver.h` signature change; `SolidSyslogSender.h` + `SolidSyslogSenderDefinition.h` gain Disconnect; `SolidSyslogUdpSender.h` + `SolidSyslogTcpSender.h` configs gain `endpoint` + `endpointVersion`.
- `Source/`: `SolidSyslogUdpSender.c` and `SolidSyslogTcpSender.c` rewritten for lazy init + Disconnect + Endpoint + fingerprint; `SolidSyslogResolver.c` simplified.
- `Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.{h,c}` and `Platform/Windows/Source/SolidSyslogWinsockResolver.{h,c}`: stateless w.r.t. destination; `_Create()` takes no callbacks.
- `Example/Common/Example{Udp,Tcp}Config.{h,c}` + `Example/{SingleTask,Threaded,Windows}/...`: provide and wire endpoint + endpointVersion.
- `Tests/`: setups updated; new contract tests added; legacy resolver test groups deleted (op no longer exists).
- `CLAUDE.md`: header table updated.

**Out of scope (deferred):**
- TCP non-blocking connect timeout → E4.
- TcpSender NULL-guard on getaddrinfo / socket() failure / `MSG_NOSIGNAL` portability → robustness backlog.
- Runtime-reconfigure BDD scenarios → reconfiguration epic.
- SwitchingSender (E20) — depends on the Disconnect op landed here.
- Resolver-singleton fix → E20 prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoint management interface for dynamic host/port configuration
  * Introduced sender disconnect functionality for explicit connection closure

* **Updates**
  * Resolver now accepts explicit destination parameters instead of callback-based configuration
  * Enhanced sender configuration with dynamic endpoint callback support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->