### PR TITLE
feat: S20.1 SwitchingSender — selector-driven multi-transport switching

### DIFF
--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -12,6 +12,8 @@ SYSLOG_NG_FULL_CONF = "Bdd/syslog-ng/syslog-ng-full.conf"
 SYSLOG_NG_CTL = "/var/lib/syslog-ng/syslog-ng.ctl"
 STORE_FILE_PATH = "/tmp/solidsyslog_store.dat"
 STORE_PATH_PREFIX = "/tmp/STORE"
+RECEIVED_UDP_LOG = "Bdd/output/received_udp.log"
+RECEIVED_TCP_LOG = "Bdd/output/received_tcp.log"
 
 
 def wait_for_tcp_port_open(host="syslog-ng", port=5514, timeout=5):

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -869,3 +869,35 @@ def step_check_last_sequence_id(context, value):
     assert actual == value, (
         f"Last message: expected sequenceId {value}, got {actual}"
     )
+
+
+# --- S20.1 SwitchingSender scaffolding (Phase 2) --------------------------
+# These steps are wired up in Phase 5 once the threaded example exposes the
+# `switch` command and syslog-ng is configured to split per-transport log
+# output. Until then they raise NotImplementedError so Behave reports the
+# scenario as failed rather than silently passing.
+
+
+@given("the switching example is running with default transport {transport:w}")
+def step_switching_example_running(context, transport):
+    raise NotImplementedError(
+        "S20.1 Phase 5: start threaded example with --transport "
+        f"{transport} wiring SwitchingSender"
+    )
+
+
+@when("the client switches to transport {transport:w}")
+def step_client_switches_transport(context, transport):
+    raise NotImplementedError(
+        "S20.1 Phase 5: send `switch "
+        f"{transport}` command to the interactive example"
+    )
+
+
+@then("syslog-ng receives {count:d} message over {transport:w}")
+@then("syslog-ng receives {count:d} messages over {transport:w}")
+def step_check_per_transport_count(context, count, transport):
+    raise NotImplementedError(
+        "S20.1 Phase 5: count records in the "
+        f"received_{transport}.log oracle file"
+    )

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -900,6 +900,9 @@ def step_switching_example_running(context, transport):
 @when("the client switches to transport {transport:w}")
 def step_client_switches_transport(context, transport):
     send_command(context.interactive_process, f"switch {transport}")
+    # Let any in-flight messages drain before subsequent sends assume the new
+    # selector is live. Matches the settle pattern used after `send`.
+    time.sleep(0.2)
 
 
 def wait_for_per_transport_messages(context, transport, expected):
@@ -926,6 +929,3 @@ def step_check_per_transport_count(context, count, transport):
     assert actual == count, (
         f"Expected {count} {transport} message(s), got {actual} in {path}"
     )
-    # Consume the baseline so subsequent per-transport assertions in the same
-    # scenario count only messages that arrived after this check.
-    context.lines_before_per_transport[transport] = line_count(path)

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -10,7 +10,17 @@ import time
 from datetime import datetime, timezone
 
 from behave import given, when, then
-from environment import STORE_FILE_PATH, STORE_PATH_PREFIX
+from environment import (
+    RECEIVED_TCP_LOG,
+    RECEIVED_UDP_LOG,
+    STORE_FILE_PATH,
+    STORE_PATH_PREFIX,
+)
+
+PER_TRANSPORT_LOG = {
+    "udp": RECEIVED_UDP_LOG,
+    "tcp": RECEIVED_TCP_LOG,
+}
 
 # POSIX-only paths used by the @buffered/threaded scenarios. The cross-platform
 # scenarios use context.example_binary / context.received_log instead, set in
@@ -396,6 +406,13 @@ def step_syslog_ng_is_running(context):
     # Field name kept (`lines_before`) for legacy callers, but for OTel one
     # JSONL file line may carry several records.
     context.lines_before = oracle_record_count(context.received_log, context.oracle_format)
+
+    # Per-transport baselines for the SwitchingSender scenarios. Only the
+    # syslog-ng oracle emits these; other oracles leave the dict empty.
+    context.lines_before_per_transport = {}
+    if context.oracle_format == "syslog-ng":
+        for transport, path in PER_TRANSPORT_LOG.items():
+            context.lines_before_per_transport[transport] = line_count(path)
 
 
 def build_threaded_command(context, transport, no_sd=False):
@@ -871,33 +888,44 @@ def step_check_last_sequence_id(context, value):
     )
 
 
-# --- S20.1 SwitchingSender scaffolding (Phase 2) --------------------------
-# These steps are wired up in Phase 5 once the threaded example exposes the
-# `switch` command and syslog-ng is configured to split per-transport log
-# output. Until then they raise NotImplementedError so Behave reports the
-# scenario as failed rather than silently passing.
+# --- S20.1 SwitchingSender steps ------------------------------------------
 
 
 @given("the switching example is running with default transport {transport:w}")
 def step_switching_example_running(context, transport):
-    raise NotImplementedError(
-        "S20.1 Phase 5: start threaded example with --transport "
-        f"{transport} wiring SwitchingSender"
-    )
+    cmd = build_threaded_command(context, transport)
+    start_threaded_example(context, cmd)
 
 
 @when("the client switches to transport {transport:w}")
 def step_client_switches_transport(context, transport):
-    raise NotImplementedError(
-        "S20.1 Phase 5: send `switch "
-        f"{transport}` command to the interactive example"
-    )
+    send_command(context.interactive_process, f"switch {transport}")
+
+
+def wait_for_per_transport_messages(context, transport, expected):
+    """Wait for `expected` new lines to appear in the per-transport oracle."""
+    path = PER_TRANSPORT_LOG[transport]
+    baseline = context.lines_before_per_transport.get(transport, 0)
+    deadline = time.monotonic() + 5
+    while line_count(path) - baseline < expected:
+        if time.monotonic() > deadline:
+            actual = line_count(path) - baseline
+            raise AssertionError(
+                f"{path} received {actual} of {expected} messages within 5 seconds"
+            )
+        time.sleep(0.1)
 
 
 @then("syslog-ng receives {count:d} message over {transport:w}")
 @then("syslog-ng receives {count:d} messages over {transport:w}")
 def step_check_per_transport_count(context, count, transport):
-    raise NotImplementedError(
-        "S20.1 Phase 5: count records in the "
-        f"received_{transport}.log oracle file"
+    wait_for_per_transport_messages(context, transport, count)
+    path = PER_TRANSPORT_LOG[transport]
+    baseline = context.lines_before_per_transport.get(transport, 0)
+    actual = line_count(path) - baseline
+    assert actual == count, (
+        f"Expected {count} {transport} message(s), got {actual} in {path}"
     )
+    # Consume the baseline so subsequent per-transport assertions in the same
+    # scenario count only messages that arrived after this check.
+    context.lines_before_per_transport[transport] = line_count(path)

--- a/Bdd/features/switching_transport.feature
+++ b/Bdd/features/switching_transport.feature
@@ -1,0 +1,14 @@
+@buffered
+Feature: Switch transport at runtime
+  The threaded example always wraps its UDP and TCP senders in a
+  SwitchingSender. The --transport CLI flag sets the initial selector
+  value, and the interactive `switch` command updates it at runtime.
+
+  Scenario: Switch from UDP to TCP mid-run delivers via both
+    Given syslog-ng is running
+    And the switching example is running with default transport udp
+    When the client sends a message
+    Then syslog-ng receives 1 message over udp
+    When the client switches to transport tcp
+    And the client sends a message
+    Then syslog-ng receives 1 message over tcp

--- a/Bdd/features/switching_transport.feature
+++ b/Bdd/features/switching_transport.feature
@@ -12,3 +12,4 @@ Feature: Switch transport at runtime
     When the client switches to transport tcp
     And the client sends a message
     Then syslog-ng receives 1 message over tcp
+    And syslog-ng receives 1 message over udp

--- a/Bdd/syslog-ng/syslog-ng-full.conf
+++ b/Bdd/syslog-ng/syslog-ng-full.conf
@@ -26,8 +26,38 @@ destination d_file {
     );
 };
 
+destination d_file_udp {
+    file(
+        "/var/log/syslog-ng/received_udp.log"
+        template("PRIORITY=${PRI} TIMESTAMP=${ISODATE} HOSTNAME=${HOST} APP_NAME=${PROGRAM} PROCID=${PID} MSGID=${MSGID} STRUCTURED_DATA=${SDATA} MSG=${MSG}\n")
+        flush_lines(1)
+        create-dirs(yes)
+        perm(0644)
+    );
+};
+
+destination d_file_tcp {
+    file(
+        "/var/log/syslog-ng/received_tcp.log"
+        template("PRIORITY=${PRI} TIMESTAMP=${ISODATE} HOSTNAME=${HOST} APP_NAME=${PROGRAM} PROCID=${PID} MSGID=${MSGID} STRUCTURED_DATA=${SDATA} MSG=${MSG}\n")
+        flush_lines(1)
+        create-dirs(yes)
+        perm(0644)
+    );
+};
+
 log {
     source(s_udp);
     source(s_tcp);
     destination(d_file);
+};
+
+log {
+    source(s_udp);
+    destination(d_file_udp);
+};
+
+log {
+    source(s_tcp);
+    destination(d_file_tcp);
 };

--- a/Bdd/syslog-ng/syslog-ng-udp-only.conf
+++ b/Bdd/syslog-ng/syslog-ng-udp-only.conf
@@ -18,7 +18,22 @@ destination d_file {
     );
 };
 
+destination d_file_udp {
+    file(
+        "/var/log/syslog-ng/received_udp.log"
+        template("PRIORITY=${PRI} TIMESTAMP=${ISODATE} HOSTNAME=${HOST} APP_NAME=${PROGRAM} PROCID=${PID} MSGID=${MSGID} STRUCTURED_DATA=${SDATA} MSG=${MSG}\n")
+        flush_lines(1)
+        create-dirs(yes)
+        perm(0644)
+    );
+};
+
 log {
     source(s_udp);
     destination(d_file);
+};
+
+log {
+    source(s_udp);
+    destination(d_file_udp);
 };

--- a/Bdd/syslog-ng/syslog-ng.conf
+++ b/Bdd/syslog-ng/syslog-ng.conf
@@ -26,8 +26,38 @@ destination d_file {
     );
 };
 
+destination d_file_udp {
+    file(
+        "/var/log/syslog-ng/received_udp.log"
+        template("PRIORITY=${PRI} TIMESTAMP=${ISODATE} HOSTNAME=${HOST} APP_NAME=${PROGRAM} PROCID=${PID} MSGID=${MSGID} STRUCTURED_DATA=${SDATA} MSG=${MSG}\n")
+        flush_lines(1)
+        create-dirs(yes)
+        perm(0644)
+    );
+};
+
+destination d_file_tcp {
+    file(
+        "/var/log/syslog-ng/received_tcp.log"
+        template("PRIORITY=${PRI} TIMESTAMP=${ISODATE} HOSTNAME=${HOST} APP_NAME=${PROGRAM} PROCID=${PID} MSGID=${MSGID} STRUCTURED_DATA=${SDATA} MSG=${MSG}\n")
+        flush_lines(1)
+        create-dirs(yes)
+        perm(0644)
+    );
+};
+
 log {
     source(s_udp);
     source(s_tcp);
     destination(d_file);
+};
+
+log {
+    source(s_udp);
+    destination(d_file_udp);
+};
+
+log {
+    source(s_tcp);
+    destination(d_file_tcp);
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Tests/Support/    — PosixFakes static lib (SocketFake, ClockFake) — shared a
 Tests/Example/    — Example code unit tests (ExampleTests executable).
 Example/Common/   — Shared example code (CLI parsing, app name, UDP/TCP config, service thread).
 Example/SingleTask/ — Single-task example (NullBuffer, bare-metal model). BDD sender.
-Example/Threaded/ — Threaded example (PosixMessageQueueBuffer, two pthreads, --transport udp|tcp). BDD sender.
+Example/Threaded/ — Threaded example (PosixMessageQueueBuffer, two pthreads, SwitchingSender over UDP + TCP; `--transport` sets initial, `switch <name>` flips at runtime). BDD sender.
 Bdd/              — BDD test infrastructure: Gherkin features, step definitions, syslog-ng config.
 ci/               — CI-specific files (e.g. docker-compose.bdd.yml).
 ```
@@ -142,6 +142,7 @@ Headers in `Interface/` are split by audience — each user includes only what t
 | `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(resolver, transport, host, port, *out)` |
 | `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
 | `SolidSyslogTcpSender.h` | System setup code using TCP transport (RFC 6587) | `SolidSyslogTcpSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogTcpSender_Create`, `_Destroy`, `SOLIDSYSLOG_TCP_DEFAULT_PORT` |
+| `SolidSyslogSwitchingSender.h` | System setup code composing multiple inner senders | `SolidSyslogSwitchingSenderConfig` (senders, senderCount, selector), `SolidSyslogSwitchingSenderSelector`, `SolidSyslogSwitchingSender_Create`, `_Destroy` |
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -6,6 +6,7 @@ if(SOLIDSYSLOG_POSIX)
         Common/ExampleUdpConfig.c
         Common/ExampleTcpConfig.c
         Common/ExampleInteractive.c
+        Common/ExampleSwitchConfig.c
     )
 
     # Single-task example: NullBuffer, direct send, bare-metal model

--- a/Example/Common/ExampleInteractive.c
+++ b/Example/Common/ExampleInteractive.c
@@ -1,5 +1,6 @@
 #include "ExampleInteractive.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,6 +16,30 @@ static void PrintPrompt(void)
 {
     printf("%s", PROMPT);
     fflush(stdout);
+}
+
+static bool MatchCommand(const char* line, const char* command, const char** args)
+{
+    size_t length = strlen(command);
+
+    if (strncmp(line, command, length) != 0)
+    {
+        return false;
+    }
+
+    if (line[length] != ' ' && line[length] != '\0')
+    {
+        return false;
+    }
+
+    const char* rest = line + length;
+    if (*rest == ' ')
+    {
+        rest++;
+    }
+
+    *args = rest;
+    return true;
 }
 
 static int ParseCount(const char* args)
@@ -59,22 +84,13 @@ void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* inpu
             break;
         }
 
-        if (strncmp(line, "send", 4) == 0 && (line[4] == ' ' || line[4] == '\0'))
+        const char* args = NULL;
+        if (MatchCommand(line, "send", &args))
         {
-            const char* args = line + 4;
-            if (*args == ' ')
-            {
-                args++;
-            }
             HandleSend(args, message);
         }
-        else if (strncmp(line, "switch", 6) == 0 && (line[6] == ' ' || line[6] == '\0') && onSwitch != NULL)
+        else if (onSwitch != NULL && MatchCommand(line, "switch", &args))
         {
-            const char* args = line + 6;
-            if (*args == ' ')
-            {
-                args++;
-            }
             onSwitch(args);
         }
 

--- a/Example/Common/ExampleInteractive.c
+++ b/Example/Common/ExampleInteractive.c
@@ -1,5 +1,4 @@
 #include "ExampleInteractive.h"
-#include "ExampleSwitchConfig.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,7 +40,7 @@ static void HandleSend(const char* args, const struct SolidSyslogMessage* messag
     printf("Sent %d message%s\n", count, (count == 1) ? "" : "s");
 }
 
-void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* input)
+void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* input, ExampleInteractiveSwitchHandler onSwitch)
 {
     char line[MAX_LINE_LENGTH];
 
@@ -69,14 +68,14 @@ void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* inpu
             }
             HandleSend(args, message);
         }
-        else if (strncmp(line, "switch", 6) == 0 && (line[6] == ' ' || line[6] == '\0'))
+        else if (strncmp(line, "switch", 6) == 0 && (line[6] == ' ' || line[6] == '\0') && onSwitch != NULL)
         {
             const char* args = line + 6;
             if (*args == ' ')
             {
                 args++;
             }
-            ExampleSwitchConfig_SetByName(args);
+            onSwitch(args);
         }
 
         PrintPrompt();

--- a/Example/Common/ExampleInteractive.c
+++ b/Example/Common/ExampleInteractive.c
@@ -1,4 +1,5 @@
 #include "ExampleInteractive.h"
+#include "ExampleSwitchConfig.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,6 +68,15 @@ void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* inpu
                 args++;
             }
             HandleSend(args, message);
+        }
+        else if (strncmp(line, "switch", 6) == 0 && (line[6] == ' ' || line[6] == '\0'))
+        {
+            const char* args = line + 6;
+            if (*args == ' ')
+            {
+                args++;
+            }
+            ExampleSwitchConfig_SetByName(args);
         }
 
         PrintPrompt();

--- a/Example/Common/ExampleInteractive.h
+++ b/Example/Common/ExampleInteractive.h
@@ -8,7 +8,9 @@
 
 EXTERN_C_BEGIN
 
-    void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* input);
+    typedef void (*ExampleInteractiveSwitchHandler)(const char* name);
+
+    void ExampleInteractive_Run(const struct SolidSyslogMessage* message, FILE* input, ExampleInteractiveSwitchHandler onSwitch);
 
 EXTERN_C_END
 

--- a/Example/Common/ExampleSwitchConfig.c
+++ b/Example/Common/ExampleSwitchConfig.c
@@ -1,0 +1,22 @@
+#include "ExampleSwitchConfig.h"
+
+#include <string.h>
+
+static volatile uint8_t selectedIndex;
+
+void ExampleSwitchConfig_SetByName(const char* name)
+{
+    if (strcmp(name, "udp") == 0)
+    {
+        selectedIndex = EXAMPLE_SWITCH_UDP;
+    }
+    else if (strcmp(name, "tcp") == 0)
+    {
+        selectedIndex = EXAMPLE_SWITCH_TCP;
+    }
+}
+
+uint8_t ExampleSwitchConfig_Selector(void)
+{
+    return selectedIndex;
+}

--- a/Example/Common/ExampleSwitchConfig.h
+++ b/Example/Common/ExampleSwitchConfig.h
@@ -1,0 +1,22 @@
+#ifndef EXAMPLESWITCHCONFIG_H
+#define EXAMPLESWITCHCONFIG_H
+
+#include "ExternC.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    enum
+    {
+        EXAMPLE_SWITCH_UDP,
+        EXAMPLE_SWITCH_TCP,
+        EXAMPLE_SWITCH_COUNT,
+    };
+
+    void    ExampleSwitchConfig_SetByName(const char* name);
+    uint8_t ExampleSwitchConfig_Selector(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+
+EXTERN_C_END
+
+#endif /* EXAMPLESWITCHCONFIG_H */

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -69,7 +69,7 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         .msg       = options.msg,
     };
 
-    ExampleInteractive_Run(&message, stdin);
+    ExampleInteractive_Run(&message, stdin, NULL);
 
     SolidSyslog_Destroy();
     SolidSyslogOriginSd_Destroy();

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
         .msg       = options.msg,
     };
 
-    ExampleInteractive_Run(&message, stdin);
+    ExampleInteractive_Run(&message, stdin, ExampleSwitchConfig_SetByName);
 
     shutdown_flag = true;
     pthread_join(serviceThread, NULL);

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -2,6 +2,7 @@
 #include "ExampleCommandLine.h"
 #include "ExampleInteractive.h"
 #include "ExampleServiceThread.h"
+#include "ExampleSwitchConfig.h"
 #include "ExampleTcpConfig.h"
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
@@ -21,6 +22,7 @@
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogSwitchingSender.h"
 #include "SolidSyslogTcpSender.h"
 #include "SolidSyslogUdpSender.h"
 
@@ -50,24 +52,34 @@ static void* ServiceThreadEntry(void* arg)
 
 static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* options)
 {
-    bool useTcp = (strcmp(options->transport, "tcp") == 0);
-
-    if (useTcp)
-    {
-        static struct SolidSyslogTcpSenderConfig tcpConfig = {0};
-        tcpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
-        tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
-        tcpConfig.endpoint                                 = ExampleTcpConfig_GetEndpoint;
-        tcpConfig.endpointVersion                          = ExampleTcpConfig_GetEndpointVersion;
-        return SolidSyslogTcpSender_Create(&tcpConfig);
-    }
+    struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create();
 
     static struct SolidSyslogUdpSenderConfig udpConfig = {0};
-    udpConfig.resolver                                 = SolidSyslogGetAddrInfoResolver_Create();
+    udpConfig.resolver                                 = resolver;
     udpConfig.datagram                                 = SolidSyslogPosixDatagram_Create();
     udpConfig.endpoint                                 = ExampleUdpConfig_GetEndpoint;
     udpConfig.endpointVersion                          = ExampleUdpConfig_GetEndpointVersion;
-    return SolidSyslogUdpSender_Create(&udpConfig);
+    struct SolidSyslogSender* udpSender                = SolidSyslogUdpSender_Create(&udpConfig);
+
+    static struct SolidSyslogTcpSenderConfig tcpConfig = {0};
+    tcpConfig.resolver                                 = resolver;
+    tcpConfig.stream                                   = SolidSyslogPosixTcpStream_Create();
+    tcpConfig.endpoint                                 = ExampleTcpConfig_GetEndpoint;
+    tcpConfig.endpointVersion                          = ExampleTcpConfig_GetEndpointVersion;
+    struct SolidSyslogSender* tcpSender                = SolidSyslogTcpSender_Create(&tcpConfig);
+
+    static struct SolidSyslogSender* inners[EXAMPLE_SWITCH_COUNT];
+    inners[EXAMPLE_SWITCH_UDP] = udpSender;
+    inners[EXAMPLE_SWITCH_TCP] = tcpSender;
+
+    static struct SolidSyslogSwitchingSenderConfig switchConfig = {0};
+    switchConfig.senders                                        = inners;
+    switchConfig.senderCount                                    = EXAMPLE_SWITCH_COUNT;
+    switchConfig.selector                                       = ExampleSwitchConfig_Selector;
+
+    ExampleSwitchConfig_SetByName(options->transport);
+
+    return SolidSyslogSwitchingSender_Create(&switchConfig);
 }
 
 static enum SolidSyslogDiscardPolicy MapDiscardPolicy(const char* policy)
@@ -119,20 +131,13 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
     return SolidSyslogNullStore_Create();
 }
 
-static void DestroySender(const struct ExampleOptions* options)
+static void DestroySender(void)
 {
-    bool useTcp = (strcmp(options->transport, "tcp") == 0);
-
-    if (useTcp)
-    {
-        SolidSyslogTcpSender_Destroy();
-        SolidSyslogPosixTcpStream_Destroy();
-    }
-    else
-    {
-        SolidSyslogUdpSender_Destroy();
-        SolidSyslogPosixDatagram_Destroy();
-    }
+    SolidSyslogSwitchingSender_Destroy();
+    SolidSyslogTcpSender_Destroy();
+    SolidSyslogPosixTcpStream_Destroy();
+    SolidSyslogUdpSender_Destroy();
+    SolidSyslogPosixDatagram_Destroy();
     SolidSyslogGetAddrInfoResolver_Destroy();
 }
 
@@ -214,7 +219,7 @@ int main(int argc, char* argv[])
     SolidSyslogAtomicCounter_Destroy();
     DestroyStore(&options);
     SolidSyslogPosixMessageQueueBuffer_Destroy();
-    DestroySender(&options);
+    DestroySender();
 
     return 0;
 }

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -102,7 +102,7 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
         .msg       = options.msg,
     };
 
-    ExampleInteractive_Run(&message, stdin);
+    ExampleInteractive_Run(&message, stdin, NULL);
 
     SolidSyslog_Destroy();
     SolidSyslogOriginSd_Destroy();

--- a/Interface/SolidSyslogSwitchingSender.h
+++ b/Interface/SolidSyslogSwitchingSender.h
@@ -1,0 +1,26 @@
+#ifndef SOLIDSYSLOGSWITCHINGSENDER_H
+#define SOLIDSYSLOGSWITCHINGSENDER_H
+
+#include "ExternC.h"
+#include "SolidSyslogSender.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    typedef uint8_t (*SolidSyslogSwitchingSenderSelector)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+
+    struct SolidSyslogSwitchingSenderConfig
+    {
+        struct SolidSyslogSender**         senders;
+        size_t                             senderCount;
+        SolidSyslogSwitchingSenderSelector selector;
+    };
+
+    struct SolidSyslogSender* SolidSyslogSwitchingSender_Create(const struct SolidSyslogSwitchingSenderConfig* config);
+    void                      SolidSyslogSwitchingSender_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSWITCHINGSENDER_H */

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Public headers are split by audience (Interface Segregation Principle):
 - **`SolidSyslogTcpSender.h`** — TCP transport with RFC 6587 octet-counting framing. Note: RFC 6587
   is a Historic RFC — the IESG recommends TLS (RFC 5425) over plain TCP for new deployments.
   TCP is provided for interoperability with existing infrastructure
+- **`SolidSyslogSwitchingSender.h`** — composition sender delegating to one of several
+  inner senders via an application-supplied selector callback; `Disconnect`s the
+  outgoing inner on every change
 - **`SolidSyslogEndpoint.h`** — destination spec for senders. Application supplies `endpoint`
   (fills host/port on (re)connect) and `endpointVersion` (cheap polled fingerprint); senders
   Disconnect and lazily reopen when the version changes — supports runtime address rotation
@@ -51,7 +54,7 @@ Public headers are split by audience (Interface Segregation Principle):
 
 Two example programs demonstrate usage:
 - **`Example/SingleTask/`** — NullBuffer, single-task bare-metal model
-- **`Example/Threaded/`** — PosixMessageQueueBuffer, two pthreads (logger + service), `--transport udp|tcp`
+- **`Example/Threaded/`** — PosixMessageQueueBuffer, two pthreads (logger + service), SwitchingSender over UDP + TCP; `--transport` sets the initial transport, `switch <name>` flips it at runtime
 
 ## Compliance
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     SolidSyslog.c
+    SolidSyslogSwitchingSender.c
     SolidSyslogBuffer.c
     SolidSyslogFormatter.c
     SolidSyslogMetaSd.c

--- a/Source/SolidSyslogSwitchingSender.c
+++ b/Source/SolidSyslogSwitchingSender.c
@@ -1,0 +1,99 @@
+#include "SolidSyslogSenderDefinition.h"
+#include "SolidSyslogSwitchingSender.h"
+
+struct SolidSyslogSwitchingSender
+{
+    struct SolidSyslogSender                base;
+    struct SolidSyslogSwitchingSenderConfig config;
+    struct SolidSyslogSender*               currentSender;
+};
+
+static bool                             Send(struct SolidSyslogSender* sender, const void* buffer, size_t size);
+static void                             Disconnect(struct SolidSyslogSender* sender);
+static inline void                      SelectSender(struct SolidSyslogSwitchingSender* self);
+static inline bool                      SenderChanged(const struct SolidSyslogSwitchingSender* self, const struct SolidSyslogSender* requestedSender);
+static inline void                      SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent);
+static inline struct SolidSyslogSender* RequestedSender(const struct SolidSyslogSwitchingSender* self);
+static bool                             NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size);
+static void                             NilDisconnect(struct SolidSyslogSender* sender);
+
+static struct SolidSyslogSender                NIL_SENDER       = {NilSend, NilDisconnect};
+static const struct SolidSyslogSwitchingSender DEFAULT_INSTANCE = {.currentSender = &NIL_SENDER};
+static struct SolidSyslogSwitchingSender       instance;
+
+struct SolidSyslogSender* SolidSyslogSwitchingSender_Create(const struct SolidSyslogSwitchingSenderConfig* config)
+{
+    instance                 = DEFAULT_INSTANCE;
+    instance.config          = *config;
+    instance.base.Send       = Send;
+    instance.base.Disconnect = Disconnect;
+    return &instance.base;
+}
+
+void SolidSyslogSwitchingSender_Destroy(void)
+{
+    instance = DEFAULT_INSTANCE;
+}
+
+static bool Send(struct SolidSyslogSender* sender, const void* buffer, size_t size)
+{
+    struct SolidSyslogSwitchingSender* self = (struct SolidSyslogSwitchingSender*) sender;
+    SelectSender(self);
+    return SolidSyslogSender_Send(self->currentSender, buffer, size);
+}
+
+static void Disconnect(struct SolidSyslogSender* sender)
+{
+    struct SolidSyslogSwitchingSender* self = (struct SolidSyslogSwitchingSender*) sender;
+    SolidSyslogSender_Disconnect(self->currentSender);
+}
+
+static inline void SelectSender(struct SolidSyslogSwitchingSender* self)
+{
+    struct SolidSyslogSender* requestedSender = RequestedSender(self);
+
+    if (SenderChanged(self, requestedSender))
+    {
+        SwitchTo(self, requestedSender);
+    }
+}
+
+static inline bool SenderChanged(const struct SolidSyslogSwitchingSender* self, const struct SolidSyslogSender* requestedSender)
+{
+    return requestedSender != self->currentSender;
+}
+
+static inline void SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent)
+{
+    SolidSyslogSender_Disconnect(self->currentSender);
+    self->currentSender = newCurrent;
+}
+
+/* Falls back to the nil sender when the selector returns an out-of-range
+ * index (including the empty-array case). Contains the application contract
+ * violation of an invalid selector without corrupting memory or crashing. */
+static inline struct SolidSyslogSender* RequestedSender(const struct SolidSyslogSwitchingSender* self)
+{
+    uint8_t                   index  = self->config.selector();
+    struct SolidSyslogSender* result = &NIL_SENDER;
+
+    if (index < self->config.senderCount)
+    {
+        result = self->config.senders[index];
+    }
+
+    return result;
+}
+
+static bool NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size)
+{
+    (void) sender;
+    (void) buffer;
+    (void) size;
+    return false;
+}
+
+static void NilDisconnect(struct SolidSyslogSender* sender)
+{
+    (void) sender;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 set(TEST_SOURCES
     SolidSyslogTest.cpp
+    SolidSyslogSwitchingSenderTest.cpp
     SolidSyslogMetaSdTest.cpp
     SolidSyslogTimeQualitySdTest.cpp
     SolidSyslogOriginSdTest.cpp

--- a/Tests/Example/CMakeLists.txt
+++ b/Tests/Example/CMakeLists.txt
@@ -17,6 +17,7 @@ if(SOLIDSYSLOG_POSIX)
         ExampleCommandLineTest.cpp
         SolidSyslogExampleTest.cpp
         ExampleServiceThreadTest.cpp
+        ExampleSwitchConfigTest.cpp
     )
     list(APPEND EXAMPLE_PRODUCTION_SOURCES
         ${CMAKE_SOURCE_DIR}/Example/SingleTask/SolidSyslogExample.c
@@ -24,6 +25,7 @@ if(SOLIDSYSLOG_POSIX)
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleServiceThread.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleUdpConfig.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleInteractive.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleSwitchConfig.c
     )
     list(APPEND EXAMPLE_TEST_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/Example/SingleTask

--- a/Tests/Example/ExampleSwitchConfigTest.cpp
+++ b/Tests/Example/ExampleSwitchConfigTest.cpp
@@ -1,0 +1,48 @@
+#include "CppUTest/TestHarness.h"
+#include "ExampleSwitchConfig.h"
+
+// clang-format off
+TEST_GROUP(ExampleSwitchConfig)
+{
+    void setup() override
+    {
+        ExampleSwitchConfig_SetByName("udp");
+    }
+};
+
+// clang-format on
+
+TEST(ExampleSwitchConfig, SetByNameUdpSelectsUdpIndex)
+{
+    ExampleSwitchConfig_SetByName("udp");
+    LONGS_EQUAL(EXAMPLE_SWITCH_UDP, ExampleSwitchConfig_Selector());
+}
+
+TEST(ExampleSwitchConfig, SetByNameTcpSelectsTcpIndex)
+{
+    ExampleSwitchConfig_SetByName("tcp");
+    LONGS_EQUAL(EXAMPLE_SWITCH_TCP, ExampleSwitchConfig_Selector());
+}
+
+TEST(ExampleSwitchConfig, UnknownNameLeavesPreviousSelection)
+{
+    ExampleSwitchConfig_SetByName("tcp");
+    ExampleSwitchConfig_SetByName("bogus");
+    LONGS_EQUAL(EXAMPLE_SWITCH_TCP, ExampleSwitchConfig_Selector());
+}
+
+TEST(ExampleSwitchConfig, EmptyNameLeavesPreviousSelection)
+{
+    ExampleSwitchConfig_SetByName("tcp");
+    ExampleSwitchConfig_SetByName("");
+    LONGS_EQUAL(EXAMPLE_SWITCH_TCP, ExampleSwitchConfig_Selector());
+}
+
+TEST(ExampleSwitchConfig, SwitchingBackAndForthTracksLatest)
+{
+    ExampleSwitchConfig_SetByName("tcp");
+    ExampleSwitchConfig_SetByName("udp");
+    LONGS_EQUAL(EXAMPLE_SWITCH_UDP, ExampleSwitchConfig_Selector());
+    ExampleSwitchConfig_SetByName("tcp");
+    LONGS_EQUAL(EXAMPLE_SWITCH_TCP, ExampleSwitchConfig_Selector());
+}

--- a/Tests/SenderFake.c
+++ b/Tests/SenderFake.c
@@ -2,6 +2,7 @@
 #include "SolidSyslogSenderDefinition.h"
 #include "TestUtils.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 enum
@@ -9,60 +10,84 @@ enum
     SENDERFAKE_MAX_BUFFER_SIZE = 1024
 };
 
-static int                      callCount;
-static char                     lastBuffer[SENDERFAKE_MAX_BUFFER_SIZE];
-static size_t                   lastSize;
-static bool                     failNextSend;
-static struct SolidSyslogSender sender;
+struct SenderFake
+{
+    struct SolidSyslogSender base;
+    int                      sendCount;
+    int                      disconnectCount;
+    char                     lastBuffer[SENDERFAKE_MAX_BUFFER_SIZE];
+    size_t                   lastSize;
+    bool                     failNextSend;
+};
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
-    (void) self;
-    size_t copySize = MinSize(size, sizeof(lastBuffer) - 1);
+    struct SenderFake* fake     = (struct SenderFake*) self;
+    size_t             copySize = MinSize(size, sizeof(fake->lastBuffer) - 1);
     // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
-    memcpy(lastBuffer, buffer, copySize);
-    lastBuffer[copySize] = '\0';
-    lastSize             = size;
-    callCount++;
+    memcpy(fake->lastBuffer, buffer, copySize);
+    fake->lastBuffer[copySize] = '\0';
+    fake->lastSize             = size;
+    fake->sendCount++;
 
-    if (failNextSend)
+    if (fake->failNextSend)
     {
-        failNextSend = false;
+        fake->failNextSend = false;
         return false;
     }
     return true;
 }
 
-void SenderFake_Reset(void)
+static void Disconnect(struct SolidSyslogSender* self)
 {
-    callCount     = 0;
-    lastBuffer[0] = '\0';
-    lastSize      = 0;
-    failNextSend  = false;
+    struct SenderFake* fake = (struct SenderFake*) self;
+    fake->disconnectCount++;
 }
 
-void SenderFake_FailNextSend(void)
+struct SolidSyslogSender* SenderFake_Create(void)
 {
-    failNextSend = true;
+    struct SenderFake* fake = (struct SenderFake*) calloc(1, sizeof(struct SenderFake));
+    fake->base.Send         = Send;
+    fake->base.Disconnect   = Disconnect;
+    return &fake->base;
 }
 
-const char* SenderFake_LastBufferAsString(void)
+void SenderFake_Destroy(struct SolidSyslogSender* sender)
 {
-    return lastBuffer;
+    free(sender);
 }
 
-struct SolidSyslogSender* SenderFake_GetSender(void)
+void SenderFake_Reset(struct SolidSyslogSender* sender)
 {
-    sender.Send = Send;
-    return &sender;
+    struct SenderFake* fake = (struct SenderFake*) sender;
+    fake->sendCount         = 0;
+    fake->disconnectCount   = 0;
+    fake->lastBuffer[0]     = '\0';
+    fake->lastSize          = 0;
+    fake->failNextSend      = false;
 }
 
-int SenderFake_CallCount(void)
+int SenderFake_SendCount(struct SolidSyslogSender* sender)
 {
-    return callCount;
+    return ((struct SenderFake*) sender)->sendCount;
 }
 
-size_t SenderFake_LastSize(void)
+int SenderFake_DisconnectCount(struct SolidSyslogSender* sender)
 {
-    return lastSize;
+    return ((struct SenderFake*) sender)->disconnectCount;
+}
+
+const char* SenderFake_LastBufferAsString(struct SolidSyslogSender* sender)
+{
+    return ((struct SenderFake*) sender)->lastBuffer;
+}
+
+size_t SenderFake_LastSize(struct SolidSyslogSender* sender)
+{
+    return ((struct SenderFake*) sender)->lastSize;
+}
+
+void SenderFake_FailNextSend(struct SolidSyslogSender* sender)
+{
+    ((struct SenderFake*) sender)->failNextSend = true;
 }

--- a/Tests/SenderFake.h
+++ b/Tests/SenderFake.h
@@ -5,12 +5,14 @@
 
 EXTERN_C_BEGIN
 
-    void                      SenderFake_Reset(void);
-    struct SolidSyslogSender* SenderFake_GetSender(void);
-    int                       SenderFake_CallCount(void);
-    const char*               SenderFake_LastBufferAsString(void);
-    size_t                    SenderFake_LastSize(void);
-    void                      SenderFake_FailNextSend(void);
+    struct SolidSyslogSender* SenderFake_Create(void);
+    void                      SenderFake_Destroy(struct SolidSyslogSender * sender);
+    void                      SenderFake_Reset(struct SolidSyslogSender * sender);
+    int                       SenderFake_SendCount(struct SolidSyslogSender * sender);
+    int                       SenderFake_DisconnectCount(struct SolidSyslogSender * sender);
+    const char*               SenderFake_LastBufferAsString(struct SolidSyslogSender * sender);
+    size_t                    SenderFake_LastSize(struct SolidSyslogSender * sender);
+    void                      SenderFake_FailNextSend(struct SolidSyslogSender * sender);
 
 EXTERN_C_END
 

--- a/Tests/SenderFakeTest.cpp
+++ b/Tests/SenderFakeTest.cpp
@@ -6,89 +6,176 @@
 // clang-format off
 TEST_GROUP(SenderFake)
 {
+    struct SolidSyslogSender* sender = nullptr;
+
     void setup() override
     {
-        SenderFake_Reset();
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        sender = SenderFake_Create();
+    }
+
+    void teardown() override
+    {
+        SenderFake_Destroy(sender);
     }
 };
 
 // clang-format on
 
-TEST(SenderFake, CallCountIsZeroAfterReset)
+TEST(SenderFake, SendCountIsZeroAfterCreate)
 {
-    LONGS_EQUAL(0, SenderFake_CallCount());
+    LONGS_EQUAL(0, SenderFake_SendCount(sender));
 }
 
-TEST(SenderFake, CallCountIncrementsOnSend)
+TEST(SenderFake, DisconnectCountIsZeroAfterCreate)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
+    LONGS_EQUAL(0, SenderFake_DisconnectCount(sender));
+}
+
+TEST(SenderFake, SendCountIncrementsOnSend)
+{
     SolidSyslogSender_Send(sender, "a", 1);
-    LONGS_EQUAL(1, SenderFake_CallCount());
+    LONGS_EQUAL(1, SenderFake_SendCount(sender));
 }
 
-TEST(SenderFake, CallCountIncrementsTwiceOnTwoSends)
+TEST(SenderFake, SendCountIncrementsTwiceOnTwoSends)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     SolidSyslogSender_Send(sender, "a", 1);
     SolidSyslogSender_Send(sender, "b", 1);
-    LONGS_EQUAL(2, SenderFake_CallCount());
+    LONGS_EQUAL(2, SenderFake_SendCount(sender));
+}
+
+TEST(SenderFake, DisconnectCountIncrementsOnDisconnect)
+{
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(1, SenderFake_DisconnectCount(sender));
+}
+
+TEST(SenderFake, DisconnectCountIncrementsTwiceOnTwoDisconnects)
+{
+    SolidSyslogSender_Disconnect(sender);
+    SolidSyslogSender_Disconnect(sender);
+    LONGS_EQUAL(2, SenderFake_DisconnectCount(sender));
 }
 
 TEST(SenderFake, LastBufferCapturesMessage)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     SolidSyslogSender_Send(sender, "hello", 5);
-    STRCMP_EQUAL("hello", SenderFake_LastBufferAsString());
+    STRCMP_EQUAL("hello", SenderFake_LastBufferAsString(sender));
 }
 
 TEST(SenderFake, LastBufferIsNullTerminated)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     SolidSyslogSender_Send(sender, "test", 4);
-    LONGS_EQUAL(0, SenderFake_LastBufferAsString()[4]);
+    LONGS_EQUAL(0, SenderFake_LastBufferAsString(sender)[4]);
 }
 
 TEST(SenderFake, LastBufferCapturesLastSend)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     SolidSyslogSender_Send(sender, "first", 5);
     SolidSyslogSender_Send(sender, "second", 6);
-    STRCMP_EQUAL("second", SenderFake_LastBufferAsString());
+    STRCMP_EQUAL("second", SenderFake_LastBufferAsString(sender));
 }
 
 TEST(SenderFake, SendReturnsTrue)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     CHECK_TRUE(SolidSyslogSender_Send(sender, "a", 1));
 }
 
 TEST(SenderFake, ResetClearsLastBuffer)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
     SolidSyslogSender_Send(sender, "hello", 5);
-    SenderFake_Reset();
-    STRCMP_EQUAL("", SenderFake_LastBufferAsString());
+    SenderFake_Reset(sender);
+    STRCMP_EQUAL("", SenderFake_LastBufferAsString(sender));
+}
+
+TEST(SenderFake, ResetClearsSendCount)
+{
+    SolidSyslogSender_Send(sender, "a", 1);
+    SenderFake_Reset(sender);
+    LONGS_EQUAL(0, SenderFake_SendCount(sender));
+}
+
+TEST(SenderFake, ResetClearsDisconnectCount)
+{
+    SolidSyslogSender_Disconnect(sender);
+    SenderFake_Reset(sender);
+    LONGS_EQUAL(0, SenderFake_DisconnectCount(sender));
 }
 
 TEST(SenderFake, FailNextSendReturnsFalse)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
-    SenderFake_FailNextSend();
+    SenderFake_FailNextSend(sender);
     CHECK_FALSE(SolidSyslogSender_Send(sender, "a", 1));
 }
 
 TEST(SenderFake, FailNextSendStillCapturesBuffer)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
-    SenderFake_FailNextSend();
+    SenderFake_FailNextSend(sender);
     SolidSyslogSender_Send(sender, "hello", 5);
-    STRCMP_EQUAL("hello", SenderFake_LastBufferAsString());
+    STRCMP_EQUAL("hello", SenderFake_LastBufferAsString(sender));
 }
 
 TEST(SenderFake, FailNextSendOnlyAffectsOneSend)
 {
-    struct SolidSyslogSender* sender = SenderFake_GetSender();
-    SenderFake_FailNextSend();
+    SenderFake_FailNextSend(sender);
     SolidSyslogSender_Send(sender, "a", 1);
     CHECK_TRUE(SolidSyslogSender_Send(sender, "b", 1));
+}
+
+// clang-format off
+TEST_GROUP(SenderFakeInstances)
+{
+    struct SolidSyslogSender* a = nullptr;
+    struct SolidSyslogSender* b = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        a = SenderFake_Create();
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        b = SenderFake_Create();
+    }
+
+    void teardown() override
+    {
+        SenderFake_Destroy(b);
+        SenderFake_Destroy(a);
+    }
+};
+
+// clang-format on
+
+TEST(SenderFakeInstances, TwoInstancesHaveDistinctHandles)
+{
+    CHECK(a != b);
+}
+
+TEST(SenderFakeInstances, SendCountsAreIndependent)
+{
+    SolidSyslogSender_Send(a, "x", 1);
+    LONGS_EQUAL(1, SenderFake_SendCount(a));
+    LONGS_EQUAL(0, SenderFake_SendCount(b));
+}
+
+TEST(SenderFakeInstances, DisconnectCountsAreIndependent)
+{
+    SolidSyslogSender_Disconnect(a);
+    LONGS_EQUAL(1, SenderFake_DisconnectCount(a));
+    LONGS_EQUAL(0, SenderFake_DisconnectCount(b));
+}
+
+TEST(SenderFakeInstances, LastBuffersAreIndependent)
+{
+    SolidSyslogSender_Send(a, "alpha", 5);
+    SolidSyslogSender_Send(b, "beta", 4);
+    STRCMP_EQUAL("alpha", SenderFake_LastBufferAsString(a));
+    STRCMP_EQUAL("beta", SenderFake_LastBufferAsString(b));
+}
+
+TEST(SenderFakeInstances, FailNextSendIsIndependent)
+{
+    SenderFake_FailNextSend(a);
+    CHECK_FALSE(SolidSyslogSender_Send(a, "a", 1));
+    CHECK_TRUE(SolidSyslogSender_Send(b, "b", 1));
 }

--- a/Tests/SolidSyslogNullBufferTest.cpp
+++ b/Tests/SolidSyslogNullBufferTest.cpp
@@ -8,18 +8,20 @@ static const size_t      TEST_MESSAGE_LEN = 5;
 // clang-format off
 TEST_GROUP(SolidSyslogNullBuffer)
 {
-    struct SolidSyslogBuffer* buffer = nullptr;
+    struct SolidSyslogSender* fakeSender = nullptr;
+    struct SolidSyslogBuffer* buffer     = nullptr;
 
     void setup() override
     {
-        SenderFake_Reset();
+        fakeSender = SenderFake_Create();
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        buffer = SolidSyslogNullBuffer_Create(SenderFake_GetSender());
+        buffer = SolidSyslogNullBuffer_Create(fakeSender);
     }
 
     void teardown() override
     {
         SolidSyslogNullBuffer_Destroy();
+        SenderFake_Destroy(fakeSender);
     }
 
     void Write() const
@@ -37,31 +39,31 @@ TEST(SolidSyslogNullBuffer, CreateDestroyWorksWithoutCrashing)
 TEST(SolidSyslogNullBuffer, WriteForwardsBufferToSender)
 {
     Write();
-    STRCMP_EQUAL(TEST_MESSAGE, SenderFake_LastBufferAsString());
+    STRCMP_EQUAL(TEST_MESSAGE, SenderFake_LastBufferAsString(fakeSender));
 }
 
 TEST(SolidSyslogNullBuffer, WriteForwardsSizeToSender)
 {
     Write();
-    LONGS_EQUAL(TEST_MESSAGE_LEN, SenderFake_LastSize());
+    LONGS_EQUAL(TEST_MESSAGE_LEN, SenderFake_LastSize(fakeSender));
 }
 
 TEST(SolidSyslogNullBuffer, WriteResultsInOneSend)
 {
     Write();
-    LONGS_EQUAL(1, SenderFake_CallCount());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
 }
 
 TEST(SolidSyslogNullBuffer, TwoWritesResultInTwoSends)
 {
     Write();
     Write();
-    LONGS_EQUAL(2, SenderFake_CallCount());
+    LONGS_EQUAL(2, SenderFake_SendCount(fakeSender));
 }
 
 TEST(SolidSyslogNullBuffer, NoWritesResultInNoSends)
 {
-    LONGS_EQUAL(0, SenderFake_CallCount());
+    LONGS_EQUAL(0, SenderFake_SendCount(fakeSender));
 }
 
 TEST(SolidSyslogNullBuffer, ReadReturnsNothingToSend)

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -90,18 +90,19 @@ TEST(SolidSyslogPosixMessageQueueBuffer, SecondReadAfterSingleWriteReturnsFalse)
 
 TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
 {
-    SenderFake_Reset();
-    SolidSyslogStore* nullStore = SolidSyslogNullStore_Create();
-    SolidSyslogConfig config    = {buffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, nullStore, nullptr, 0};
+    struct SolidSyslogSender* fakeSender = SenderFake_Create();
+    SolidSyslogStore*         nullStore  = SolidSyslogNullStore_Create();
+    SolidSyslogConfig         config     = {buffer, fakeSender, nullptr, nullptr, nullptr, nullptr, nullStore, nullptr, 0};
     SolidSyslog_Create(&config);
 
     SolidSyslogMessage message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
     SolidSyslog_Log(&message);
     SolidSyslog_Service();
-    LONGS_EQUAL(1, SenderFake_CallCount());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslogNullStore_Destroy();
+    SenderFake_Destroy(fakeSender);
 }
 
 IGNORE_TEST(SolidSyslogPosixMessageQueueBuffer, HappyPathOnly)

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -1,0 +1,229 @@
+#include "CppUTest/TestHarness.h"
+#include "SenderFake.h"
+#include "SolidSyslogSender.h"
+#include "SolidSyslogSwitchingSender.h"
+#include "TestUtils.h"
+
+/* Selector return values — named for the inner sender they select, so tests
+ * read as `selectorReturn = INNER_B`. */
+enum
+{
+    INNER_A = 0,
+    INNER_B = 1,
+    INNER_C = 2,
+};
+
+/* Boundary sentinel for the default 2-sender fixture: equals senderCount,
+ * the first index past the end. Using this exact value (rather than any
+ * large invalid number) is what catches off-by-one errors in the bounds
+ * check. Declared separately so it does not sit alongside INNER_C with
+ * the same numeric value. */
+enum
+{
+    BEYOND_END = 2,
+};
+
+static uint8_t selectorReturn;
+
+static uint8_t TestSelector() // NOLINT(modernize-redundant-void-arg) -- matches C callback signature
+{
+    return selectorReturn;
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogSwitchingSender)
+{
+    struct SolidSyslogSender* innerA = nullptr;
+    struct SolidSyslogSender* innerB = nullptr;
+    struct SolidSyslogSender* innerC = nullptr;
+    struct SolidSyslogSender* inners[3] = {nullptr, nullptr, nullptr};
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogSender* sender = nullptr;
+
+    void setup() override
+    {
+        selectorReturn = INNER_A;
+        innerA = SenderFake_Create();
+        innerB = SenderFake_Create();
+        innerC = SenderFake_Create();
+        inners[0] = innerA;
+        inners[1] = innerB;
+        inners[2] = innerC;
+        CreateSwitchingSender(2);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogSwitchingSender_Destroy();
+        SenderFake_Destroy(innerC);
+        SenderFake_Destroy(innerB);
+        SenderFake_Destroy(innerA);
+    }
+
+    void CreateSwitchingSender(size_t count)
+    {
+        struct SolidSyslogSwitchingSenderConfig config = {inners, count, TestSelector};
+        sender                                         = SolidSyslogSwitchingSender_Create(&config);
+    }
+
+    void Send(const void* buffer, size_t size) const
+    {
+        SolidSyslogSender_Send(sender, buffer, size);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogSwitchingSender, CreateDestroyWorksWithoutCrashing)
+{
+}
+
+TEST(SolidSyslogSwitchingSender, DestroyDoesNotSendToInnerSenders)
+{
+    SolidSyslogSwitchingSender_Destroy();
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, DestroyDoesNotDisconnectInnerSenders)
+{
+    SolidSyslogSwitchingSender_Destroy();
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, SendDelegatesToSenderAtSelectedIndex)
+{
+    Send("x", 1);
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, SecondSendAtSameIndexDoesNotDisconnect)
+{
+    Send("x", 1);
+    Send("y", 1);
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), TWICE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, SelectorChangeDisconnectsOutgoingAndSendsOnIncoming)
+{
+    Send("x", 1);
+    selectorReturn = INNER_B;
+    Send("y", 1);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, SteadyStateAfterSwitchDoesNotDisconnectAgain)
+{
+    Send("x", 1);
+    selectorReturn = INNER_B;
+    Send("y", 1);
+    Send("z", 1);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), TWICE);
+}
+
+TEST(SolidSyslogSwitchingSender, DisconnectBeforeAnySendDoesNotTouchInnerSenders)
+{
+    SolidSyslogSender_Disconnect(sender);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, DisconnectForwardsToCurrentSender)
+{
+    Send("x", 1);
+    SolidSyslogSender_Disconnect(sender);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, DisconnectAfterSwitchForwardsToNewActive)
+{
+    Send("x", 1);
+    selectorReturn = INNER_B;
+    Send("y", 1);
+    SolidSyslogSender_Disconnect(sender);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), ONCE);
+}
+
+TEST(SolidSyslogSwitchingSender, SelectorReturningNonZeroOnFirstSendLandsOnThatIndex)
+{
+    selectorReturn = INNER_B;
+    Send("x", 1);
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), ONCE);
+}
+
+TEST(SolidSyslogSwitchingSender, SendForwardsBufferVerbatimToActive)
+{
+    Send("payload", 7);
+    LONGS_EQUAL(7, SenderFake_LastSize(innerA));
+    STRCMP_EQUAL("payload", SenderFake_LastBufferAsString(innerA));
+}
+
+TEST(SolidSyslogSwitchingSender, SendReturnsActiveSenderResult)
+{
+    SenderFake_FailNextSend(innerA);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, "x", 1));
+    CHECK_TRUE(SolidSyslogSender_Send(sender, "y", 1));
+}
+
+TEST(SolidSyslogSwitchingSender, SelectorAtLastValidIndexDelegatesToThatSender)
+{
+    CreateSwitchingSender(3);
+    selectorReturn = INNER_C;
+    Send("x", 1);
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerC), ONCE);
+}
+
+TEST(SolidSyslogSwitchingSender, ZeroSenderCountSendReturnsFalse)
+{
+    CreateSwitchingSender(0);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, "x", 1));
+}
+
+TEST(SolidSyslogSwitchingSender, ZeroSenderCountDisconnectDoesNotCrash)
+{
+    CreateSwitchingSender(0);
+    SolidSyslogSender_Disconnect(sender);
+}
+
+TEST(SolidSyslogSwitchingSender, SelectorBeyondEndSendReturnsFalseAndDoesNotTouchInnerSenders)
+{
+    selectorReturn = BEYOND_END;
+    CHECK_FALSE(SolidSyslogSender_Send(sender, "x", 1));
+    CALLED_FUNCTION(SenderFake_SendCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_SendCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, DisconnectAfterSwitchingBeyondEndIsNilSafe)
+{
+    Send("x", 1);
+    selectorReturn = BEYOND_END;
+    Send("y", 1);
+    // innerA was active, switched away — one Disconnect from the switch
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+    // explicit Disconnect now resolves to nil — no inner sender touched
+    SolidSyslogSender_Disconnect(sender);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
+TEST(SolidSyslogSwitchingSender, SelectorBeyondEndDisconnectBeforeSendDoesNotTouchInnerSenders)
+{
+    selectorReturn = BEYOND_END;
+    SolidSyslogSender_Disconnect(sender);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), NEVER);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -4,6 +4,8 @@
 #include "SolidSyslogSwitchingSender.h"
 #include "TestUtils.h"
 
+using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for CALLED_FUNCTION
+
 /* Selector return values — named for the inner sender they select, so tests
  * read as `selectorReturn = INNER_B`. */
 enum

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -154,6 +154,17 @@ TEST(SolidSyslogSwitchingSender, DisconnectAfterSwitchForwardsToNewActive)
     CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), ONCE);
 }
 
+TEST(SolidSyslogSwitchingSender, DisconnectAfterSelectorChangeWithoutSendForwardsToPreviouslyActive)
+{
+    Send("x", 1);              // currentSender becomes innerA
+    selectorReturn = INNER_B;  // selector flips, but no Send yet
+    SolidSyslogSender_Disconnect(sender);
+    // Disconnect does not re-consult the selector — it forwards to the
+    // currently-held sender, so innerA receives the Disconnect.
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerA), ONCE);
+    CALLED_FUNCTION(SenderFake_DisconnectCount(innerB), NEVER);
+}
+
 TEST(SolidSyslogSwitchingSender, SelectorReturningNonZeroOnFirstSendLandsOnThatIndex)
 {
     selectorReturn = INNER_B;

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -156,8 +156,8 @@ TEST(SolidSyslogSwitchingSender, DisconnectAfterSwitchForwardsToNewActive)
 
 TEST(SolidSyslogSwitchingSender, DisconnectAfterSelectorChangeWithoutSendForwardsToPreviouslyActive)
 {
-    Send("x", 1);              // currentSender becomes innerA
-    selectorReturn = INNER_B;  // selector flips, but no Send yet
+    Send("x", 1);             // currentSender becomes innerA
+    selectorReturn = INNER_B; // selector flips, but no Send yet
     SolidSyslogSender_Disconnect(sender);
     // Disconnect does not re-consult the selector — it forwards to the
     // currently-held sender, so innerA receives the Disconnect.

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -207,15 +207,18 @@ TEST_GROUP(SolidSyslog)
     SolidSyslogBuffer *buffer;
     // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogStore  *store;
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    struct SolidSyslogSender *fakeSender;
 
     void setup() override
     {
-        SenderFake_Reset();
+        fakeSender = SenderFake_Create();
         StringFake_Reset();
-        buffer = SolidSyslogNullBuffer_Create(SenderFake_GetSender());
+        buffer = SolidSyslogNullBuffer_Create(fakeSender);
         store  = SolidSyslogNullStore_Create();
         config = {buffer, nullptr, nullptr, StringFake_GetHostname, StringFake_GetAppName, StringFake_GetProcessId, store, nullptr, 0};
         SolidSyslog_Create(&config);
+        // cppcheck-suppress unreadVariable -- read via Log() through &message; cppcheck does not model CppUTest macros
         message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
     }
 
@@ -224,6 +227,7 @@ TEST_GROUP(SolidSyslog)
         SolidSyslog_Destroy();
         SolidSyslogNullStore_Destroy();
         SolidSyslogNullBuffer_Destroy();
+        SenderFake_Destroy(fakeSender);
     }
 
     void Log() const
@@ -231,9 +235,9 @@ TEST_GROUP(SolidSyslog)
         SolidSyslog_Log(&message);
     }
 
-    static const char *LastMessage()
+    [[nodiscard]] const char *LastMessage() const
     {
-        return SenderFake_LastBufferAsString();
+        return SenderFake_LastBufferAsString(fakeSender);
     }
 };
 
@@ -245,13 +249,13 @@ TEST(SolidSyslog, CreateDestroyWorksWithoutCrashing)
 
 TEST(SolidSyslog, NoMessagesAreSentWhenLogIsNotCalled)
 {
-    LONGS_EQUAL(0, SenderFake_CallCount());
+    LONGS_EQUAL(0, SenderFake_SendCount(fakeSender));
 }
 
 TEST(SolidSyslog, SingleLogCallResultsInOneSend)
 {
     Log();
-    LONGS_EQUAL(1, SenderFake_CallCount());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
 }
 
 TEST(SolidSyslog, PriValIs134)
@@ -1066,17 +1070,17 @@ TEST(SolidSyslog, EmptyProcessIdProducesNilvalue)
 TEST(SolidSyslog, ServiceSendsMessageReadFromBuffer)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "test", 4);
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(1, SenderFake_CallCount());
-    STRCMP_EQUAL("test", SenderFake_LastBufferAsString());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
+    STRCMP_EQUAL("test", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1087,17 +1091,17 @@ TEST(SolidSyslog, ServiceSendsBufferedMessageWithNullStore)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  nullStore     = SolidSyslogNullStore_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, nullStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, nullStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "test", 4);
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(1, SenderFake_CallCount());
-    STRCMP_EQUAL("test", SenderFake_LastBufferAsString());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
+    STRCMP_EQUAL("test", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1109,17 +1113,17 @@ TEST(SolidSyslog, ServiceSendsFromStoreWhenHasUnsent)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogStore_Write(fakeStore, "stored", 6);
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(1, SenderFake_CallCount());
-    STRCMP_EQUAL("stored", SenderFake_LastBufferAsString());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
+    STRCMP_EQUAL("stored", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1131,7 +1135,7 @@ TEST(SolidSyslog, ServiceMarksSentAfterSuccessfulSend)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
@@ -1151,13 +1155,13 @@ TEST(SolidSyslog, ServiceDoesNotMarkSentOnSendFailure)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogStore_Write(fakeStore, "stored", 6);
-    SenderFake_FailNextSend();
+    SenderFake_FailNextSend(fakeSender);
     SolidSyslog_Service();
 
     CHECK_TRUE(SolidSyslogStore_HasUnsent(fakeStore));
@@ -1172,13 +1176,13 @@ TEST(SolidSyslog, ServiceWritesBufferMessageToStore)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "buffered", 8);
-    SenderFake_FailNextSend();
+    SenderFake_FailNextSend(fakeSender);
     SolidSyslog_Service();
 
     char   readData[512];
@@ -1197,17 +1201,17 @@ TEST(SolidSyslog, ServiceSendsStoreMessageNotBufferMessage)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogStore_Write(fakeStore, "old", 3);
     SolidSyslogBuffer_Write(fakeBuffer, "new", 3);
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    STRCMP_EQUAL("old", SenderFake_LastBufferAsString());
+    STRCMP_EQUAL("old", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1219,18 +1223,18 @@ TEST(SolidSyslog, ServiceSendsDirectlyWhenStoreWriteFails)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "direct", 6);
     StoreFake_FailNextWrite();
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(1, SenderFake_CallCount());
-    STRCMP_EQUAL("direct", SenderFake_LastBufferAsString());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
+    STRCMP_EQUAL("direct", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1242,17 +1246,17 @@ TEST(SolidSyslog, ServiceDoesNotSendWhenStoreReadFails)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogStore_Write(fakeStore, "stored", 6);
     StoreFake_FailNextRead();
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(0, SenderFake_CallCount());
+    LONGS_EQUAL(0, SenderFake_SendCount(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1264,7 +1268,7 @@ TEST(SolidSyslog, ServiceDoesNotMarkSentWhenSendingFromBuffer)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
@@ -1272,11 +1276,11 @@ TEST(SolidSyslog, ServiceDoesNotMarkSentWhenSendingFromBuffer)
     SolidSyslogStore_Write(fakeStore, "in-store", 8);
     SolidSyslogStore_MarkSent(fakeStore);
     SolidSyslogBuffer_Write(fakeBuffer, "from-buffer", 11);
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(1, SenderFake_CallCount());
-    STRCMP_EQUAL("from-buffer", SenderFake_LastBufferAsString());
+    LONGS_EQUAL(1, SenderFake_SendCount(fakeSender));
+    STRCMP_EQUAL("from-buffer", SenderFake_LastBufferAsString(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
@@ -1288,17 +1292,17 @@ TEST(SolidSyslog, ServiceDoesNothingWhenStoreIsHalted)
 {
     SolidSyslogBuffer* fakeBuffer    = BufferFake_Create();
     SolidSyslogStore*  fakeStore     = StoreFake_Create();
-    SolidSyslogConfig  serviceConfig = {fakeBuffer, SenderFake_GetSender(), nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
+    SolidSyslogConfig  serviceConfig = {fakeBuffer, fakeSender, nullptr, nullptr, nullptr, nullptr, fakeStore, nullptr, 0};
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&serviceConfig);
 
     SolidSyslogBuffer_Write(fakeBuffer, "test", 4);
     StoreFake_SetHalted();
-    SenderFake_Reset();
+    SenderFake_Reset(fakeSender);
     SolidSyslog_Service();
 
-    LONGS_EQUAL(0, SenderFake_CallCount());
+    LONGS_EQUAL(0, SenderFake_SendCount(fakeSender));
 
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -54,42 +54,42 @@ static const int TIMESTAMP_OFFSET_OFFSET       = 26;
 // clang-format on
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
-#define CHECK_PRIVAL(expected) STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_HEADER).c_str(), strlen(expected))
+#define CHECK_PRIVAL(expected) STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_HEADER).c_str(), strlen(expected))
 
 #define CHECK_TIMESTAMP_YEAR(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_YEAR_OFFSET, TIMESTAMP_YEAR_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_YEAR_OFFSET, TIMESTAMP_YEAR_LENGTH)
 
 #define CHECK_TIMESTAMP_MONTH(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MONTH_OFFSET, TIMESTAMP_MONTH_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MONTH_OFFSET, TIMESTAMP_MONTH_LENGTH)
 
 #define CHECK_TIMESTAMP_DAY(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_DAY_OFFSET, TIMESTAMP_DAY_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_DAY_OFFSET, TIMESTAMP_DAY_LENGTH)
 
 #define CHECK_TIMESTAMP_HOUR(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_HOUR_OFFSET, TIMESTAMP_HOUR_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_HOUR_OFFSET, TIMESTAMP_HOUR_LENGTH)
 
 #define CHECK_TIMESTAMP_MINUTE(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MINUTE_OFFSET, TIMESTAMP_MINUTE_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MINUTE_OFFSET, TIMESTAMP_MINUTE_LENGTH)
 
 #define CHECK_TIMESTAMP_SECOND(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_SECOND_OFFSET, TIMESTAMP_SECOND_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_SECOND_OFFSET, TIMESTAMP_SECOND_LENGTH)
 
 #define CHECK_TIMESTAMP_MICROSECOND(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MICROSECOND_OFFSET, TIMESTAMP_MICROSECOND_LENGTH)
+    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str() + TIMESTAMP_MICROSECOND_OFFSET, TIMESTAMP_MICROSECOND_LENGTH)
 
-#define CHECK_TIMESTAMP(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str())
+#define CHECK_TIMESTAMP(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str())
 
-#define CHECK_TIMESTAMP_OFFSET(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).substr(TIMESTAMP_OFFSET_OFFSET).c_str())
+#define CHECK_TIMESTAMP_OFFSET(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).substr(TIMESTAMP_OFFSET_OFFSET).c_str())
 
-#define CHECK_TIMESTAMP_IS_NILVALUE() STRCMP_EQUAL("-", SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str())
+#define CHECK_TIMESTAMP_IS_NILVALUE() STRCMP_EQUAL("-", SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str())
 
-#define CHECK_HOSTNAME(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_HOSTNAME).c_str())
+#define CHECK_HOSTNAME(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_HOSTNAME).c_str())
 
-#define CHECK_APP_NAME(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_APP_NAME).c_str())
+#define CHECK_APP_NAME(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_APP_NAME).c_str())
 
-#define CHECK_PROCID(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_PROCID).c_str())
+#define CHECK_PROCID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_PROCID).c_str())
 
-#define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(LastMessage(), SYSLOG_FIELD_MSGID).c_str())
+#define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_MSGID).c_str())
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
@@ -235,7 +235,7 @@ TEST_GROUP(SolidSyslog)
         SolidSyslog_Log(&message);
     }
 
-    [[nodiscard]] const char *LastMessage() const
+    [[nodiscard]] const char *lastMessage() const
     {
         return SenderFake_LastBufferAsString(fakeSender);
     }
@@ -327,7 +327,7 @@ TEST(SolidSyslog, OutOfRangeSeverityProducesErrorPrival)
 TEST(SolidSyslog, VersionIs1)
 {
     Log();
-    std::string header         = SyslogField(LastMessage(), SYSLOG_FIELD_HEADER);
+    std::string header         = SyslogField(lastMessage(), SYSLOG_FIELD_HEADER);
     auto        closingBracket = header.find('>');
     BYTES_EQUAL('1', header.at(closingBracket + 1));
 }
@@ -457,7 +457,7 @@ TEST(SolidSyslog, MessageIdAt33CharsIsTruncatedTo32)
 TEST(SolidSyslog, StructuredDataIsNilValue)
 {
     Log();
-    STRCMP_EQUAL(TEST_SDATA, SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL(TEST_SDATA, SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, InjectedSdObjectFormatIsCalledDuringLog)
@@ -468,7 +468,7 @@ TEST(SolidSyslog, InjectedSdObjectFormatIsCalledDuringLog)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("[spy]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[spy]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, MetaSdProducesSequenceIdInStructuredData)
@@ -481,7 +481,7 @@ TEST(SolidSyslog, MetaSdProducesSequenceIdInStructuredData)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
 }
@@ -497,7 +497,7 @@ TEST(SolidSyslog, MetaSdSequenceIdIncrementsAcrossLogCalls)
     SolidSyslog_Create(&config);
     Log();
     Log();
-    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
 }
@@ -513,7 +513,7 @@ TEST(SolidSyslog, MsgFieldPreservedWithMetaSd)
     SolidSyslog_Create(&config);
     message.msg = "hello world";
     Log();
-    STRCMP_EQUAL("hello world", SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL("hello world", SyslogMsg(lastMessage()).c_str());
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
 }
@@ -526,7 +526,7 @@ TEST(SolidSyslog, MultipleSdItemsAreConcatenated)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("[spy][spy2]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[spy][spy2]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, SingleSdReturningZeroBytesProducesNilvalue)
@@ -537,7 +537,7 @@ TEST(SolidSyslog, SingleSdReturningZeroBytesProducesNilvalue)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("-", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("-", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, FailingSdIsSkippedWhenOtherSdSucceeds)
@@ -548,7 +548,7 @@ TEST(SolidSyslog, FailingSdIsSkippedWhenOtherSdSucceeds)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("[spy]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[spy]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, AllSdFailingProducesNilvalue)
@@ -559,7 +559,7 @@ TEST(SolidSyslog, AllSdFailingProducesNilvalue)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("-", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("-", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
 }
 
 TEST(SolidSyslog, MetaSdAndTimeQualitySdCoexistInSdArray)
@@ -573,7 +573,7 @@ TEST(SolidSyslog, MetaSdAndTimeQualitySdCoexistInSdArray)
     SolidSyslog_Destroy();
     SolidSyslog_Create(&config);
     Log();
-    STRCMP_EQUAL("[meta sequenceId=\"1\"][timeQuality tzKnown=\"1\" isSynced=\"1\"]", SyslogField(LastMessage(), SYSLOG_FIELD_SDATA).c_str());
+    STRCMP_EQUAL("[meta sequenceId=\"1\"][timeQuality tzKnown=\"1\" isSynced=\"1\"]", SyslogField(lastMessage(), SYSLOG_FIELD_SDATA).c_str());
     SolidSyslogTimeQualitySd_Destroy();
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
@@ -582,35 +582,35 @@ TEST(SolidSyslog, MetaSdAndTimeQualitySdCoexistInSdArray)
 TEST(SolidSyslog, NullMessageOmitsMsgField)
 {
     Log();
-    STRCMP_EQUAL("", SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL("", SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, MessageBodyAppearsInMessage)
 {
     message.msg = "system started";
     Log();
-    STRCMP_EQUAL("system started", SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL("system started", SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, EmptyMessageOmitsMsgField)
 {
     message.msg = "";
     Log();
-    STRCMP_EQUAL("", SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL("", SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, MessageBodyIsNotHardCoded)
 {
     message.msg = TEST_MSG;
     Log();
-    STRCMP_EQUAL(TEST_MSG, SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL(TEST_MSG, SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, MessageWithSpacesIsPreserved)
 {
     message.msg = "hello world with spaces";
     Log();
-    STRCMP_EQUAL("hello world with spaces", SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL("hello world with spaces", SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, MessageFillsRemainingBuffer)
@@ -620,7 +620,7 @@ TEST(SolidSyslog, MessageFillsRemainingBuffer)
     std::string longMsg(maxMsg, 'X');
     message.msg = longMsg.c_str();
     Log();
-    STRCMP_EQUAL(longMsg.c_str(), SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL(longMsg.c_str(), SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, MessageTruncatedWhenExceedingBuffer)
@@ -631,7 +631,7 @@ TEST(SolidSyslog, MessageTruncatedWhenExceedingBuffer)
     message.msg = longMsg.c_str();
     Log();
     std::string expected(maxMsg, 'X');
-    STRCMP_EQUAL(expected.c_str(), SyslogMsg(LastMessage()).c_str());
+    STRCMP_EQUAL(expected.c_str(), SyslogMsg(lastMessage()).c_str());
 }
 
 TEST(SolidSyslog, HugeMessageDoesNotCorruptMemory)
@@ -639,7 +639,7 @@ TEST(SolidSyslog, HugeMessageDoesNotCorruptMemory)
     std::string hugeMsg(10000, 'Z');
     message.msg = hugeMsg.c_str();
     Log();
-    std::string result = SyslogMsg(LastMessage());
+    std::string result = SyslogMsg(lastMessage());
     CHECK(result.size() <= SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 }
 
@@ -737,7 +737,7 @@ TEST(SolidSyslogTimestamp, MicrosecondFormatsAsSixDigitZeroPadded)
 TEST(SolidSyslogTimestamp, DateFieldsSeparatedByHyphen)
 {
     Log();
-    std::string timestamp = SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP);
+    std::string timestamp = SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP);
     BYTES_EQUAL('-', timestamp.at(TIMESTAMP_DATE_SEPARATOR_1));
     BYTES_EQUAL('-', timestamp.at(TIMESTAMP_DATE_SEPARATOR_2));
 }
@@ -745,14 +745,14 @@ TEST(SolidSyslogTimestamp, DateFieldsSeparatedByHyphen)
 TEST(SolidSyslogTimestamp, DateAndTimeSeparatedByT)
 {
     Log();
-    std::string timestamp = SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP);
+    std::string timestamp = SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP);
     BYTES_EQUAL('T', timestamp.at(TIMESTAMP_DATE_TIME_SEPARATOR));
 }
 
 TEST(SolidSyslogTimestamp, TimeFieldsSeparatedByColon)
 {
     Log();
-    std::string timestamp = SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP);
+    std::string timestamp = SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP);
     BYTES_EQUAL(':', timestamp.at(TIMESTAMP_TIME_SEPARATOR_1));
     BYTES_EQUAL(':', timestamp.at(TIMESTAMP_TIME_SEPARATOR_2));
 }
@@ -760,7 +760,7 @@ TEST(SolidSyslogTimestamp, TimeFieldsSeparatedByColon)
 TEST(SolidSyslogTimestamp, FractionalSecondsPrecededByDot)
 {
     Log();
-    std::string timestamp = SyslogField(LastMessage(), SYSLOG_FIELD_TIMESTAMP);
+    std::string timestamp = SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP);
     BYTES_EQUAL('.', timestamp.at(TIMESTAMP_MICROSECOND_OFFSET));
 }
 

--- a/Tests/TestUtils.h
+++ b/Tests/TestUtils.h
@@ -8,18 +8,28 @@ static inline size_t MinSize(size_t a, size_t b)
     return (a < b) ? a : b;
 }
 
-/* Expected call counts — readable names for CALLED_FUNCTION assertions. */
+#ifdef __cplusplus
+
+namespace CososoTesting
+{
+/* Expected call counts — readable names for CALLED_FUNCTION assertions.
+ * Namespaced because NEVER/ONCE are common identifiers that could collide
+ * at include sites. Tests opt in via `using namespace CososoTesting;`. */
 enum
 {
     NEVER  = 0,
     ONCE   = 1,
     TWICE  = 2,
-    THRICE = 3
+    THRICE = 3,
 };
+} // namespace CososoTesting
 
 /* Assert that a call-count expression equals an expected count.
- * Reads as: CALLED_FUNCTION(SenderFake_SendCount(inner), ONCE); */
+ * Reads as: CALLED_FUNCTION(SenderFake_SendCount(inner), ONCE);
+ * (with `using namespace CososoTesting;` in scope). */
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- CppUTest assertions are macro-based */
 #define CALLED_FUNCTION(f, n) LONGS_EQUAL((n), (f))
+
+#endif /* __cplusplus */
 
 #endif /* TESTUTILS_H */

--- a/Tests/TestUtils.h
+++ b/Tests/TestUtils.h
@@ -8,4 +8,18 @@ static inline size_t MinSize(size_t a, size_t b)
     return (a < b) ? a : b;
 }
 
+/* Expected call counts — readable names for CALLED_FUNCTION assertions. */
+enum
+{
+    NEVER  = 0,
+    ONCE   = 1,
+    TWICE  = 2,
+    THRICE = 3
+};
+
+/* Assert that a call-count expression equals an expected count.
+ * Reads as: CALLED_FUNCTION(SenderFake_SendCount(inner), ONCE); */
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- CppUTest assertions are macro-based */
+#define CALLED_FUNCTION(f, n) LONGS_EQUAL((n), (f))
+
 #endif /* TESTUTILS_H */


### PR DESCRIPTION
## Purpose

Implements story S20.1 (#162) under epic E20 "Multi-Transport Selection and
Failover" (#160). Lets applications compose multiple inner senders (UDP, TCP,
future TLS, anything implementing `SolidSyslogSender`) behind a pull-model
selector callback. On each Send the switching sender polls the selector; if
the index has changed it `Disconnect`s the outgoing inner and delegates to
the new one, which lazy-opens via its own state (S3.4 prerequisite).

## Change Description

**New public header** `SolidSyslogSwitchingSender.h` with:
- `SolidSyslogSwitchingSenderConfig` (senders array, count, selector callback)
- `SolidSyslogSwitchingSenderSelector` typedef (cheap pull callback)
- `_Create` / `_Destroy` singleton API — matches UdpSender/TcpSender pattern

**Source implementation** mirrors the S3.4 `Reconcile` family: `SelectSender`
polls, `SenderChanged` detects transitions, `SwitchTo` performs the
disconnect-and-adopt, `RequestedSender` resolves the index and falls back to
an internal nil sender for out-of-range values (including empty-array case).
Nil fallback contains application contract violations without corrupting
memory or crashing — Send drops, Disconnect is a no-op.

**Test infrastructure:** `SenderFake` refactored from singleton to
instance-based (malloc/free, per-instance Send/Disconnect counters).
`TestUtils.h` gains `CALLED_FUNCTION(f, n)` macro plus `NEVER/ONCE/TWICE/THRICE`
enum for readable call-count assertions.

**Threaded example** always wraps UDP + TCP in `SwitchingSender`. The
`--transport udp|tcp` flag sets the initial selector value; a new `switch
<name>` interactive command flips it at runtime. A single
`GetAddrInfoResolver` is now shared across both senders (S3.4 made the
resolver stateless; memory on the singleton limitation retired).

**BDD:** new `switching_transport.feature` exercises "UDP → switch → TCP".
`syslog-ng.conf` now writes per-transport destinations (`received_udp.log`,
`received_tcp.log`) in addition to the combined log so the Then steps can
verify which transport delivered.

## Test Evidence

- **19 new unit tests** for `SolidSyslogSwitchingSender` driven red → green →
  refactor, covering: Create/Destroy does not touch inner senders; Send
  delegation to selected index; no Disconnect on steady state; Disconnect on
  selector change; steady state after switch; explicit Disconnect forwarding;
  initial-state safety; last-valid-index boundary; zero-count degenerate case;
  beyond-end (one past senderCount) out-of-range cases for both Send and
  Disconnect.
- **5 new unit tests** for `ExampleSwitchConfig` (name mapping, unknown-name
  preservation, switch round-trip).
- **12 new + updated tests** in `SenderFakeTest` for the instance-based API
  including Disconnect counter and instance isolation.
- **New BDD scenario** "Switch from UDP to TCP mid-run delivers via both"
  passes end-to-end against syslog-ng.
- **All presets green** locally: debug (590 tests), clang-debug, sanitize,
  coverage (99.9% — unchanged from main, 100% on new code, 258 functions),
  tidy, cppcheck, format, bdd (32/32 scenarios).

## Areas Affected

- `Interface/` — new `SolidSyslogSwitchingSender.h`
- `Source/` — new `SolidSyslogSwitchingSender.c`
- `Tests/` — new `SolidSyslogSwitchingSenderTest.cpp`; `SenderFake.{h,c}` and
  `SenderFakeTest.cpp` reworked to instance-based; `TestUtils.h` extended;
  downstream test migrations in `SolidSyslogTest.cpp`,
  `SolidSyslogNullBufferTest.cpp`, `SolidSyslogPosixMessageQueueBufferTest.cpp`
- `Tests/Example/` — new `ExampleSwitchConfigTest.cpp`
- `Example/Common/` — new `ExampleSwitchConfig.{h,c}`; `ExampleInteractive.c`
  adds `switch <name>` command
- `Example/Threaded/main.c` — always builds both UDP + TCP senders with a
  shared resolver, wraps in SwitchingSender
- `Bdd/syslog-ng/*.conf` — per-transport destinations added to all three configs
- `Bdd/features/` — new `switching_transport.feature`, three new step defs,
  per-transport baseline in `step_syslog_ng_is_running`
- `CLAUDE.md` — header-table row + Threaded example description
- `README.md` — SwitchingSender entry in public-header list, Threaded example description

No breaking changes. No impact on derived projects — existing senders'
signatures and behaviour are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime transport switching: start with UDP/TCP and switch protocols at runtime via an interactive "switch" command
  * Per-transport message logging: UDP and TCP messages are also written to separate protocol-specific logs

* **Examples**
  * Interactive example updated to accept and handle the new "switch" command

* **Documentation**
  * README and examples updated to describe switching sender and usage

* **Tests**
  * Added tests exercising transport switching and per-transport baselines; test framework updated for independent fake-sender instances
<!-- end of auto-generated comment: release notes by coderabbit.ai -->