### PR TITLE
chore: bump container images to sha-18f19e1 / sha-0385cea

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gcc:
-    image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+    image: ghcr.io/davidcozens/cpputest:sha-18f19e1
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
@@ -61,7 +61,7 @@ services:
     command: sleep infinity
 
   clang:
-    image: ghcr.io/davidcozens/cpputest-clang:sha-6ea3f95
+    image: ghcr.io/davidcozens/cpputest-clang:sha-0385cea
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       checks: write
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -67,7 +67,7 @@ jobs:
       contents: read
       checks: write
     container:
-      image: ghcr.io/davidcozens/cpputest-clang:sha-6ea3f95
+      image: ghcr.io/davidcozens/cpputest-clang:sha-0385cea
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -105,7 +105,7 @@ jobs:
       contents: read
       checks: write
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -145,7 +145,7 @@ jobs:
       pages: write
       id-token: write
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -223,7 +223,7 @@ jobs:
   tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -251,7 +251,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -269,7 +269,7 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest:sha-6acaccf
+      image: ghcr.io/davidcozens/cpputest:sha-18f19e1
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -4,8 +4,8 @@
 
 | Image | Tag | Used by |
 |---|---|---|
-| `ghcr.io/davidcozens/cpputest` | `sha-e7aa8a1` | devcontainer (`gcc` service), all CI jobs except clang |
-| `ghcr.io/davidcozens/cpputest-clang` | `sha-6ea3f95` | `clang` compose service, `clang-build-and-test` CI job |
+| `ghcr.io/davidcozens/cpputest` | `sha-18f19e1` | devcontainer (`gcc` service), all CI jobs except clang |
+| `ghcr.io/davidcozens/cpputest-clang` | `sha-0385cea` | `clang` compose service, `clang-build-and-test` CI job |
 | `balabit/syslog-ng` | `latest` | `syslog-ng` service — BDD test oracle |
 | `ghcr.io/davidcozens/behave` | `sha-b871b1c` | `behave` service — Debian trixie + Python 3.12 + Behave for BDD scenarios |
 


### PR DESCRIPTION
## Purpose

Prerequisite for [E3 TLS transport](https://github.com/DavidCozens/solid-syslog/issues/5) (first story: [S3.7](https://github.com/DavidCozens/solid-syslog/issues/165)). The new \`SolidSyslogPosixTlsStream\` component will link against libssl/libcrypto, so both compiler containers now ship \`libssl-dev\` (headers + linker symlinks).

## Change Description

- \`cpputest\`: \`sha-6acaccf\` → \`sha-18f19e1\` (brings in libssl-dev via [CppUTestDocker#1](https://github.com/DavidCozens/CppUTestDocker/pull/1))
- \`cpputest-clang\`: \`sha-6ea3f95\` → \`sha-0385cea\` (brings in libssl-dev via [CppUTestDockerClang#1](https://github.com/DavidCozens/CppUTestDockerClang/pull/1))

Also corrects drift in [\`docs/containers.md\`](docs/containers.md) — it had \`sha-e7aa8a1\` listed for \`cpputest\` while [\`.devcontainer/docker-compose.yml\`](.devcontainer/docker-compose.yml) and [\`.github/workflows/ci.yml\`](.github/workflows/ci.yml) actually used \`sha-6acaccf\`.

No Windows / BDD-Windows / Behave container references changed — only the Linux compiler-container jobs (\`build-and-test\`, \`clang-build-and-test\`, \`sanitize\`, \`coverage\`, \`tidy\`, \`format\`, \`cppcheck\`) and the two devcontainer compose services.

## Test Evidence

After recreating the \`gcc\` and \`clang\` compose services on the new images, the full local preset gauntlet is green:

- [x] Verified OpenSSL dev files present in both new images (\`libssl-dev 3.0.19-1~deb12u2\`, \`/usr/include/openssl/ssl.h\`, \`/usr/lib/x86_64-linux-gnu/libssl.so\`)
- [x] \`debug\` — 582 tests passed
- [x] \`clang-debug\` — 582 tests passed
- [x] \`sanitize\` (ASan + UBSan) — 582 tests passed
- [x] \`coverage\` — 99.9% overall (1108/1109 lines), 100% functions
- [x] \`tidy\` (clang-tidy, all warnings-as-errors) — clean
- [x] \`cppcheck\` — clean
- [x] \`format\` (clang-format dry-run with \`-Werror\`) — clean
- [x] \`bdd\` (behave + syslog-ng) — 15 features / 32 scenarios / 168 steps passed

## Areas Affected

- Devcontainer — \`gcc\` and \`clang\` services. A \"Dev Containers: Rebuild Container\" is required locally on merge.
- CI — all seven Linux container jobs run against the new images.
- \`docs/containers.md\` — image-tag table brought back in sync.
- No runtime behaviour change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images for development and continuous integration environments to newer pinned versions.

* **Documentation**
  * Updated container image references in documentation to reflect the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->