### PR TITLE
chore: bump container image to sha-3faff14

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         wait
 
   behave:
-    image: ghcr.io/davidcozens/behave:sha-b871b1c
+    image: ghcr.io/davidcozens/behave:sha-3faff14
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - ../Bdd/output:/workspaces/SolidSyslog/Bdd/output

--- a/ci/docker-compose.bdd.yml
+++ b/ci/docker-compose.bdd.yml
@@ -25,7 +25,7 @@ services:
       retries: 10
 
   behave:
-    image: ghcr.io/davidcozens/behave:sha-b871b1c
+    image: ghcr.io/davidcozens/behave:sha-3faff14
     user: "0"
     volumes:
       - ..:/workspaces/SolidSyslog

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -7,7 +7,7 @@
 | `ghcr.io/davidcozens/cpputest` | `sha-18f19e1` | devcontainer (`gcc` service), all CI jobs except clang |
 | `ghcr.io/davidcozens/cpputest-clang` | `sha-0385cea` | `clang` compose service, `clang-build-and-test` CI job |
 | `balabit/syslog-ng` | `latest` | `syslog-ng` service — BDD test oracle |
-| `ghcr.io/davidcozens/behave` | `sha-b871b1c` | `behave` service — Debian trixie + Python 3.12 + Behave for BDD scenarios |
+| `ghcr.io/davidcozens/behave` | `sha-3faff14` | `behave` service — Debian trixie + Python 3.12 + Behave for BDD scenarios |
 
 ## Docker Compose setup
 


### PR DESCRIPTION
## Purpose

Pins the \`behave\` image to [BehaveDocker#1](https://github.com/DavidCozens/BehaveDocker/pull/1), which explicitly declares \`libssl3t64\` as a runtime dependency. No functional change today — libssl3t64 was already pulled in transitively via \`debian:trixie-slim\`. This bump removes the ambiguity so [E3 (TLS transport)](https://github.com/DavidCozens/solid-syslog/issues/5) — which links the example binary against OpenSSL — doesn't depend on the transitive graph holding stable.

## Change Description

- \`behave\`: \`sha-b871b1c\` → \`sha-3faff14\` in [\`.devcontainer/docker-compose.yml\`](.devcontainer/docker-compose.yml), [\`ci/docker-compose.bdd.yml\`](ci/docker-compose.bdd.yml), and [\`docs/containers.md\`](docs/containers.md)

Companion to the recent [PR #167](https://github.com/DavidCozens/solid-syslog/pull/167) that bumped the compiler containers for \`libssl-dev\`. Development deps there, runtime here.

## Test Evidence

- [x] New image pulled and verified: \`dpkg -l libssl3t64\` shows \`3.5.5-1~deb13u2\`, \`behave 1.3.3\` intact
- [x] Full BDD suite green against the new image (15 features / 32 scenarios / 168 steps)

## Areas Affected

- BDD CI job (\`bdd\` on ubuntu-latest) and the local BDD compose
- Devcontainer \`behave\` service — a "Dev Containers: Rebuild Container" is required locally on merge if that service gets started
- No production code, no Windows jobs, no non-BDD Linux jobs touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)