### PR TITLE
chore: close last coverage gap in FileStore (oversized security policy fallback)

### DIFF
--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -542,6 +542,27 @@ TEST(SolidSyslogFileStoreConfig, NullSecurityPolicyDefaultsToNoOp)
     VerifyWriteAndReadBack();
 }
 
+TEST(SolidSyslogFileStoreConfig, OversizedSecurityPolicyLeavesNoIntegrityGap)
+{
+    struct SolidSyslogSecurityPolicy oversizedPolicy = {
+        SOLIDSYSLOG_MAX_INTEGRITY_SIZE + 1,
+        nullptr,
+        nullptr,
+    };
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.securityPolicy                    = &oversizedPolicy;
+    store                                    = SolidSyslogFileStore_Create(&config);
+
+    const char   body[]  = "HELLO WORLD";
+    const size_t bodyLen = sizeof(body) - 1;
+    CHECK_TRUE(SolidSyslogStore_Write(store, body, bodyLen));
+
+    const size_t RECORD_HEADER = 4;
+    const size_t SENT_FLAG     = 1;
+    LONGS_EQUAL(RECORD_HEADER + bodyLen + SENT_FLAG, FileFake_FileSize());
+    MEMCMP_EQUAL(body, static_cast<const uint8_t*>(FileFake_FileContent()) + RECORD_HEADER, bodyLen);
+}
+
 /* ------------------------------------------------------------------
  * Error paths
  * ----------------------------------------------------------------*/


### PR DESCRIPTION
## Purpose

Restore the 100% line-coverage target. `SolidSyslogFileStore.c:322` — the defensive fallback that substitutes `SolidSyslogNullSecurityPolicy` when a caller-supplied `SecurityPolicy` requests more integrity bytes than the library's fixed record-format slot (`SOLIDSYSLOG_MAX_INTEGRITY_SIZE` = 32) — was the single uncovered line (99.9 → 100.0%). Covering it via a behavioural test rather than a spy-observation.

No ticket — standing coverage maintenance.

## Change Description

Adds one new test to the existing `SolidSyslogFileStoreConfig` group, mirroring the adjacent `NullSecurityPolicyDefaultsToNoOp` test:

- Supplies a `SolidSyslogSecurityPolicy` with `integritySize = SOLIDSYSLOG_MAX_INTEGRITY_SIZE + 1` and `nullptr` for both vtable functions — the null pointers are deliberate; they make the "fallback didn't run" case a crash rather than a subtle pass.
- Writes `"HELLO WORLD"` through `SolidSyslogStore_Write`.
- Asserts the on-disk record equals exactly `[magic:2][length:2][body:11][sent_flag:1]` = 16 bytes, with the body sitting plain-text immediately after the 4-byte header (via `FileFake_FileContent`/`FileFake_FileSize`, same helpers as `FileFakeTest`).

If the fallback at line 322 ever regresses:
- file size would be 49 (record + 33-byte integrity slot) instead of 16, or
- the `nullptr` ComputeIntegrity gets invoked during Write and the test segfaults.

Either is a loud failure — verified by commenting out the fallback and re-running the suite:

```
bash: line 2: 28667 Segmentation fault  (core dumped) ./build/debug/Tests/SolidSyslogTests -sg SolidSyslogFileStoreConfig
exit status: 139
```

Restoring the line, the test passes and coverage returns to 100.0% (1182/1182 lines, 272/272 functions).

The fallback itself is the null-object pattern used throughout the library: defensive substitution to keep the store working when the caller asks for something the library can't honour. When E12 (#31) lands it will add a `SolidSyslogError` call alongside, but the silent fallback must remain the safe default.

## Test Evidence

- New test: `TEST(SolidSyslogFileStoreConfig, OversizedSecurityPolicyLeavesNoIntegrityGap)` in [Tests/SolidSyslogFileStoreTest.cpp](Tests/SolidSyslogFileStoreTest.cpp).
- Red/green cycle demonstrated locally (see above).
- All local presets green post-change: `debug`, `sanitize`, `coverage` (100.0%), `tidy`, `cppcheck`, `format`.

## Areas Affected

- `Tests/SolidSyslogFileStoreTest.cpp` only. No production code touched.
- No API changes, no new exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)