### PR TITLE
chore: correct SOLIDSYSLOG_TCP_DEFAULT_PORT to 601 per RFC 6587 / IANA

### DIFF
--- a/Example/Common/ExampleTcpConfig.c
+++ b/Example/Common/ExampleTcpConfig.c
@@ -3,7 +3,8 @@
 
 #include <stdint.h>
 
-/* Unprivileged mirror of SOLIDSYSLOG_TCP_DEFAULT_PORT (514, see SolidSyslogPosixTcpStream.h) for BDD containers */
+/* Unprivileged port used by the BDD syslog-ng container — library default is
+   SOLIDSYSLOG_TCP_DEFAULT_PORT (601, RFC 6587 §3.2 / IANA) which requires root. */
 enum
 {
     EXAMPLE_TCP_PORT = 5514

--- a/Platform/Posix/Interface/SolidSyslogPosixTcpStream.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixTcpStream.h
@@ -7,7 +7,7 @@ EXTERN_C_BEGIN
 
     enum
     {
-        SOLIDSYSLOG_TCP_DEFAULT_PORT = 514 /* RFC 6587 convention — same as UDP; no IANA assignment for plain TCP syslog */
+        SOLIDSYSLOG_TCP_DEFAULT_PORT = 601 /* RFC 6587 §3.2 / IANA assignment for syslog over TCP */
     };
 
     struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void);

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -240,3 +240,8 @@ TEST(SolidSyslogPosixTcpStream, DestroyClosesWithSocketFd)
     SolidSyslogPosixTcpStream_Destroy();
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
+
+TEST(SolidSyslogPosixTcpStream, DefaultPortMatchesRfc6587)
+{
+    LONGS_EQUAL(601, SOLIDSYSLOG_TCP_DEFAULT_PORT);
+}

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -47,8 +47,8 @@ Status key:
 
 | Section | Requirement | Status | Notes |
 |---|---|---|---|
-| 3.2 | Sender initiates TCP connection | Supported | `SolidSyslogStreamSender` connects lazily on first send (S3.4) |
-| 3.2 | Default port 601 | Partial | `SOLIDSYSLOG_TCP_DEFAULT_PORT` defined but defaults to 514. Should be 601 per IANA |
+| 3.2 | Sender initiates TCP connection | Supported | `SolidSyslogStreamSender` connects lazily on first send (S03.04) |
+| 3.2 | Default port 601 | Supported | `SOLIDSYSLOG_TCP_DEFAULT_PORT = 601` per IANA assignment |
 | 3.4.1 | Octet counting framing | Supported | `MSG-LEN SP MSG` prefix on every send |
 | 3.4.2 | Non-transparent framing (LF trailer) | Not supported | Octet counting is the recommended method |
 | 3.5 | Session closure handling | Supported | On send failure the stream is closed; the next Send transparently reconnects (S3.4) |


### PR DESCRIPTION
## Purpose

`SOLIDSYSLOG_TCP_DEFAULT_PORT` has been `514` (the historical UDP convention) with a comment claiming "no IANA assignment for plain TCP syslog". Both the value and the comment are wrong — RFC 6587 §3.2 pins the IANA-assigned port for syslog-over-TCP at **601**. `docs/rfc-compliance.md:51` already flagged this row as `Partial` with a pointer to the gap.

Flagged by CodeRabbit on PR #166 (the S03.06 rename) and deferred from that PR to keep it a pure refactor.

No ticket — straight chore.

## Change Description

- `Platform/Posix/Interface/SolidSyslogPosixTcpStream.h`: `SOLIDSYSLOG_TCP_DEFAULT_PORT = 514` → `601`. Misleading comment replaced with `RFC 6587 §3.2 / IANA assignment for syslog over TCP`.
- `Example/Common/ExampleTcpConfig.c`: comment updated — the example uses 5514 as an unprivileged port for BDD-container testing, which is no longer a "mirror" of the library default (it was when both were 514).
- `docs/rfc-compliance.md`: row `Default port 601` flipped from `Partial` to `Supported`; the "should be 601 per IANA" note removed.
- New pinning test `DefaultPortMatchesRfc6587` in `Tests/SolidSyslogPosixTcpStreamTest.cpp` catches future regressions.

No production behaviour changes beyond the default value — callers that pass an explicit port are unaffected.

## Test Evidence

**Red-first** demonstrated locally before the fix:

```
/workspaces/SolidSyslog/Tests/SolidSyslogPosixTcpStreamTest.cpp:246: error:
  Failure in TEST(SolidSyslogPosixTcpStream, DefaultPortMatchesRfc6587)
  expected <601 (0x259)>
Errors (1 failures, 727 tests, 29 ran, 33 checks, 0 ignored, 698 filtered out, 0 ms)
```

After flipping the enum:

```
OK (727 tests, 29 ran, 33 checks, 0 ignored, 698 filtered out, 0 ms)
```

All local gates green post-change: `debug`, `sanitize`, `coverage` (**100.0%** — 1182/1182 lines, 272/272 functions), `tidy`, `cppcheck`, `format`.

No runtime dependency on `514` as the TCP default existed: the several `TEST_PORT = 514` literals in unrelated socket tests (UDP / Datagram / Stream) pick an arbitrary port and do not read the library default.

## Areas Affected

- Library: `Platform/Posix/Interface/SolidSyslogPosixTcpStream.h`.
- Example code: `Example/Common/ExampleTcpConfig.c` (comment only).
- Tests: new test in `Tests/SolidSyslogPosixTcpStreamTest.cpp`.
- Docs: `docs/rfc-compliance.md` RFC 6587 row.

No API break — the constant keeps the same name and type, only its value changes. Callers currently relying on port 514 via the symbol will need to reconsider whether they want the standards default or an explicit 514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)