### PR TITLE
chore: assert FailNext* tests prove the first call actually fails

### DIFF
--- a/Tests/FileFakeTest.cpp
+++ b/Tests/FileFakeTest.cpp
@@ -116,7 +116,7 @@ TEST(FileFake, FailNextOpenMakesOpenReturnFalse)
 TEST(FileFake, FailNextOpenOnlyAffectsOneCall)
 {
     FileFake_FailNextOpen();
-    SolidSyslogFile_Open(api, "test.dat");
+    CHECK_FALSE(SolidSyslogFile_Open(api, "test.dat"));
     CHECK_TRUE(SolidSyslogFile_Open(api, "test.dat"));
 }
 
@@ -131,7 +131,7 @@ TEST(FileFake, FailNextWriteOnlyAffectsOneCall)
 {
     SolidSyslogFile_Open(api, "test.dat");
     FileFake_FailNextWrite();
-    SolidSyslogFile_Write(api, "hello", 5);
+    CHECK_FALSE(SolidSyslogFile_Write(api, "hello", 5));
     CHECK_TRUE(SolidSyslogFile_Write(api, "world", 5));
 }
 
@@ -154,7 +154,7 @@ TEST(FileFake, FailNextReadOnlyAffectsOneCall)
     FileFake_FailNextRead();
 
     char buf[16] = {};
-    SolidSyslogFile_Read(api, buf, 5);
+    CHECK_FALSE(SolidSyslogFile_Read(api, buf, 5));
     SolidSyslogFile_SeekTo(api, 0);
     CHECK_TRUE(SolidSyslogFile_Read(api, buf, 5));
 }

--- a/Tests/SenderFakeTest.cpp
+++ b/Tests/SenderFakeTest.cpp
@@ -119,7 +119,7 @@ TEST(SenderFake, FailNextSendStillCapturesBuffer)
 TEST(SenderFake, FailNextSendOnlyAffectsOneSend)
 {
     SenderFake_FailNextSend(sender);
-    SolidSyslogSender_Send(sender, "a", 1);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, "a", 1));
     CHECK_TRUE(SolidSyslogSender_Send(sender, "b", 1));
 }
 


### PR DESCRIPTION
## Purpose

Four tests named `…OnlyAffectsOneCall` / `…OnlyAffectsOneSend` were over-claiming their promise: they invoked the failure-injected call but only asserted on the follow-up *recovery* call, not on the injected failure itself. If a fake silently stopped honouring `FailNext*`, these tests would still pass — the name says "only affects one call" but nothing pinned that it affected *any* call.

Flagged by CodeRabbit on PR #103 (S05.05 review), deferred at the time because it was outside that story's scope. Picked up now as a low-effort assertion-hygiene chore.

No ticket — standing review-debt tidy.

## Change Description

Adds a `CHECK_FALSE` on the first (injected) call in each of:

- `Tests/FileFakeTest.cpp` — `FailNextOpenOnlyAffectsOneCall`, `FailNextWriteOnlyAffectsOneCall`, `FailNextReadOnlyAffectsOneCall`.
- `Tests/SenderFakeTest.cpp` — `FailNextSendOnlyAffectsOneSend`.

Example diff:

```diff
 TEST(FileFake, FailNextOpenOnlyAffectsOneCall)
 {
     FileFake_FailNextOpen();
-    SolidSyslogFile_Open(api, "test.dat");
+    CHECK_FALSE(SolidSyslogFile_Open(api, "test.dat"));
     CHECK_TRUE(SolidSyslogFile_Open(api, "test.dat"));
 }
```

Straight assertion addition — no production change. The fakes already behave correctly (`FailNext*MakesXReturnFalse` tests cover the single-call failure, so a regression would have surfaced there); this PR just brings the follow-up tests in line with what their names already claim.

## Test Evidence

No new tests; existing tests now assert more.

All local gates green: `debug`, `sanitize`, `coverage` (**100.0%** — 1182/1182 lines, 272/272 functions), `tidy`, `cppcheck`, `format`.

Audit also checked `StoreFake`: its `FailNextWrite` / `FailNextRead` tests at [Tests/StoreFakeTest.cpp:72–89](Tests/StoreFakeTest.cpp#L72) are already written with `CHECK_FALSE` on the injected call, so no changes needed there. Pattern is now consistent across all fakes.

## Areas Affected

- `Tests/FileFakeTest.cpp` — 3 tests strengthened.
- `Tests/SenderFakeTest.cpp` — 1 test strengthened.
- No production code, no API, no documentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)