### PR TITLE
docs: retire S03.10 — cert rotation covered by Open-rebuilds-CTX

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,34 @@
 # Dev Log
 
+## 2026-04-22 — S03.10 retired (cert rotation covered by reconnect)
+
+### Decisions
+- Closed S03.10 (cert rotation via version-fingerprint callback) as not
+  planned. `SolidSyslogTlsStream` rebuilds `SSL_CTX` on every `Open` and
+  re-reads cert material from disk, so replacing `client.pem` / `client.key`
+  (or `caBundlePath`) and waiting for reconnect — or calling
+  `SolidSyslogSender_Disconnect` — picks up new material without any
+  callback plumbing.
+- Maps cleanly onto IEC 62443-4-2 **CR 1.5 c** (authenticator
+  change/refresh) and **CR 1.8 c** (PKI update) — both are *capability*
+  requirements, satisfied by file-replacement-on-reconnect. A
+  version-fingerprint callback would only add value for forced
+  mid-connection rotation; no deployment has surfaced that need.
+- `docs/iec62443.md` updated: rotation is now a first-class bullet in the
+  TLS hardening section (with explicit CR 1.5 / CR 1.8 attribution),
+  and the "Remaining E03 work" paragraph no longer lists S03.10 — only
+  S03.11 (Planned → Available promotion) remains.
+- Epic #5 story table updated: S03.10 row marked Retired with the same
+  rationale. Removed stale "cert-version callback" mention from the
+  Example architecture-boundary bullet.
+
+### Deferred
+- None. If a concrete deployment later needs forced mid-connection
+  rotation, reopen a fresh story designed to that requirement.
+
+### Open questions
+- None.
+
 ## 2026-04-22 — S03.09 mutual TLS (SL4 CR 2.12)
 
 ### Decisions

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -177,16 +177,21 @@ depend on the client:
   with `SSL_CTX_check_private_key` confirming the pairing locally before any
   bytes hit the wire. Both fields are opt-in and all-or-nothing: supply both
   to enable mTLS, leave both NULL for server-auth TLS. Supplying only one is
-  rejected at Open time — no silent downgrade. The `SSL_CTX` is rebuilt on
-  every Open, so cert rotation happens automatically on reconnect — new
-  material on disk is picked up the next time the sender re-establishes.
+  rejected at Open time — no silent downgrade.
+- **Certificate rotation (CR 1.5 authenticator refresh, CR 1.8 PKI update).**
+  `SolidSyslogTlsStream` rebuilds the `SSL_CTX` on every `Open`, re-reading the
+  cert material from `caBundlePath` / `clientCertChainPath` / `clientKeyPath`
+  from disk each time. Rotation is therefore a deployment operation: replace
+  the files on disk, and the new material takes effect on the next reconnect
+  — via natural churn (retry, outage recovery) or by calling
+  `SolidSyslogSender_Disconnect` to force one. No library-level callback or
+  version-fingerprint API is needed to satisfy the capability requirement.
 - **Resource lifecycle.** `Close`/`Destroy` release `SSL_CTX`, `SSL`, and
   `BIO_METHOD` idempotently — no leaks on partial Open failure, no double
   frees if both are called.
 
-Remaining E03 work for a full SL4 TLS posture: explicit cert-rotation story
-([S03.10](https://github.com/DavidCozens/solid-syslog/issues/174)) and the
-formal doc promotion from Planned to Available
+Remaining E03 work for a full SL4 TLS posture: formal doc promotion from
+Planned to Available
 ([S03.11](https://github.com/DavidCozens/solid-syslog/issues/175)).
 
 ## Architecture for Security


### PR DESCRIPTION
## Purpose

Retires S03.10 (cert rotation via version-fingerprint callback) as not needed. Closes #174 (already closed as not planned; this PR captures the docs side of the decision).

## Change Description

`SolidSyslogTlsStream` rebuilds `SSL_CTX` on every `Open`, re-reading `caBundlePath` / `clientCertChainPath` / `clientKeyPath` from disk each time. Replacing the files and waiting for reconnect — via natural churn or `SolidSyslogSender_Disconnect` — picks up the new material without any callback API.

That maps cleanly onto IEC 62443-4-2 **CR 1.5 c** (authenticator change/refresh) and **CR 1.8 c** (PKI update). Both are capability requirements, satisfied by file-replacement-on-reconnect. A version-fingerprint callback would only add value for forced mid-connection rotation; no deployment has surfaced that need. If one does, a fresh story can be designed to that concrete requirement.

- `docs/iec62443.md` — rotation is now a first-class TLS hardening bullet with explicit CR 1.5 / CR 1.8 attribution. "Remaining E03 work" paragraph drops S03.10, leaving only S03.11 (Planned → Available promotion).
- `DEVLOG.md` — new session entry capturing the decision and the rationale.
- Epic #5 story table updated outside this PR (issue body edits only); stale "cert-version callback" mention in the Example architecture-boundary bullet also removed.

## Test Evidence

Docs-only change; no production or test code touched. CI runs as a sanity check on the build.

## Areas Affected

- `docs/iec62443.md` — SL4 TLS hardening section, Remaining work paragraph.
- `DEVLOG.md` — new session entry.

No code or interface changes. No impact on derived projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified certificate rotation behavior in TLS hardening documentation, specifying how certificate material is re-read from disk and when rotation takes effect on reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->