### PR TITLE
docs: S03.11 promote TLS to Available and sweep markdown drift

### DIFF
--- a/Bdd/syslog-ng/tls/README.md
+++ b/Bdd/syslog-ng/tls/README.md
@@ -1,16 +1,19 @@
 # BDD TLS test material
 
 **TEST ONLY.** These keys and certificates exist solely to drive the BDD TLS
-scenarios (`Bdd/features/tls_transport.feature` et al.) against syslog-ng
-running in a BDD compose container. They must never be used for any purpose
-that touches real data.
+and mTLS scenarios (`Bdd/features/tls_transport.feature`,
+`Bdd/features/mtls_transport.feature`) against syslog-ng running in a BDD
+compose container. They must never be used for any purpose that touches real
+data.
 
 | File | Role |
 |---|---|
-| `ca.key` | Test CA private key. Signs the server cert. |
-| `ca.pem` | Test CA certificate. Bundled into the example binary via `--tls-ca`. |
+| `ca.key` | Test CA private key. Signs the server and client certs. |
+| `ca.pem` | Test CA certificate. Trust anchor for both the example binary (verifies the server) and syslog-ng (verifies the client in mTLS mode). |
 | `server.key` | syslog-ng server private key. |
 | `server.pem` | syslog-ng server certificate, signed by the test CA. SANs: `syslog-ng`, `localhost`, `127.0.0.1`. |
+| `client.key` | Client (SolidSyslog-under-test) private key for mTLS. |
+| `client.pem` | Client certificate for mTLS, signed by the test CA. CN: `solidsyslog-bdd-client`. |
 
 Validity is 10 years from generation, so these effectively never expire for
 test purposes.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,50 @@
 # Dev Log
 
+## 2026-04-22 — S03.11 TLS promoted to Available + docs sanity pass
+
+### Decisions
+- Promoted TLS from Planned to Available in `docs/iec62443.md`: new
+  `SolidSyslogTlsStream` row in the SL4 components table, present-tense
+  bullets for what SL4 now adds, and a "Still to come" block carrying the
+  remaining E17 (integrity + encryption at rest) and S12.x (string hygiene)
+  items. Dropped the "Remaining E03 work" paragraph — there's no
+  compliance-relevant E03 work left; S03.12 / S03.13 are architectural.
+- Added CR 1.5 (Authenticator management) and CR 1.8 (PKI certificates) to
+  the Relevant Requirements table at SL4 and wired both into the
+  traceability matrix. Both are honestly claimed: library covers the bits
+  it can (load / refresh / authenticity / integrity), and the notes call
+  out the integrator-owned pieces (at-rest key protection is filesystem /
+  HSM; revocation is deferred to the OS trust store per the S03.08 ADR;
+  enrolment is the caller's PKI process). Better to state the gaps than
+  to overclaim.
+- README Status section rewritten: "Approaching feature-complete for POSIX
+  and Windows"; not production-ready; explicit known-gaps list covering
+  API churn, at-rest cryptography, CRL/OCSP, PRINTUSASCII / UTF-8 hygiene,
+  and error-guard rollout. Keeps the "not production-ready" signal but
+  stops undersellling where the library actually is.
+- Sanity-checked the other repo markdown and fixed the drift that was
+  visible: `docs/rfc-compliance.md` RFC 5425 section (all rows were
+  Planned — now 6 Supported + 1 Partial for the absent
+  `SOLIDSYSLOG_TLS_DEFAULT_PORT` constant); `docs/bdd.md` architecture
+  diagram + syslog-ng source list + `@tls` / `@mtls` feature tags;
+  `Bdd/syslog-ng/tls/README.md` now lists `client.key` / `client.pem` and
+  mentions `mtls_transport.feature`; `docs/ci.md` gains
+  `openssl-integration` and `bdd-windows` rows; `SKILL.md` lists RFC 6587
+  and notes the epic-number range has grown beyond the original #2–#12.
+- Epic #5 story table synced: S03.06 / S03.07 / S03.08 / S03.09 marked Done
+  with PR links.
+
+### Deferred
+- `SOLIDSYSLOG_TLS_DEFAULT_PORT = 6514` constant — would promote the RFC
+  5425 §4.2 row from Partial to Supported. Small, mechanical, not urgent.
+- `docs/template-updates.md` claims `docs/` is template-owned. That
+  conflicts with the reality that `docs/iec62443.md` /
+  `docs/rfc-compliance.md` are clearly project-specific. Worth tightening
+  the template-ownership list on a later pass.
+
+### Open questions
+- None.
+
 ## 2026-04-22 — S03.10 retired (cert rotation covered by reconnect)
 
 ### Decisions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,25 @@ Designed for resource-constrained environments:
 
 ## Status
 
-Early development. Walking skeleton in place. Not yet suitable for production use.
+Approaching feature-complete for POSIX and Windows: RFC 5424 structured
+formatting, UDP / TCP / TLS / mTLS transport, asynchronous buffering, rotating
+file store-and-forward with CRC-16 integrity, and the full
+[IEC 62443 SL1–SL4 component set](docs/iec62443.md).
+
+**Not yet production-ready**, and no API stability guarantee yet. Known gaps:
+
+- Public API may evolve — multi-instance senders / streams
+  ([#169](https://github.com/DavidCozens/solid-syslog/issues/169)) and
+  additional platform backends (RTOS, custom) are still to land.
+- At-rest integrity is CRC-16 only; HMAC + AES-at-rest are planned for SL4
+  ([E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105)).
+- TLS revocation (CRL / OCSP) is deferred to the OS trust store; the library
+  itself does not perform revocation checks.
+- PRINTUSASCII header validation and UTF-8-safe body truncation not yet
+  enforced ([#120](https://github.com/DavidCozens/solid-syslog/issues/120),
+  [#121](https://github.com/DavidCozens/solid-syslog/issues/121)).
+- Comprehensive error guards still rolling out
+  ([E12 #31](https://github.com/DavidCozens/solid-syslog/issues/31)).
 
 ## Building and testing
 
@@ -34,9 +52,12 @@ Public headers are split by audience (Interface Segregation Principle):
 - **`SolidSyslogNullBuffer.h`** — direct-send buffer for single-task systems
 - **`SolidSyslogPosixMessageQueueBuffer.h`** — thread-safe POSIX message queue buffer
 - **`SolidSyslogUdpSender.h`** — UDP transport (RFC 5426)
-- **`SolidSyslogStreamSender.h`** — octet-framed syslog (RFC 6587) over any Stream (TCP today, TLS in future). Note: RFC 6587
+- **`SolidSyslogStreamSender.h`** — octet-framed syslog (RFC 6587) over any Stream. Note: RFC 6587
   is a Historic RFC — the IESG recommends TLS (RFC 5425) over plain TCP for new deployments.
   TCP is provided for interoperability with existing infrastructure
+- **`SolidSyslogTlsStream.h`** — OpenSSL-backed TLS 1.2+ Stream (RFC 5425): server cert validation,
+  hostname verification, cipher pinning, optional mutual TLS. Plugs into `SolidSyslogStreamSender`
+  as a drop-in for `SolidSyslogPosixTcpStream`
 - **`SolidSyslogSwitchingSender.h`** — composition sender delegating to one of several
   inner senders via an application-supplied selector callback; `Disconnect`s the
   outgoing inner on every change
@@ -54,7 +75,7 @@ Public headers are split by audience (Interface Segregation Principle):
 
 Two example programs demonstrate usage:
 - **`Example/SingleTask/`** — NullBuffer, single-task bare-metal model
-- **`Example/Threaded/`** — PosixMessageQueueBuffer, two pthreads (logger + service), SwitchingSender over UDP + TCP; `--transport` sets the initial transport, `switch <name>` flips it at runtime
+- **`Example/Threaded/`** — PosixMessageQueueBuffer, two pthreads (logger + service), SwitchingSender over UDP + TCP + TLS + mTLS (TLS build required for the last two); `--transport` sets the initial transport, `switch <name>` flips it at runtime
 
 ## Compliance
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,9 +2,9 @@
 
 ## What this project is
 
-SolidSyslog is a C syslog client library implementing RFC 5424/5426/5425 for embedded
-and industrial systems. It is developed under the "Crafted with AI" blog series by
-Cozens Software Solutions Limited.
+SolidSyslog is a C syslog client library implementing RFC 5424/5426/6587/5425 for
+embedded and industrial systems. It is developed under the "Crafted with AI" blog
+series by Cozens Software Solutions Limited.
 
 ## Collaboration architecture
 
@@ -91,7 +91,8 @@ Test progression follows ZOMBIES order.
 
 ## Key references
 
-- Epics tracked as GitHub Issues #2–#12, Project board "SolidSyslog" (project #1)
+- Epics tracked as GitHub Issues, Project board "SolidSyslog" (project #1); active and future epics are labelled `epic` and numbered beyond the original #2–#12 range (e.g. E12 #31, E14 #64, E17 #105, E18 #112)
 - RFC 5424 — structured syslog message format
 - RFC 5426 — syslog over UDP
+- RFC 6587 — syslog over TCP (octet counting)
 - RFC 5425 — syslog over TLS

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -24,7 +24,8 @@ fail here.
                               │   binary     ││
                               └──────┬───────┘│
                                      │        │
-                                UDP 5514      │
+                            UDP 5514 / TCP 5514│
+                            TLS 6514 / mTLS 6515
                                      │        │
                                      ▼        │
                               ┌──────────────┐│
@@ -33,14 +34,14 @@ fail here.
                               └──────┬───────┘│
                                      │ writes │
                                      ▼        ▼
-                              Bdd/output/received.log
+                              Bdd/output/received*.log
 ```
 
 Two Docker Compose services collaborate:
 
 | Service | Role |
 |---|---|
-| `syslog-ng` | Receives UDP syslog on port 5514, parses RFC 5424, writes parsed fields to a log file |
+| `syslog-ng` | Receives syslog on UDP / TCP 5514, TLS 6514, and mTLS 6515; parses RFC 5424; writes parsed fields to per-transport log files |
 | `behave` | Runs Gherkin scenarios that invoke the example binary and assert on the parsed output |
 
 The example binary is built in the `gcc` container but executed by Behave via `subprocess.run`.
@@ -60,9 +61,11 @@ syslog-ng (writer) and Behave (reader) without any network file transfer.
 
 ## syslog-ng configuration
 
-The syslog-ng config (`Bdd/syslog-ng/syslog-ng.conf`) uses the `syslog()` source driver,
-which understands RFC 5424 natively. It writes one line per received message using a key=value
-template:
+The syslog-ng config (`Bdd/syslog-ng/syslog-ng.conf`) declares four `syslog()` sources —
+UDP and TCP on 5514, server-auth TLS on 6514, and mutual TLS (`peer-verify(required-trusted)`)
+on 6515 — all parsing RFC 5424 natively. Every message is tee'd to both `received.log`
+(catch-all) and a per-transport log file (`received_udp.log`, `received_tcp.log`,
+`received_tls.log`, `received_mtls.log`) using a key=value template:
 
 ```
 PRIORITY=14 TIMESTAMP=2009-03-23T00:00:00+00:00 HOSTNAME=TestHost APP_NAME=TestApp PROCID=1234 MSGID=TestMsgId STRUCTURED_DATA= MSG=Test message
@@ -103,8 +106,9 @@ response = sock.recv(1024)  # b'OK Config reload successful\n.\n'
 sock.close()
 ```
 
-This will be needed when BDD scenarios require different syslog-ng source configurations —
-for example, switching from UDP to TLS transport in E3.
+This is exercised by scenarios that need a different syslog-ng source configuration — for
+example, the TLS and mTLS scenarios swap in tighter `peer-verify` settings and reload without
+restarting the container.
 
 ## Feature tags
 
@@ -117,6 +121,8 @@ etc.) without rewriting feature tags.
 | --- | --- |
 | `@udp` | Needs UDP transport |
 | `@tcp` | Needs TCP transport (RFC 6587 framing) |
+| `@tls` | Needs TLS transport (RFC 5425, server-auth) |
+| `@mtls` | Needs mutual TLS (client cert + key) |
 | `@buffered` | Drives the long-running threaded example (interactive process protocol — buffer + service thread; transitively covers store-and-forward, oracle reload, signal-kill scenarios) |
 
 Two rollout markers are also used (temporary; remove once the scenario passes):

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,7 +14,9 @@ GitHub Actions runs all jobs in parallel on every push and pull request to `main
 | `cppcheck` | `cppcheck` | cppcheck static analysis |
 | `format` | — | clang-format dry-run; fails if any file needs reformatting |
 | `windows-build-and-test` | `msvc-debug` | MSVC build on `windows-latest`; CppUTest via vcpkg; test results annotated on PR |
-| `bdd` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave) |
+| `openssl-integration` | `debug` | Runs the in-process TLS integration tests against libssl (no network oracle) |
+| `bdd` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave), Linux runner |
+| `bdd-windows` | — | Windows-eligible BDD scenarios driven against an OTel Collector oracle |
 
 ## Branch protection
 

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -21,6 +21,8 @@ from IEC 62443-3-3 and IEC 62443-4-2 are addressed by an audit logging library:
 
 | Requirement | Description | SL1 | SL2 | SL3 | SL4 |
 |---|---|---|---|---|---|
+| CR 1.5 | Authenticator management | — | — | — | Required |
+| CR 1.8 | Public key infrastructure certificates | — | — | — | Required |
 | CR 2.8 | Auditable events | Required | Required | Required | Required |
 | CR 2.9 | Audit storage capacity | — | Required | Required | Required |
 | CR 2.10 | Response to audit processing failures | — | — | Required | Required |
@@ -29,6 +31,10 @@ from IEC 62443-3-3 and IEC 62443-4-2 are addressed by an audit logging library:
 | CR 3.9 | Audit information protection | — | Required | Required | Required |
 | SR 6.1 | Audit log accessibility | Required | Required | Required | Required |
 | SR 6.2 | Continuous monitoring | — | Required | Required | Required |
+
+CR 1.5 and CR 1.8 are included because SL4 mutual TLS uses a client certificate
+as the device's authenticator to the SIEM. They are not relevant at SL1–SL3
+where server-auth TLS (or no TLS) is the chosen posture.
 
 ## Component Selection by Security Level
 
@@ -70,7 +76,7 @@ brief disruptions and events must be attributable to a specific source.
 | Component | Header | Purpose |
 |---|---|---|
 | *All SL1 components* | | |
-| `SolidSyslogStreamSender` | `SolidSyslogStreamSender.h` | Reliable octet-framed transport (RFC 6587) over a Stream (TCP today, TLS in future) |
+| `SolidSyslogStreamSender` | `SolidSyslogStreamSender.h` | Reliable octet-framed transport (RFC 6587) over a Stream — `SolidSyslogPosixTcpStream` at SL2, `SolidSyslogTlsStream` at SL4 |
 | `SolidSyslogPosixMessageQueueBuffer` | `SolidSyslogPosixMessageQueueBuffer.h` | Async buffering (thread-safe) |
 | `SolidSyslogPosixClock` | `SolidSyslogPosixClock.h` | System clock timestamps |
 | `SolidSyslogPosixHostname` | `SolidSyslogPosixHostname.h` | POSIX hostname identification |
@@ -131,30 +137,37 @@ non-repudiation and assured delivery.
 ### SL4 — High-Assurance Logging
 
 Requires cryptographic integrity, encryption, and assured delivery with
-non-repudiation. Currently partially supported — the architecture is designed
-for SL4 extension but some components are not yet implemented.
+non-repudiation. TLS transport has landed; remaining SL4 items are at-rest
+cryptography and RFC 5424 string-hygiene.
 
 | Component | Header | Purpose | Status |
 |---|---|---|---|
 | *All SL3 components* | | | Available |
-| TLS sender | — | Encrypted transport (RFC 5425) | Planned — [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
+| `SolidSyslogTlsStream` | `SolidSyslogTlsStream.h` | OpenSSL-backed TLS 1.2+ transport (RFC 5425): server cert validation, hostname verification, cipher pinning, optional mutual TLS, rotation on reconnect | Available |
 | Authenticated integrity policy | — | HMAC/AES-CMAC on stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | PRINTUSASCII validation | — | Header field character compliance | Planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
 | UTF-8 safe truncation | — | No split multi-byte sequences | Planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
 | Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
 
-**What SL4 will add over SL3:**
-- TLS transport — encrypted, authenticated delivery to SIEM (CR 3.9)
-- Cryptographic integrity — HMAC or AES-CMAC replaces CRC-16, making stored
-  record tampering detectable even by a local attacker (CR 2.12, CR 3.9)
-- Encryption at rest — stored records unreadable without key material (CR 3.9)
-- Full RFC 5424 character compliance — PRINTUSASCII validation on header fields,
-  UTF-8 safe truncation on message body
+**What SL4 adds over SL3:**
+- TLS transport — encrypted, authenticated delivery to SIEM via
+  `SolidSyslogTlsStream` plugged into `SolidSyslogStreamSender` (CR 3.9).
+- Mutual TLS — device-to-SIEM authentication via client cert + key, with
+  `SSL_CTX_check_private_key` confirming the pairing before any bytes hit the
+  wire (CR 1.5, CR 2.12).
+- Cert rotation — `SSL_CTX` rebuilt on every `Open`, so file replacement +
+  reconnect refreshes authenticators and trust anchors (CR 1.5, CR 1.8).
 
-**TLS hardening (SL4 substrate in place).** `SolidSyslogTlsStream` — the
-OpenSSL-backed client-side TLS substrate — ships with the SL4 controls that
-depend on the client:
+**Still to come at SL4:**
+- Cryptographic integrity at rest — HMAC or AES-CMAC replacing CRC-16, making
+  stored-record tampering detectable even by a local attacker (CR 2.12, CR 3.9).
+- Encryption at rest — stored records unreadable without key material (CR 3.9).
+- Full RFC 5424 character compliance — PRINTUSASCII validation on header
+  fields, UTF-8 safe truncation on message body.
+
+**SL4 TLS substrate.** `SolidSyslogTlsStream` — the OpenSSL-backed client-side
+TLS substrate — ships with the SL4 controls that depend on the client:
 
 - **Hostname verification.** `SolidSyslogTlsStreamConfig.serverName` is
   forwarded to both SNI (`SSL_set_tlsext_host_name`) and the cert check
@@ -189,10 +202,6 @@ depend on the client:
 - **Resource lifecycle.** `Close`/`Destroy` release `SSL_CTX`, `SSL`, and
   `BIO_METHOD` idempotently — no leaks on partial Open failure, no double
   frees if both are called.
-
-Remaining E03 work for a full SL4 TLS posture: formal doc promotion from
-Planned to Available
-([S03.11](https://github.com/DavidCozens/solid-syslog/issues/175)).
 
 ## Architecture for Security
 
@@ -258,11 +267,13 @@ the collector can alert on missing sequence numbers without polling the device.
 
 | IEC 62443 Requirement | SolidSyslog Component | Notes |
 |---|---|---|
+| CR 1.5 Authenticator management | `SolidSyslogTlsStream` — mTLS client cert + key loaded from caller-supplied paths; rotation via file replacement + reconnect | Library ships no default authenticators (vacuous (b)). (d) at-rest key protection — filesystem permissions / HSM — is the integrator's responsibility |
+| CR 1.8 PKI certificates | `SolidSyslogTlsStream` — libssl chain validation (`SSL_VERIFY_PEER`), hostname verification (`SSL_set1_host`), update via reconnect | Revocation (CRL / OCSP) deferred to OS trust store per S03.08 ADR; enrolment is the caller's PKI process |
 | CR 2.8 Auditable events | `SolidSyslog_Log`, RFC 5424 formatting | Application defines what to log |
 | CR 2.9 Audit storage capacity | `SolidSyslogFileStore` (SL3+) | Configurable max files and file size |
 | CR 2.10 Response to audit failures | `SolidSyslogStoreFullCallback`, halt policy | Callback on storage full, optional halt |
 | CR 2.11 Timestamps | `SolidSyslogClockFunction`, `SolidSyslogTimeQualitySd` | Injected clock with quality metadata |
-| CR 2.12 Non-repudiation | `SolidSyslogMetaSd` (sequenceId), `SolidSyslogCrc16Policy` | Sequence gaps detectable by SIEM |
-| CR 3.9 Audit information protection | `SolidSyslogCrc16Policy` (SL3), TLS + encryption (SL4) | SL4 TLS substrate hardened by [S03.08](https://github.com/DavidCozens/solid-syslog/issues/172) (hostname verify, TLS 1.2 floor, cipher pinning) and [S03.09](https://github.com/DavidCozens/solid-syslog/issues/173) (mutual TLS — client cert + key, satisfying CR 2.12 non-repudiation); remaining TLS work in [E03](https://github.com/DavidCozens/solid-syslog/issues/5); integrity/encryption at rest in [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
+| CR 2.12 Non-repudiation | `SolidSyslogMetaSd` (sequenceId), `SolidSyslogCrc16Policy`, `SolidSyslogTlsStream` mTLS | Sequence gaps detectable by SIEM; mTLS cryptographically identifies the sender |
+| CR 3.9 Audit information protection | `SolidSyslogCrc16Policy` (at rest, SL3), `SolidSyslogTlsStream` (in transit, SL4) | TLS substrate hardened by [S03.08](https://github.com/DavidCozens/solid-syslog/issues/172) and [S03.09](https://github.com/DavidCozens/solid-syslog/issues/173); cryptographic integrity and encryption at rest remain in [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | SR 6.1 Audit log accessibility | `SolidSyslog_Service`, sender vtable | Non-blocking Log, background Service |
 | SR 6.2 Continuous monitoring | TCP/TLS transport, store-and-forward | Assured delivery via replay on reconnect |

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -60,13 +60,13 @@ Status key:
 
 | Section | Requirement | Status | Notes |
 |---|---|---|---|
-| 4.1 | TLS over TCP | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
-| 4.2 | Default port 6514 | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
-| 5.1 | Server certificate validation | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
-| 5.2 | Mutual TLS (client certificate) | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
-| 5.3 | TLS 1.2+ cipher suites | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
-| 5.4 | Octet counting framing (mandatory for TLS) | Planned | Will reuse existing octet counting from TCP sender |
-| 5.5 | TLS close_notify handling | Planned | [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
+| 4.1 | TLS over TCP | Supported | `SolidSyslogTlsStream` wraps a TCP `Stream` (typically `SolidSyslogPosixTcpStream`) |
+| 4.2 | Default port 6514 | Partial | Caller-supplied via endpoint callback; no `SOLIDSYSLOG_TLS_DEFAULT_PORT` constant shipped. The Threaded example uses 6514 |
+| 5.1 | Server certificate validation | Supported | `SSL_VERIFY_PEER` + `SSL_CTX_load_verify_locations` + `SSL_set1_host` hostname check |
+| 5.2 | Mutual TLS (client certificate) | Supported | Optional `clientCertChainPath` / `clientKeyPath` on `SolidSyslogTlsStreamConfig`; `SSL_CTX_check_private_key` confirms pairing |
+| 5.3 | TLS 1.2+ cipher suites | Supported | `SSL_CTX_set_min_proto_version(TLS1_2_VERSION)` pinned; caller-supplied `cipherList` via `SSL_CTX_set_cipher_list` |
+| 5.4 | Octet counting framing (mandatory for TLS) | Supported | Reuses `SolidSyslogStreamSender` (RFC 6587 framing is identical) |
+| 5.5 | TLS close_notify handling | Supported | `SSL_shutdown` in `TlsStream_Close` |
 
 ## Summary
 
@@ -75,4 +75,4 @@ Status key:
 | RFC 5424 | 17 | 10 | 5 | 2 | 0 |
 | RFC 5426 | 6 | 3 | 1 | 0 | 2 |
 | RFC 6587 | 6 | 2 | 2 | 2 | 0 |
-| RFC 5425 | 7 | 0 | 0 | 7 | 0 |
+| RFC 5425 | 7 | 6 | 1 | 0 | 0 |


### PR DESCRIPTION
## Purpose

Closes #175. TLS transport is in on main after S03.06–S03.09; this PR brings the documentation in line. Also a sanity-check pass over the rest of the repo's markdown to fix the drift that accumulated during the E03 stories.

## Change Description

**`docs/iec62443.md` — TLS promotion + honest CR 1.5 / CR 1.8 claim.**
- SL4 components table: replace the "TLS sender — Planned — E3" row with `SolidSyslogTlsStream` marked Available, summarising the hardening (TLS 1.2+ floor, hostname verify, cipher pinning, optional mTLS, rotation on reconnect).
- SL2 table: `SolidSyslogStreamSender` description names the Stream implementations explicitly (`SolidSyslogPosixTcpStream` at SL2, `SolidSyslogTlsStream` at SL4) instead of the stale "TCP today, TLS in future".
- "What SL4 adds over SL3" is now present-tense for the items that have landed, with a new "Still to come" block for the E17 / S12.x remainder.
- Heading "(SL4 substrate in place)" reduced to "SL4 TLS substrate" — no longer an interim state.
- **Relevant Requirements table and traceability matrix** gain CR 1.5 (Authenticator management) and CR 1.8 (PKI certificates). Each row spells out what the library covers and what the integrator owns — at-rest key protection (filesystem / HSM), CRL / OCSP revocation (deferred to OS trust store per S03.08 ADR), PKI enrolment (caller's process). Better to state the gaps than to overclaim.
- "Remaining E03 work" paragraph removed — S03.12 / S03.13 are architectural follow-ons, not compliance gaps.

**`README.md` — Status block rewritten.** "Approaching feature-complete for POSIX and Windows", still **not production-ready**, with an explicit known-gaps list: API churn pending multi-instance work, at-rest integrity is CRC-16 only, revocation deferred, PRINTUSASCII / UTF-8 body hygiene not yet enforced, error guards still rolling out. Also: `SolidSyslogTlsStream.h` added to the public-headers list; "TCP today, TLS in future" parenthetical dropped; Threaded example description updated to list UDP / TCP / TLS / mTLS.

**`docs/rfc-compliance.md` — RFC 5425 promoted.** Six rows to Supported; 4.2 "default port 6514" stays **Partial** because no `SOLIDSYSLOG_TLS_DEFAULT_PORT` constant is shipped (caller supplies the port via endpoint callback; the Threaded example happens to use 6514). Summary table reflows.

**`docs/bdd.md` — infrastructure catch-up.** ASCII architecture diagram, syslog-ng role description, and source-configuration paragraph updated to reflect TLS (6514) and mTLS (6515) sources alongside UDP / TCP on 5514. The "will be needed when BDD scenarios require different syslog-ng source configurations" forward-look is rewritten as present-tense. Feature-tag table gains `@tls` and `@mtls`.

**`Bdd/syslog-ng/tls/README.md` — client cert additions.** Preamble now mentions `mtls_transport.feature`; fixture table lists `client.key` / `client.pem` (added in S03.09).

**`docs/ci.md` — jobs table additions.** Adds `openssl-integration` (in-process libssl integration tests) and `bdd-windows` (OTel-oracle BDD on Windows) — both are active required checks per `gh pr checks`.

**`SKILL.md` — minor corrections.** RFC list now includes 6587 alongside 5424/5426/5425. The "Epics tracked as GitHub Issues #2–#12" reference acknowledges that epic numbers have grown beyond that range (E12 #31, E14 #64, E17 #105, E18 #112).

**Outside the PR (issue body edit):** epic #5 story table synced — S03.06 (#166), S03.07 (#170), S03.08 (#183), S03.09 (#184) marked Done with PR links. S03.11 stays Todo until this PR lands.

## Test Evidence

Docs-only change; no production or test code touched. CI runs as a sanity check on the build.

## Areas Affected

- Compliance documentation (`docs/iec62443.md`, `docs/rfc-compliance.md`).
- Front-matter documentation (`README.md`, `SKILL.md`).
- BDD documentation (`docs/bdd.md`, `Bdd/syslog-ng/tls/README.md`).
- CI documentation (`docs/ci.md`).
- DEVLOG.
- Epic #5 body (outside this PR).

No code or interface changes.