### PR TITLE
feat: S03.12 multi-instance senders and streams

### DIFF
--- a/Bdd/features/switching_transport.feature
+++ b/Bdd/features/switching_transport.feature
@@ -13,3 +13,14 @@ Feature: Switch transport at runtime
     And the client sends a message
     Then syslog-ng receives 1 message over tcp
     And syslog-ng receives 1 message over udp
+
+  @tls
+  Scenario: Switch from TCP to TLS mid-run delivers via both reliable transports
+    Given syslog-ng is running
+    And the switching example is running with default transport tcp
+    When the client sends a message
+    Then syslog-ng receives 1 message over tcp
+    When the client switches to transport tls
+    And the client sends a message
+    Then syslog-ng receives 1 message over tls
+    And syslog-ng receives 1 message over tcp

--- a/Core/Interface/SolidSyslogStreamSender.h
+++ b/Core/Interface/SolidSyslogStreamSender.h
@@ -5,6 +5,8 @@
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogStream.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
 
     struct SolidSyslogSender;
@@ -17,8 +19,18 @@ EXTERN_C_BEGIN
         SolidSyslogEndpointVersionFunction endpointVersion; /* polled cheaply on every Send for stale check */
     };
 
-    struct SolidSyslogSender* SolidSyslogStreamSender_Create(const struct SolidSyslogStreamSenderConfig* config);
-    void                      SolidSyslogStreamSender_Destroy(void);
+    enum
+    {
+        SOLIDSYSLOG_STREAM_SENDER_SIZE = (sizeof(intptr_t) * 7) + sizeof(uint32_t)
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_STREAM_SENDER_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogStreamSenderStorage;
+
+    struct SolidSyslogSender* SolidSyslogStreamSender_Create(SolidSyslogStreamSenderStorage * storage, const struct SolidSyslogStreamSenderConfig* config);
+    void                      SolidSyslogStreamSender_Destroy(struct SolidSyslogSender * sender);
 
 EXTERN_C_END
 

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -39,25 +39,39 @@ static bool                         SendBytes(struct SolidSyslogStreamSender* se
 static void                         NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 static uint32_t                     NilEndpointVersion(void);
 
-static const struct SolidSyslogStreamSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
-static struct SolidSyslogStreamSender       instance;
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogStreamSender) <= sizeof(SolidSyslogStreamSenderStorage),
+                          "SOLIDSYSLOG_STREAM_SENDER_SIZE is too small for struct SolidSyslogStreamSender");
 
-struct SolidSyslogSender* SolidSyslogStreamSender_Create(const struct SolidSyslogStreamSenderConfig* config)
+static const struct SolidSyslogStreamSender DEFAULT_INSTANCE = {
+    {Send, Disconnect},
+    {NULL, NULL, NilEndpoint, NilEndpointVersion},
+    false,
+    0,
+};
+
+static const struct SolidSyslogStreamSender DESTROYED_INSTANCE = {
+    {NULL, NULL},
+    {NULL, NULL, NilEndpoint, NilEndpointVersion},
+    false,
+    0,
+};
+
+struct SolidSyslogSender* SolidSyslogStreamSender_Create(SolidSyslogStreamSenderStorage* storage, const struct SolidSyslogStreamSenderConfig* config)
 {
-    instance                 = DEFAULT_INSTANCE;
-    instance.config.resolver = config->resolver;
-    instance.config.stream   = config->stream;
-    ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
-    ASSIGN_IF_NON_NULL(instance.config.endpointVersion, config->endpointVersion);
-    instance.base.Send       = Send;
-    instance.base.Disconnect = Disconnect;
-    return &instance.base;
+    struct SolidSyslogStreamSender* sender = (struct SolidSyslogStreamSender*) storage;
+    *sender                                = DEFAULT_INSTANCE;
+    sender->config.resolver                = config->resolver;
+    sender->config.stream                  = config->stream;
+    ASSIGN_IF_NON_NULL(sender->config.endpoint, config->endpoint);
+    ASSIGN_IF_NON_NULL(sender->config.endpointVersion, config->endpointVersion);
+    return &sender->base;
 }
 
-void SolidSyslogStreamSender_Destroy(void)
+void SolidSyslogStreamSender_Destroy(struct SolidSyslogSender* sender)
 {
-    Disconnect(&instance.base);
-    instance = DEFAULT_INSTANCE;
+    struct SolidSyslogStreamSender* self = (struct SolidSyslogStreamSender*) sender;
+    Disconnect(sender);
+    *self = DESTROYED_INSTANCE;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,57 @@
 # Dev Log
 
+## 2026-04-22 — S03.12 multi-instance senders and streams
+
+### Decisions
+- Converted `SolidSyslogStreamSender`, `SolidSyslogPosixTcpStream`,
+  `SolidSyslogTlsStream`, and `SolidSyslogPosixFile` from static-singleton
+  `_Create(config)` / `_Destroy()` pairs to multi-instance with
+  caller-supplied storage. `_Create` now takes a `SolidSyslog<X>Storage*` and
+  the config; `_Destroy` takes the returned handle. Heap stays out —
+  caller owns the memory, static / stack / pool allocation all work.
+- Settled on one canonical "opaque storage" pattern for fixed-size classes
+  and codified it in memory (`feedback_storage_pattern.md`): `SOLIDSYSLOG_<X>_SIZE`
+  as its own enum with `(sizeof(intptr_t) * N) + sizeof(uint32_t) + ...`;
+  storage typedef using ceiling-divided `intptr_t slots[...]`; static_assert
+  `sizeof(struct) <= sizeof(storage)`; `DEFAULT_INSTANCE` / `DESTROYED_INSTANCE`
+  + struct assignment in Create/Destroy. One spelling across the library,
+  Formatter's variable-size macro remains the documented exception. Picked
+  the `intptr_t slots` flavour over PosixFile's original `uint8_t opaque[...]`
+  for pointer-alignment; realigned PosixFile in the same pass.
+- Size formula authoring rule: each `sizeof(intptr_t) * N` slot covers
+  pointer-scaling fields (function pointers, object pointers, `int`, `bool`,
+  enums) so 16/32/64-bit targets pay only for what they need, and each
+  explicit `sizeof(uint32_t)` / `sizeof(uint64_t)` term covers a fixed-width
+  stdint field. Ceiling division in the slot count stops a stdint-tail size
+  (e.g. StreamSender's `(sizeof(intptr_t)*7) + sizeof(uint32_t)` = 60 on
+  64-bit) from silently under-allocating when a future field is added.
+- Added exactly one new regression-net test per class:
+  `CreateReturnsHandleInsideCallerSuppliedStorage` with
+  `POINTERS_EQUAL(&storage, handle)`. That single check proves the storage
+  contract and, by extension, multi-instance independence — didn't write a
+  separate "create two, they don't collide" test.
+- Threaded example rewired to always wire UDP + plain TCP + TLS
+  simultaneously at launch. `--transport` now only sets the initial selector;
+  runtime `switch` works across all three. New BDD scenario
+  (`switching_transport.feature`) covers the TCP↔TLS path.
+
+### Deferred
+- Audit of the remaining static-singleton `_Create` pairs (UdpSender,
+  PosixDatagram, MetaSd, OriginSd, TimeQualitySd, Crc16Policy,
+  NullBuffer / NullStore / NullSecurityPolicy, GetAddrInfoResolver,
+  AtomicCounter, FileStore, PosixMessageQueueBuffer, SwitchingSender)
+  to the future allocation-strategy epic. S03.12 was the tactical enabler
+  for TLS + TCP coexistence; the broader dual-API (heap vs caller-storage)
+  redesign is out of scope.
+- Stored-length vs null-termination tightening on Origin SD (project
+  memory already records this).
+- Error-reporting integration — still on E12.
+
+### Open questions
+- None — pattern is locked in via `feedback_storage_pattern.md`, ready to
+  be applied consistently as further classes get converted under the future
+  allocation-strategy epic.
+
 ## 2026-04-22 — S03.11 TLS promoted to Available + docs sanity pass
 
 ### Decisions

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -38,10 +38,21 @@
 #include <string.h>
 #include <unistd.h>
 
-static const char* const       STORE_PATH_PREFIX = "/tmp/STORE";
-static struct SolidSyslogFile* storeReadFile;
-static struct SolidSyslogFile* storeWriteFile;
-static bool                    tlsModeActive;
+static const char* const                STORE_PATH_PREFIX = "/tmp/STORE";
+static struct SolidSyslogFile*          storeReadFile;
+static struct SolidSyslogFile*          storeWriteFile;
+static SolidSyslogPosixTcpStreamStorage plainTcpStreamStorage;
+static struct SolidSyslogStream*        plainTcpStream;
+static SolidSyslogStreamSenderStorage   plainTcpSenderStorage;
+static struct SolidSyslogSender*        plainTcpSender;
+#ifdef SOLIDSYSLOG_HAVE_OPENSSL
+static SolidSyslogPosixTcpStreamStorage tlsUnderlyingStreamStorage;
+static struct SolidSyslogStream*        tlsUnderlyingStream;
+static SolidSyslogTlsStreamStorage      tlsStreamStorage;
+static struct SolidSyslogStream*        tlsStream;
+static SolidSyslogStreamSenderStorage   tlsSenderStorage;
+static struct SolidSyslogSender*        tlsSender;
+#endif
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 {
@@ -59,16 +70,9 @@ static void* ServiceThreadEntry(void* arg)
     return NULL;
 }
 
-/* SolidSyslogStreamSender and SolidSyslogPosixTcpStream are singletons in this
- * walking-skeleton build, so we can't wire plain TCP and TLS simultaneously.
- * The launched --transport picks one: "tls" wires UDP + TLS; anything else
- * wires UDP + plain TCP (the pre-existing behaviour). Switching to the
- * non-enabled reliable transport at runtime falls back to UDP.
- */
 static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* options)
 {
     bool mtlsModeActive = (strcmp(options->transport, "mtls") == 0);
-    tlsModeActive       = (strcmp(options->transport, "tls") == 0) || mtlsModeActive;
 
     struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create();
 
@@ -79,51 +83,49 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     udpConfig.endpointVersion                          = ExampleUdpConfig_GetEndpointVersion;
     struct SolidSyslogSender* udpSender                = SolidSyslogUdpSender_Create(&udpConfig);
 
-    struct SolidSyslogSender* reliableSender = NULL;
-    if (tlsModeActive)
-    {
-#ifdef SOLIDSYSLOG_HAVE_OPENSSL
-        static struct SolidSyslogTlsStreamConfig tlsStreamConfig = {0};
-        tlsStreamConfig.transport                                = SolidSyslogPosixTcpStream_Create();
-        if (mtlsModeActive)
-        {
-            tlsStreamConfig.caBundlePath        = ExampleMtlsConfig_GetCaBundlePath();
-            tlsStreamConfig.serverName          = ExampleMtlsConfig_GetServerName();
-            tlsStreamConfig.clientCertChainPath = ExampleMtlsConfig_GetClientCertChainPath();
-            tlsStreamConfig.clientKeyPath       = ExampleMtlsConfig_GetClientKeyPath();
-        }
-        else
-        {
-            tlsStreamConfig.caBundlePath = ExampleTlsConfig_GetCaBundlePath();
-            tlsStreamConfig.serverName   = ExampleTlsConfig_GetServerName();
-        }
-        struct SolidSyslogStream* tlsStream = SolidSyslogTlsStream_Create(&tlsStreamConfig);
+    plainTcpStream                                        = SolidSyslogPosixTcpStream_Create(&plainTcpStreamStorage);
+    static struct SolidSyslogStreamSenderConfig tcpConfig = {0};
+    tcpConfig.resolver                                    = resolver;
+    tcpConfig.stream                                      = plainTcpStream;
+    tcpConfig.endpoint                                    = ExampleTcpConfig_GetEndpoint;
+    tcpConfig.endpointVersion                             = ExampleTcpConfig_GetEndpointVersion;
+    plainTcpSender                                        = SolidSyslogStreamSender_Create(&plainTcpSenderStorage, &tcpConfig);
 
-        static struct SolidSyslogStreamSenderConfig tlsSenderConfig = {0};
-        tlsSenderConfig.resolver                                    = resolver;
-        tlsSenderConfig.stream                                      = tlsStream;
-        tlsSenderConfig.endpoint                                    = mtlsModeActive ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
-        tlsSenderConfig.endpointVersion = mtlsModeActive ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
-        reliableSender                  = SolidSyslogStreamSender_Create(&tlsSenderConfig);
-#else
-        /* --transport tls/mtls requested but the build has no OpenSSL — falls back to plain TCP sender; TLS slot maps to UDP at runtime. */
-        tlsModeActive = false;
-#endif
-    }
-    if (!tlsModeActive && reliableSender == NULL)
+    struct SolidSyslogSender* tlsSlot = NULL;
+#ifdef SOLIDSYSLOG_HAVE_OPENSSL
+    tlsUnderlyingStream                                      = SolidSyslogPosixTcpStream_Create(&tlsUnderlyingStreamStorage);
+    static struct SolidSyslogTlsStreamConfig tlsStreamConfig = {0};
+    tlsStreamConfig.transport                                = tlsUnderlyingStream;
+    if (mtlsModeActive)
     {
-        static struct SolidSyslogStreamSenderConfig tcpConfig = {0};
-        tcpConfig.resolver                                    = resolver;
-        tcpConfig.stream                                      = SolidSyslogPosixTcpStream_Create();
-        tcpConfig.endpoint                                    = ExampleTcpConfig_GetEndpoint;
-        tcpConfig.endpointVersion                             = ExampleTcpConfig_GetEndpointVersion;
-        reliableSender                                        = SolidSyslogStreamSender_Create(&tcpConfig);
+        tlsStreamConfig.caBundlePath        = ExampleMtlsConfig_GetCaBundlePath();
+        tlsStreamConfig.serverName          = ExampleMtlsConfig_GetServerName();
+        tlsStreamConfig.clientCertChainPath = ExampleMtlsConfig_GetClientCertChainPath();
+        tlsStreamConfig.clientKeyPath       = ExampleMtlsConfig_GetClientKeyPath();
     }
+    else
+    {
+        tlsStreamConfig.caBundlePath = ExampleTlsConfig_GetCaBundlePath();
+        tlsStreamConfig.serverName   = ExampleTlsConfig_GetServerName();
+    }
+    tlsStream = SolidSyslogTlsStream_Create(&tlsStreamStorage, &tlsStreamConfig);
+
+    static struct SolidSyslogStreamSenderConfig tlsSenderConfig = {0};
+    tlsSenderConfig.resolver                                    = resolver;
+    tlsSenderConfig.stream                                      = tlsStream;
+    tlsSenderConfig.endpoint                                    = mtlsModeActive ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
+    tlsSenderConfig.endpointVersion                             = mtlsModeActive ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
+    tlsSender                                                   = SolidSyslogStreamSender_Create(&tlsSenderStorage, &tlsSenderConfig);
+    tlsSlot                                                     = tlsSender;
+#else
+    (void) mtlsModeActive;
+    tlsSlot = udpSender; /* fallback when TLS not built — keeps switching selector total */
+#endif
 
     static struct SolidSyslogSender* inners[EXAMPLE_SWITCH_COUNT];
     inners[EXAMPLE_SWITCH_UDP] = udpSender;
-    inners[EXAMPLE_SWITCH_TCP] = tlsModeActive ? udpSender : reliableSender;
-    inners[EXAMPLE_SWITCH_TLS] = tlsModeActive ? reliableSender : udpSender;
+    inners[EXAMPLE_SWITCH_TCP] = plainTcpSender;
+    inners[EXAMPLE_SWITCH_TLS] = tlsSlot;
 
     static struct SolidSyslogSwitchingSenderConfig switchConfig = {0};
     switchConfig.senders                                        = inners;
@@ -131,7 +133,6 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     switchConfig.selector                                       = ExampleSwitchConfig_Selector;
 
     ExampleSwitchConfig_SetByName(options->transport);
-
     return SolidSyslogSwitchingSender_Create(&switchConfig);
 }
 
@@ -164,8 +165,8 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
 
     if (useFile)
     {
-        static struct SolidSyslogPosixFileStorage readStorage;
-        static struct SolidSyslogPosixFileStorage writeStorage;
+        static SolidSyslogPosixFileStorage readStorage;
+        static SolidSyslogPosixFileStorage writeStorage;
         storeReadFile  = SolidSyslogPosixFile_Create(&readStorage);
         storeWriteFile = SolidSyslogPosixFile_Create(&writeStorage);
 
@@ -187,14 +188,13 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
 static void DestroySender(void)
 {
     SolidSyslogSwitchingSender_Destroy();
-    SolidSyslogStreamSender_Destroy();
 #ifdef SOLIDSYSLOG_HAVE_OPENSSL
-    if (tlsModeActive)
-    {
-        SolidSyslogTlsStream_Destroy();
-    }
+    SolidSyslogStreamSender_Destroy(tlsSender);
+    SolidSyslogTlsStream_Destroy(tlsStream);
+    SolidSyslogPosixTcpStream_Destroy(tlsUnderlyingStream);
 #endif
-    SolidSyslogPosixTcpStream_Destroy();
+    SolidSyslogStreamSender_Destroy(plainTcpSender);
+    SolidSyslogPosixTcpStream_Destroy(plainTcpStream);
     SolidSyslogUdpSender_Destroy();
     SolidSyslogPosixDatagram_Destroy();
     SolidSyslogGetAddrInfoResolver_Destroy();

--- a/Platform/OpenSsl/Interface/SolidSyslogTlsStream.h
+++ b/Platform/OpenSsl/Interface/SolidSyslogTlsStream.h
@@ -3,7 +3,19 @@
 
 #include "SolidSyslogStream.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
+
+    enum
+    {
+        SOLIDSYSLOG_TLS_STREAM_SIZE = sizeof(intptr_t) * 13
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_TLS_STREAM_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogTlsStreamStorage;
 
     struct SolidSyslogTlsStreamConfig
     {
@@ -15,8 +27,8 @@ EXTERN_C_BEGIN
         const char*               clientKeyPath;       /* PEM: matching private key; NULL = no mTLS */
     };
 
-    struct SolidSyslogStream* SolidSyslogTlsStream_Create(const struct SolidSyslogTlsStreamConfig* config);
-    void                      SolidSyslogTlsStream_Destroy(void);
+    struct SolidSyslogStream* SolidSyslogTlsStream_Create(SolidSyslogTlsStreamStorage * storage, const struct SolidSyslogTlsStreamConfig* config);
+    void                      SolidSyslogTlsStream_Destroy(struct SolidSyslogStream * stream);
 
 EXTERN_C_END
 

--- a/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
+++ b/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
@@ -1,3 +1,4 @@
+#include "SolidSyslogMacros.h"
 #include "SolidSyslogStreamDefinition.h"
 #include "SolidSyslogTlsStream.h"
 
@@ -11,6 +12,9 @@ struct SolidSyslogTlsStream
     SSL*                              ssl;
     BIO_METHOD*                       bioMethod;
 };
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogTlsStream) <= sizeof(SolidSyslogTlsStreamStorage),
+                          "SOLIDSYSLOG_TLS_STREAM_SIZE is too small for struct SolidSyslogTlsStream");
 
 static inline bool             TlsStream_AttachTransportBio(struct SolidSyslogTlsStream* stream);
 static inline void             TlsStream_Close(struct SolidSyslogStream* self);
@@ -38,26 +42,28 @@ static inline long             TlsStream_TransportBioCtrl(BIO* bio, int cmd, lon
 static inline int              TlsStream_TransportBioRead(BIO* bio, char* buffer, int size);
 static inline int              TlsStream_TransportBioWrite(BIO* bio, const char* buffer, int size);
 
-static const struct SolidSyslogStream VTABLE = {
-    .Open  = TlsStream_Open,
-    .Send  = TlsStream_Send,
-    .Read  = TlsStream_Read,
-    .Close = TlsStream_Close,
+static const struct SolidSyslogTlsStream DEFAULT_INSTANCE = {
+    {TlsStream_Open, TlsStream_Send, TlsStream_Read, TlsStream_Close}, {NULL, NULL, NULL, NULL, NULL, NULL}, NULL, NULL, NULL,
 };
 
-static struct SolidSyslogTlsStream instance;
+static const struct SolidSyslogTlsStream DESTROYED_INSTANCE = {
+    {NULL, NULL, NULL, NULL}, {NULL, NULL, NULL, NULL, NULL, NULL}, NULL, NULL, NULL,
+};
 
-struct SolidSyslogStream* SolidSyslogTlsStream_Create(const struct SolidSyslogTlsStreamConfig* config)
+struct SolidSyslogStream* SolidSyslogTlsStream_Create(SolidSyslogTlsStreamStorage* storage, const struct SolidSyslogTlsStreamConfig* config)
 {
-    instance.config = *config;
-    instance.base   = VTABLE;
-    return &instance.base;
+    struct SolidSyslogTlsStream* stream = (struct SolidSyslogTlsStream*) storage;
+    *stream                             = DEFAULT_INSTANCE;
+    stream->config                      = *config;
+    return &stream->base;
 }
 
-void SolidSyslogTlsStream_Destroy(void)
+void SolidSyslogTlsStream_Destroy(struct SolidSyslogStream* stream)
 {
-    TlsStream_ReleaseHandshakeState(&instance);
-    TlsStream_ReleaseSslContext(&instance);
+    struct SolidSyslogTlsStream* self = (struct SolidSyslogTlsStream*) stream;
+    TlsStream_ReleaseHandshakeState(self);
+    TlsStream_ReleaseSslContext(self);
+    *self = DESTROYED_INSTANCE;
 }
 
 static inline void TlsStream_ReleaseHandshakeState(struct SolidSyslogTlsStream* stream)

--- a/Platform/Posix/Interface/SolidSyslogPosixFile.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixFile.h
@@ -9,15 +9,15 @@ EXTERN_C_BEGIN
 
     enum
     {
-        SOLIDSYSLOG_POSIX_FILE_STORAGE_SLOTS = 11
+        SOLIDSYSLOG_POSIX_FILE_SIZE = sizeof(intptr_t) * 11
     };
 
-    struct SolidSyslogPosixFileStorage
+    typedef struct
     {
-        uint8_t opaque[SOLIDSYSLOG_POSIX_FILE_STORAGE_SLOTS * sizeof(void*)];
-    };
+        intptr_t slots[(SOLIDSYSLOG_POSIX_FILE_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogPosixFileStorage;
 
-    struct SolidSyslogFile* SolidSyslogPosixFile_Create(struct SolidSyslogPosixFileStorage * storage);
+    struct SolidSyslogFile* SolidSyslogPosixFile_Create(SolidSyslogPosixFileStorage * storage);
     void                    SolidSyslogPosixFile_Destroy(struct SolidSyslogFile * file);
 
 EXTERN_C_END

--- a/Platform/Posix/Interface/SolidSyslogPosixTcpStream.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixTcpStream.h
@@ -2,6 +2,7 @@
 #define SOLIDSYSLOGPOSIXTCPSTREAM_H
 
 #include "SolidSyslogStream.h"
+#include <stdint.h>
 
 EXTERN_C_BEGIN
 
@@ -10,8 +11,18 @@ EXTERN_C_BEGIN
         SOLIDSYSLOG_TCP_DEFAULT_PORT = 601 /* RFC 6587 §3.2 / IANA assignment for syslog over TCP */
     };
 
-    struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void);
-    void                      SolidSyslogPosixTcpStream_Destroy(void);
+    enum
+    {
+        SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE = sizeof(intptr_t) * 5
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogPosixTcpStreamStorage;
+
+    struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(SolidSyslogPosixTcpStreamStorage * storage);
+    void                      SolidSyslogPosixTcpStream_Destroy(struct SolidSyslogStream * stream);
 
 EXTERN_C_END
 

--- a/Platform/Posix/Source/SolidSyslogPosixFile.c
+++ b/Platform/Posix/Source/SolidSyslogPosixFile.c
@@ -31,8 +31,8 @@ struct SolidSyslogPosixFile
     int                    fd;
 };
 
-SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixFile) == sizeof(struct SolidSyslogPosixFileStorage),
-                          "SolidSyslogPosixFileStorage size does not match struct SolidSyslogPosixFile");
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixFile) <= sizeof(SolidSyslogPosixFileStorage),
+                          "SOLIDSYSLOG_POSIX_FILE_SIZE is too small for struct SolidSyslogPosixFile");
 
 static const struct SolidSyslogPosixFile DEFAULT_INSTANCE = {
     {Open, Close, IsOpen, Read, Write, SeekTo, Size, Truncate, Exists, Delete},
@@ -44,7 +44,7 @@ static const struct SolidSyslogPosixFile DESTROYED_INSTANCE = {
     INVALID_FD,
 };
 
-struct SolidSyslogFile* SolidSyslogPosixFile_Create(struct SolidSyslogPosixFileStorage* storage)
+struct SolidSyslogFile* SolidSyslogPosixFile_Create(SolidSyslogPosixFileStorage* storage)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) storage;
     *posix                             = DEFAULT_INSTANCE;

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -1,5 +1,6 @@
 #include "SolidSyslogPosixTcpStream.h"
 #include "SolidSyslogAddressInternal.h"
+#include "SolidSyslogMacros.h"
 #include "SolidSyslogStreamDefinition.h"
 
 #include <netinet/tcp.h>
@@ -25,24 +26,31 @@ struct SolidSyslogPosixTcpStream
     int                      fd;
 };
 
-static struct SolidSyslogPosixTcpStream instance = {.fd = INVALID_FD};
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixTcpStream) <= SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE,
+                          "SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE is too small for struct SolidSyslogPosixTcpStream");
 
-struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(void)
+static const struct SolidSyslogPosixTcpStream DEFAULT_INSTANCE = {
+    {Open, Send, Read, Close},
+    INVALID_FD,
+};
+
+static const struct SolidSyslogPosixTcpStream DESTROYED_INSTANCE = {
+    {NULL, NULL, NULL, NULL},
+    INVALID_FD,
+};
+
+struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(SolidSyslogPosixTcpStreamStorage* storage)
 {
-    instance.base.Open  = Open;
-    instance.base.Send  = Send;
-    instance.base.Read  = Read;
-    instance.base.Close = Close;
-    return &instance.base;
+    struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) storage;
+    *stream                                  = DEFAULT_INSTANCE;
+    return &stream->base;
 }
 
-void SolidSyslogPosixTcpStream_Destroy(void)
+void SolidSyslogPosixTcpStream_Destroy(struct SolidSyslogStream* stream)
 {
-    Close(&instance.base);
-    instance.base.Open  = NULL;
-    instance.base.Send  = NULL;
-    instance.base.Read  = NULL;
-    instance.base.Close = NULL;
+    struct SolidSyslogPosixTcpStream* self = (struct SolidSyslogPosixTcpStream*) stream;
+    Close(stream);
+    *self = DESTROYED_INSTANCE;
 }
 
 static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)

--- a/Tests/OpenSslIntegration/SolidSyslogTlsStreamIntegrationTest.cpp
+++ b/Tests/OpenSslIntegration/SolidSyslogTlsStreamIntegrationTest.cpp
@@ -22,6 +22,7 @@ TEST_GROUP(TlsStreamIntegration)
     struct TlsTestServer*             server         = nullptr;
     struct SolidSyslogStream*         transport      = nullptr;
     struct SolidSyslogTlsStreamConfig tlsConfig      = {};
+    SolidSyslogTlsStreamStorage       tlsStreamStorage{};
     struct SolidSyslogStream*         tlsStream      = nullptr;
     SolidSyslogAddressStorage         addrStorage    = {};
     struct SolidSyslogAddress*        addr           = nullptr;
@@ -36,7 +37,7 @@ TEST_GROUP(TlsStreamIntegration)
 
     void teardown() override
     {
-        if (tlsStream != nullptr)         { SolidSyslogTlsStream_Destroy(); }
+        if (tlsStream != nullptr)         { SolidSyslogTlsStream_Destroy(tlsStream); }
         if (transport != nullptr)         { BioPairStream_Destroy(transport); }
         if (server != nullptr)            { TlsTestServer_Destroy(server); }
         if (cert.cert != nullptr)         { TlsTestCert_Destroy(&cert); }
@@ -77,7 +78,7 @@ TEST_GROUP(TlsStreamIntegration)
         tlsConfig.transport    = transport;
         tlsConfig.caBundlePath = caPath;
         tlsConfig.serverName   = clientServerName;
-        tlsStream              = SolidSyslogTlsStream_Create(&tlsConfig);
+        tlsStream              = SolidSyslogTlsStream_Create(&tlsStreamStorage, &tlsConfig);
     }
 
     /* Creates the client-side mTLS material and writes it to disk.

--- a/Tests/SolidSyslogFileStorePosixTest.cpp
+++ b/Tests/SolidSyslogFileStorePosixTest.cpp
@@ -34,8 +34,8 @@ TEST_GROUP(SolidSyslogFileStorePosix)
     static const size_t RECORD_OVERHEAD    = 5; /* 2 (magic) + 2 (length) + 1 (sent flag) */
     static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD;
 
-    struct SolidSyslogPosixFileStorage readStorage = {};
-    struct SolidSyslogPosixFileStorage writeStorage = {};
+    SolidSyslogPosixFileStorage readStorage = {};
+    SolidSyslogPosixFileStorage writeStorage = {};
     struct SolidSyslogFile* readFile = nullptr;
     struct SolidSyslogFile* writeFile = nullptr;
     struct SolidSyslogStore* store = nullptr;

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -9,7 +9,7 @@ static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
 // clang-format off
 TEST_GROUP(SolidSyslogPosixFile)
 {
-    struct SolidSyslogPosixFileStorage storage = {};
+    SolidSyslogPosixFileStorage storage = {};
     struct SolidSyslogFile* file = nullptr;
 
     void setup() override
@@ -37,6 +37,14 @@ TEST_GROUP(SolidSyslogPosixFile)
 TEST(SolidSyslogPosixFile, CreateReturnsNonNull)
 {
     CHECK_TRUE(file != nullptr);
+}
+
+TEST(SolidSyslogPosixFile, CreateReturnsHandleInsideCallerSuppliedStorage)
+{
+    SolidSyslogPosixFileStorage localStorage{};
+    struct SolidSyslogFile*     localFile = SolidSyslogPosixFile_Create(&localStorage);
+    POINTERS_EQUAL(&localStorage, localFile);
+    SolidSyslogPosixFile_Destroy(localFile);
 }
 
 TEST(SolidSyslogPosixFile, IsOpenReturnsFalseBeforeOpen)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -17,6 +17,7 @@ static const int         TEST_PORT        = 514;
 
 TEST_GROUP(SolidSyslogPosixTcpStream)
 {
+    SolidSyslogPosixTcpStreamStorage streamStorage{};
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStream* stream = nullptr;
     SolidSyslogAddressStorage addrStorage{};
@@ -27,7 +28,7 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
     {
         SocketFake_Reset();
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
-        stream = SolidSyslogPosixTcpStream_Create();
+        stream = SolidSyslogPosixTcpStream_Create(&streamStorage);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
         auto* bytes = reinterpret_cast<std::uint8_t*>(&addrStorage);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- reinterpret to platform layout, storage is intptr_t-aligned
@@ -41,7 +42,7 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
 
     void teardown() override
     {
-        SolidSyslogPosixTcpStream_Destroy();
+        SolidSyslogPosixTcpStream_Destroy(stream);
     }
 };
 
@@ -49,6 +50,14 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
 
 TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
 {
+}
+
+TEST(SolidSyslogPosixTcpStream, CreateReturnsHandleInsideCallerSuppliedStorage)
+{
+    SolidSyslogPosixTcpStreamStorage storage{};
+    struct SolidSyslogStream*        localStream = SolidSyslogPosixTcpStream_Create(&storage);
+    POINTERS_EQUAL(&storage, localStream);
+    SolidSyslogPosixTcpStream_Destroy(localStream);
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsSocketOnce)
@@ -230,14 +239,14 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsRecvReturnValue)
 TEST(SolidSyslogPosixTcpStream, DestroyClosesOpenSocket)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogPosixTcpStream_Destroy();
+    SolidSyslogPosixTcpStream_Destroy(stream);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
 
 TEST(SolidSyslogPosixTcpStream, DestroyClosesWithSocketFd)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogPosixTcpStream_Destroy();
+    SolidSyslogPosixTcpStream_Destroy(stream);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
 

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -77,9 +77,11 @@ static uint32_t TestEndpointVersion() // NOLINT(modernize-use-trailing-return-ty
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSender)
 {
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogStream*   stream   = nullptr;
+    struct SolidSyslogResolver*      resolver = nullptr;
+    SolidSyslogPosixTcpStreamStorage streamStorage{};
+    struct SolidSyslogStream*        stream = nullptr;
     struct SolidSyslogStreamSenderConfig config;
+    SolidSyslogStreamSenderStorage senderStorage{};
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
@@ -91,16 +93,16 @@ TEST_GROUP(SolidSyslogStreamSender)
         endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
-        stream          = SolidSyslogPosixTcpStream_Create();
+        stream          = SolidSyslogPosixTcpStream_Create(&streamStorage);
         config          = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
-        sender = SolidSyslogStreamSender_Create(&config);
+        sender = SolidSyslogStreamSender_Create(&senderStorage, &config);
     }
 
     void teardown() override
     {
-        SolidSyslogStreamSender_Destroy();
-        SolidSyslogPosixTcpStream_Destroy();
+        SolidSyslogStreamSender_Destroy(sender);
+        SolidSyslogPosixTcpStream_Destroy(stream);
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -115,6 +117,15 @@ TEST_GROUP(SolidSyslogStreamSender)
 TEST(SolidSyslogStreamSender, CreateReturnsNonNull)
 {
     CHECK_TRUE(sender != nullptr);
+}
+
+TEST(SolidSyslogStreamSender, CreateReturnsHandleInsideCallerSuppliedStorage)
+{
+    SolidSyslogStreamSenderStorage       localStorage{};
+    struct SolidSyslogStreamSenderConfig localConfig = {resolver, stream, TestEndpoint, TestEndpointVersion};
+    struct SolidSyslogSender*            localSender = SolidSyslogStreamSender_Create(&localStorage, &localConfig);
+    POINTERS_EQUAL(&localStorage, localSender);
+    SolidSyslogStreamSender_Destroy(localSender);
 }
 
 TEST(SolidSyslogStreamSender, CreateDoesNotOpenSocket)
@@ -141,9 +152,11 @@ TEST(SolidSyslogStreamSender, FirstSendSetsTcpNoDelay)
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderDestroy)
 {
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogStream*   stream   = nullptr;
+    struct SolidSyslogResolver*      resolver = nullptr;
+    SolidSyslogPosixTcpStreamStorage streamStorage{};
+    struct SolidSyslogStream*        stream = nullptr;
     struct SolidSyslogStreamSenderConfig config;
+    SolidSyslogStreamSenderStorage senderStorage{};
 
     void setup() override
     {
@@ -152,21 +165,21 @@ TEST_GROUP(SolidSyslogStreamSenderDestroy)
         endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
-        stream          = SolidSyslogPosixTcpStream_Create();
+        stream          = SolidSyslogPosixTcpStream_Create(&streamStorage);
         // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
         config = {resolver, stream, TestEndpoint, TestEndpointVersion};
     }
 
     void teardown() override
     {
-        SolidSyslogPosixTcpStream_Destroy();
+        SolidSyslogPosixTcpStream_Destroy(stream);
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
-    void CreateAndDestroy() const
+    void CreateAndDestroy()
     {
-        SolidSyslogStreamSender_Create(&config);
-        SolidSyslogStreamSender_Destroy();
+        struct SolidSyslogSender* localSender = SolidSyslogStreamSender_Create(&senderStorage, &config);
+        SolidSyslogStreamSender_Destroy(localSender);
     }
 };
 
@@ -180,19 +193,19 @@ TEST(SolidSyslogStreamSenderDestroy, DestroyWithoutSendDoesNotClose)
 
 TEST(SolidSyslogStreamSenderDestroy, DestroyAfterSendClosesSocket)
 {
-    struct SolidSyslogSender* sender = SolidSyslogStreamSender_Create(&config);
+    struct SolidSyslogSender* sender = SolidSyslogStreamSender_Create(&senderStorage, &config);
     SolidSyslogSender_Send(sender, "x", 1);
-    SolidSyslogStreamSender_Destroy();
+    SolidSyslogStreamSender_Destroy(sender);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
 }
 
 TEST(SolidSyslogStreamSenderDestroy, DestroyAfterDisconnectDoesNotDoubleClose)
 {
-    struct SolidSyslogSender* sender = SolidSyslogStreamSender_Create(&config);
+    struct SolidSyslogSender* sender = SolidSyslogStreamSender_Create(&senderStorage, &config);
     SolidSyslogSender_Send(sender, "x", 1);
     SolidSyslogSender_Disconnect(sender);
-    SolidSyslogStreamSender_Destroy();
+    SolidSyslogStreamSender_Destroy(sender);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
 
@@ -317,6 +330,9 @@ TEST_GROUP(SolidSyslogStreamSenderConfig)
     const char* (*getHostFn)(void) = GetHost; // NOLINT(modernize-redundant-void-arg) -- C idiom
     // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
     int (*getPortFn)(void) = GetPort; // NOLINT(modernize-redundant-void-arg) -- C idiom
+    SolidSyslogPosixTcpStreamStorage streamStorage{};
+    struct SolidSyslogStream*        stream = nullptr;
+    SolidSyslogStreamSenderStorage senderStorage{};
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
@@ -333,8 +349,8 @@ TEST_GROUP(SolidSyslogStreamSenderConfig)
 
     void teardown() override
     {
-        SolidSyslogStreamSender_Destroy();
-        SolidSyslogPosixTcpStream_Destroy();
+        SolidSyslogStreamSender_Destroy(sender);
+        SolidSyslogPosixTcpStream_Destroy(stream);
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -342,11 +358,11 @@ TEST_GROUP(SolidSyslogStreamSenderConfig)
     {
         endpointGetHost = getHostFn;
         endpointGetPort = getPortFn;
-        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
-        struct SolidSyslogStream*         stream   = SolidSyslogPosixTcpStream_Create();
-        struct SolidSyslogStreamSenderConfig config   = {resolver, stream, TestEndpoint, TestEndpointVersion};
+        struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create();
+        stream                               = SolidSyslogPosixTcpStream_Create(&streamStorage);
+        struct SolidSyslogStreamSenderConfig config = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
-        sender = SolidSyslogStreamSender_Create(&config);
+        sender = SolidSyslogStreamSender_Create(&senderStorage, &config);
     }
 
     void Send() const
@@ -420,9 +436,11 @@ TEST(SolidSyslogStreamSenderConfig, GetAddrInfoCalledWithHostname)
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderFailure)
 {
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogStream*   stream   = nullptr;
+    struct SolidSyslogResolver*      resolver = nullptr;
+    SolidSyslogPosixTcpStreamStorage streamStorage{};
+    struct SolidSyslogStream*        stream = nullptr;
     struct SolidSyslogStreamSenderConfig config;
+    SolidSyslogStreamSenderStorage senderStorage{};
     // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
@@ -434,16 +452,16 @@ TEST_GROUP(SolidSyslogStreamSenderFailure)
         endpointVersion = 0;
         endpointGetPort = GetPort;
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
-        stream          = SolidSyslogPosixTcpStream_Create();
+        stream          = SolidSyslogPosixTcpStream_Create(&streamStorage);
         config          = {resolver, stream, TestEndpoint, TestEndpointVersion};
         // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
-        sender = SolidSyslogStreamSender_Create(&config);
+        sender = SolidSyslogStreamSender_Create(&senderStorage, &config);
     }
 
     void teardown() override
     {
-        SolidSyslogStreamSender_Destroy();
-        SolidSyslogPosixTcpStream_Destroy();
+        SolidSyslogStreamSender_Destroy(sender);
+        SolidSyslogPosixTcpStream_Destroy(stream);
         SolidSyslogGetAddrInfoResolver_Destroy();
     }
 
@@ -486,7 +504,7 @@ TEST(SolidSyslogStreamSenderFailure, DestroyAfterSendFailureDoesNotDoubleClose)
 {
     SocketFake_SetSendFails(true);
     Send();
-    SolidSyslogStreamSender_Destroy();
+    SolidSyslogStreamSender_Destroy(sender);
     LONGS_EQUAL(1, SocketFake_CloseCallCount());
 }
 
@@ -602,9 +620,9 @@ TEST(SolidSyslogStreamSenderFailure, SendRecoversAfterTransientResolveFailure)
 
 TEST(SolidSyslogStreamSenderFailure, NoEndpointConfiguredConnectsToPortZero)
 {
-    SolidSyslogStreamSender_Destroy();
+    SolidSyslogStreamSender_Destroy(sender);
     struct SolidSyslogStreamSenderConfig configNoEndpoint = {resolver, stream, nullptr, nullptr};
-    struct SolidSyslogSender*            senderNoEndpoint = SolidSyslogStreamSender_Create(&configNoEndpoint);
+    struct SolidSyslogSender*            senderNoEndpoint = SolidSyslogStreamSender_Create(&senderStorage, &configNoEndpoint);
     SolidSyslogSender_Send(senderNoEndpoint, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(1, SocketFake_ConnectCallCount());
     LONGS_EQUAL(0, SocketFake_LastConnectPort());

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -11,6 +11,7 @@ TEST_GROUP(SolidSyslogTlsStream)
 {
     struct SolidSyslogStream*         transport   = nullptr;
     struct SolidSyslogTlsStreamConfig config      = {};
+    SolidSyslogTlsStreamStorage       streamStorage{};
     struct SolidSyslogStream*         stream      = nullptr;
     SolidSyslogAddressStorage         addrStorage = {0};
     struct SolidSyslogAddress*        addr        = nullptr;
@@ -21,14 +22,14 @@ TEST_GROUP(SolidSyslogTlsStream)
         transport        = StreamFake_Create();
         config.transport = transport;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        stream = SolidSyslogTlsStream_Create(&config);
+        stream = SolidSyslogTlsStream_Create(&streamStorage, &config);
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         addr = SolidSyslogAddress_FromStorage(&addrStorage);
     }
 
     void teardown() override
     {
-        SolidSyslogTlsStream_Destroy();
+        SolidSyslogTlsStream_Destroy(stream);
         StreamFake_Destroy(transport);
     }
 };
@@ -38,6 +39,16 @@ TEST_GROUP(SolidSyslogTlsStream)
 TEST(SolidSyslogTlsStream, CreateSucceeds)
 {
     CHECK_TRUE(stream != nullptr);
+}
+
+TEST(SolidSyslogTlsStream, CreateReturnsHandleInsideCallerSuppliedStorage)
+{
+    SolidSyslogTlsStreamStorage       localStorage{};
+    struct SolidSyslogTlsStreamConfig localConfig = {};
+    localConfig.transport                         = transport;
+    struct SolidSyslogStream* localStream         = SolidSyslogTlsStream_Create(&localStorage, &localConfig);
+    POINTERS_EQUAL(&localStorage, localStream);
+    SolidSyslogTlsStream_Destroy(localStream);
 }
 
 TEST(SolidSyslogTlsStream, OpenOpensTransport)
@@ -60,9 +71,9 @@ TEST(SolidSyslogTlsStream, OpenCreatesSslContext)
 
 TEST(SolidSyslogTlsStream, OpenLoadsCaBundleFromConfig)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.caBundlePath = "/some/path/ca.pem";
-    stream              = SolidSyslogTlsStream_Create(&config);
+    stream              = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("/some/path/ca.pem", OpenSslFake_LastCaBundlePath());
 }
@@ -81,9 +92,9 @@ TEST(SolidSyslogTlsStream, OpenSetsTls12Floor)
 
 TEST(SolidSyslogTlsStream, OpenPassesCipherListToSslCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.cipherList = "ECDHE+AESGCM";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("ECDHE+AESGCM", OpenSslFake_LastCipherList());
 }
@@ -96,18 +107,18 @@ TEST(SolidSyslogTlsStream, OpenSkipsCipherListSetupWhenNotConfigured)
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenCipherListRejected)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.cipherList = "not-a-real-cipher";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetCipherListFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, CipherListFailureFreesCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.cipherList = "not-a-real-cipher";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetCipherListFails(true);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
@@ -163,18 +174,18 @@ TEST(SolidSyslogTlsStream, OpenPassesSslToConnect)
 
 TEST(SolidSyslogTlsStream, OpenSetsSniHostnameFromConfig)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("logs.example", OpenSslFake_LastSniHostname());
 }
 
 TEST(SolidSyslogTlsStream, OpenSetsExpectedCertHostname)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("logs.example", OpenSslFake_LastSet1Host());
 }
@@ -315,7 +326,7 @@ TEST(SolidSyslogTlsStream, CloseFreesBioMethod)
 TEST(SolidSyslogTlsStream, DestroyFreesSslContext)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
     /* teardown re-Destroys safely */
 }
@@ -323,7 +334,7 @@ TEST(SolidSyslogTlsStream, DestroyFreesSslContext)
 TEST(SolidSyslogTlsStream, DestroyFreesBioMethodWhenCloseNotCalled)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     LONGS_EQUAL(1, OpenSslFake_BioMethFreeCallCount());
     /* teardown re-Destroys safely */
 }
@@ -332,14 +343,14 @@ TEST(SolidSyslogTlsStream, DestroyAfterCloseDoesNotDoubleFreeBioMethod)
 {
     SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Close(stream);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     LONGS_EQUAL(1, OpenSslFake_BioMethFreeCallCount());
 }
 
 TEST(SolidSyslogTlsStream, DestroyFreesSslWhenCloseNotCalled)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     LONGS_EQUAL(1, OpenSslFake_FreeCallCount());
 }
 
@@ -347,7 +358,7 @@ TEST(SolidSyslogTlsStream, DestroyAfterCloseDoesNotDoubleFreeSsl)
 {
     SolidSyslogStream_Open(stream, addr);
     SolidSyslogStream_Close(stream);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     LONGS_EQUAL(1, OpenSslFake_FreeCallCount());
 }
 
@@ -412,18 +423,18 @@ TEST(SolidSyslogTlsStream, OpenPassesSameBioForReadAndWrite)
 
 TEST(SolidSyslogTlsStream, OpenPassesSslToSniCtrl)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastSslReturned(), OpenSslFake_LastSslCtrlSslArg());
 }
 
 TEST(SolidSyslogTlsStream, OpenPassesSslFromNewToSet1Host)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastSslReturned(), OpenSslFake_LastSet1HostSslArg());
 }
@@ -454,7 +465,7 @@ TEST(SolidSyslogTlsStream, ClosePassesSslFromNewToFree)
 TEST(SolidSyslogTlsStream, DestroyPassesCtxFromNewToCtxFree)
 {
     SolidSyslogStream_Open(stream, addr);
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     POINTERS_EQUAL(OpenSslFake_LastCtxReturned(), OpenSslFake_LastCtxFreeCtxArg());
 }
 
@@ -475,18 +486,18 @@ TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenHandshakeFails)
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenSet1HostFails)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetSet1HostFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenSniHostnameSetupFails)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.serverName = "logs.example";
-    stream            = SolidSyslogTlsStream_Create(&config);
+    stream            = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetSniHostnameFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
@@ -636,20 +647,20 @@ TEST(SolidSyslogTlsStream, OpenSkipsClientIdentityWhenBothPathsAreNull)
 
 TEST(SolidSyslogTlsStream, OpenLoadsClientCertChainFromConfig)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("/some/path/client.pem", OpenSslFake_LastClientCertChainPath());
 }
 
 TEST(SolidSyslogTlsStream, OpenLoadsClientKeyFromConfig)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     STRCMP_EQUAL("/some/path/client.key", OpenSslFake_LastClientKeyPath());
     LONGS_EQUAL(SSL_FILETYPE_PEM, OpenSslFake_LastClientKeyFileType());
@@ -657,29 +668,29 @@ TEST(SolidSyslogTlsStream, OpenLoadsClientKeyFromConfig)
 
 TEST(SolidSyslogTlsStream, OpenChecksClientKeyMatchesCert)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CheckPrivateKeyCallCount());
 }
 
 TEST(SolidSyslogTlsStream, OpenFailsWhenOnlyClientCertIsSet)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = nullptr;
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, OpenMakesNoClientIdentityCallsWhenOnlyClientCertIsSet)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = nullptr;
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(0, OpenSslFake_UseCertChainFileCallCount());
     LONGS_EQUAL(0, OpenSslFake_UsePrivateKeyFileCallCount());
@@ -688,19 +699,19 @@ TEST(SolidSyslogTlsStream, OpenMakesNoClientIdentityCallsWhenOnlyClientCertIsSet
 
 TEST(SolidSyslogTlsStream, OpenFailsWhenOnlyClientKeyIsSet)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = nullptr;
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, OpenMakesNoClientIdentityCallsWhenOnlyClientKeyIsSet)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = nullptr;
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(0, OpenSslFake_UseCertChainFileCallCount());
     LONGS_EQUAL(0, OpenSslFake_UsePrivateKeyFileCallCount());
@@ -709,30 +720,30 @@ TEST(SolidSyslogTlsStream, OpenMakesNoClientIdentityCallsWhenOnlyClientKeyIsSet)
 
 TEST(SolidSyslogTlsStream, PartialClientIdentityConfigFreesCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = nullptr;
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
 }
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenUseCertChainFileFails)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetUseCertChainFileFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, UseCertChainFileFailureFreesCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetUseCertChainFileFails(true);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
@@ -740,20 +751,20 @@ TEST(SolidSyslogTlsStream, UseCertChainFileFailureFreesCtx)
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenUsePrivateKeyFileFails)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetUsePrivateKeyFileFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, UsePrivateKeyFileFailureFreesCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetUsePrivateKeyFileFails(true);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
@@ -761,20 +772,20 @@ TEST(SolidSyslogTlsStream, UsePrivateKeyFileFailureFreesCtx)
 
 TEST(SolidSyslogTlsStream, OpenReturnsFalseWhenCheckPrivateKeyFails)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetCheckPrivateKeyFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
 }
 
 TEST(SolidSyslogTlsStream, CheckPrivateKeyFailureFreesCtx)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     OpenSslFake_SetCheckPrivateKeyFails(true);
     SolidSyslogStream_Open(stream, addr);
     LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
@@ -782,30 +793,30 @@ TEST(SolidSyslogTlsStream, CheckPrivateKeyFailureFreesCtx)
 
 TEST(SolidSyslogTlsStream, OpenPassesCtxFromNewToUseCertChainFile)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastCtxReturned(), OpenSslFake_LastUseCertChainFileCtxArg());
 }
 
 TEST(SolidSyslogTlsStream, OpenPassesCtxFromNewToUsePrivateKeyFile)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastCtxReturned(), OpenSslFake_LastUsePrivateKeyFileCtxArg());
 }
 
 TEST(SolidSyslogTlsStream, OpenPassesCtxFromNewToCheckPrivateKey)
 {
-    SolidSyslogTlsStream_Destroy();
+    SolidSyslogTlsStream_Destroy(stream);
     config.clientCertChainPath = "/some/path/client.pem";
     config.clientKeyPath       = "/some/path/client.key";
-    stream                     = SolidSyslogTlsStream_Create(&config);
+    stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastCtxReturned(), OpenSslFake_LastCheckPrivateKeyCtxArg());
 }


### PR DESCRIPTION
## Purpose
S03.12 (#169) — convert `SolidSyslogStreamSender`, `SolidSyslogPosixTcpStream`, and `SolidSyslogTlsStream` from static singletons to multi-instance with caller-supplied storage, so the Threaded example can wire UDP + TCP + TLS simultaneously (previously mutually exclusive). `SolidSyslogPosixFile` was realigned in the same pass so the codebase ends up on one storage pattern.

## Change Description
- One canonical pattern for multi-instance classes with a fixed internal size: `SOLIDSYSLOG_<X>_SIZE = (sizeof(intptr_t) * N) + sizeof(uint32_t) + ...` expressed as pointer-scaling slots plus explicit stdint terms, opaque storage typedef `intptr_t slots[ceil(SIZE/sizeof(intptr_t))]`, static-assert in the `.c`, `DEFAULT_INSTANCE` / `DESTROYED_INSTANCE` + struct-assignment Create/Destroy.
- Size formula handles 16/32/64-bit correctly — stdint widths stay fixed, pointer-scale terms follow the architecture, ceiling division keeps the typedef pointer-aligned.
- PosixFile realigned from its earlier `uint8_t opaque[SLOTS*sizeof(void*)]` spelling to the canonical form (no storage-size change).
- Formatter keeps its variable-sized macro form — the permitted exception.
- Threaded example now always wires UDP + plain TCP + TLS; `--transport` at launch selects the initially-active slot, and runtime `switch` moves between any of the three.

## Test Evidence
- One pointer-equality test per converted class (`CreateReturnsHandleInsideCallerSuppliedStorage`) — proves the storage contract and, by extension, multi-instance safety.
- Existing unit tests unchanged in logic — only setup/teardown updated for the new signatures. All pass.
- OpenSSL integration tests pass.
- BDD locally: 17/17 features, 34/34 scenarios, 176/176 steps pass, including `switching_transport` and all fault-injection scenarios.
- Local pre-push CI gates run green: debug, clang-debug, sanitize (ASan/UBSan), tidy, cppcheck, clang-format.

## Areas Affected
- \`Core/Interface/SolidSyslogStreamSender.h\` + source.
- \`Platform/Posix/Interface/SolidSyslogPosixTcpStream.h\` + source.
- \`Platform/Posix/Interface/SolidSyslogPosixFile.h\` + source (realigned).
- \`Platform/OpenSsl/Interface/SolidSyslogTlsStream.h\` + source.
- \`Example/Threaded/main.c\` — simultaneous transport wiring.
- Test setup/teardown in \`Tests/SolidSyslog{PosixTcpStream,TlsStream,StreamSender,PosixFile,FileStorePosix}Test.cpp\` and the OpenSSL integration test.

Out of scope for this PR (follow-on commits on this branch before merge):
- New BDD scenario explicitly covering TCP↔TLS runtime switching.
- DEVLOG entry.

Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Stream sender initialization now requires caller-supplied storage and configuration parameters.
  * TLS stream and TCP stream creation methods updated to accept explicit storage parameters.
  * All stream destruction methods now require explicit instance handles rather than implicit global cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->