### PR TITLE
feat: S03.13 Example TLS backend composition via CMake

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,49 @@
 # Dev Log
 
+## 2026-04-22 — S03.13 TLS backend composition via CMake
+
+### Decisions
+- Factored TLS sender construction out of `Example/Threaded/main.c` into
+  per-backend files selected at CMake link time, matching the existing
+  repo idiom of link-time composition (platform subdirectories,
+  `POSIX_FAKES_SOURCES`, etc.). `main.c` now has zero TLS `#ifdef`s, no
+  `SOLIDSYSLOG_HAVE_OPENSSL` compile define, and no knowledge of whether
+  the TLS backend is real or a stub — it just calls
+  `ExampleTlsSender_Create(resolver, mtls)` / `_Destroy()`.
+- Two backends today: `ExampleTlsSender_OpenSsl.c` (the real wiring
+  previously inside `main.c::CreateSender`) and
+  `ExampleTlsSender_Unavailable.c` (nil-object stub). A third
+  `ExampleTlsSender_WolfSsl.c` is deliberately not created here — the
+  `_<Backend>.c` filename convention is the extension point for future
+  backends; adding wolfSSL is its own story.
+- Stub is a nil-object, not an exit-on-create. Under S03.12 all three
+  switching-slot senders are created on startup regardless of the
+  launch-time transport, so exiting from the stub's `_Create` would kill
+  UDP/TCP launches too. The nil sender's `Send` prints a one-shot stderr
+  message ("TLS support not compiled in — messages routed to the TLS slot
+  will be dropped") and returns false; `Disconnect` is a no-op. Not a
+  silent fallback (user sees the message), not an abrupt exit (UDP/TCP
+  keep working), consistent with existing null-object conventions
+  (NullBuffer, NullStore, NullSecurityPolicy). `warned` latch is reset in
+  `_Create` so repeated Create/Destroy cycles stay quiet on subsequent
+  Sends in the normal case but re-warn after any genuine re-setup.
+- Dropped the draft `ExampleTlsSender_Available()` function — the
+  nil-object approach makes it unnecessary. `main.c` doesn't branch on
+  availability; it just wires whatever the linker gave it.
+- `ExampleTlsConfig.c` and `ExampleMtlsConfig.c` link alongside the
+  OpenSSL backend, dropped with the Unavailable one. The Unavailable
+  build no longer compiles the TLS/mTLS config modules at all.
+
+### Deferred
+- Actual wolfSSL / mbedTLS backends — separate future story per-backend.
+- Extending the same composition idiom to other transports (UDP / plain
+  TCP) — only TLS has the optional-dependency problem today.
+- Runtime backend registration / dynamic plugin loading — not needed in
+  the foreseeable roadmap.
+
+### Open questions
+- None.
+
 ## 2026-04-22 — S03.12 multi-instance senders and streams
 
 ### Decisions

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -9,10 +9,6 @@ if(SOLIDSYSLOG_POSIX)
         Common/ExampleSwitchConfig.c
     )
 
-    if(SOLIDSYSLOG_OPENSSL)
-        list(APPEND COMMON_SOURCES Common/ExampleTlsConfig.c Common/ExampleMtlsConfig.c)
-    endif()
-
     # Single-task example: NullBuffer, direct send, bare-metal model
     add_executable(SolidSyslogExample SingleTask/main.c SingleTask/SolidSyslogExample.c ${COMMON_SOURCES})
     target_link_libraries(SolidSyslogExample PRIVATE ${PROJECT_NAME})
@@ -22,15 +18,26 @@ if(SOLIDSYSLOG_POSIX)
     )
 
     # Threaded example: PosixMessageQueueBuffer, two pthreads (requires POSIX threads and mqueue).
-    # TLS transport (optional via SOLIDSYSLOG_OPENSSL) adds OpenSSL linkage.
-    add_executable(SolidSyslogThreadedExample Threaded/main.c ${COMMON_SOURCES})
+    # TLS transport is selected at link time via the ExampleTlsSender_<backend>.c
+    # source file — OpenSSL when SOLIDSYSLOG_OPENSSL, nil-object stub otherwise.
+    set(THREADED_SOURCES Threaded/main.c ${COMMON_SOURCES})
+    if(SOLIDSYSLOG_OPENSSL)
+        list(APPEND THREADED_SOURCES
+            Threaded/ExampleTlsSender_OpenSsl.c
+            Common/ExampleTlsConfig.c
+            Common/ExampleMtlsConfig.c
+        )
+    else()
+        list(APPEND THREADED_SOURCES Threaded/ExampleTlsSender_Unavailable.c)
+    endif()
+    add_executable(SolidSyslogThreadedExample ${THREADED_SOURCES})
     target_link_libraries(SolidSyslogThreadedExample PRIVATE ${PROJECT_NAME} Threads::Threads)
     target_include_directories(SolidSyslogThreadedExample PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/Common
+        ${CMAKE_CURRENT_SOURCE_DIR}/Threaded
     )
     if(SOLIDSYSLOG_OPENSSL)
         target_link_libraries(SolidSyslogThreadedExample PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-        target_compile_definitions(SolidSyslogThreadedExample PRIVATE SOLIDSYSLOG_HAVE_OPENSSL=1)
     endif()
 elseif(SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM)
     # Windows example: NullBuffer + Winsock UDP + Windows clock/hostname/process-id.

--- a/Example/Threaded/ExampleTlsSender.h
+++ b/Example/Threaded/ExampleTlsSender.h
@@ -1,0 +1,18 @@
+#ifndef EXAMPLETLSSENDER_H
+#define EXAMPLETLSSENDER_H
+
+#include "ExternC.h"
+
+#include <stdbool.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogResolver;
+    struct SolidSyslogSender;
+
+    struct SolidSyslogSender* ExampleTlsSender_Create(struct SolidSyslogResolver * resolver, bool mtls);
+    void                      ExampleTlsSender_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* EXAMPLETLSSENDER_H */

--- a/Example/Threaded/ExampleTlsSender_OpenSsl.c
+++ b/Example/Threaded/ExampleTlsSender_OpenSsl.c
@@ -1,0 +1,50 @@
+#include "ExampleMtlsConfig.h"
+#include "ExampleTlsConfig.h"
+#include "ExampleTlsSender.h"
+#include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogStreamSender.h"
+#include "SolidSyslogTlsStream.h"
+
+static SolidSyslogPosixTcpStreamStorage underlyingStreamStorage;
+static struct SolidSyslogStream*        underlyingStream;
+static SolidSyslogTlsStreamStorage      tlsStreamStorage;
+static struct SolidSyslogStream*        tlsStream;
+static SolidSyslogStreamSenderStorage   senderStorage;
+static struct SolidSyslogSender*        sender;
+
+struct SolidSyslogSender* ExampleTlsSender_Create(struct SolidSyslogResolver* resolver, bool mtls)
+{
+    underlyingStream = SolidSyslogPosixTcpStream_Create(&underlyingStreamStorage);
+
+    static struct SolidSyslogTlsStreamConfig tlsStreamConfig = {0};
+    tlsStreamConfig.transport                                = underlyingStream;
+    if (mtls)
+    {
+        tlsStreamConfig.caBundlePath        = ExampleMtlsConfig_GetCaBundlePath();
+        tlsStreamConfig.serverName          = ExampleMtlsConfig_GetServerName();
+        tlsStreamConfig.clientCertChainPath = ExampleMtlsConfig_GetClientCertChainPath();
+        tlsStreamConfig.clientKeyPath       = ExampleMtlsConfig_GetClientKeyPath();
+    }
+    else
+    {
+        tlsStreamConfig.caBundlePath = ExampleTlsConfig_GetCaBundlePath();
+        tlsStreamConfig.serverName   = ExampleTlsConfig_GetServerName();
+    }
+    tlsStream = SolidSyslogTlsStream_Create(&tlsStreamStorage, &tlsStreamConfig);
+
+    static struct SolidSyslogStreamSenderConfig senderConfig = {0};
+    senderConfig.resolver                                    = resolver;
+    senderConfig.stream                                      = tlsStream;
+    senderConfig.endpoint                                    = mtls ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
+    senderConfig.endpointVersion                             = mtls ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
+    sender                                                   = SolidSyslogStreamSender_Create(&senderStorage, &senderConfig);
+
+    return sender;
+}
+
+void ExampleTlsSender_Destroy(void)
+{
+    SolidSyslogStreamSender_Destroy(sender);
+    SolidSyslogTlsStream_Destroy(tlsStream);
+    SolidSyslogPosixTcpStream_Destroy(underlyingStream);
+}

--- a/Example/Threaded/ExampleTlsSender_OpenSsl.c
+++ b/Example/Threaded/ExampleTlsSender_OpenSsl.c
@@ -16,8 +16,9 @@ struct SolidSyslogSender* ExampleTlsSender_Create(struct SolidSyslogResolver* re
 {
     underlyingStream = SolidSyslogPosixTcpStream_Create(&underlyingStreamStorage);
 
-    static struct SolidSyslogTlsStreamConfig tlsStreamConfig = {0};
-    tlsStreamConfig.transport                                = underlyingStream;
+    static struct SolidSyslogTlsStreamConfig tlsStreamConfig;
+    tlsStreamConfig           = (struct SolidSyslogTlsStreamConfig) {0};
+    tlsStreamConfig.transport = underlyingStream;
     if (mtls)
     {
         tlsStreamConfig.caBundlePath        = ExampleMtlsConfig_GetCaBundlePath();
@@ -32,12 +33,13 @@ struct SolidSyslogSender* ExampleTlsSender_Create(struct SolidSyslogResolver* re
     }
     tlsStream = SolidSyslogTlsStream_Create(&tlsStreamStorage, &tlsStreamConfig);
 
-    static struct SolidSyslogStreamSenderConfig senderConfig = {0};
-    senderConfig.resolver                                    = resolver;
-    senderConfig.stream                                      = tlsStream;
-    senderConfig.endpoint                                    = mtls ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
-    senderConfig.endpointVersion                             = mtls ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
-    sender                                                   = SolidSyslogStreamSender_Create(&senderStorage, &senderConfig);
+    static struct SolidSyslogStreamSenderConfig senderConfig;
+    senderConfig                 = (struct SolidSyslogStreamSenderConfig) {0};
+    senderConfig.resolver        = resolver;
+    senderConfig.stream          = tlsStream;
+    senderConfig.endpoint        = mtls ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
+    senderConfig.endpointVersion = mtls ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
+    sender                       = SolidSyslogStreamSender_Create(&senderStorage, &senderConfig);
 
     return sender;
 }

--- a/Example/Threaded/ExampleTlsSender_Unavailable.c
+++ b/Example/Threaded/ExampleTlsSender_Unavailable.c
@@ -1,0 +1,39 @@
+#include "ExampleTlsSender.h"
+#include "SolidSyslogSenderDefinition.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+static bool warned;
+
+static bool NilSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+{
+    (void) self;
+    (void) buffer;
+    (void) size;
+    if (!warned)
+    {
+        (void) fprintf(stderr, "ExampleTlsSender: TLS support not compiled in — messages routed to the TLS slot will be dropped\n");
+        warned = true;
+    }
+    return false;
+}
+
+static void NilDisconnect(struct SolidSyslogSender* self)
+{
+    (void) self;
+}
+
+static struct SolidSyslogSender nilSender = {NilSend, NilDisconnect};
+
+struct SolidSyslogSender* ExampleTlsSender_Create(struct SolidSyslogResolver* resolver, bool mtls)
+{
+    (void) resolver;
+    (void) mtls;
+    warned = false;
+    return &nilSender;
+}
+
+void ExampleTlsSender_Destroy(void)
+{
+}

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -4,6 +4,7 @@
 #include "ExampleServiceThread.h"
 #include "ExampleSwitchConfig.h"
 #include "ExampleTcpConfig.h"
+#include "ExampleTlsSender.h"
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogAtomicCounter.h"
@@ -26,14 +27,6 @@
 #include "SolidSyslogStreamSender.h"
 #include "SolidSyslogUdpSender.h"
 
-/* TODO(S3.13, #171): replace these three #ifdef blocks with a per-backend
- * ExampleTlsSender factory selected at CMake time. */
-#ifdef SOLIDSYSLOG_HAVE_OPENSSL
-#include "ExampleMtlsConfig.h"
-#include "ExampleTlsConfig.h"
-#include "SolidSyslogTlsStream.h"
-#endif
-
 #include <pthread.h>
 #include <string.h>
 #include <unistd.h>
@@ -45,14 +38,6 @@ static SolidSyslogPosixTcpStreamStorage plainTcpStreamStorage;
 static struct SolidSyslogStream*        plainTcpStream;
 static SolidSyslogStreamSenderStorage   plainTcpSenderStorage;
 static struct SolidSyslogSender*        plainTcpSender;
-#ifdef SOLIDSYSLOG_HAVE_OPENSSL
-static SolidSyslogPosixTcpStreamStorage tlsUnderlyingStreamStorage;
-static struct SolidSyslogStream*        tlsUnderlyingStream;
-static SolidSyslogTlsStreamStorage      tlsStreamStorage;
-static struct SolidSyslogStream*        tlsStream;
-static SolidSyslogStreamSenderStorage   tlsSenderStorage;
-static struct SolidSyslogSender*        tlsSender;
-#endif
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 {
@@ -91,41 +76,12 @@ static struct SolidSyslogSender* CreateSender(const struct ExampleOptions* optio
     tcpConfig.endpointVersion                             = ExampleTcpConfig_GetEndpointVersion;
     plainTcpSender                                        = SolidSyslogStreamSender_Create(&plainTcpSenderStorage, &tcpConfig);
 
-    struct SolidSyslogSender* tlsSlot = NULL;
-#ifdef SOLIDSYSLOG_HAVE_OPENSSL
-    tlsUnderlyingStream                                      = SolidSyslogPosixTcpStream_Create(&tlsUnderlyingStreamStorage);
-    static struct SolidSyslogTlsStreamConfig tlsStreamConfig = {0};
-    tlsStreamConfig.transport                                = tlsUnderlyingStream;
-    if (mtlsModeActive)
-    {
-        tlsStreamConfig.caBundlePath        = ExampleMtlsConfig_GetCaBundlePath();
-        tlsStreamConfig.serverName          = ExampleMtlsConfig_GetServerName();
-        tlsStreamConfig.clientCertChainPath = ExampleMtlsConfig_GetClientCertChainPath();
-        tlsStreamConfig.clientKeyPath       = ExampleMtlsConfig_GetClientKeyPath();
-    }
-    else
-    {
-        tlsStreamConfig.caBundlePath = ExampleTlsConfig_GetCaBundlePath();
-        tlsStreamConfig.serverName   = ExampleTlsConfig_GetServerName();
-    }
-    tlsStream = SolidSyslogTlsStream_Create(&tlsStreamStorage, &tlsStreamConfig);
-
-    static struct SolidSyslogStreamSenderConfig tlsSenderConfig = {0};
-    tlsSenderConfig.resolver                                    = resolver;
-    tlsSenderConfig.stream                                      = tlsStream;
-    tlsSenderConfig.endpoint                                    = mtlsModeActive ? ExampleMtlsConfig_GetEndpoint : ExampleTlsConfig_GetEndpoint;
-    tlsSenderConfig.endpointVersion                             = mtlsModeActive ? ExampleMtlsConfig_GetEndpointVersion : ExampleTlsConfig_GetEndpointVersion;
-    tlsSender                                                   = SolidSyslogStreamSender_Create(&tlsSenderStorage, &tlsSenderConfig);
-    tlsSlot                                                     = tlsSender;
-#else
-    (void) mtlsModeActive;
-    tlsSlot = udpSender; /* fallback when TLS not built — keeps switching selector total */
-#endif
+    struct SolidSyslogSender* tlsSender = ExampleTlsSender_Create(resolver, mtlsModeActive);
 
     static struct SolidSyslogSender* inners[EXAMPLE_SWITCH_COUNT];
     inners[EXAMPLE_SWITCH_UDP] = udpSender;
     inners[EXAMPLE_SWITCH_TCP] = plainTcpSender;
-    inners[EXAMPLE_SWITCH_TLS] = tlsSlot;
+    inners[EXAMPLE_SWITCH_TLS] = tlsSender;
 
     static struct SolidSyslogSwitchingSenderConfig switchConfig = {0};
     switchConfig.senders                                        = inners;
@@ -188,11 +144,7 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
 static void DestroySender(void)
 {
     SolidSyslogSwitchingSender_Destroy();
-#ifdef SOLIDSYSLOG_HAVE_OPENSSL
-    SolidSyslogStreamSender_Destroy(tlsSender);
-    SolidSyslogTlsStream_Destroy(tlsStream);
-    SolidSyslogPosixTcpStream_Destroy(tlsUnderlyingStream);
-#endif
+    ExampleTlsSender_Destroy();
     SolidSyslogStreamSender_Destroy(plainTcpSender);
     SolidSyslogPosixTcpStream_Destroy(plainTcpStream);
     SolidSyslogUdpSender_Destroy();


### PR DESCRIPTION
## Purpose
S03.13 (#171) — move TLS wiring out of `Example/Threaded/main.c` into per-backend source files selected at CMake link time, so `main.c` is free of `#ifdef SOLIDSYSLOG_HAVE_OPENSSL` (and the compile define is dropped).

## Change Description
- `Example/Threaded/ExampleTlsSender.h` declares `ExampleTlsSender_Create(resolver, mtls)` / `_Destroy()`.
- `Example/Threaded/ExampleTlsSender_OpenSsl.c` is the real backend — it owns the file-scope storage previously sitting in `main.c`.
- `Example/Threaded/ExampleTlsSender_Unavailable.c` is a nil-object stub: `_Create` returns a static nil sender; that sender's `Send` prints a one-shot stderr warning and returns false; `Disconnect` is a no-op.
- `Example/CMakeLists.txt` links exactly one of the two backends based on `SOLIDSYSLOG_OPENSSL`. `ExampleTlsConfig.c` and `ExampleMtlsConfig.c` only link alongside the OpenSSL backend.
- `main.c` has zero TLS `#ifdef`s, no `SOLIDSYSLOG_HAVE_OPENSSL` compile define, and doesn't know whether the linker gave it the real backend or the stub. It just calls `ExampleTlsSender_Create` and plumbs the result into the switching sender's TLS slot.
- The draft `ExampleTlsSender_Available()` function was dropped — the nil-object approach makes it unnecessary.

Nil-object is the right stub shape here because under S03.12 the TLS slot is always populated at startup regardless of launch-time `--transport`. Exiting from the stub's `_Create` would kill `--transport udp` and `--transport tcp` launches too.

## Test Evidence
- Local CI gates all green: debug, clang-debug, sanitize (ASan/UBSan), tidy, cppcheck, clang-format.
- `cmake -DSOLIDSYSLOG_OPENSSL=OFF` builds cleanly.
- Smoke test with `OPENSSL=OFF`: `--transport tcp` runs silently; `--transport tls` prints `ExampleTlsSender: TLS support not compiled in — messages routed to the TLS slot will be dropped` on the first send and keeps running.
- BDD: 17/17 features, 35/35 scenarios, 184/184 steps pass (includes TLS, mTLS, and TCP↔TLS switching scenarios).

## Areas Affected
- New: `Example/Threaded/ExampleTlsSender.h`, `Example/Threaded/ExampleTlsSender_OpenSsl.c`, `Example/Threaded/ExampleTlsSender_Unavailable.c`.
- `Example/Threaded/main.c` — three `#ifdef` blocks removed, file-scope TLS storage moved into the OpenSSL backend, Destroy simplified.
- `Example/CMakeLists.txt` — link-time backend selection; `SOLIDSYSLOG_HAVE_OPENSSL` compile define dropped.
- `DEVLOG.md` — entry added.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized TLS backend integration to use per-backend implementations selected at build time, eliminating build-time conditionals from the main code path.

* **Improvements**
  * Enhanced error messaging when TLS support is unavailable in a build, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->