### PR TITLE
test: S03.14 BDD exercises TLS 1.3 — syslog-ng configured to require it

### DIFF
--- a/Bdd/features/tls_transport.feature
+++ b/Bdd/features/tls_transport.feature
@@ -8,3 +8,13 @@ Feature: TLS message delivery
     When the threaded example sends a syslog message with transport tls
     Then syslog-ng receives 1 message over tls
     And syslog-ng receives a message with priority "134"
+
+  @tls13
+  Scenario: Library negotiates TLS 1.3 against a server that requires it
+    # syslog-ng's TLS receivers in syslog-ng-full.conf disable all protocols
+    # below 1.3 via ssl-options, so message delivery here proves the handshake
+    # completed at TLS 1.3 — the library has no 1.3-specific knob, it just
+    # happens because OpenSSL prefers the highest mutually-supported version.
+    Given syslog-ng is running
+    When the threaded example sends a syslog message with transport tls
+    Then syslog-ng receives 1 message over tls

--- a/Bdd/syslog-ng/syslog-ng-full.conf
+++ b/Bdd/syslog-ng/syslog-ng-full.conf
@@ -26,6 +26,7 @@ source s_tls {
             cert-file("/etc/syslog-ng/tls/server.pem")
             ca-file("/etc/syslog-ng/tls/ca.pem")
             peer-verify(optional-untrusted)
+            ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")
         )
     );
 };
@@ -40,6 +41,7 @@ source s_mtls {
             cert-file("/etc/syslog-ng/tls/server.pem")
             ca-file("/etc/syslog-ng/tls/ca.pem")
             peer-verify(required-trusted)
+            ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")
         )
     );
 };

--- a/Bdd/syslog-ng/syslog-ng.conf
+++ b/Bdd/syslog-ng/syslog-ng.conf
@@ -26,6 +26,7 @@ source s_tls {
             cert-file("/etc/syslog-ng/tls/server.pem")
             ca-file("/etc/syslog-ng/tls/ca.pem")
             peer-verify(optional-untrusted)
+            ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")
         )
     );
 };
@@ -40,6 +41,7 @@ source s_mtls {
             cert-file("/etc/syslog-ng/tls/server.pem")
             ca-file("/etc/syslog-ng/tls/ca.pem")
             peer-verify(required-trusted)
+            ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")
         )
     );
 };

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,38 @@
 # Dev Log
 
+## 2026-04-22 — S03.14 BDD exercises TLS 1.3
+
+### Decisions
+- Tightened syslog-ng's TLS and mTLS receivers
+  (`syslog-ng-full.conf`) to require TLS 1.3 only by adding
+  `ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")`
+  to both `tls(...)` blocks. Existing `@tls` / `@mtls` / switching-TCP↔TLS
+  scenarios remain unmodified and now prove 1.3 negotiation implicitly —
+  they all pass because our TLS stream's minimum-version floor is 1.2
+  (allows 1.3) and OpenSSL prefers the highest mutually-supported version.
+- Added one new explicit scenario to `tls_transport.feature` tagged
+  `@tls13`, with comment noting that message delivery here proves TLS 1.3
+  negotiation because the receiver refuses anything else. The
+  `syslog-ng-full.conf` is the contract; any future loosening of the
+  receiver would turn the scenario back into a generic "TLS works" test,
+  so the contract-via-config is self-documenting.
+- No library code changes. Current code already negotiates 1.3
+  transparently. 1.3-specific cipher pinning via
+  `SSL_CTX_set_ciphersuites` is a separate concern; deferred to a future
+  story if a deployment needs it. The existing 1.2 cipher-list pin is
+  ignored under 1.3 (different OpenSSL API path) — no breakage.
+
+### Deferred
+- 1.3 cipher-suite pinning API exposure.
+- Explicit assertion in BDD that reads the negotiated version from
+  syslog-ng logs — not worth the template + oracle plumbing while the
+  syslog-ng receiver config is the binding contract.
+- Running the library against a 1.3-only server on a different OpenSSL
+  version (e.g. boringssl) — separate TLS-backend story.
+
+### Open questions
+- None. E03 is now story-complete; closing the epic on merge.
+
 ## 2026-04-22 — S03.13 TLS backend composition via CMake
 
 ### Decisions


### PR DESCRIPTION
## Purpose
S03.14 (#182) — close out Epic E03 by proving the library negotiates TLS 1.3 end-to-end. Tighten syslog-ng's BDD TLS / mTLS receivers to require 1.3, leaving 1.2 and below refused on the wire.

## Change Description
- `Bdd/syslog-ng/syslog-ng-full.conf` — added `ssl-options("no-sslv2", "no-sslv3", "no-tlsv1", "no-tlsv11", "no-tlsv12")` to both the TLS (6514) and mTLS (6515) source blocks. `syslog-ng.conf` (runtime copy) updated to match the new full-conf.
- `Bdd/features/tls_transport.feature` — added a `@tls13` scenario with a comment explaining that message delivery here proves 1.3 negotiation because the receiver refuses anything else.
- `DEVLOG.md` — entry added.

No library changes. Today's code already negotiates 1.3 transparently: `SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION)` is a floor (1.2 or higher), not a pin, and OpenSSL prefers the highest mutually-supported version. The 1.2 cipher-list pin from S03.08 is ignored under 1.3 (different OpenSSL API) so there's no break.

## Test Evidence
- Existing `@tls` scenario, `@mtls` scenario, and `@tls` `Switch from TCP to TLS mid-run` scenario all continue to pass against the 1.3-only receivers — that's the primary evidence that the library is negotiating 1.3 transparently.
- New `@tls13` scenario passes.
- Full BDD: 17/17 features, 36/36 scenarios, 187/187 steps pass.
- Unit + integration tests unchanged in shape, pass.

## Areas Affected
- `Bdd/syslog-ng/syslog-ng-full.conf` + `syslog-ng.conf` — TLS receiver tightening.
- `Bdd/features/tls_transport.feature` — new scenario.
- `DEVLOG.md`.

## Out of scope (example code only, deferred by agreement)
- 1.3 cipher-suite pinning via `SSL_CTX_set_ciphersuites` — separate future story if a deployment requires it.
- BDD assertion that reads the negotiated version from syslog-ng logs — the receiver config is the binding contract already.

Closes #182