### PR TITLE
docs: clarify TLS is a reference implementation, not a library capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ Headers in `Core/Interface/` are split by audience — each user includes only w
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct (`Send`, `Disconnect`) |
 | `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(resolver, transport, host, port, *out)` |
 | `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
-| `SolidSyslogStreamSender.h` | System setup code using octet-framed transport (RFC 6587) over any Stream — TCP today, TLS in future | `SolidSyslogStreamSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogStreamSender_Create`, `_Destroy` |
+| `SolidSyslogStreamSender.h` | System setup code using octet-framed transport (RFC 6587) over any Stream — `SolidSyslogPosixTcpStream` (TCP), `SolidSyslogTlsStream` (TLS; OpenSSL reference integration), or a caller-supplied Stream backend | `SolidSyslogStreamSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogStreamSender_Create`, `_Destroy` |
 | `SolidSyslogSwitchingSender.h` | System setup code composing multiple inner senders | `SolidSyslogSwitchingSenderConfig` (senders, senderCount, selector), `SolidSyslogSwitchingSenderSelector`, `SolidSyslogSwitchingSender_Create`, `_Destroy` |
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # SolidSyslog
 
 A structured syslog client library for embedded and industrial systems, implementing
-RFC 5424 (structured syslog), RFC 5426 (UDP transport), RFC 6587 (TCP transport),
-and RFC 5425 (TLS transport).
+RFC 5424 (structured syslog) with RFC 5426 (UDP) and RFC 6587 (TCP) transports.
+TLS per RFC 5425 is available via a pluggable Stream abstraction — the repo ships
+a reference OpenSSL integration, and callers can plug in any TLS library (wolfSSL,
+mbedTLS, hardware-offload, …) by implementing the same Stream vtable. TLS itself
+is not a core dependency; Core has zero OpenSSL references.
 
 Designed for resource-constrained environments:
 - C99, no dynamic memory allocation required — allocator is caller-injected


### PR DESCRIPTION
## Purpose
Align the public-facing framing with the actual architecture: the library provides a `SolidSyslogStream` abstraction and an octet-framing `SolidSyslogStreamSender`, and TLS support is enabled by plugging a TLS-aware Stream implementation in. The repo ships a reference OpenSSL integration at `Platform/OpenSsl/Source/SolidSyslogTlsStream.c`, but Core itself has zero OpenSSL references.

Two spots in the docs overclaimed or had drifted:

## Change Description
- **README.md** lead paragraph split RFC 5424 / 5426 / 6587 (library-implemented) from RFC 5425 (TLS, via the pluggable Stream abstraction with an OpenSSL reference integration). Explicitly names wolfSSL / mbedTLS / hardware-offload as caller-supplied alternatives to make the extension point unmistakable, and states "TLS itself is not a core dependency; Core has zero OpenSSL references."
- **CLAUDE.md** header audience table — `SolidSyslogStreamSender.h` row's "TCP today, TLS in future" note was a stale pre-S03.07 TODO. Replaced with the current reality: TCP via `SolidSyslogPosixTcpStream`, TLS via `SolidSyslogTlsStream` (OpenSSL reference integration), or a caller-supplied Stream backend.

No code changes.

## Test Evidence
Docs-only change; no CI gates exercise the changed content. The facts stated are verifiable:
- `grep -r openssl Core/` returns zero matches.
- `Platform/OpenSsl/` is the only TLS implementation site; it's a Tier-2 directory per the support tiers defined in CLAUDE.md.

## Areas Affected
- `README.md`, `CLAUDE.md`.

Closes out the doc-framing point raised during the S03.14 sanity check.