### PR TITLE
chore: configure release-please to stay on 0.x until 1.0 is explicitly cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "bump-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
## Purpose
Align release-please's version-bump policy with the repo's stated release strategy: 0.x is the beta series, breaking changes during 0.x are expected, 1.0.0 is cut deliberately when the API is stable.

Today the standing release-please PR ([#101](https://github.com/DavidCozens/solid-syslog/pull/101)) proposes `1.0.0` because the commit history contains a `BREAKING CHANGE` (the S3.6 TcpSender → StreamSender rename) and release-please's default pre-1.0 behaviour jumps straight to 1.0 on any `!` commit. That doesn't match intent — we're not ready to commit to API stability.

## Change Description
Add `"bump-minor-pre-major": true` to `release-please-config.json`. With this flag, in the 0.x series:
- `feat:` / `feat!:` / `BREAKING CHANGE` → 0.x → 0.(x+1) (minor bump, no jump to 1.0).
- `fix:` → 0.x.y → 0.x.(y+1) (patch).

After 1.0.0 is cut (whenever that happens), the flag is a no-op and normal SemVer resumes: `feat!:` → major, `feat:` → minor, `fix:` → patch.

## Test Evidence
- JSON validated.
- No CI gate exercises this file.
- Observable effect: once this merges to main, release-please re-runs and PR #101's title updates from `chore(main): release 1.0.0` to `chore(main): release 0.1.0`. That's the confirmation signal.

## Areas Affected
- `release-please-config.json` — one line added.

No code or docs touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning configuration to adjust how version bumps are performed before major releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->