### PR TITLE
chore: pin release-please's first release to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "initial-version": "0.1.0",
       "bump-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },


### PR DESCRIPTION
## Purpose
Finish the job #191 started. `bump-minor-pre-major: true` was the right flag for post-first-release behaviour in 0.x, but it doesn't affect the **first** release computation — that uses a separate path. Result: PR #101 still proposes `1.0.0` because release-please sees a `feat!:` in history and, without `initial-version`, falls back to the standard "breaking change → 1.0.0" rule for the first release.

## Change Description
Add `"initial-version": "0.1.0"` to `release-please-config.json`. Combined effect:

| Event | Next version |
|---|---|
| First release merge (PR #101) | `0.1.0` |
| Subsequent `feat:` in 0.x | minor bump (`0.1.0` → `0.2.0`) |
| Subsequent `feat!:` / BREAKING in 0.x | minor bump (`0.1.0` → `0.2.0`) — capped by `bump-minor-pre-major` |
| Subsequent `fix:` in 0.x | patch bump |
| After 1.0.0 is cut | normal SemVer resumes |

## Test Evidence
- JSON validated.
- Observable effect: once merged, release-please re-runs on main and PR #101's title should flip from `chore(main): release 1.0.0` to `chore(main): release 0.1.0`, and the proposed manifest in that PR updates from `1.0.0` to `0.1.0`. That's the confirmation signal.
- Inspected the release-please v17.1.3 config schema to confirm `initial-version` is a supported package-level key (`"Releases the initial library with a specified version"`).

## Areas Affected
- `release-please-config.json` — one line added.