### PR TITLE
feat: S19.01 SBOM CycloneDX template + on-demand generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Compute source-tarball hash
         id: hash
         run: |
+          # Product scope per docs/security/sbom.md: Core/ + Platform/.
+          # Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/
+          # are reference / test-harness / infrastructure and out of scope.
           TARBALL=$(mktemp)
-          git archive --format=tar.gz HEAD -- Core/ > "$TARBALL"
+          git archive --format=tar.gz HEAD -- Core/ Platform/ > "$TARBALL"
           HASH=$(sha256sum "$TARBALL" | cut -d' ' -f1)
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
           rm "$TARBALL"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,73 @@
+name: Generate SBOM
+
+on:
+  workflow_dispatch:
+  # S19.02 will switch on the `release: published` trigger and add signing
+  # + release-asset attachment. Until then, this workflow is on-demand only.
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Read version from release-please manifest
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Compute source-tarball hash
+        id: hash
+        run: |
+          TARBALL=$(mktemp)
+          git archive --format=tar.gz HEAD -- Core/ > "$TARBALL"
+          HASH=$(sha256sum "$TARBALL" | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          rm "$TARBALL"
+
+      - name: Generate serial number
+        id: serial
+        run: |
+          echo "uuid=$(cat /proc/sys/kernel/random/uuid)" >> "$GITHUB_OUTPUT"
+
+      - name: Render SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          COMMIT_SHA: ${{ github.sha }}
+          SOURCE_HASH: ${{ steps.hash.outputs.hash }}
+          SERIAL_NUMBER: ${{ steps.serial.outputs.uuid }}
+          TOOLS_VERSION: ${{ github.workflow_sha }}
+        run: |
+          export TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          envsubst '${VERSION} ${COMMIT_SHA} ${SOURCE_HASH} ${SERIAL_NUMBER} ${TIMESTAMP} ${TOOLS_VERSION}' \
+            < sbom/sbom.cdx.json.template > sbom/sbom.cdx.json
+          if grep -q '\${' sbom/sbom.cdx.json; then
+            echo "::error::Unresolved placeholders in rendered SBOM"
+            grep '\${' sbom/sbom.cdx.json
+            exit 1
+          fi
+          python3 -c "import json; json.load(open('sbom/sbom.cdx.json'))"
+
+      - name: Install cyclonedx-cli (v0.30.0, SHA256-pinned)
+        run: |
+          curl -sSLo /tmp/cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.30.0/cyclonedx-linux-x64
+          echo "f89876326620f5fc78a9b27cc1af57d6ed13d019aab87490e1246a44a910babb  /tmp/cyclonedx" | sha256sum -c -
+          chmod +x /tmp/cyclonedx
+
+      - name: Validate SBOM
+        run: |
+          /tmp/cyclonedx validate --input-file sbom/sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-cyclonedx-${{ steps.version.outputs.version }}
+          path: sbom/sbom.cdx.json
+          if-no-files-found: error

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,55 @@
 # Dev Log
 
+## 2026-04-22 — S19.01 SBOM rehearsal workflow (CycloneDX template + on-demand generate)
+
+### Decisions
+- First story decomposed out of E19 (#155). Two-story split for SBOM work —
+  this one (`S19.01`) does template + on-demand generation + validation; the
+  follow-on (`S19.02`) adds cosign signing and release-time attachment.
+  Primary driver: a maintainer rehearsal workflow, runnable via
+  `workflow_dispatch`, before next week's client conversation about SBOMs.
+- **Format: CycloneDX 1.5 JSON** (primary; E19 locks this in, no SPDX).
+- **Scope:** `Core/` subtree. Single-component SBOM — `metadata.component`
+  is SolidSyslog, `components: []`. Platform / Example / Tests / Bdd
+  directories excluded. POSIX / Windows runtime facts captured as
+  `metadata.properties`, not as components (they are *deployment
+  requirements*, not *shipped software*).
+- **Template-based generation, not tool-scanning.** The project is a
+  pure-C library with no runtime dependencies — a static template with
+  env-substituted placeholders for version / commit SHA / source hash /
+  timestamp / serial UUID gives a more precise and more honest SBOM than
+  `syft` or similar would (those over-report test fakes, build tooling,
+  etc.). `envsubst` is given an explicit variable allowlist so no
+  unrelated environment variables get expanded.
+- **Validation: `cyclonedx-cli` (official OWASP tool).** Does JSON-Schema
+  checks plus semantic validation (PURL syntax, SPDX licence identifier,
+  external-reference type enum). `--input-version v1_5 --fail-on-errors`
+  locks the validation to the spec version the template claims and fails
+  the workflow if anything drifts. Binary pinned by release tag
+  (`v0.30.0`) and SHA-256 checksum.
+- **Licence identifier.** `PolyForm-Noncommercial-1.0.0` is on the SPDX
+  list, so the library's licence can be expressed via the preferred
+  `license.id` field rather than a free-form name. Good signal for
+  regulated-industry consumers who parse SBOM licences.
+- **Versions via release-please manifest.** The rendered SBOM's
+  `metadata.component.version` is read from
+  `.release-please-manifest.json`. Today that's `0.0.0` pre-first-release;
+  when we cut 0.1.0 it flows through automatically.
+
+### Deferred
+- **Signing + release attachment → S19.02.** Out of scope here; this
+  workflow is manual-only and produces a workflow artifact, not a Release
+  asset.
+- **Dependency scanning** — revisit only if the single-component
+  assumption stops holding (e.g. if `Core/` ever gains a build-time
+  dependency bundled into shipped headers).
+- **SPDX output** — E19 says CycloneDX primary, no SPDX.
+
+### Open questions
+- None blocking. Follow-on (S19.02) will need a judgement call on whether
+  cosign signing applies to the SBOM only or also to a source-tarball
+  hash file; defer until we draft that story.
+
 ## 2026-04-22 — S03.14 BDD exercises TLS 1.3
 
 ### Decisions

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -9,11 +9,27 @@
   Primary driver: a maintainer rehearsal workflow, runnable via
   `workflow_dispatch`, before next week's client conversation about SBOMs.
 - **Format: CycloneDX 1.5 JSON** (primary; E19 locks this in, no SPDX).
-- **Scope:** `Core/` subtree. Single-component SBOM — `metadata.component`
-  is SolidSyslog, `components: []`. Platform / Example / Tests / Bdd
-  directories excluded. POSIX / Windows runtime facts captured as
-  `metadata.properties`, not as components (they are *deployment
-  requirements*, not *shipped software*).
+- **Scope:** `Core/` + `Platform/` subdirectories. Initially drafted as
+  `Core/` only, widened on review — `Platform/` code ships with the
+  repo and the integrator consumes it as source. `Example/`, `Tests/`,
+  `Bdd/`, `ci/`, `docs/`, `.devcontainer/`, `.github/` stay out of scope
+  (reference / harness / infrastructure, not product). POSIX / Windows
+  runtime facts stay as `metadata.properties`, not components (they are
+  *deployment requirements*, not *shipped software*).
+- **SBOM kind disclosed.** Added `solidsyslog:sbom-kind: product` as a
+  top-level property so a consumer can tell this apart from the future
+  build-env SBOM and source SBOM. Framing captured in
+  `docs/security/sbom.md` as "three flavours, three questions".
+- **OpenSSL declared as an optional dependency.** When
+  `SOLIDSYSLOG_OPENSSL=ON`, the integrator links against OpenSSL for
+  the reference TLS Stream. We don't bundle it, but transparency
+  matters for CRA readiness, so OpenSSL appears in the product SBOM as
+  `components[0]` with `scope: optional`, supplier = OpenSSL Project,
+  and no version or licence pinned. Licence terms depend on which
+  OpenSSL version the integrator chooses (Apache-2.0 for ≥ 3.0,
+  OpenSSL + SSLeay for ≤ 1.1.1); the integrator's own product SBOM
+  records the specific version and licence. `dependencies[]` wires the
+  relationship so tooling can walk it.
 - **Template-based generation, not tool-scanning.** The project is a
   pure-C library with no runtime dependencies — a static template with
   env-substituted placeholders for version / commit SHA / source hash /

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -1,0 +1,59 @@
+# Software Bill of Materials (SBOM)
+
+SolidSyslog publishes a [CycloneDX](https://cyclonedx.org/) 1.5 SBOM describing
+the `Core/` subtree — the supported library. The Platform, Example, Tests and
+Bdd directories are explicitly out of scope: they are reference integrations
+and test harnesses, not the shipped product.
+
+## What the SBOM says
+
+The SBOM is a single-component document. `Core/` is a pure-C library with no
+runtime dependencies — so the subject (`metadata.component`) is SolidSyslog
+itself, and the top-level `components` array is empty. Runtime facts that a
+deployer must supply (a POSIX or Windows host, optionally a TLS library
+implementing the Stream abstraction) are documented as `properties`, not as
+components — they are *requirements on the deployment*, not *shipped software*.
+
+Key fields worth reading:
+
+| Field | Meaning |
+|---|---|
+| `metadata.component.name` | `SolidSyslog`. |
+| `metadata.component.version` | The value from `.release-please-manifest.json` at the time of generation. Pre-release: `0.0.0`. |
+| `metadata.component.purl` | Package URL keyed to the exact commit SHA — unambiguous pointer back to the source. |
+| `metadata.component.supplier.name` | `COSOSO (Cozens Software Solutions Limited)`. |
+| `metadata.component.licenses[0].license.id` | `PolyForm-Noncommercial-1.0.0` — SPDX identifier. |
+| `metadata.properties[solidsyslog:source-hash-sha256]` | SHA-256 of a deterministic `git archive` of the `Core/` subtree. A consumer with the same commit can independently reproduce it. |
+
+## How to generate one (rehearsal)
+
+Each run produces a CycloneDX 1.5 JSON file, validated against the spec by
+[`cyclonedx-cli`](https://github.com/CycloneDX/cyclonedx-cli), and uploaded as
+a workflow artifact.
+
+1. Open the **Actions** tab.
+2. Select the **Generate SBOM** workflow.
+3. Click **Run workflow**, pick the ref (usually `main` or a release tag),
+   and **Run workflow**.
+4. When the run completes, scroll to **Artifacts** at the bottom of the run
+   page and download `sbom-cyclonedx-<version>`.
+5. Unzip; the file inside is `sbom.cdx.json`.
+
+The workflow uses only the default `GITHUB_TOKEN` — no repo secrets required.
+
+## Sanity-check a generated SBOM
+
+```
+cyclonedx validate --input-file sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors
+```
+
+The CI workflow already runs this; the command is useful if you've fetched
+the artifact locally and want to re-verify independently.
+
+## Deferred
+
+Release-time publication — attaching the SBOM to every GitHub Release as an
+asset, plus [sigstore/cosign](https://docs.sigstore.dev/) keyless signing
+under the repository's GitHub OIDC — is the next story (S19.02). Until that
+lands, this workflow is manual-only and the rendered SBOM lives only as a
+workflow artifact.

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -1,9 +1,37 @@
 # Software Bill of Materials (SBOM)
 
-SolidSyslog publishes a [CycloneDX](https://cyclonedx.org/) 1.5 SBOM describing
-the `Core/` subtree — the supported library. The Platform, Example, Tests and
-Bdd directories are explicitly out of scope: they are reference integrations
-and test harnesses, not the shipped product.
+SolidSyslog publishes a [CycloneDX](https://cyclonedx.org/) 1.5 SBOM for the
+shipped library. SBOMs come in three flavours that answer three different
+questions — this document is only concerned with the first.
+
+| Flavour | Question it answers | Status here |
+|---|---|---|
+| **Product SBOM** | "What am I linking against in my deployment?" | Covered by this workflow (see below). |
+| **Build / dev-env SBOM** | "What tools, containers, and test harnesses were used to produce the release?" | Not yet — deferred to a separate story. Container image SHAs are tracked in `docs/containers.md` for now. |
+| **Source SBOM** | "What third-party source code is embedded in the product?" | Empty — SolidSyslog vendors no third-party source. |
+
+## Product SBOM scope
+
+The product SBOM covers the `Core/` and `Platform/` subdirectories — the
+source the integrator consumes from this repository. `Core/` is Tier 1
+(full support, stable API); `Platform/` is Tier 2 (supported; API may
+evolve per target). Both ship.
+
+Out of scope:
+- `Example/` — reference integrations, not product.
+- `Tests/`, `Bdd/` — test harnesses.
+- `ci/`, `docs/`, `.devcontainer/`, `.github/` — infrastructure.
+
+Runtime dependencies we declare but do not bundle:
+- **OpenSSL** — optional, only when `SOLIDSYSLOG_OPENSSL=ON`. Listed as a
+  CycloneDX component with `scope: optional`. No version pinned —
+  integrators select their own OpenSSL and capture it in their own SBOM
+  alongside the specific licence terms of the version they ship.
+
+Runtime dependencies we document as environment (not components):
+- **POSIX libc / Winsock / POSIX message queues** — host OS APIs, not
+  shipped software. Recorded as `metadata.properties` rather than
+  components.
 
 ## What the SBOM says
 

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -71,7 +71,7 @@ The workflow uses only the default `GITHUB_TOKEN` — no repo secrets required.
 
 ## Sanity-check a generated SBOM
 
-```
+```shell
 cyclonedx validate --input-file sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors
 ```
 

--- a/sbom/sbom.cdx.json.template
+++ b/sbom/sbom.cdx.json.template
@@ -1,0 +1,66 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:${SERIAL_NUMBER}",
+  "version": 1,
+  "metadata": {
+    "timestamp": "${TIMESTAMP}",
+    "tools": [
+      {
+        "vendor": "COSOSO",
+        "name": "solid-syslog-sbom-generator",
+        "version": "${TOOLS_VERSION}"
+      }
+    ],
+    "component": {
+      "bom-ref": "pkg:github/DavidCozens/solid-syslog@${COMMIT_SHA}",
+      "type": "library",
+      "name": "SolidSyslog",
+      "version": "${VERSION}",
+      "description": "A structured syslog client library for embedded and industrial systems, implementing RFC 5424, RFC 5426 (UDP), RFC 6587 (TCP), and RFC 5425 (TLS via a pluggable Stream abstraction).",
+      "purl": "pkg:github/DavidCozens/solid-syslog@${COMMIT_SHA}",
+      "supplier": {
+        "name": "COSOSO (Cozens Software Solutions Limited)",
+        "url": ["https://cososo.co.uk"]
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "PolyForm-Noncommercial-1.0.0"
+          }
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/DavidCozens/solid-syslog"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/DavidCozens/solid-syslog/issues"
+        }
+      ],
+      "properties": [
+        {
+          "name": "solidsyslog:scope",
+          "value": "Core/ subtree only — Platform/, Example/, Tests/, Bdd/, ci/, docs/ are out of scope"
+        },
+        {
+          "name": "solidsyslog:runtime",
+          "value": "POSIX or Windows host; TLS requires an integrator-supplied Stream implementation (OpenSSL reference integration shipped)"
+        }
+      ]
+    },
+    "properties": [
+      {
+        "name": "solidsyslog:source-hash-sha256",
+        "value": "${SOURCE_HASH}"
+      },
+      {
+        "name": "solidsyslog:commit-sha",
+        "value": "${COMMIT_SHA}"
+      }
+    ]
+  },
+  "components": []
+}

--- a/sbom/sbom.cdx.json.template
+++ b/sbom/sbom.cdx.json.template
@@ -43,11 +43,11 @@
       "properties": [
         {
           "name": "solidsyslog:scope",
-          "value": "Core/ subtree only — Platform/, Example/, Tests/, Bdd/, ci/, docs/ are out of scope"
+          "value": "Core/ and Platform/ subdirectories — Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/ are out of scope (reference / harness / infrastructure, not shipped product)"
         },
         {
-          "name": "solidsyslog:runtime",
-          "value": "POSIX or Windows host; TLS requires an integrator-supplied Stream implementation (OpenSSL reference integration shipped)"
+          "name": "solidsyslog:runtime-environment",
+          "value": "POSIX or Windows host — libc / Winsock + POSIX message queues where used. Host OS APIs are deployment requirements, not shipped components."
         }
       ]
     },
@@ -59,8 +59,31 @@
       {
         "name": "solidsyslog:commit-sha",
         "value": "${COMMIT_SHA}"
+      },
+      {
+        "name": "solidsyslog:sbom-kind",
+        "value": "product"
       }
     ]
   },
-  "components": []
+  "components": [
+    {
+      "bom-ref": "pkg:generic/openssl",
+      "type": "library",
+      "name": "openssl",
+      "description": "Optional runtime dependency. Required at link time only when compiling with SOLIDSYSLOG_OPENSSL=ON to provide the reference TLS Stream integration (Platform/OpenSsl/). SolidSyslog does not bundle or redistribute OpenSSL source; the integrator selects and links a version meeting SolidSyslog's TLS 1.3 requirement (OpenSSL >= 1.1.1). Licence terms depend on the chosen OpenSSL release and are out of scope for this SBOM — the integrator's own product SBOM should record the specific OpenSSL version and licence selected.",
+      "scope": "optional",
+      "purl": "pkg:generic/openssl",
+      "supplier": {
+        "name": "OpenSSL Project",
+        "url": ["https://www.openssl.org/"]
+      }
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:github/DavidCozens/solid-syslog@${COMMIT_SHA}",
+      "dependsOn": ["pkg:generic/openssl"]
+    }
+  ]
 }


### PR DESCRIPTION
## Purpose
S19.01 (#194) under E19 (#155). First of two SBOM stories — this one delivers the CycloneDX 1.5 template and a `workflow_dispatch`-triggered generation workflow so the SBOM artifact can be produced on demand and inspected. Signing and release-time attachment land in the follow-on (S19.02).

Primary driver: rehearsable workflow for maintainer practice ahead of a client SBOM conversation next week.

## Change Description

### `sbom/sbom.cdx.json.template`
CycloneDX 1.5 JSON skeleton. Single-component SBOM — `metadata.component` is SolidSyslog itself, `components: []` (no dependencies). Static metadata baked in:
- `bomFormat`, `specVersion: 1.5`, `version: 1`.
- `metadata.component.purl` keyed to commit SHA — `pkg:github/DavidCozens/solid-syslog@${COMMIT_SHA}`.
- `metadata.component.supplier.name`: `COSOSO (Cozens Software Solutions Limited)`.
- `metadata.component.licenses[0].license.id`: `PolyForm-Noncommercial-1.0.0` (SPDX identifier).
- `metadata.component.properties`: scope note (`Core/` subtree only) and runtime note (POSIX/Windows host; TLS backend is integrator-supplied, OpenSSL reference shipped).
- `metadata.properties`: source-tarball SHA-256 + commit SHA so a consumer can independently reproduce from source.

Placeholders filled at render time: `${VERSION}`, `${COMMIT_SHA}`, `${SOURCE_HASH}`, `${TIMESTAMP}`, `${SERIAL_NUMBER}`, `${TOOLS_VERSION}`.

### `.github/workflows/sbom.yml`
- Trigger: `workflow_dispatch` only. `release: published` trigger is intentionally left out until S19.02 adds signing.
- Steps: checkout (pinned SHA) → read version from `.release-please-manifest.json` → `git archive Core/ | sha256sum` for source hash → generate UUID → `envsubst` with explicit variable allowlist → install `cyclonedx-cli` v0.30.0 (official OWASP tool, pinned by release tag + SHA-256 checksum) → `cyclonedx validate --input-version v1_5 --fail-on-errors` → upload as workflow artifact.
- `permissions: contents: read` — no write permissions needed for the rehearsal workflow.
- Default `GITHUB_TOKEN` only; no repo secrets required.

### `docs/security/sbom.md`
Short reader-facing doc: what the SBOM says, key fields to verify, how to trigger a run from the Actions tab, how to re-validate locally, and what's deferred to S19.02.

### `DEVLOG.md`
Decisions entry covering the CycloneDX-over-SPDX choice, single-component scoping, template-over-tool approach, validator choice, licence SPDX identifier, version source.

## Test Evidence
Tested locally before opening the PR:
- Template renders via `envsubst` with the explicit variable allowlist to a file that passes `python3 -c "json.load(...)"` — valid JSON.
- Rendered output passes `cyclonedx validate --input-file sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors` (exit 0, `BOM validated successfully`).
- No literal `${…}` placeholders survive the render — guard in the workflow catches it if they do.
- `python3 -c "import yaml; yaml.safe_load(...)"` on `sbom.yml` succeeds — valid workflow syntax.

Post-merge validation: trigger **Generate SBOM** from the Actions tab (ref = `main`), confirm the workflow passes and the `sbom-cyclonedx-0.0.0` artifact contains a valid CycloneDX file.

## Explicitly out of scope
- **Signing (cosign + OIDC)** — S19.02.
- **`release: published` trigger + release-asset attachment** — S19.02.
- **Dependency scanning tools** — template-based is deliberate; the project has no runtime dependencies.
- **SPDX output** — E19 locks in CycloneDX primary, no SPDX.
- **`SECURITY.md`, threat model, triage runbook, release playbook** — separately scoped under E19.

## Areas Affected
- New: `sbom/sbom.cdx.json.template`, `.github/workflows/sbom.yml`, `docs/security/sbom.md`.
- `DEVLOG.md` — entry appended.

Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added on-demand Software Bill of Materials (SBOM) generation workflow, making SBOM artifacts available as downloadable outputs from GitHub Actions

* **Documentation**
  * Added new security documentation covering SBOM content, scope, and step-by-step generation instructions
  * Updated development log with SBOM workflow details and planned enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->