### PR TITLE
feat: S19.02 SBOM signing and release-asset attachment

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -2,15 +2,17 @@ name: Generate SBOM
 
 on:
   workflow_dispatch:
-  # S19.02 will switch on the `release: published` trigger and add signing
-  # + release-asset attachment. Until then, this workflow is on-demand only.
-
-permissions:
-  contents: read
+  release:
+    types: [published]
 
 jobs:
   sbom:
+    # Generation + validation — shared by both triggers. Read-only; no secrets.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -68,9 +70,66 @@ jobs:
         run: |
           /tmp/cyclonedx validate --input-file sbom/sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors
 
-      - name: Upload SBOM artifact
+      - name: Write source-sha256.txt
+        run: |
+          echo "${{ steps.hash.outputs.hash }}  solid-syslog-${{ steps.version.outputs.version }}.tar.gz" > sbom/source-sha256.txt
+          cat sbom/source-sha256.txt
+
+      - name: Upload workflow artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-cyclonedx-${{ steps.version.outputs.version }}
-          path: sbom/sbom.cdx.json
+          path: |
+            sbom/sbom.cdx.json
+            sbom/source-sha256.txt
           if-no-files-found: error
+
+  publish:
+    # Release-only: keyless-sign the SBOM and source hash file, attach both
+    # (plus signatures) to the GitHub Release as assets. Advisory-only on
+    # initial rollout (per E19 guidance) — continue-on-error is set on the
+    # sign + attach steps so a signing failure does not block the release.
+    if: github.event_name == 'release'
+    needs: sbom
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download SBOM workflow artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sbom-cyclonedx-${{ needs.sbom.outputs.version }}
+          path: sbom/
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v3.0.6'
+        continue-on-error: true
+
+      - name: Sign SBOM (keyless, GitHub OIDC)
+        continue-on-error: true
+        run: |
+          cosign sign-blob --yes \
+            --bundle sbom/sbom.cdx.json.bundle \
+            sbom/sbom.cdx.json
+
+      - name: Sign source-sha256.txt (keyless, GitHub OIDC)
+        continue-on-error: true
+        run: |
+          cosign sign-blob --yes \
+            --bundle sbom/source-sha256.txt.bundle \
+            sbom/source-sha256.txt
+
+      - name: Attach assets to Release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            sbom/sbom.cdx.json \
+            sbom/sbom.cdx.json.bundle \
+            sbom/source-sha256.txt \
+            sbom/source-sha256.txt.bundle \
+            --clobber

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,76 @@
 # Dev Log
 
+## 2026-04-22 — S19.02 SBOM signing and release-asset attachment
+
+### Decisions
+- Extended `sbom.yml` with a second trigger (`release: published`) and a
+  second job (`publish`) that keyless-signs the SBOM and a source-hash
+  file with cosign, then attaches four assets to the GitHub Release.
+  `workflow_dispatch` remains as the rehearsal path — generates the SBOM
+  and source hash, uploads as a workflow artifact, does no signing or
+  release interaction.
+- **Keyless signing via GitHub OIDC** (cosign + Fulcio + Rekor). Zero
+  long-lived keys or secrets in the repo; every signature is a
+  short-lived certificate issued to the workflow's OIDC identity and
+  recorded in Sigstore's public transparency log. The `id-token: write`
+  permission is on the `publish` job only, not the `sbom` job — keeps
+  the generation path read-only.
+- **Two-job split with narrow permissions.** The `sbom` job runs with
+  `contents: read` only (no write permissions, no OIDC token). The
+  `publish` job depends on it via `needs:`, only runs on `release`, and
+  gets `contents: write` (for `gh release upload`) plus `id-token:
+  write` (for cosign). Minimises permission surface on the workflow
+  that runs on every rehearsal.
+- **cosign signature bundles**, not raw `.sig` files. A `.bundle` is a
+  single JSON blob containing signature + certificate + Rekor inclusion
+  proof, which is what a downstream verifier needs for offline checks.
+  Two files per signed artefact (original + `.bundle`) instead of three
+  (original + `.sig` + `.pem`).
+- **Source-hash file committed to the signed set.** A one-line
+  `source-sha256.txt` captures the SHA-256 of
+  `git archive --format=tar.gz HEAD -- Core/ Platform/` — the same hash
+  value as the SBOM's `solidsyslog:source-hash-sha256` property. A
+  verifier can reproduce from `git archive` at the release tag and
+  cross-check. Caveat: `git archive` byte-output can vary slightly
+  across git versions — documented as a gotcha in
+  `docs/security/release-verification.md`.
+- **Cert-identity convention:** signatures pin to
+  `https://github.com/DavidCozens/solid-syslog/.github/workflows/sbom.yml@refs/tags/v<version>`.
+  That binds the signing event to "this workflow, this repo, this tag"
+  — the mechanism a verifier uses to tell apart a real SolidSyslog SBOM
+  from any other CycloneDX document claiming the same name. Fork
+  signatures, random-branch signatures, and impersonator workflows all
+  fail verification.
+- **Advisory-only rollout.** All signing + upload steps carry
+  `continue-on-error: true` per E19 guidance — a signing-infrastructure
+  outage at release time should not block the release itself. Tighten
+  after the first real release (`v0.1.0`) demonstrates the pipeline
+  works. Follow-on `chore:` PR.
+- **New doc: `docs/security/release-verification.md`** — step-by-step
+  guide for a downstream integrator, ordered the way they'd actually
+  run verification (source-hash → SBOM signature → source-hash
+  signature → optional SBOM re-validation). Includes "what verification
+  does not tell you" so a reader doesn't over-interpret a green
+  result.
+
+### Deferred
+- **`cosign attest`** (signed SLSA provenance statement on top of raw
+  signatures). Natural next step; separate E19 follow-on.
+- **Flipping `continue-on-error` off.** Deliberate. First real release
+  gets to prove the pipeline works; the tightening is a `chore:` PR
+  after that.
+- **Backfilling signatures for old releases.** No prior releases exist
+  (manifest was `0.0.0` before `initial-version: 0.1.0` pinned the
+  first release target).
+
+### Open questions
+- None blocking. Live test will be the first `release: published` event
+  — covered by the rehearsal plan in the S19.02 issue (#196). Plan is
+  to cut a throwaway `v0.0.1-sbom-test` pre-release on `main`, verify
+  all four assets land, verify `cosign verify-blob` passes, then delete
+  the throwaway. After that the first real release (`v0.1.0`) will
+  exercise it for real.
+
 ## 2026-04-22 — S19.01 SBOM rehearsal workflow (CycloneDX template + on-demand generate)
 
 ### Decisions

--- a/docs/security/release-verification.md
+++ b/docs/security/release-verification.md
@@ -1,0 +1,116 @@
+# Release Verification Guide
+
+You have a SolidSyslog release on disk and want to convince yourself, or an
+auditor, that it was produced by the repo it claims to come from. This guide
+walks through the verification a careful integrator would run, in the order
+they'd naturally run it.
+
+Prerequisites:
+- [cosign](https://docs.sigstore.dev/system_config/installation/) v2 or
+  later on your `$PATH`.
+- [cyclonedx-cli](https://github.com/CycloneDX/cyclonedx-cli) v0.30.0 or
+  later (optional — only needed to re-validate the SBOM).
+- A `git` checkout of the repo at the release's tag (optional — only
+  needed to reproduce the source hash yourself).
+
+All four Release assets should be present:
+
+```text
+sbom.cdx.json
+sbom.cdx.json.bundle
+source-sha256.txt
+source-sha256.txt.bundle
+```
+
+## 1. Verify the source is what we claim
+
+`source-sha256.txt` contains one line: the SHA-256 of
+`git archive --format=tar.gz HEAD -- Core/ Platform/` at the release tag.
+To reproduce:
+
+```shell
+git clone --depth 1 --branch v<version> https://github.com/DavidCozens/solid-syslog.git
+cd solid-syslog
+git archive --format=tar.gz HEAD -- Core/ Platform/ | sha256sum
+```
+
+Compare the hash to the one in `source-sha256.txt`. If they match, the source
+you just cloned is byte-identical to the source the SBOM describes.
+
+(Note: `git archive` output can vary slightly across git versions — if the
+hash doesn't match, try a recent git; if it still doesn't match, cross-check
+the content against the SBOM's `metadata.properties[solidsyslog:commit-sha]`
+property and inspect the source directly.)
+
+## 2. Verify the SBOM signature
+
+The signature commits to the GitHub Actions workflow that produced it.
+A valid signature proves three things:
+
+1. This exact SBOM came from the SolidSyslog repo's `sbom.yml` workflow.
+2. The workflow ran at the release tag you think it did (not on a random
+   branch, not on a fork).
+3. The signing event was logged to the Sigstore transparency log at the
+   time claimed.
+
+Verification:
+
+```shell
+cosign verify-blob \
+  --bundle sbom.cdx.json.bundle \
+  --certificate-identity "https://github.com/DavidCozens/solid-syslog/.github/workflows/sbom.yml@refs/tags/v<version>" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  sbom.cdx.json
+```
+
+`cosign` outputs `Verified OK` and exits 0 on success. Any of these
+conditions fail the verification loudly:
+
+- The SBOM has been modified after signing.
+- The signature was produced by a different workflow file.
+- The signature was produced on a different repo (e.g. a fork).
+- The signature was produced against a different tag.
+- The Sigstore transparency log entry is missing or doesn't match.
+
+## 3. Verify the source-hash signature
+
+```shell
+cosign verify-blob \
+  --bundle source-sha256.txt.bundle \
+  --certificate-identity "https://github.com/DavidCozens/solid-syslog/.github/workflows/sbom.yml@refs/tags/v<version>" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  source-sha256.txt
+```
+
+Same guarantees as step 2, but for the source-hash file. Combined with the
+hash match from step 1, you now know the source you have is the source the
+SBOM describes, and the SBOM is the one the workflow produced.
+
+## 4. (Optional) Re-validate the SBOM against CycloneDX
+
+```shell
+cyclonedx validate \
+  --input-file sbom.cdx.json \
+  --input-format json \
+  --input-version v1_5 \
+  --fail-on-errors
+```
+
+This isn't strictly a provenance check — the CI already ran it — but it
+confirms the document on your disk is structurally and semantically a valid
+CycloneDX 1.5 SBOM. Useful if you're plugging it into an SBOM-consuming tool
+and want to rule out corruption-in-transit.
+
+## What verification does *not* tell you
+
+- It doesn't tell you whether the code behind the SBOM is bug-free, secure,
+  or fit for purpose. The SBOM is provenance evidence, not a quality
+  claim.
+- It doesn't tell you anything about dependencies that SolidSyslog chose
+  not to bundle. OpenSSL appears in the SBOM's `components[]` with
+  `scope: optional`, but picking and verifying your OpenSSL is your job.
+- It doesn't tell you whether the SolidSyslog licence is compatible with
+  your intended use. That's a licence review, not a signature check.
+
+See `docs/iec62443.md` for the security posture, and `docs/security/sbom.md`
+for a walk-through of what the SBOM actually says.

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -78,10 +78,53 @@ cyclonedx validate --input-file sbom.cdx.json --input-format json --input-versio
 The CI workflow already runs this; the command is useful if you've fetched
 the artifact locally and want to re-verify independently.
 
+## Verifying a signed SBOM
+
+Every GitHub Release created by Release Please gets four assets attached:
+
+| Asset | Contents |
+|---|---|
+| `sbom.cdx.json` | The SBOM itself. |
+| `sbom.cdx.json.bundle` | [sigstore/cosign](https://docs.sigstore.dev/) signature bundle — signature + ephemeral signing certificate + Rekor inclusion proof, in a single JSON blob. |
+| `source-sha256.txt` | One line: SHA-256 of `git archive --format=tar.gz HEAD -- Core/ Platform/`. |
+| `source-sha256.txt.bundle` | cosign bundle for the above. |
+
+Signing is **keyless** via GitHub OIDC — no private keys live in this repo.
+The signature commits to the specific workflow run (`sbom.yml` in this repo
+at the tagged commit) that produced the SBOM; a verifier checks the
+certificate identity against an expected workflow identity to tell "this
+SBOM" apart from any other CycloneDX document.
+
+To verify a downloaded asset set:
+
+```shell
+cosign verify-blob \
+  --bundle sbom.cdx.json.bundle \
+  --certificate-identity "https://github.com/DavidCozens/solid-syslog/.github/workflows/sbom.yml@refs/tags/v<version>" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  sbom.cdx.json
+```
+
+The same pattern verifies `source-sha256.txt.bundle` against `source-sha256.txt`.
+
+Every cosign signature is also logged to [Rekor](https://docs.sigstore.dev/logging/overview/),
+Sigstore's public transparency log. Anyone can look up the signature entry
+by its hash and confirm it was issued at the stated time — independent of
+whether GitHub, Sigstore, or this project still exist at the time of audit.
+
+For a step-by-step verification guide aimed at downstream integrators, see
+[`release-verification.md`](./release-verification.md).
+
 ## Deferred
 
-Release-time publication — attaching the SBOM to every GitHub Release as an
-asset, plus [sigstore/cosign](https://docs.sigstore.dev/) keyless signing
-under the repository's GitHub OIDC — is the next story (S19.02). Until that
-lands, this workflow is manual-only and the rendered SBOM lives only as a
-workflow artifact.
+- **Signed SLSA provenance attestation.** `cosign attest` on top of
+  `sign-blob` is a natural next step — it produces an attestation
+  statement that says "this SBOM was produced by this workflow from
+  these inputs" rather than just "this SBOM was signed by this
+  workflow." Separate E19 follow-on.
+- **Binary-artefact signing.** The project is source-only; nothing to
+  sign beyond the SBOM and source-tarball hash.
+- **Flip the signing/attach steps off `continue-on-error: true`.** The
+  initial rollout keeps those steps advisory so a signing infrastructure
+  outage doesn't block a release. Tighten to hard-fail after the first
+  real release has demonstrated the pipeline works.


### PR DESCRIPTION
## Purpose
S19.02 (#196) under E19 (#155). Builds on S19.01 (#194 / #195) so every GitHub Release created by Release Please automatically gets an SBOM + signature + source-tarball hash + signature attached as Release assets. Signing is keyless via GitHub OIDC — no long-lived keys, no secrets in the repo.

`workflow_dispatch` stays as the rehearsal trigger, unchanged from S19.01's shape (plus the new `source-sha256.txt` alongside the SBOM in the workflow artifact for hand verification).

## Change Description

### `.github/workflows/sbom.yml` — extended into two jobs
- **`sbom` job** (both triggers): generate → validate → write `source-sha256.txt` → upload workflow artifact. `permissions: contents: read` only — no OIDC, no write permissions.
- **`publish` job** (`release.published` only, `needs: sbom`): download the sbom job's artifact → install cosign (pinned `sigstore/cosign-installer@v4.1.1`, cosign release `v3.0.6`) → `cosign sign-blob --yes --bundle` both files → `gh release upload` all four assets. `permissions: contents: write, id-token: write`. All sign + attach steps carry `continue-on-error: true` per E19 guidance (advisory-only rollout; tighten in a follow-up after first real release proves the pipeline).

Signature bundles (`.bundle`) rather than raw `.sig` + `.pem` files — a bundle is a single JSON blob containing signature + certificate + Rekor inclusion proof, which is what a downstream verifier actually needs.

### `docs/security/sbom.md`
New "Verifying a signed SBOM" section: asset inventory (SBOM, `.bundle`, source hash, `.bundle`), `cosign verify-blob` recipe, pointer to Sigstore's Rekor transparency log, pointer to the new verification walkthrough. Replaces the old "Deferred" paragraph that said this work was pending.

### `docs/security/release-verification.md` (new)
Step-by-step verification guide aimed at a downstream integrator, in the order a cautious one would actually run it:
1. Reproduce the source-tarball hash from `git archive`.
2. `cosign verify-blob` on the SBOM.
3. `cosign verify-blob` on the source-hash file.
4. (Optional) Re-validate the SBOM against CycloneDX 1.5.

Includes a "what verification does *not* tell you" footer so readers don't over-interpret a green result — provenance, not quality.

### `DEVLOG.md`
Decisions entry covering the two-job permission split, keyless OIDC approach, bundle-over-sig choice, cert-identity convention, and the `continue-on-error` advisory-only posture.

## Test Evidence
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Workflow structure reviewed against S19.01's passing rehearsal run — the `sbom` job is a superset of what ran green on #195; the `publish` job is purely additive and guarded by `if: github.event_name == 'release'`.
- Full end-to-end rehearsal deferred to the rehearsal plan captured in #196 — throwaway `v0.0.1-sbom-test` pre-release on `main` post-merge to confirm all four assets attach and `cosign verify-blob` passes against each. Rehearsal captured in the issue rather than this PR because it needs a real `release: published` event on `main`.

## Explicitly out of scope
- **SLSA provenance attestation** (`cosign attest`) — natural next step but scope-extending. Separate E19 follow-on.
- **Flipping `continue-on-error: false`.** Deliberate — first real release demonstrates the pipeline; tighten in a follow-up `chore:` PR after `v0.1.0`.
- **Backfilling signatures for old releases.** Nothing to backfill; no prior releases exist.

## Areas Affected
- `.github/workflows/sbom.yml` — split into `sbom` + `publish` jobs, release trigger added.
- `docs/security/sbom.md` — signing/verification section added.
- `docs/security/release-verification.md` — new.
- `DEVLOG.md` — entry appended.

Closes #196