### PR TITLE
fix: S19.02 pass --repo to gh release upload in SBOM publish job

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -127,9 +127,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # --repo is required here: the publish job doesn't check out the
+          # source, so `gh` has no git config to infer the repo from.
           gh release upload "${{ github.event.release.tag_name }}" \
             sbom/sbom.cdx.json \
             sbom/sbom.cdx.json.bundle \
             sbom/source-sha256.txt \
             sbom/source-sha256.txt.bundle \
-            --clobber
+            --clobber \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Purpose
Rehearsal of #196 surfaced a real bug in the S19.02 workflow: the `Attach assets to Release` step fails because the `publish` job doesn't check out the source, so `gh` can't infer the target repo from git config. `continue-on-error: true` swallowed the failure silently, leaving the release with no SBOM assets.

Evidence — from workflow run 24804953250 log:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Process completed with exit code 1
```

(All four earlier steps in the `publish` job — download artifact, install cosign, sign SBOM, sign source-hash — actually succeeded. Both `.bundle` files were written correctly. Only the upload failed.)

## Change Description
Add `--repo "${{ github.repository }}"` to the `gh release upload` call. Short comment above the command so future-us doesn't re-learn.

No intentional behaviour change to any other path. `workflow_dispatch` (which doesn't run this job) is unaffected.

## Test Evidence
- YAML parses cleanly.
- Post-merge rehearsal plan: cut a second throwaway pre-release (e.g. `v0.0.1-sbom-test-2`) to exercise the fixed upload. Delete the current `v0.0.1-sbom-test` release after the new one demonstrates four-asset attachment.

## Areas Affected
- `.github/workflows/sbom.yml` — one argument added, one rationale comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated release asset upload process to ensure reliable and consistent delivery of release artifacts during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->