### PR TITLE
refactor: S19.02 swap source-tarball hash for content-tree hash

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -25,17 +25,37 @@ jobs:
           VERSION=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Compute source-tarball hash
+      - name: Compute content-tree hash
         id: hash
         run: |
+          # Content-tree hash: sha256 of sorted "<content-sha256>  <path>"
+          # lines for every tracked file in Core/ + Platform/ at HEAD.
+          # Reproducible byte-for-byte across git versions, archive formats,
+          # locales, and tooling — only needs sha256sum + sort + either
+          # `git ls-tree + git show` or an extracted working tree.
+          #
           # Product scope per docs/security/sbom.md: Core/ + Platform/.
           # Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/
           # are reference / test-harness / infrastructure and out of scope.
-          TARBALL=$(mktemp)
-          git archive --format=tar.gz HEAD -- Core/ Platform/ > "$TARBALL"
-          HASH=$(sha256sum "$TARBALL" | cut -d' ' -f1)
+          set -euo pipefail
+          HASHLIST=$(mktemp)
+          PATHS=$(mktemp)
+          trap 'rm -f "$HASHLIST" "$PATHS"' EXIT
+          git ls-tree -r --name-only HEAD -- Core/ Platform/ | LC_ALL=C sort > "$PATHS"
+          while IFS= read -r path; do
+            # pipefail propagates a failing `git show` through the pipeline;
+            # the explicit length check catches any degenerate empty-string
+            # hash (sha256 of empty input is 64 hex chars, so this is
+            # belt-and-braces against truncation elsewhere).
+            content_hash=$(git show "HEAD:$path" | sha256sum | cut -d' ' -f1)
+            if [ "${#content_hash}" -ne 64 ]; then
+              echo "::error::unexpected hash length for $path: '$content_hash'" >&2
+              exit 1
+            fi
+            printf '%s  %s\n' "$content_hash" "$path" >> "$HASHLIST"
+          done < "$PATHS"
+          HASH=$(sha256sum < "$HASHLIST" | cut -d' ' -f1)
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          rm "$TARBALL"
 
       - name: Generate serial number
         id: serial
@@ -70,10 +90,18 @@ jobs:
         run: |
           /tmp/cyclonedx validate --input-file sbom/sbom.cdx.json --input-format json --input-version v1_5 --fail-on-errors
 
-      - name: Write source-sha256.txt
+      - name: Write source-tree-sha256.txt
         run: |
-          echo "${{ steps.hash.outputs.hash }}  solid-syslog-${{ steps.version.outputs.version }}.tar.gz" > sbom/source-sha256.txt
-          cat sbom/source-sha256.txt
+          cat > sbom/source-tree-sha256.txt <<EOF
+          # SolidSyslog content-tree SHA-256
+          # Scope: Core/ + Platform/ subdirectories (shipped library).
+          # Commit: ${{ github.sha }}
+          # Algorithm: sha256 of sorted "<content-sha256>  <path>" lines (LC_ALL=C sort).
+          # Verification guide: docs/security/release-verification.md
+
+          ${{ steps.hash.outputs.hash }}
+          EOF
+          cat sbom/source-tree-sha256.txt
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -81,7 +109,7 @@ jobs:
           name: sbom-cyclonedx-${{ steps.version.outputs.version }}
           path: |
             sbom/sbom.cdx.json
-            sbom/source-sha256.txt
+            sbom/source-tree-sha256.txt
           if-no-files-found: error
 
   publish:
@@ -115,12 +143,12 @@ jobs:
             --bundle sbom/sbom.cdx.json.bundle \
             sbom/sbom.cdx.json
 
-      - name: Sign source-sha256.txt (keyless, GitHub OIDC)
+      - name: Sign source-tree-sha256.txt (keyless, GitHub OIDC)
         continue-on-error: true
         run: |
           cosign sign-blob --yes \
-            --bundle sbom/source-sha256.txt.bundle \
-            sbom/source-sha256.txt
+            --bundle sbom/source-tree-sha256.txt.bundle \
+            sbom/source-tree-sha256.txt
 
       - name: Attach assets to Release
         continue-on-error: true
@@ -132,7 +160,7 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             sbom/sbom.cdx.json \
             sbom/sbom.cdx.json.bundle \
-            sbom/source-sha256.txt \
-            sbom/source-sha256.txt.bundle \
+            sbom/source-tree-sha256.txt \
+            sbom/source-tree-sha256.txt.bundle \
             --clobber \
             --repo "${{ github.repository }}"

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,56 @@
 # Dev Log
 
+## 2026-04-23 — S19.02 swap source-tarball hash for content-tree hash
+
+### Decisions
+- Rehearsal of the signing pipeline against `v0.0.2-sbom-test` surfaced
+  a reproducibility caveat: the original `source-sha256.txt` hashed the
+  output of `git archive --format=tar.gz HEAD -- Core/ Platform/`. Git
+  archive's byte output is not guaranteed stable across git versions —
+  the runner (recent git) and a local WSL Ubuntu (git 2.25.1) produced
+  different hashes for the same commit. Commit-SHA and signatures all
+  matched, but the convenience hash didn't, which is exactly the kind
+  of "why doesn't this match" conversation a client-facing asset
+  shouldn't invite.
+- **Swap to a content-tree hash.** Deterministic across git versions,
+  archive formats, locales, and tooling. Algorithm:
+  ```shell
+  git ls-tree -r --name-only HEAD -- Core/ Platform/ \
+    | LC_ALL=C sort \
+    | while IFS= read -r path; do
+        printf "%s  %s\n" "$(git show "HEAD:$path" | sha256sum | cut -d' ' -f1)" "$path"
+      done \
+    | sha256sum
+  ```
+  A consumer can reproduce with `git ls-tree` + `git show` + `sha256sum`
+  + `sort` (LC_ALL=C) and have no sensitivity to `git archive` output
+  formatting, gzip implementation, or locale collation.
+- **Portable non-git fallback.** If a consumer has an extracted source
+  tree but no git clone, `find Core Platform -type f | sort | ... |
+  sha256sum` produces the same hash. Documented as the secondary path
+  in `docs/security/release-verification.md`.
+- **File renamed** `source-sha256.txt` → `source-tree-sha256.txt` so
+  the filename signals the algorithm change. SBOM template property
+  correspondingly renamed from `solidsyslog:source-hash-sha256` to
+  `solidsyslog:source-tree-sha256`. No prior releases shipped the old
+  name (both throwaway `v0.0.*-sbom-test` releases were deleted), so
+  this is a clean replace — no backwards-compatibility concern.
+- **Self-documenting file content.** The new `source-tree-sha256.txt`
+  opens with comment-prefixed header lines (scope, commit, algorithm,
+  pointer to the verification guide) before the hash itself. `#`-lines
+  are ignored by `sha256sum -c` so the file remains machine-friendly.
+
+### Deferred
+- **Mode-aware content-tree hash.** Current form hashes contents only,
+  not file modes. Source files are all `100644`; a mode flip on a
+  source file would be unusual. If regulated use ever needs it, extend
+  the format to `<mode>\t<content-sha>\t<path>` and document. Not
+  worth the complexity cost today.
+
+### Open questions
+- None. Next rehearsal (throwaway pre-release) will re-verify the new
+  path end-to-end; I'll drive that after this PR merges.
+
 ## 2026-04-22 — S19.02 SBOM signing and release-asset attachment
 
 ### Decisions

--- a/docs/security/release-verification.md
+++ b/docs/security/release-verification.md
@@ -18,29 +18,71 @@ All four Release assets should be present:
 ```text
 sbom.cdx.json
 sbom.cdx.json.bundle
-source-sha256.txt
-source-sha256.txt.bundle
+source-tree-sha256.txt
+source-tree-sha256.txt.bundle
 ```
 
 ## 1. Verify the source is what we claim
 
-`source-sha256.txt` contains one line: the SHA-256 of
-`git archive --format=tar.gz HEAD -- Core/ Platform/` at the release tag.
-To reproduce:
+`source-tree-sha256.txt` records the content-tree SHA-256 of the `Core/` and
+`Platform/` subdirectories at the release commit. The hash is deterministic
+across git versions, archive formats, locales, and tooling — it depends only
+on the bytes of each tracked file and the sorted list of paths.
+
+### Reproduce with git (authoritative)
 
 ```shell
 git clone --depth 1 --branch v<version> https://github.com/DavidCozens/solid-syslog.git
 cd solid-syslog
-git archive --format=tar.gz HEAD -- Core/ Platform/ | sha256sum
+git ls-tree -r --name-only HEAD -- Core/ Platform/ \
+  | LC_ALL=C sort \
+  | while IFS= read -r path; do
+      printf "%s  %s\n" "$(git show "HEAD:$path" | sha256sum | cut -d' ' -f1)" "$path"
+    done \
+  | sha256sum | cut -d' ' -f1
 ```
 
-Compare the hash to the one in `source-sha256.txt`. If they match, the source
-you just cloned is byte-identical to the source the SBOM describes.
+Compare the output to the hash in `source-tree-sha256.txt`. The file has a
+few `#`-prefixed header lines (scope / commit / algorithm / pointer) and one
+blank line before the hash, so extract the value with:
 
-(Note: `git archive` output can vary slightly across git versions — if the
-hash doesn't match, try a recent git; if it still doesn't match, cross-check
-the content against the SBOM's `metadata.properties[solidsyslog:commit-sha]`
-property and inspect the source directly.)
+```shell
+grep -v '^#' source-tree-sha256.txt | grep -v '^$' | head -n 1
+```
+
+If that matches your computed hash, your source tree is byte-identical to
+the tree the SBOM describes.
+
+### Reproduce without git (fallback, working tree only)
+
+If you don't have a git clone — e.g. you received a source archive instead —
+but you do have an extracted `Core/` and `Platform/` directory tree:
+
+```shell
+find Core Platform -type f \
+  | LC_ALL=C sort \
+  | while IFS= read -r path; do
+      printf "%s  %s\n" "$(sha256sum "$path" | cut -d' ' -f1)" "$path"
+    done \
+  | sha256sum | cut -d' ' -f1
+```
+
+Same hash expected, same comparison. Caveat: this form assumes the working
+tree is clean — any untracked or locally-modified file under `Core/` or
+`Platform/` will change the hash. The git form is stricter because it
+always reads from the committed tree.
+
+### If the hashes don't match
+
+The SBOM's `metadata.properties[solidsyslog:commit-sha]` property names the
+exact commit the hash was computed at. Verify you're on that commit:
+
+```shell
+git rev-parse HEAD
+```
+
+If the commit matches and the hash still doesn't, something on your side
+has modified a file; `git status --short` and `git diff` will show what.
 
 ## 2. Verify the SBOM signature
 
@@ -72,19 +114,19 @@ conditions fail the verification loudly:
 - The signature was produced against a different tag.
 - The Sigstore transparency log entry is missing or doesn't match.
 
-## 3. Verify the source-hash signature
+## 3. Verify the source-tree-hash signature
 
 ```shell
 cosign verify-blob \
-  --bundle source-sha256.txt.bundle \
+  --bundle source-tree-sha256.txt.bundle \
   --certificate-identity "https://github.com/DavidCozens/solid-syslog/.github/workflows/sbom.yml@refs/tags/v<version>" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  source-sha256.txt
+  source-tree-sha256.txt
 ```
 
-Same guarantees as step 2, but for the source-hash file. Combined with the
-hash match from step 1, you now know the source you have is the source the
-SBOM describes, and the SBOM is the one the workflow produced.
+Same guarantees as step 2, but for the content-tree-hash file. Combined
+with the hash match from step 1, you now know the source you have is the
+source the SBOM describes, and the SBOM is the one the workflow produced.
 
 ## 4. (Optional) Re-validate the SBOM against CycloneDX
 

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -51,7 +51,7 @@ Key fields worth reading:
 | `metadata.component.purl` | Package URL keyed to the exact commit SHA — unambiguous pointer back to the source. |
 | `metadata.component.supplier.name` | `COSOSO (Cozens Software Solutions Limited)`. |
 | `metadata.component.licenses[0].license.id` | `PolyForm-Noncommercial-1.0.0` — SPDX identifier. |
-| `metadata.properties[solidsyslog:source-hash-sha256]` | SHA-256 of a deterministic `git archive` of the `Core/` subtree. A consumer with the same commit can independently reproduce it. |
+| `metadata.properties[solidsyslog:source-tree-sha256]` | Content-tree hash: SHA-256 of a sorted list of `<content-sha256>  <path>` lines for every tracked file in `Core/` and `Platform/` at the commit. Reproducible byte-for-byte from any clone, with no dependency on `git archive` output format or git version. |
 
 ## How to generate one (rehearsal)
 
@@ -86,8 +86,8 @@ Every GitHub Release created by Release Please gets four assets attached:
 |---|---|
 | `sbom.cdx.json` | The SBOM itself. |
 | `sbom.cdx.json.bundle` | [sigstore/cosign](https://docs.sigstore.dev/) signature bundle — signature + ephemeral signing certificate + Rekor inclusion proof, in a single JSON blob. |
-| `source-sha256.txt` | One line: SHA-256 of `git archive --format=tar.gz HEAD -- Core/ Platform/`. |
-| `source-sha256.txt.bundle` | cosign bundle for the above. |
+| `source-tree-sha256.txt` | The content-tree SHA-256 with a human-readable header. Reproducible from any clone at the SBOM's commit with `git ls-tree` + `git show` + `sha256sum` + `sort`. |
+| `source-tree-sha256.txt.bundle` | cosign bundle for the above. |
 
 Signing is **keyless** via GitHub OIDC — no private keys live in this repo.
 The signature commits to the specific workflow run (`sbom.yml` in this repo
@@ -105,7 +105,7 @@ cosign verify-blob \
   sbom.cdx.json
 ```
 
-The same pattern verifies `source-sha256.txt.bundle` against `source-sha256.txt`.
+The same pattern verifies `source-tree-sha256.txt.bundle` against `source-tree-sha256.txt`.
 
 Every cosign signature is also logged to [Rekor](https://docs.sigstore.dev/logging/overview/),
 Sigstore's public transparency log. Anyone can look up the signature entry
@@ -123,7 +123,7 @@ For a step-by-step verification guide aimed at downstream integrators, see
   these inputs" rather than just "this SBOM was signed by this
   workflow." Separate E19 follow-on.
 - **Binary-artefact signing.** The project is source-only; nothing to
-  sign beyond the SBOM and source-tarball hash.
+  sign beyond the SBOM and content-tree hash.
 - **Flip the signing/attach steps off `continue-on-error: true`.** The
   initial rollout keeps those steps advisory so a signing infrastructure
   outage doesn't block a release. Tighten to hard-fail after the first

--- a/sbom/sbom.cdx.json.template
+++ b/sbom/sbom.cdx.json.template
@@ -53,7 +53,7 @@
     },
     "properties": [
       {
-        "name": "solidsyslog:source-hash-sha256",
+        "name": "solidsyslog:source-tree-sha256",
         "value": "${SOURCE_HASH}"
       },
       {


### PR DESCRIPTION
## Purpose
The `v0.0.2-sbom-test` rehearsal of S19.02 surfaced a real-world reproducibility gap: `git archive --format=tar.gz` output is not byte-stable across git versions, so the convenience `source-sha256.txt` hash didn't reproduce when recomputed on a local WSL Ubuntu (git 2.25.1) even though everything else — commit SHA, cosign signatures, SBOM schema validity — verified cleanly. Exactly the kind of "why doesn't this match" conversation a client-facing asset shouldn't invite.

Swap to a content-tree hash: `sha256 of sorted "<content-sha256>  <path>" lines for every tracked file in Core/ + Platform/`. Deterministic across git versions, archive formats, locales, and tooling — depends only on the bytes of each tracked file and the sorted list of paths.

## Change Description

### Algorithm
```shell
git ls-tree -r --name-only HEAD -- Core/ Platform/ \
  | LC_ALL=C sort \
  | while read path; do
      printf "%s  %s\n" "$(git show "HEAD:$path" | sha256sum | cut -d' ' -f1)" "$path"
    done \
  | sha256sum | cut -d' ' -f1
```

Verified deterministic across back-to-back runs locally (107 files in scope, hash `e5aeee9007e5f05b4701ce95fc5fbb9faab8255712860fcc65c9e28dea6efcb5`).

### File layout
- Workflow computes content-tree hash in the `sbom` job (same place the tarball hash used to live).
- Output file renamed: `source-sha256.txt` → `source-tree-sha256.txt` so the name signals the algorithm change.
- File content gains a header — scope, commit SHA, algorithm, pointer to `docs/security/release-verification.md` — then the hash. `#` comment lines are ignored by `sha256sum -c` so the file stays machine-friendly.
- SBOM template property renamed `solidsyslog:source-hash-sha256` → `solidsyslog:source-tree-sha256`.

### Documentation
- `docs/security/sbom.md` — asset inventory updated (new filename, new description). Bullet about source-tarball hash in deferred section updated to content-tree.
- `docs/security/release-verification.md` — step 1 replaced. Primary recipe uses `git ls-tree` + `git show`. Fallback recipe for consumers with a plain source tree but no git clone (`find Core Platform -type f | sort | ...`). Troubleshooting footer for the hash-mismatch case (most likely cause: locally-modified files).

### No backwards-compatibility concern
Both throwaway `v0.0.*-sbom-test` releases were deleted, so no real release shipped the old filename. Clean replace.

## Test Evidence
- Rendered SBOM passes `cyclonedx validate --input-version v1_5 --fail-on-errors` with the new property name.
- `python3 -c "import yaml; yaml.safe_load(...)"` on the updated workflow.
- Algorithm tested end-to-end locally: deterministic across back-to-back runs, reproducible from the working tree (fallback path) and from the git tree (primary path).
- Post-merge rehearsal: cut another throwaway pre-release, verify the four assets attach, confirm `cosign verify-blob` passes, reproduce the content-tree hash locally from the tag.

## Areas Affected
- `.github/workflows/sbom.yml`
- `sbom/sbom.cdx.json.template`
- `docs/security/sbom.md`
- `docs/security/release-verification.md`
- `DEVLOG.md`

Related #196.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated verification and SBOM docs to describe a deterministic content-tree hashing method for source reproducibility and how to verify the signed sidecar.
* **Chores**
  * CI/CD updated to produce, sign, and publish the new content-tree hash sidecar and corresponding signature bundles; SBOM metadata aligned with the new approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->