### PR TITLE
refactor: S19.02 widen SBOM product scope to include build contract + licence

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -29,19 +29,28 @@ jobs:
         id: hash
         run: |
           # Content-tree hash: sha256 of sorted "<content-sha256>  <path>"
-          # lines for every tracked file in Core/ + Platform/ at HEAD.
+          # lines for every tracked file in the product scope at HEAD.
           # Reproducible byte-for-byte across git versions, archive formats,
           # locales, and tooling — only needs sha256sum + sort + either
           # `git ls-tree + git show` or an extracted working tree.
           #
-          # Product scope per docs/security/sbom.md: Core/ + Platform/.
-          # Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/
-          # are reference / test-harness / infrastructure and out of scope.
+          # Product scope per docs/security/sbom.md:
+          #   - Core/ + Platform/ subdirectories (shipped library source)
+          #   - Top-level CMakeLists.txt + CMakePresets.json (build contract
+          #     an integrator invokes directly)
+          #   - LICENSE.md (licence text we are legally bound by)
+          #
+          # Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/,
+          # sbom/, scripts/, and the other root-level docs/meta files are
+          # reference / test-harness / CI / dev-infra / meta — out of scope.
           set -euo pipefail
           HASHLIST=$(mktemp)
           PATHS=$(mktemp)
           trap 'rm -f "$HASHLIST" "$PATHS"' EXIT
-          git ls-tree -r --name-only HEAD -- Core/ Platform/ | LC_ALL=C sort > "$PATHS"
+          git ls-tree -r --name-only HEAD -- \
+              Core/ Platform/ \
+              CMakeLists.txt CMakePresets.json LICENSE.md \
+            | LC_ALL=C sort > "$PATHS"
           while IFS= read -r path; do
             # pipefail propagates a failing `git show` through the pipeline;
             # the explicit length check catches any degenerate empty-string
@@ -94,7 +103,7 @@ jobs:
         run: |
           cat > sbom/source-tree-sha256.txt <<EOF
           # SolidSyslog content-tree SHA-256
-          # Scope: Core/ + Platform/ subdirectories (shipped library).
+          # Scope: Core/ + Platform/ + top-level CMakeLists.txt, CMakePresets.json, LICENSE.md.
           # Commit: ${{ github.sha }}
           # Algorithm: sha256 of sorted "<content-sha256>  <path>" lines (LC_ALL=C sort).
           # Verification guide: docs/security/release-verification.md

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,34 @@
 # Dev Log
 
+## 2026-04-23 — S19.02 widen SBOM product scope to include build contract and licence
+
+### Decisions
+- SBOM product scope widened from `Core/` + `Platform/` to
+  `Core/` + `Platform/` + root `CMakeLists.txt` + `CMakePresets.json`
+  + `LICENSE.md`. Rationale: the earlier scope matched the CLAUDE.md
+  support tiers (Tier 1 Core, Tier 2 Platform) but missed two
+  integrator-facing realities — the top-level build contract
+  (CMakeLists.txt, CMakePresets.json) and the licence text
+  (LICENSE.md). Tampering with either is a genuine integrity concern;
+  not covering them left a gap a careful client would notice.
+- Deliberately still excluded: docs, tests, examples, CI, dev-env,
+  VSCode config, scripts, the SBOM template itself, and the root-level
+  meta files (README, CHANGELOG, CLAUDE, SKILL, DEVLOG, .clang-format,
+  .clang-tidy, .gitattributes, .gitignore, .release-please-manifest).
+  Informational or agent-facing, not library source. Including them
+  would inflate the scope without reducing integrity risk.
+- Content-tree hash algorithm unchanged — just the pathspec list
+  widens. Primary (git-based) and fallback (find-based) recipes both
+  updated. Local double-check: both recipes produce the same hash for
+  the new 110-file scope.
+
+### Deferred
+- None for this scope decision.
+
+### Open questions
+- None. Next rehearsal throwaway release will demonstrate the new
+  hash value flows through cleanly, as before.
+
 ## 2026-04-23 — S19.02 swap source-tarball hash for content-tree hash
 
 ### Decisions

--- a/docs/security/release-verification.md
+++ b/docs/security/release-verification.md
@@ -24,17 +24,20 @@ source-tree-sha256.txt.bundle
 
 ## 1. Verify the source is what we claim
 
-`source-tree-sha256.txt` records the content-tree SHA-256 of the `Core/` and
-`Platform/` subdirectories at the release commit. The hash is deterministic
-across git versions, archive formats, locales, and tooling — it depends only
-on the bytes of each tracked file and the sorted list of paths.
+`source-tree-sha256.txt` records the content-tree SHA-256 of the product at
+the release commit. The product scope is `Core/` + `Platform/` plus the
+root-level `CMakeLists.txt`, `CMakePresets.json`, and `LICENSE.md`. The hash
+is deterministic across git versions, archive formats, locales, and tooling
+— it depends only on the bytes of each tracked file and the sorted list of
+paths.
 
 ### Reproduce with git (authoritative)
 
 ```shell
 git clone --depth 1 --branch v<version> https://github.com/DavidCozens/solid-syslog.git
 cd solid-syslog
-git ls-tree -r --name-only HEAD -- Core/ Platform/ \
+git ls-tree -r --name-only HEAD -- \
+    Core/ Platform/ CMakeLists.txt CMakePresets.json LICENSE.md \
   | LC_ALL=C sort \
   | while IFS= read -r path; do
       printf "%s  %s\n" "$(git show "HEAD:$path" | sha256sum | cut -d' ' -f1)" "$path"
@@ -56,10 +59,10 @@ the tree the SBOM describes.
 ### Reproduce without git (fallback, working tree only)
 
 If you don't have a git clone — e.g. you received a source archive instead —
-but you do have an extracted `Core/` and `Platform/` directory tree:
+but you do have an extracted working tree with the product files present:
 
 ```shell
-find Core Platform -type f \
+find Core Platform CMakeLists.txt CMakePresets.json LICENSE.md -type f \
   | LC_ALL=C sort \
   | while IFS= read -r path; do
       printf "%s  %s\n" "$(sha256sum "$path" | cut -d' ' -f1)" "$path"
@@ -67,10 +70,14 @@ find Core Platform -type f \
   | sha256sum | cut -d' ' -f1
 ```
 
-Same hash expected, same comparison. Caveat: this form assumes the working
-tree is clean — any untracked or locally-modified file under `Core/` or
-`Platform/` will change the hash. The git form is stricter because it
-always reads from the committed tree.
+Same hash expected, same comparison. Caveats:
+- Assumes the working tree is clean — any untracked or locally-modified
+  file under the in-scope paths will change the hash.
+- Assumes line endings are LF on disk (git's `.gitattributes` enforces
+  this at checkout; some extraction tools may convert on platforms that
+  default to CRLF).
+
+The git form is stricter because it always reads from the committed tree.
 
 ### If the hashes don't match
 

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -12,15 +12,24 @@ questions — this document is only concerned with the first.
 
 ## Product SBOM scope
 
-The product SBOM covers the `Core/` and `Platform/` subdirectories — the
-source the integrator consumes from this repository. `Core/` is Tier 1
-(full support, stable API); `Platform/` is Tier 2 (supported; API may
-evolve per target). Both ship.
+In scope:
+- `Core/` — Tier 1 (full support, stable API).
+- `Platform/` — Tier 2 (supported; API may evolve per target).
+- Root `CMakeLists.txt` + `CMakePresets.json` — the build contract an
+  integrator invokes directly. Tampering here affects the built library.
+- Root `LICENSE.md` — the licence text we are legally bound by and that
+  downstream integrators inherit. Tampering here is a compliance issue.
 
 Out of scope:
 - `Example/` — reference integrations, not product.
 - `Tests/`, `Bdd/` — test harnesses.
-- `ci/`, `docs/`, `.devcontainer/`, `.github/` — infrastructure.
+- `ci/`, `docs/`, `.devcontainer/`, `.github/`, `.vscode/` — dev/CI infrastructure.
+- `sbom/` — the SBOM template itself (meta; including it would be self-referential).
+- `scripts/` — utility scripts not consumed by the integrator.
+- Other root-level meta files (`CLAUDE.md`, `SKILL.md`, `DEVLOG.md`,
+  `README.md`, `CHANGELOG.md`, `.clang-format`, `.clang-tidy`,
+  `.gitattributes`, `.gitignore`, `.release-please-manifest.json`).
+  Informational / agent-facing / git configuration, not library source.
 
 Runtime dependencies we declare but do not bundle:
 - **OpenSSL** — optional, only when `SOLIDSYSLOG_OPENSSL=ON`. Listed as a

--- a/sbom/sbom.cdx.json.template
+++ b/sbom/sbom.cdx.json.template
@@ -43,7 +43,7 @@
       "properties": [
         {
           "name": "solidsyslog:scope",
-          "value": "Core/ and Platform/ subdirectories — Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/ are out of scope (reference / harness / infrastructure, not shipped product)"
+          "value": "Core/ and Platform/ subdirectories, plus root-level CMakeLists.txt, CMakePresets.json, and LICENSE.md (shipped library source + build contract + licence text). Example/, Tests/, Bdd/, ci/, docs/, .devcontainer/, .github/, sbom/, scripts/, and the other root-level docs/meta files are out of scope (reference / harness / CI / dev-infra / meta, not shipped product)."
         },
         {
           "name": "solidsyslog:runtime-environment",


### PR DESCRIPTION
## Purpose
Extend the product SBOM scope from `Core/` + `Platform/` to `Core/` + `Platform/` + root `CMakeLists.txt` + `CMakePresets.json` + `LICENSE.md`. The earlier scope matched the support-tier split in CLAUDE.md (Tier 1 Core, Tier 2 Platform) but missed two integrator-facing realities that an attentive client would ask about:

- **Build contract.** The top-level `CMakeLists.txt` and `CMakePresets.json` are what an integrator invokes directly. Tampering would change the built library without the SBOM's hash noticing.
- **Licence text.** `LICENSE.md` is legally binding and inherited by downstream integrators. Tampering is a compliance issue.

Deliberately still excluded: docs, tests, examples, CI, dev-env, VSCode config, scripts, the SBOM template itself, and the root-level meta files (README, CHANGELOG, CLAUDE, SKILL, DEVLOG, `.clang-format`, `.clang-tidy`, `.gitattributes`, `.gitignore`, `.release-please-manifest.json`). Informational or agent-facing, not library source — including would inflate the hash without reducing integrity risk, and make it noisy (DEVLOG changes every session).

## Change Description
- `.github/workflows/sbom.yml` — pathspec on the `git ls-tree` call in the compute step extended to include the three root files. Scope comment updated to explain the new contents. `source-tree-sha256.txt` header line ("Scope: …") updated to match.
- `sbom/sbom.cdx.json.template` — `solidsyslog:scope` property wording re-drawn: explicit in-scope list (Core/, Platform/, three root files) and explicit out-of-scope list.
- `docs/security/sbom.md` — "Product SBOM scope" section re-shaped with "In scope" / "Out of scope" bullet lists. Gives a reader (or client) an unambiguous answer to "what's covered by this hash?"
- `docs/security/release-verification.md` — primary (git-based) and fallback (find-based) recipes both updated to cover the new pathspec. Fallback section gains a caveat about line endings as a forward reference to the pending `.gitattributes` / `.editorconfig` / `.clang-format` CRLF-policy chore.
- `DEVLOG.md` — decisions entry covering the trade-off, what's excluded and why, and the line-endings cross-reference.

## Test Evidence
Local double-check:
- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow — valid.
- Rendered SBOM with the new scope property passes `cyclonedx validate --input-version v1_5 --fail-on-errors`.
- Content-tree hash computed via git-based recipe: 110 files, `9bf02a1185ac…`.
- Same hash computed via find-based fallback recipe: **matches exactly**.

Post-merge rehearsal plan: cut a throwaway `v0.0.4-sbom-test` pre-release to confirm the four assets land, the new scope value is in the SBOM, and `cosign verify-blob` still passes. Same pattern as previous rehearsals.

## Areas Affected
- `.github/workflows/sbom.yml`
- `sbom/sbom.cdx.json.template`
- `docs/security/sbom.md`
- `docs/security/release-verification.md`
- `DEVLOG.md`

Related #196.