### PR TITLE
chore: enforce line-ending + editor consistency across platforms

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ IndentWidth: 4
 UseTab: Never
 TabWidth: 4
 ColumnLimit: 160
+LineEnding: LF
 
 # Spacing
 SpaceBeforeParens: ControlStatements

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig — https://editorconfig.org
+# Keeps editor behaviour consistent across developers regardless of OS or
+# IDE, so local working-tree state matches what git stores (see
+# .gitattributes) and what clang-format produces.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+# Markdown uses trailing double-space for hard line breaks — preserve it.
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.{bat,cmd,ps1,psm1,psd1}]
+# Windows-native scripts need CRLF — keeps the editor aligned with the
+# .gitattributes override so a Windows developer doesn't see flip-flopping
+# line endings between save and checkout.
+end_of_line = crlf
+
+[Makefile]
+# Makefiles require tab indentation — syntactic.
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,28 @@
+# Default: auto-detect text vs binary, store and check out text as LF.
+# This is the strong guarantee the content-tree hash relies on.
 * text=auto eol=lf
+
+# Explicit LF for the file types integrators interact with most. Redundant
+# with the default rule but acts as documentation of intent.
+*.c        text eol=lf
+*.h        text eol=lf
+*.cpp      text eol=lf
+*.hpp      text eol=lf
+*.cmake    text eol=lf
+*.md       text eol=lf
+*.yml      text eol=lf
+*.yaml     text eol=lf
+*.json     text eol=lf
+*.sh       text eol=lf
+*.py       text eol=lf
+
+# Windows-native scripts — the batch interpreter and older PowerShell require
+# CRLF for specific constructs (here-strings, multi-line control flow).
+# Override the default so these land as CRLF on every platform, including
+# Linux checkouts. The repo has no such files today; these entries are
+# prophylactic so the first one added doesn't immediately break.
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+*.psm1     text eol=crlf
+*.psd1     text eol=crlf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,25 @@
 {
-    "junitTestExplorer.pathForResultFiles": "${workspaceFolder}/build/debug/cpputest_*.xml"
+    "junitTestExplorer.pathForResultFiles": "${workspaceFolder}/build/debug/cpputest_*.xml",
+
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+
+    "[markdown]": {
+        "files.trimTrailingWhitespace": false
+    },
+    "[yaml]": {
+        "editor.tabSize": 2
+    },
+    "[json]": {
+        "editor.tabSize": 2
+    },
+    "[bat]": {
+        "files.eol": "\r\n"
+    },
+    "[powershell]": {
+        "files.eol": "\r\n"
+    }
 }


### PR DESCRIPTION
## Purpose
Close the CRLF/editor loop flagged during the S19.02 rehearsal. Three layers (git / editor / formatter) now agree on line endings and indentation, so a Windows developer's working tree no longer drifts from what git stores — which keeps the SBOM content-tree hash reproducible from the working-tree fallback recipe too.

Also sets up the `.bat` / `.ps1` CRLF overrides prophylactically (repo has no such files today; first one added won't break).

## Change Description
- **`.gitattributes`** — keep the default `* text=auto eol=lf`, add explicit per-extension LF rules for the integrator-facing file types (`.c`, `.h`, `.cpp`, `.hpp`, `.cmake`, `.md`, `.yml`, `.yaml`, `.json`, `.sh`, `.py`) as documentation of intent, and add CRLF overrides for Windows-native script types (`.bat`, `.cmd`, `.ps1`, `.psm1`, `.psd1`).
- **`.editorconfig`** — new. utf-8, LF, trim trailing whitespace, final newline, 4-space indent. Per-language exceptions: `[*.md]` keeps trailing whitespace (double-space = hard line break, syntactic); `[*.{yml,yaml,json}]` indents 2; `[*.{bat,cmd,ps1,psm1,psd1}]` uses CRLF; `[Makefile]` uses tab indent.
- **`.vscode/settings.json`** — extend the existing minimal file with `files.eol: "\n"`, trim/final-newline defaults, 4-space tabs. Per-language `[markdown]`, `[yaml]`, `[json]`, `[bat]`, `[powershell]` overrides match the editorconfig so VSCode doesn't fight it.
- **`.clang-format`** — add `LineEnding: LF` so `clang-format -i` on a CRLF file produces LF output instead of preserving CRLF. Container's clang-format 19.1.7 supports the key (added in 16).

## Test Evidence
- `clang-format --dry-run --Werror` over all `Core/` + `Platform/` `*.c`/`*.h`/`*.cpp`/`*.hpp` stays clean after the `LineEnding: LF` addition (no reflow).
- `.vscode/settings.json` parses as valid JSON (`python3 -m json.tool`).
- `.editorconfig` follows the EditorConfig spec; top-level `root = true` is expected.

## Areas Affected
- `.gitattributes`, `.editorconfig` (new), `.vscode/settings.json`, `.clang-format`.

No code changes. No DEVLOG entry — this is plain dev-ergonomics infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized editor and code formatting configuration files to ensure consistent development environments and coding standards across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->