### PR TITLE
feat: S07.04 escape RFC 5424 PARAM-VALUE specials

### DIFF
--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -19,6 +19,9 @@ EXTERN_C_BEGIN
 #define SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(bufferSize) \
     (SOLIDSYSLOG_FORMATTER_OVERHEAD + (((bufferSize) + sizeof(SolidSyslogFormatterStorage) - 1) / sizeof(SolidSyslogFormatterStorage)))
 
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- compile-time worst-case size for EscapedString output */
+#define SOLIDSYSLOG_ESCAPED_MAX_SIZE(rawMax) (2 * (rawMax))
+
     struct SolidSyslogFormatter;
 
     static inline struct SolidSyslogFormatter* SolidSyslogFormatter_FromStorage(SolidSyslogFormatterStorage * storage)
@@ -29,6 +32,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
     void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
+    void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter * formatter, uint32_t value);

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -14,8 +14,15 @@ struct SolidSyslogFormatter
 SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogFormatter) == SOLIDSYSLOG_FORMATTER_OVERHEAD * sizeof(SolidSyslogFormatterStorage),
                           "SOLIDSYSLOG_FORMATTER_OVERHEAD does not match struct layout");
 
+static const char QUOTE         = '"';
+static const char BACKSLASH     = '\\';
+static const char CLOSE_BRACKET = ']';
+static const char ESCAPE_PREFIX = '\\';
+
 static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void NullTerminate(struct SolidSyslogFormatter* formatter);
+static inline bool NeedsEscape(char value);
 static inline char DigitToChar(uint32_t value);
 static size_t      CountDigits(uint32_t value);
 
@@ -66,6 +73,32 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
         len++;
     }
     NullTerminate(formatter);
+}
+
+void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
+{
+    size_t len = 0;
+
+    while ((len < maxRawLength) && (source[len] != '\0'))
+    {
+        WriteEscapedChar(formatter, source[len]);
+        len++;
+    }
+    NullTerminate(formatter);
+}
+
+static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
+{
+    if (NeedsEscape(value))
+    {
+        WriteChar(formatter, ESCAPE_PREFIX);
+    }
+    WriteChar(formatter, value);
+}
+
+static inline bool NeedsEscape(char value)
+{
+    return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
 }
 
 void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)

--- a/Core/Source/SolidSyslogOriginSd.c
+++ b/Core/Source/SolidSyslogOriginSd.c
@@ -6,7 +6,9 @@ enum
 {
     ORIGIN_SOFTWARE_MAX  = 48,
     ORIGIN_SWVERSION_MAX = 32,
-    ORIGIN_FORMATTED_MAX = 115
+    ORIGIN_LITERAL_BYTES = 33, /* [origin software="" swVersion=""] */
+    ORIGIN_CONTENT_MAX   = ORIGIN_LITERAL_BYTES + SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SOFTWARE_MAX) + SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SWVERSION_MAX),
+    ORIGIN_FORMATTED_MAX = ORIGIN_CONTENT_MAX + 1 /* null terminator */
 };
 
 struct SolidSyslogOriginSd
@@ -34,9 +36,9 @@ struct SolidSyslogStructuredData* SolidSyslogOriginSd_Create(const char* softwar
 
     instance.base.Format = Format;
     SolidSyslogFormatter_BoundedString(f, SD_SOFTWARE_PREFIX, sizeof(SD_SOFTWARE_PREFIX) - 1);
-    SolidSyslogFormatter_BoundedString(f, software, ORIGIN_SOFTWARE_MAX);
+    SolidSyslogFormatter_EscapedString(f, software, ORIGIN_SOFTWARE_MAX);
     SolidSyslogFormatter_BoundedString(f, SD_VERSION_PREFIX, sizeof(SD_VERSION_PREFIX) - 1);
-    SolidSyslogFormatter_BoundedString(f, swVersion, ORIGIN_SWVERSION_MAX);
+    SolidSyslogFormatter_EscapedString(f, swVersion, ORIGIN_SWVERSION_MAX);
     SolidSyslogFormatter_BoundedString(f, SD_SUFFIX, sizeof(SD_SUFFIX) - 1);
 
     return &instance.base;

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,58 @@
 # Dev Log
 
+## 2026-04-23 — S07.04 escape RFC 5424 PARAM-VALUE specials
+
+### Decisions
+- **Escape is a formatter primitive, not an SD helper.** New
+  `SolidSyslogFormatter_EscapedString(formatter, source, maxRawLength)`
+  lives alongside `BoundedString` and the digit formatters. Avoids
+  mixing dispatch and format-time plumbing in `StructuredData.c`, and
+  gives E14 custom-SD writers the same primitive to compose into their
+  pre-formatted storage.
+- **`maxRawLength` bounds raw input, not output bytes.** Follows from
+  the RFC's "the documented field limits apply to source content".
+  Each of the escape tests uses `maxRawLength = strlen(input)` so the
+  bound is only satisfied under raw-input semantics; an additional
+  test (`EscapedStringMaxRawLengthBoundsInputNotOutput`) sets the
+  bound below the input length and relies on the resulting output
+  being 2×-not-1× the bound to prove the semantic.
+- **SD pre-format storage sized for worst-case 2× expansion.**
+  `OriginSd`'s storage moved from 115 to 194 bytes (193 content + null).
+  Expressed as a sum of named parts (`ORIGIN_LITERAL_BYTES`,
+  `ORIGIN_CONTENT_MAX`, null terminator) using the new
+  `SOLIDSYSLOG_ESCAPED_MAX_SIZE(rawMax)` macro. Drift-protected by a
+  worst-case test (48 × `]` + 32 × `"`).
+- **Truncation in the main message buffer is the SIEM's concern.**
+  Considered atomic-escape-pair behaviour to avoid dangling `\` on
+  overflow; rejected because no rewind produces a valid message once
+  we're inside an unterminated SD — all strategies (drop char / drop
+  SD / drop message) produce RFC-invalid fragments, same as any
+  truncated datagram. Don't smooth it over at the primitive level.
+
+### Deferred
+- **SD-NAME syntax validation** (RFC 5424 §6.3.2) — the three
+  standard SDs have compile-time-constant names, so validation
+  protects nothing until callers supply names. Moved to E14 (#64)
+  with an explicit scope bullet; original story (#68) updated to
+  reflect the deferral.
+- **Oracle round-trip BDD for escape rules** — proving syslog-ng
+  decodes our escaped output back to the intended value needs a
+  parameterised example fixture. Deferred to E14 where caller-supplied
+  PARAM-VALUE is the natural API surface to drive such scenarios.
+
+### Open questions for the blog source
+- **When does a sizing constant earn a macro?** Between "the magic 194"
+  and "an enum computed from parts via `SOLIDSYSLOG_ESCAPED_MAX_SIZE`
+  plus a null-terminator addend" there's a taste call about how much
+  structure pays for itself. The DRY argument — E14 custom SDs will
+  size the same way — is load-bearing here; for a one-off it would be
+  over-engineered.
+- **Test-double vs. oracle in test helpers.** `escapeEach` in the
+  worst-case test is functionally the escape function, hand-written
+  to match RFC 5424. Not circular (it's the specification oracle)
+  but worth noting the smell: if the oracle drifts from the RFC, both
+  the helper and the production code could be wrong together.
+
 ## 2026-04-23 — S19.02 widen SBOM product scope to include build contract and licence
 
 ### Decisions

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -304,3 +304,59 @@ TEST(SolidSyslogFormatter, Uint32FitsExactly)
 
     CHECK_FORMATTED("123");
 }
+
+TEST(SolidSyslogFormatter, EscapedStringWithEmptyInputWritesNothing)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "", 0);
+
+    CHECK_FORMATTED("");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringPassesOrdinaryCharacterThrough)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "a", 1);
+
+    CHECK_FORMATTED("a");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringTruncatesAtMaxRawLength)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "hello", 3);
+
+    CHECK_FORMATTED("hel");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringEscapesDoubleQuote)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "a\"b", 3);
+
+    CHECK_FORMATTED("a\\\"b");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringEscapesBackslash)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "a\\b", 3);
+
+    CHECK_FORMATTED("a\\\\b");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringEscapesCloseBracket)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "a]b", 3);
+
+    CHECK_FORMATTED("a\\]b");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringEscapesAllThreeSpecialsInOneValue)
+{
+    SolidSyslogFormatter_EscapedString(formatter, "\"\\]", 3);
+
+    CHECK_FORMATTED("\\\"\\\\\\]");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringMaxRawLengthBoundsInputNotOutput)
+{
+    SolidSyslogFormatter_EscapedString(formatter, R"(""""")", 2);
+
+    CHECK_FORMATTED(R"(\"\")");
+}

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -4,11 +4,37 @@
 #include "SolidSyslogStructuredData.h"
 
 #include <cstring>
+#include <string>
 
 enum
 {
     TEST_BUFFER_SIZE = 256
 };
+
+namespace
+{
+std::string repeated(char c, size_t n)
+{
+    std::string result(n, c);
+    return result;
+}
+
+std::string escapeEach(const std::string& allSpecials)
+{
+    std::string out;
+    for (char c : allSpecials)
+    {
+        out += '\\';
+        out += c;
+    }
+    return out;
+}
+
+std::string originSdWith(const std::string& software, const std::string& swVersion)
+{
+    return "[origin software=\"" + software + "\" swVersion=\"" + swVersion + "\"]";
+}
+} // namespace
 
 // clang-format off
 TEST_GROUP(SolidSyslogOriginSd)
@@ -163,4 +189,37 @@ TEST(SolidSyslogOriginSd, NullSwVersionReturnsNull)
 TEST(SolidSyslogOriginSd, DestroyDoesNotCrash)
 {
     // Covered by teardown — this test documents the intent
+}
+
+TEST(SolidSyslogOriginSd, SoftwareContainingSpecialsIsEscaped)
+{
+    SolidSyslogOriginSd_Destroy();
+    sd = SolidSyslogOriginSd_Create("a\"b\\c]d", "1.0");
+
+    resetFormatter();
+    format();
+    STRCMP_EQUAL("[origin software=\"a\\\"b\\\\c\\]d\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
+}
+
+TEST(SolidSyslogOriginSd, SwVersionContainingSpecialsIsEscaped)
+{
+    SolidSyslogOriginSd_Destroy();
+    sd = SolidSyslogOriginSd_Create("S", "1\"2\\3]4");
+
+    resetFormatter();
+    format();
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"1\\\"2\\\\3\\]4\"]", SolidSyslogFormatter_AsString(formatter));
+}
+
+TEST(SolidSyslogOriginSd, WorstCaseFullyEscapedInputFitsPreFormattedStorage)
+{
+    const std::string software  = repeated(']', 48); /* ORIGIN_SOFTWARE_MAX */
+    const std::string swVersion = repeated('"', 32); /* ORIGIN_SWVERSION_MAX */
+
+    SolidSyslogOriginSd_Destroy();
+    sd = SolidSyslogOriginSd_Create(software.c_str(), swVersion.c_str());
+
+    resetFormatter();
+    format();
+    STRCMP_EQUAL(originSdWith(escapeEach(software), escapeEach(swVersion)).c_str(), SolidSyslogFormatter_AsString(formatter));
 }

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -23,7 +23,7 @@ Status key:
 | 6.2.5 | PROCID — max 128 chars, PRINTUSASCII | Partial | Truncated to 128. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
 | 6.2.6 | MSGID — max 32 chars, PRINTUSASCII | Partial | Truncated to 32. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
 | 6.3 | STRUCTURED-DATA — SD-ELEMENTs or NILVALUE | Supported | Extensible via `SolidSyslogStructuredData` vtable |
-| 6.3 | SD-PARAM value escaping (`]`, `\`, `"`) | Not yet | Planned — [E14](https://github.com/DavidCozens/solid-syslog/issues/64) |
+| 6.3.3 | SD-PARAM value escaping (`]`, `\`, `"`) | Supported | `SolidSyslogFormatter_EscapedString`; `OriginSd` escapes software/swVersion. SD-NAME syntax validation planned — [E14](https://github.com/DavidCozens/solid-syslog/issues/64) |
 | 6.3.3 | timeQuality SD — tzKnown, isSynced, syncAccuracy | Supported | `SolidSyslogTimeQualitySd` |
 | 6.3.4 | origin SD — software, swVersion | Supported | `SolidSyslogOriginSd`. `ip` and `enterpriseId` not implemented |
 | 6.3.5 | meta SD — sequenceId | Supported | `SolidSyslogMetaSd`. Starts at 1, increments per message. `sysUpTime` and `language` not implemented |


### PR DESCRIPTION
## Purpose
Closes #68.

RFC 5424 §6.3.3 requires the three characters `"`, `\`, `]` in
PARAM-VALUE to be backslash-escaped. Before this change, caller-supplied
values in `origin.software` / `origin.swVersion` were emitted raw,
producing malformed SD-ELEMENTs whenever a caller happened to pass a
value containing any of those characters.

## Change Description

- New formatter primitive `SolidSyslogFormatter_EscapedString(formatter, source, maxRawLength)` in
  `Core/Interface/SolidSyslogFormatter.h`, alongside a sizing macro
  `SOLIDSYSLOG_ESCAPED_MAX_SIZE(rawMax)` that SD authors use to size
  their pre-formatted storage for the worst-case 2× expansion.
- Implementation in `Core/Source/SolidSyslogFormatter.c` factored into
  `WriteEscapedChar` + `NeedsEscape`, with the three special
  characters and the escape prefix captured as named
  `static const char` constants.
- `SolidSyslogOriginSd` adopts `EscapedString` for its two
  caller-supplied fields and sizes its pre-formatted storage from
  named parts (`ORIGIN_LITERAL_BYTES + ESCAPED(software) + ESCAPED(swVersion) + null`).
- Scope deliberately narrower than the original story: SD-NAME syntax
  validation and oracle round-trip BDD moved to E14 (#64), where
  caller-supplied names and the parameterised example fixture
  respectively make them load-bearing. Both deferrals are documented
  on both issues.

## Test Evidence

Strict TDD — one red test then minimum production code per step.

- Seven formatter tests covering: empty input, passthrough, raw-bound
  truncation, each of the three RFC specials, all-three-in-one-value,
  and an explicit `MaxRawLengthBoundsInputNotOutput` (5-char input,
  bound 2, output 4 bytes — impossible under an output-byte bound).
- Every escape test uses `maxRawLength = strlen(input)`: the assertion
  only holds under raw-input semantics.
- Three OriginSd tests: software and swVersion containing specials are
  escaped; and `WorstCaseFullyEscapedInputFitsPreFormattedStorage` —
  48 × `]` + 32 × `"` — proves the pre-formatted storage at 194 bytes
  holds the full worst-case output. Helpers (`repeated`, `escapeEach`,
  `originSdWith`) in an anonymous namespace let the test body read as
  its claim; the `48`/`32` literals are intentionally untracked against
  the private production enum so a limit change fails this test as
  drift detection.
- Local CI gate: debug, clang-debug, sanitize, coverage, tidy,
  cppcheck, clang-format all green. Coverage remains 100% lines and
  functions.
- No new BDD; existing `origin.feature` is unaffected on the wire
  (`SolidSyslogExample` / `0.7.0` have no escape-triggering chars).

## Areas Affected

- `Core/Interface/SolidSyslogFormatter.h` — new API
- `Core/Source/SolidSyslogFormatter.c` — new primitive, helpers, constants
- `Core/Source/SolidSyslogOriginSd.c` — adopts primitive, storage resized
- `Tests/SolidSyslogFormatterTest.cpp` — 7 new tests
- `Tests/SolidSyslogOriginSdTest.cpp` — 3 new tests + anonymous-namespace helpers

No impact on transport, BDD, or examples. E14 (#64) now carries two
explicit follow-on requirements that originated here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string escaping for syslog parameter values to properly handle special characters (quotes, backslashes, brackets).
  * Introduced new formatter function for escaped string output with configurable input length limits.

* **Tests**
  * Added comprehensive test coverage for string escaping behavior and special character handling.

* **Documentation**
  * Added design documentation for RFC 5424 parameter value escaping implementation and sizing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->