### PR TITLE
feat: S12.09 PRINTUSASCII validation for RFC 5424 header fields

### DIFF
--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -33,6 +33,7 @@ EXTERN_C_BEGIN
     void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
+    void                         SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter * formatter, uint32_t value);

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -323,7 +323,7 @@ static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslog
 
     if (fieldLength > 0)
     {
-        SolidSyslogFormatter_BoundedString(f, SolidSyslogFormatter_AsString(field), fieldLength);
+        SolidSyslogFormatter_PrintUsAsciiString(f, SolidSyslogFormatter_AsString(field), fieldLength);
     }
     else
     {
@@ -337,7 +337,7 @@ static inline void FormatMsgId(struct SolidSyslogFormatter* f, const char* messa
 
     if (StringIsValid(messageId))
     {
-        SolidSyslogFormatter_BoundedString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
+        SolidSyslogFormatter_PrintUsAsciiString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
     }
 
     if (SolidSyslogFormatter_Length(f) == lengthBefore)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -14,15 +14,20 @@ struct SolidSyslogFormatter
 SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogFormatter) == SOLIDSYSLOG_FORMATTER_OVERHEAD * sizeof(SolidSyslogFormatterStorage),
                           "SOLIDSYSLOG_FORMATTER_OVERHEAD does not match struct layout");
 
-static const char QUOTE         = '"';
-static const char BACKSLASH     = '\\';
-static const char CLOSE_BRACKET = ']';
-static const char ESCAPE_PREFIX = '\\';
+static const char QUOTE                      = '"';
+static const char BACKSLASH                  = '\\';
+static const char CLOSE_BRACKET              = ']';
+static const char ESCAPE_PREFIX              = '\\';
+static const char LOWEST_PRINTABLE_US_ASCII  = '!';
+static const char HIGHEST_PRINTABLE_US_ASCII = '~';
+static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 
 static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline bool NeedsEscape(char value);
+static inline bool IsPrintableUsAscii(char value);
 static inline char DigitToChar(uint32_t value);
 static size_t      CountDigits(uint32_t value);
 
@@ -99,6 +104,35 @@ static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char
 static inline bool NeedsEscape(char value)
 {
     return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
+}
+
+void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
+{
+    size_t len = 0;
+
+    while ((len < maxLength) && (source[len] != '\0'))
+    {
+        WritePrintableUsAsciiChar(formatter, source[len]);
+        len++;
+    }
+    NullTerminate(formatter);
+}
+
+static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
+{
+    if (IsPrintableUsAscii(value))
+    {
+        WriteChar(formatter, value);
+    }
+    else
+    {
+        WriteChar(formatter, NON_PRINTABLE_SUBSTITUTE);
+    }
+}
+
+static inline bool IsPrintableUsAscii(char value)
+{
+    return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
 }
 
 void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,64 @@
 # Dev Log
 
+## 2026-04-23 — S12.09 PRINTUSASCII validation for RFC 5424 header fields
+
+### Decisions
+- **New formatter primitive `SolidSyslogFormatter_PrintUsAsciiString`.**
+  Sits alongside `BoundedString` and `EscapedString` in the same family
+  — same call shape, same null-terminate discipline, same bounded-loop
+  semantics. Validation lives in the primitive, not in
+  `FormatStringField` or `FormatMsgId`, because MSGID goes through a
+  different call path than the three callback-driven fields;
+  primitive-level keeps the rule in one place and the adoption a
+  one-line swap per call site.
+- **Substitute non-PRINTUSASCII bytes with `?`.** Matches syslog-ng /
+  rsyslog convention. Silent — no PRIVAL flag, no counter SD-ELEMENT.
+  PRIVAL is `facility × 8 + severity`, not a flag carrier; flipping a
+  severity bit would lose semantic information. SIEMs that care detect
+  `?` themselves.
+- **Signed / unsigned `char` both handled.** The RFC's PRINTUSASCII
+  range `[33, 126]` implemented as
+  `(value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII)`
+  — `'~'` is 126, so a `signed char` high-bit byte (negative) and an
+  `unsigned char` high-bit byte (> 126) both fail the upper bound.
+  No explicit `unsigned char` cast needed.
+- **Same truncation semantic as `BoundedString`.** Substitution is
+  1-byte-in / 1-byte-out, so `maxLength` bounds input consumed and
+  output bytes identically. No 2× storage considerations like
+  `EscapedString`.
+- **Name registers split deliberately.** Public API
+  `SolidSyslogFormatter_PrintUsAsciiString` echoes the RFC token
+  `PRINTUSASCII`. Internal helpers and constants use the English
+  descriptor "Printable" (`IsPrintableUsAscii`, `LOWEST_PRINTABLE_US_ASCII`,
+  `NON_PRINTABLE_SUBSTITUTE`) because they read as prose in context.
+
+### Deferred
+- **Oracle round-trip BDD.** No parameterised fixture today that drives
+  non-printable bytes through hostname/app-name/procid/msgid
+  end-to-end. Same argument as S07.04 — cost of scaffolding exceeds
+  benefit given how well unit tests cover the primitive. If a
+  parameterised BDD fixture arrives later (E14 is one candidate host),
+  PRINTUSASCII scenarios plug into it.
+
+### Open questions for the blog source
+- **What makes a primitive promotion-worthy?** `EscapedString` and
+  `PrintUsAsciiString` both started as "do one thing at each char".
+  They earned their place in the formatter family because (a) every
+  call site that needed the rule could get it with a one-line swap,
+  and (b) the rule was uniform across call sites. If either failed,
+  you'd want the rule expressed inline or in a higher-level helper.
+  That's a clean heuristic for future policy primitives (UTF-8 safe
+  truncation next).
+- **Duplication of idiom vs duplication of logic.** Three of the
+  formatter primitives now share
+  `while ((len < maxLength) && (source[len] != '\0'))`. Considered
+  extracting — function pointer, macro, `MoreToFormat()` helper — all
+  rejected: the repeated thing is a C idiom for bounded-nul iteration,
+  the distinctive content is the one-line per-char dispatch, and
+  future divergence (UTF-8 boundary-walk in S12.10) would fight a
+  shared abstraction. Rule of three presumes repeated *logic*, not
+  repeated *idiom*.
+
 ## 2026-04-23 — S07.04 escape RFC 5424 PARAM-VALUE specials
 
 ### Decisions

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -360,3 +360,78 @@ TEST(SolidSyslogFormatter, EscapedStringMaxRawLengthBoundsInputNotOutput)
 
     CHECK_FORMATTED(R"(\"\")");
 }
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringWithEmptyInputWritesNothing)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, "", 0);
+
+    CHECK_FORMATTED("");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringPassesPrintableCharacterThrough)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, "A", 1);
+
+    CHECK_FORMATTED("A");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringTruncatesAtMaxLength)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, "hello", 3);
+
+    CHECK_FORMATTED("hel");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringSubstitutesSpace)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, "a b", 3);
+
+    CHECK_FORMATTED("a?b");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringSubstitutesControlCharacter)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter,
+                                            "a\x01"
+                                            "b",
+                                            3);
+
+    CHECK_FORMATTED("a?b");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringSubstitutesDel)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter,
+                                            "a\x7F"
+                                            "b",
+                                            3);
+
+    CHECK_FORMATTED("a?b");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringSubstitutesHighBitByte)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter,
+                                            "a\xC3"
+                                            "b",
+                                            3);
+
+    CHECK_FORMATTED("a?b");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringPassesBangAndTildeBoundariesThrough)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, "!~", 2);
+
+    CHECK_FORMATTED("!~");
+}
+
+TEST(SolidSyslogFormatter, PrintUsAsciiStringTruncationBoundsSubstitution)
+{
+    SolidSyslogFormatter_PrintUsAsciiString(formatter,
+                                            "abc\x01"
+                                            "def",
+                                            3);
+
+    CHECK_FORMATTED("abc");
+}

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -454,6 +454,13 @@ TEST(SolidSyslog, MessageIdAt33CharsIsTruncatedTo32)
     CHECK_MSGID(expected.c_str());
 }
 
+TEST(SolidSyslog, MessageIdNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    message.messageId = "a b";
+    Log();
+    CHECK_MSGID("a?b");
+}
+
 TEST(SolidSyslog, StructuredDataIsNilValue)
 {
     Log();
@@ -990,6 +997,14 @@ TEST(SolidSyslog, HostnameAt256CharsIsTruncatedTo255)
     CHECK_HOSTNAME(expected.c_str());
 }
 
+TEST(SolidSyslog, HostnameNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetHostname("a\x01"
+                           "b");
+    Log();
+    CHECK_HOSTNAME("a?b");
+}
+
 TEST(SolidSyslog, AppNameAt48CharsIsAccepted)
 {
     std::string longAppName(48, 'A');
@@ -1007,6 +1022,14 @@ TEST(SolidSyslog, AppNameAt49CharsIsTruncatedTo48)
     CHECK_APP_NAME(expected.c_str());
 }
 
+TEST(SolidSyslog, AppNameNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetAppName("a\x7F"
+                          "b");
+    Log();
+    CHECK_APP_NAME("a?b");
+}
+
 TEST(SolidSyslog, ProcessIdAt128CharsIsAccepted)
 {
     std::string longProcessId(128, 'P');
@@ -1022,6 +1045,14 @@ TEST(SolidSyslog, ProcessIdAt129CharsIsTruncatedTo128)
     Log();
     std::string expected(128, 'P');
     CHECK_PROCID(expected.c_str());
+}
+
+TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetProcessId("a\xC3"
+                            "b");
+    Log();
+    CHECK_PROCID("a?b");
 }
 
 TEST(SolidSyslog, AllFieldsAtMaxLengthProducesValidMessage)

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -137,8 +137,10 @@ non-repudiation and assured delivery.
 ### SL4 — High-Assurance Logging
 
 Requires cryptographic integrity, encryption, and assured delivery with
-non-repudiation. TLS transport has landed; remaining SL4 items are at-rest
-cryptography and RFC 5424 string-hygiene.
+non-repudiation. TLS transport has landed and RFC 5424 string-hygiene is
+closed (SD escaping + PRINTUSASCII header-field validation); remaining
+SL4 items are at-rest cryptography and UTF-8 safe truncation of the MSG
+body.
 
 | Component | Header | Purpose | Status |
 |---|---|---|---|
@@ -146,7 +148,7 @@ cryptography and RFC 5424 string-hygiene.
 | `SolidSyslogTlsStream` | `SolidSyslogTlsStream.h` | OpenSSL-backed TLS 1.2+ transport (RFC 5425): server cert validation, hostname verification, cipher pinning, optional mutual TLS, rotation on reconnect | Available |
 | Authenticated integrity policy | — | HMAC/AES-CMAC on stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
-| PRINTUSASCII validation | — | Header field character compliance | Planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
+| PRINTUSASCII validation | — | Header field character compliance | Available — non-compliant bytes substituted with `?` via `SolidSyslogFormatter_PrintUsAsciiString` |
 | UTF-8 safe truncation | — | No split multi-byte sequences | Planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
 | Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
 
@@ -163,8 +165,8 @@ cryptography and RFC 5424 string-hygiene.
 - Cryptographic integrity at rest — HMAC or AES-CMAC replacing CRC-16, making
   stored-record tampering detectable even by a local attacker (CR 2.12, CR 3.9).
 - Encryption at rest — stored records unreadable without key material (CR 3.9).
-- Full RFC 5424 character compliance — PRINTUSASCII validation on header
-  fields, UTF-8 safe truncation on message body.
+- UTF-8 safe truncation on message body — no split multi-byte sequences
+  when MSG is truncated at the wire limit.
 
 **SL4 TLS substrate.** `SolidSyslogTlsStream` — the OpenSSL-backed client-side
 TLS substrate — ships with the SL4 controls that depend on the client:

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -18,10 +18,10 @@ Status key:
 | 6.2.1 | VERSION = 1 | Supported | |
 | 6.2.2 | TIMESTAMP — ISO 8601 with microseconds | Supported | 6-digit fractional seconds, UTC offset or `Z` |
 | 6.2.2 | TIMESTAMP — NILVALUE when clock unavailable | Supported | NilClock produces `-` |
-| 6.2.3 | HOSTNAME — max 255 chars, PRINTUSASCII | Partial | Truncated to 255. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
-| 6.2.4 | APP-NAME — max 48 chars, PRINTUSASCII | Partial | Truncated to 48. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
-| 6.2.5 | PROCID — max 128 chars, PRINTUSASCII | Partial | Truncated to 128. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
-| 6.2.6 | MSGID — max 32 chars, PRINTUSASCII | Partial | Truncated to 32. PRINTUSASCII validation planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
+| 6.2.3 | HOSTNAME — max 255 chars, PRINTUSASCII | Supported | Truncated to 255. Non-PRINTUSASCII bytes substituted with `?` via `SolidSyslogFormatter_PrintUsAsciiString` |
+| 6.2.4 | APP-NAME — max 48 chars, PRINTUSASCII | Supported | Truncated to 48. Non-PRINTUSASCII bytes substituted with `?` |
+| 6.2.5 | PROCID — max 128 chars, PRINTUSASCII | Supported | Truncated to 128. Non-PRINTUSASCII bytes substituted with `?` |
+| 6.2.6 | MSGID — max 32 chars, PRINTUSASCII | Supported | Truncated to 32. Non-PRINTUSASCII bytes substituted with `?` |
 | 6.3 | STRUCTURED-DATA — SD-ELEMENTs or NILVALUE | Supported | Extensible via `SolidSyslogStructuredData` vtable |
 | 6.3.3 | SD-PARAM value escaping (`]`, `\`, `"`) | Supported | `SolidSyslogFormatter_EscapedString`; `OriginSd` escapes software/swVersion. SD-NAME syntax validation planned — [E14](https://github.com/DavidCozens/solid-syslog/issues/64) |
 | 6.3.3 | timeQuality SD — tzKnown, isSynced, syncAccuracy | Supported | `SolidSyslogTimeQualitySd` |
@@ -30,7 +30,7 @@ Status key:
 | 6.3.5 | meta SD — sequenceId wraps at 2147483647 to 1 | Not yet | Planned — see [sequenceId rules](https://github.com/DavidCozens/solid-syslog/issues/31) |
 | 6.4 | MSG — UTF-8 preferred | Partial | Passes through caller's encoding. No BOM prefix. UTF-8 safe truncation planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
 | 8.1 | Message size — max 2048 recommended | Supported | Default `SOLIDSYSLOG_MAX_MESSAGE_SIZE` = 512. Configurable via CMake |
-| 9 | PRINTUSASCII in header fields (codes 33-126) | Not yet | Planned — [S12.9](https://github.com/DavidCozens/solid-syslog/issues/120) |
+| 9 | PRINTUSASCII in header fields (codes 33-126) | Supported | Non-compliant bytes substituted with `?` at format time (HOSTNAME, APP-NAME, PROCID, MSGID) |
 
 ## RFC 5426 — Transmission of Syslog Messages over UDP
 
@@ -72,7 +72,7 @@ Status key:
 
 | RFC | Total requirements | Supported | Partial | Planned | N/A |
 |---|---|---|---|---|---|
-| RFC 5424 | 17 | 10 | 5 | 2 | 0 |
+| RFC 5424 | 17 | 15 | 1 | 1 | 0 |
 | RFC 5426 | 6 | 3 | 1 | 0 | 2 |
 | RFC 6587 | 6 | 2 | 2 | 2 | 0 |
 | RFC 5425 | 7 | 6 | 1 | 0 | 0 |


### PR DESCRIPTION
## Purpose
Closes #120.

RFC 5424 §9 restricts HOSTNAME, APP-NAME, PROCID, and MSGID to
PRINTUSASCII (codes 33–126). Before this change, non-compliant bytes
(space, DEL, control characters, high-bit UTF-8 bytes from real-world
callers) passed through verbatim, producing RFC-invalid headers. The
MSGID path was the worst case — an embedded space was read by field
parsers as the end of MSGID, silently corrupting downstream STRUCTURED
DATA and MSG parsing.

## Change Description

- New formatter primitive
  `SolidSyslogFormatter_PrintUsAsciiString(formatter, source, maxLength)`
  in `Core/Interface/SolidSyslogFormatter.h`. Writes bytes in `[33,126]`
  as-is; substitutes everything else with `?`. Same truncation and
  null-terminate discipline as `BoundedString` / `EscapedString`.
- Implementation factored into `WritePrintableUsAsciiChar` +
  `IsPrintableUsAscii` with named constants (`NON_PRINTABLE_SUBSTITUTE`,
  `LOWEST_PRINTABLE_US_ASCII`, `HIGHEST_PRINTABLE_US_ASCII`), mirroring
  the shape introduced by `EscapedString` in S07.04.
- Adoption: two one-line swaps in `Core/Source/SolidSyslog.c` —
  `FormatStringField` (covers HOSTNAME / APP-NAME / PROCID) and
  `FormatMsgId` (covers MSGID).
- Silent substitution, no PRIVAL flag. Rationale recorded on #120 and
  in the DEVLOG.

## Test Evidence

Strict TDD — one red test then minimum production code per step.

- Formatter primitive: 9 unit tests covering empty input, printable
  passthrough, truncation at `maxLength`, substitution of space (32),
  control character (`\x01`), DEL (127), high-bit byte (`\xC3`),
  both boundary characters (`!` = 33, `~` = 126), and the
  truncation-bounds-substitution interaction.
- Adoption: 4 unit tests in `SolidSyslogTest.cpp`, one per header
  field, using `StringFake_Set*` (or `message.messageId`) to inject a
  non-printable byte and asserting `?` appears on the wire. APP-NAME
  and PROCID tests turn green on the `FormatStringField` swap alongside
  HOSTNAME — they document the per-field contract.
- Existing at-max-length and truncation tests (HOSTNAME 255,
  APP-NAME 48, PROCID 128, MSGID 32) continue to pass unchanged —
  their inputs are all printable ASCII.
- Local CI gate: debug, clang-debug, sanitize, coverage, tidy,
  cppcheck, clang-format all green. Coverage remains 100% lines and
  functions.
- No new BDD — existing scenarios use printable ASCII hostnames /
  app-names / msg-ids, so the change is transparent on the wire for
  the example program. Oracle round-trip BDD for non-printable bytes
  deferred (no parameterised fixture).

## Areas Affected

- `Core/Interface/SolidSyslogFormatter.h` — new API
- `Core/Source/SolidSyslogFormatter.c` — new primitive, helpers, constants
- `Core/Source/SolidSyslog.c` — two one-line adoption swaps
- `Tests/SolidSyslogFormatterTest.cpp` — 9 new tests
- `Tests/SolidSyslogTest.cpp` — 4 new tests
- `docs/rfc-compliance.md` — 5 rows tightened in the RFC 5424 matrix
- `docs/iec62443.md` — SL4 PRINTUSASCII row flipped to Available;
  narrative updated to reflect that only UTF-8 safe truncation
  remains from the string-hygiene triad

No impact on transport, BDD, or examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added US-ASCII string validation for syslog header fields, automatically replacing non-compliant characters with `?` to ensure RFC 5424 PRINTUSASCII compliance.

* **Documentation**
  * Updated RFC 5424 compliance matrix to reflect completion of header-field string-hygiene validation.
  * Updated security documentation to document PRINTUSASCII validation implementation.

* **Tests**
  * Added comprehensive test coverage for US-ASCII character validation and string formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->