### PR TITLE
feat: S12.10 UTF-8 safety across the formatter API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ Headers in `Core/Interface/` are split by audience — each user includes only w
 |---|---|---|
 | `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log`, `SolidSyslog_Service` |
 | `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy`, `SolidSyslogStringFunction` |
-| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsString`, `_Length` |
+| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsFormattedBuffer`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
 | `SolidSyslogEndpoint.h` | System setup code that supplies destination host/port (and version on changes) | `SolidSyslogEndpoint`, `SolidSyslogEndpointFunction`, `SolidSyslogEndpointVersionFunction`, `SOLIDSYSLOG_MAX_HOST_SIZE` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,24 @@ Names should be self-documenting — prefer clarity over brevity.
 
 ---
 
+## Function Ordering
+
+Within a source file, functions are ordered top-down so the reader sees the lifecycle and public API
+first, then drills into helpers as they appear:
+
+1. `_Create` function first.
+2. `_Destroy` function second.
+3. Other public functions after, in whatever order reads naturally (often call order).
+4. Helper functions are **forward-declared** at the top of the file (after constants/types, before
+   the first definition), usually `static inline`, and **defined immediately beneath the function
+   that first calls them**. If a second public function also calls that helper, the helper stays
+   where it was — with its first caller.
+
+This puts "what the file does" at the top, and every helper next to its nearest use. Forward
+declarations are the price paid to keep that top-down reading order.
+
+---
+
 ## Container Images
 
 See [`docs/containers.md`](docs/containers.md) for the full image reference, Docker Compose setup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ Headers in `Core/Interface/` are split by audience — each user includes only w
 |---|---|---|
 | `SolidSyslog.h` | Application code that logs events | `SolidSyslogMessage`, `SolidSyslog_Log`, `SolidSyslog_Service` |
 | `SolidSyslogConfig.h` | System setup code | `SolidSyslogConfig`, `SolidSyslog_Create`, `SolidSyslog_Destroy`, `SolidSyslogStringFunction` |
-| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_Character`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsFormattedBuffer`, `_Length` |
+| `SolidSyslogFormatter.h` | Any code that formats into a bounded buffer | `SolidSyslogFormatter`, `SolidSyslogFormatterStorage`, `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE`, `_Create`, `_FromStorage`, `_AsciiCharacter`, `_BoundedString`, `_Uint32`, `_TwoDigit`, `_FourDigit`, `_SixDigit`, `_AsFormattedBuffer`, `_Length` |
 | `SolidSyslogPrival.h` | Any code that needs facility/severity enums | `SolidSyslog_Facility`, `SolidSyslog_Severity` |
 | `SolidSyslogTimestamp.h` | Any code that needs the timestamp struct | `SolidSyslogTimestamp`, `SolidSyslogClockFunction` |
 | `SolidSyslogEndpoint.h` | System setup code that supplies destination host/port (and version on changes) | `SolidSyslogEndpoint`, `SolidSyslogEndpointFunction`, `SolidSyslogEndpointVersionFunction`, `SOLIDSYSLOG_MAX_HOST_SIZE` |

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -39,11 +39,12 @@ EXTERN_C_BEGIN
     void                         SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     /* Returns a pointer to the formatted bytes. The buffer is NUL-terminated for
-     * convenience but the content is not a C string: UTF-8 content may contain
-     * embedded NUL (U+0000) and a truncated multi-byte tail is masked with a NUL
-     * so strlen stops before any invalid UTF-8. Pair with _Length to get the
-     * full byte count the formatter has written. */
-    const char* SolidSyslogFormatter_AsFormattedBuffer(const struct SolidSyslogFormatter* formatter);
+     * convenience but the content is not a C string — UTF-8 content may contain
+     * embedded NUL (U+0000), and a truncated multi-byte tail is masked with NULs
+     * so strlen stops before any invalid UTF-8. _Length reports the raw byte
+     * count (independent of the trim); bytes in [strlen(_AsFormattedBuffer),
+     * _Length) are guaranteed zero-padding. */
+    const char* SolidSyslogFormatter_AsFormattedBuffer(struct SolidSyslogFormatter * formatter);
     size_t      SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
 
 EXTERN_C_END

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -38,8 +38,13 @@ EXTERN_C_BEGIN
     void                         SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter * formatter, uint32_t value);
-    const char*                  SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter);
-    size_t                       SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
+    /* Returns a pointer to the formatted bytes. The buffer is NUL-terminated for
+     * convenience but the content is not a C string: UTF-8 content may contain
+     * embedded NUL (U+0000) and a truncated multi-byte tail is masked with a NUL
+     * so strlen stops before any invalid UTF-8. Pair with _Length to get the
+     * full byte count the formatter has written. */
+    const char* SolidSyslogFormatter_AsFormattedBuffer(const struct SolidSyslogFormatter* formatter);
+    size_t      SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -32,6 +32,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
     void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
+    void                         SolidSyslogFormatter_RawBoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
     void                         SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -30,7 +30,7 @@ EXTERN_C_BEGIN
     }
 
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
-    void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
+    void                         SolidSyslogFormatter_AsciiCharacter(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
     void                         SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -32,7 +32,6 @@ EXTERN_C_BEGIN
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
     void                         SolidSyslogFormatter_Character(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
-    void                         SolidSyslogFormatter_RawBoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
     void                         SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -20,7 +20,7 @@ EXTERN_C_BEGIN
     (SOLIDSYSLOG_FORMATTER_OVERHEAD + (((bufferSize) + sizeof(SolidSyslogFormatterStorage) - 1) / sizeof(SolidSyslogFormatterStorage)))
 
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- compile-time worst-case size for EscapedString output */
-#define SOLIDSYSLOG_ESCAPED_MAX_SIZE(rawMax) (2 * (rawMax))
+#define SOLIDSYSLOG_ESCAPED_MAX_SIZE(maxDecodedLength) (2 * (maxDecodedLength))
 
     struct SolidSyslogFormatter;
 
@@ -32,7 +32,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage * storage, size_t bufferSize);
     void                         SolidSyslogFormatter_AsciiCharacter(struct SolidSyslogFormatter * formatter, char value);
     void                         SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
-    void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxRawLength);
+    void                         SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxDecodedLength);
     void                         SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter * formatter, const char* source, size_t maxLength);
     void                         SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter * formatter, uint32_t value);
     void                         SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter * formatter, uint32_t value);

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -168,27 +168,27 @@ void SolidSyslog_Log(const struct SolidSyslogMessage* message)
 static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)
 {
     FormatPrival(f, MakePrival(message));
-    SolidSyslogFormatter_Character(f, '1');
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, '1');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatTimestamp(f, instance.clock);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatStringField(f, instance.getHostname, SOLIDSYSLOG_MAX_HOSTNAME_SIZE);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatStringField(f, instance.getAppName, SOLIDSYSLOG_MAX_APP_NAME_SIZE);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatStringField(f, instance.getProcessId, SOLIDSYSLOG_MAX_PROCESS_ID_SIZE);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatMsgId(f, message->messageId);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     FormatStructuredData(f, instance.sd, instance.sdCount);
     FormatMsg(f, message->msg);
 }
 
 static inline void FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival)
 {
-    SolidSyslogFormatter_Character(f, '<');
+    SolidSyslogFormatter_AsciiCharacter(f, '<');
     SolidSyslogFormatter_Uint32(f, prival);
-    SolidSyslogFormatter_Character(f, '>');
+    SolidSyslogFormatter_AsciiCharacter(f, '>');
 }
 
 static inline uint8_t MakePrival(const struct SolidSyslogMessage* message)
@@ -263,17 +263,17 @@ static inline bool TimestampIsValid(const struct SolidSyslogTimestamp* ts)
 static inline void FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts)
 {
     SolidSyslogFormatter_FourDigit(f, ts->year);
-    SolidSyslogFormatter_Character(f, '-');
+    SolidSyslogFormatter_AsciiCharacter(f, '-');
     SolidSyslogFormatter_TwoDigit(f, ts->month);
-    SolidSyslogFormatter_Character(f, '-');
+    SolidSyslogFormatter_AsciiCharacter(f, '-');
     SolidSyslogFormatter_TwoDigit(f, ts->day);
-    SolidSyslogFormatter_Character(f, 'T');
+    SolidSyslogFormatter_AsciiCharacter(f, 'T');
     SolidSyslogFormatter_TwoDigit(f, ts->hour);
-    SolidSyslogFormatter_Character(f, ':');
+    SolidSyslogFormatter_AsciiCharacter(f, ':');
     SolidSyslogFormatter_TwoDigit(f, ts->minute);
-    SolidSyslogFormatter_Character(f, ':');
+    SolidSyslogFormatter_AsciiCharacter(f, ':');
     SolidSyslogFormatter_TwoDigit(f, ts->second);
-    SolidSyslogFormatter_Character(f, '.');
+    SolidSyslogFormatter_AsciiCharacter(f, '.');
     SolidSyslogFormatter_SixDigit(f, ts->microsecond);
     FormatUtcOffset(f, ts->utcOffsetMinutes);
 }
@@ -282,7 +282,7 @@ static inline void FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offse
 {
     if (offsetMinutes == 0)
     {
-        SolidSyslogFormatter_Character(f, 'Z');
+        SolidSyslogFormatter_AsciiCharacter(f, 'Z');
     }
     else
     {
@@ -294,9 +294,9 @@ static inline void FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_
 {
     int16_t absoluteMinutes = AbsoluteInt16(offsetMinutes);
 
-    SolidSyslogFormatter_Character(f, (offsetMinutes > 0) ? '+' : '-');
+    SolidSyslogFormatter_AsciiCharacter(f, (offsetMinutes > 0) ? '+' : '-');
     SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes / 60));
-    SolidSyslogFormatter_Character(f, ':');
+    SolidSyslogFormatter_AsciiCharacter(f, ':');
     SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes % 60));
 }
 
@@ -370,12 +370,12 @@ static inline void FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
 {
     if (StringIsValid(msg))
     {
-        SolidSyslogFormatter_Character(f, ' ');
+        SolidSyslogFormatter_AsciiCharacter(f, ' ');
         SolidSyslogFormatter_BoundedString(f, msg, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
     }
 }
 
 static inline void FormatNilvalue(struct SolidSyslogFormatter* f)
 {
-    SolidSyslogFormatter_Character(f, '-');
+    SolidSyslogFormatter_AsciiCharacter(f, '-');
 }

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -162,7 +162,7 @@ void SolidSyslog_Log(const struct SolidSyslogMessage* message)
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
     FormatMessage(f, message);
-    SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsString(f), SolidSyslogFormatter_Length(f));
+    SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsFormattedBuffer(f), SolidSyslogFormatter_Length(f));
 }
 
 static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)
@@ -323,7 +323,7 @@ static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslog
 
     if (fieldLength > 0)
     {
-        SolidSyslogFormatter_PrintUsAsciiString(f, SolidSyslogFormatter_AsString(field), fieldLength);
+        SolidSyslogFormatter_PrintUsAsciiString(f, SolidSyslogFormatter_AsFormattedBuffer(field), fieldLength);
     }
     else
     {

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -212,7 +212,7 @@ static inline const char* FormatFilename(SolidSyslogFormatterStorage* storage, u
     SolidSyslogFormatter_TwoDigit(f, sequence);
     SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
 
-    return SolidSyslogFormatter_AsString(f);
+    return SolidSyslogFormatter_AsFormattedBuffer(f);
 }
 
 static inline uint8_t NextSequence(uint8_t current)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -22,14 +22,15 @@ static const char LOWEST_PRINTABLE_US_ASCII  = '!';
 static const char HIGHEST_PRINTABLE_US_ASCII = '~';
 static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 
-static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void NullTerminate(struct SolidSyslogFormatter* formatter);
-static inline bool NeedsEscape(char value);
-static inline bool IsPrintableUsAscii(char value);
-static inline char DigitToChar(uint32_t value);
-static size_t      CountDigits(uint32_t value);
+static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
+static inline bool   NeedsEscape(char value);
+static inline bool   IsPrintableUsAscii(char value);
+static inline size_t SkipBadUtf8(const char* source);
+static inline char   DigitToChar(uint32_t value);
+static size_t        CountDigits(uint32_t value);
 
 static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter)
 {
@@ -74,10 +75,34 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        WriteChar(formatter, source[len]);
-        len++;
+        size_t skipped = SkipBadUtf8(&source[len]);
+        if (skipped > 0)
+        {
+            WriteChar(formatter, '\xEF');
+            WriteChar(formatter, '\xBF');
+            WriteChar(formatter, '\xBD');
+            len += skipped;
+        }
+        else
+        {
+            WriteChar(formatter, source[len]);
+            len++;
+        }
     }
     NullTerminate(formatter);
+}
+
+static inline size_t SkipBadUtf8(const char* source)
+{
+    size_t skip  = 0;
+    char   value = source[0];
+
+    if (((value & 0xC0) == 0x80) || ((value & 0xFE) == 0xC0) || (value == '\xF5') || ((value & 0xF8) == 0xF8))
+    {
+        skip = 1;
+    }
+
+    return skip;
 }
 
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -22,21 +22,9 @@ static const char LOWEST_PRINTABLE_US_ASCII  = '!';
 static const char HIGHEST_PRINTABLE_US_ASCII = '~';
 static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 
+/* UTF-8 replacement character U+FFFD, emitted in place of each invalid
+ * byte per Unicode §3.9 best practice for per-byte maximal subpart. */
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
-
-static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
-static inline bool   NeedsEscape(char value);
-static inline bool   IsPrintableUsAscii(char value);
-static inline bool   IsValidUtf8SingleByte(char value);
-static inline bool   IsValidUtf8TwoByte(char lead, char continuation);
-static inline bool   IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
-static inline bool   IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
-static inline size_t Utf8CodepointLength(const char* source);
-static inline char   DigitToChar(uint32_t value);
-static size_t        CountDigits(uint32_t value);
 
 static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter)
 {
@@ -75,20 +63,137 @@ void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char
     NullTerminate(formatter);
 }
 
+/*
+ * UTF-8 validation per RFC 3629 §4 and Unicode §3.9.
+ *
+ *   1-byte  0xxxxxxx                                   U+0000  - U+007F
+ *   2-byte  110xxxxx 10xxxxxx                          U+0080  - U+07FF    lead C2-DF
+ *   3-byte  1110xxxx 10xxxxxx 10xxxxxx                 U+0800  - U+FFFF    lead E0-EF
+ *   4-byte  11110xxx 10xxxxxx 10xxxxxx 10xxxxxx        U+10000 - U+10FFFF  lead F0-F4
+ *
+ * Excluded sequences:
+ *   C0, C1             overlong 2-byte encodings
+ *   E0 + cont1 80-9F   overlong 3-byte encodings
+ *   ED + cont1 A0-BF   UTF-16 surrogate range (U+D800..U+DFFF)
+ *   F0 + cont1 80-8F   overlong 4-byte encodings
+ *   F4 + cont1 90-BF   codepoints above U+10FFFF
+ *   F5-F7              codepoints above U+10FFFF
+ *   F8-FF              5+ byte prefix patterns removed by RFC 3629
+ */
+
+static inline bool IsUtf8Continuation(char byte)
+{
+    return (byte & 0xC0) == 0x80;
+}
+
+static inline bool IsTwoByteLead(char byte)
+{
+    return (byte & 0xE0) == 0xC0;
+}
+
+static inline bool IsThreeByteLead(char byte)
+{
+    return (byte & 0xF0) == 0xE0;
+}
+
+static inline bool IsFourByteLead(char byte)
+{
+    return (byte & 0xF8) == 0xF0;
+}
+
+static inline bool IsOverlongTwoByteLead(char byte)
+{
+    return (byte & 0xFE) == 0xC0;
+}
+
+static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1)
+{
+    return (lead == '\xE0') && ((continuation1 & 0xE0) == 0x80);
+}
+
+static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1)
+{
+    return (lead == '\xED') && ((continuation1 & 0xE0) == 0xA0);
+}
+
+static inline bool IsOverlongFourByteEncoding(char lead, char continuation1)
+{
+    return (lead == '\xF0') && ((continuation1 & 0xF0) == 0x80);
+}
+
+static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
+{
+    bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
+    bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
+    return f4WithCont1Above8F || f5OrHigherLead;
+}
+
+static inline bool IsValidUtf8SingleByte(char byte)
+{
+    return (byte & 0x80) == 0;
+}
+
+static inline bool IsValidUtf8TwoByte(char lead, char continuation1)
+{
+    return IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) && IsUtf8Continuation(continuation1);
+}
+
+static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
+{
+    return IsThreeByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) &&
+           !IsOverlongThreeByteEncoding(lead, continuation1) && !IsUtf16SurrogateEncoding(lead, continuation1);
+}
+
+static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
+{
+    return IsFourByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) && IsUtf8Continuation(continuation3) &&
+           !IsOverlongFourByteEncoding(lead, continuation1) && !IsAboveUnicodeMaxEncoding(lead, continuation1);
+}
+
+static inline size_t Utf8CodepointLength(const char* source)
+{
+    size_t length = 0;
+
+    if (IsValidUtf8SingleByte(source[0]))
+    {
+        length = 1;
+    }
+    else if (IsValidUtf8TwoByte(source[0], source[1]))
+    {
+        length = 2;
+    }
+    else if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    {
+        length = 3;
+    }
+    else if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
+    {
+        length = 4;
+    }
+
+    return length;
+}
+
+static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
+{
+    for (size_t i = 0; i < count; i++)
+    {
+        WriteChar(formatter, bytes[i]);
+    }
+}
+
 void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
 {
     size_t len = 0;
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        const char* copyFrom = &source[len];
-        size_t      copyCount;
+        const char* copyFrom  = &source[len];
+        size_t      copyCount = Utf8CodepointLength(&source[len]);
 
-        size_t length = Utf8CodepointLength(&source[len]);
-        if (length > 0)
+        if (copyCount > 0)
         {
-            copyCount = length;
-            len += length;
+            len += copyCount;
         }
         else
         {
@@ -97,57 +202,23 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
             len += 1;
         }
 
-        for (size_t i = 0; i < copyCount; i++)
-        {
-            WriteChar(formatter, copyFrom[i]);
-        }
+        WriteBytes(formatter, copyFrom, copyCount);
     }
     NullTerminate(formatter);
 }
 
-static inline bool IsValidUtf8SingleByte(char value)
+static inline bool NeedsEscape(char value)
 {
-    return (value & 0x80) == 0x00;
+    return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
 }
 
-static inline bool IsValidUtf8TwoByte(char lead, char continuation)
+static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
 {
-    return ((lead & 0xE0) == 0xC0) && ((lead & 0xFE) != 0xC0) && ((continuation & 0xC0) == 0x80);
-}
-
-static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
-{
-    return ((lead & 0xF0) == 0xE0) && ((continuation1 & 0xC0) == 0x80) && ((continuation2 & 0xC0) == 0x80)
-           && !((lead == '\xE0') && ((continuation1 & 0xE0) == 0x80))
-           && !((lead == '\xED') && ((continuation1 & 0xE0) == 0xA0));
-}
-
-static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
-{
-    return (((lead & 0xFC) == 0xF0) || (lead == '\xF4')) && ((continuation1 & 0xC0) == 0x80) && ((continuation2 & 0xC0) == 0x80) && ((continuation3 & 0xC0) == 0x80)
-           && !((lead == '\xF0') && ((continuation1 & 0xF0) == 0x80))
-           && !((lead == '\xF4') && ((continuation1 & 0xF0) != 0x80));
-}
-
-static inline size_t Utf8CodepointLength(const char* source)
-{
-    if (IsValidUtf8SingleByte(source[0]))
+    if (NeedsEscape(value))
     {
-        return 1;
+        WriteChar(formatter, ESCAPE_PREFIX);
     }
-    if (IsValidUtf8TwoByte(source[0], source[1]))
-    {
-        return 2;
-    }
-    if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
-    {
-        return 3;
-    }
-    if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
-    {
-        return 4;
-    }
-    return 0;
+    WriteChar(formatter, value);
 }
 
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
@@ -162,30 +233,9 @@ void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, 
     NullTerminate(formatter);
 }
 
-static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
+static inline bool IsPrintableUsAscii(char value)
 {
-    if (NeedsEscape(value))
-    {
-        WriteChar(formatter, ESCAPE_PREFIX);
-    }
-    WriteChar(formatter, value);
-}
-
-static inline bool NeedsEscape(char value)
-{
-    return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
-}
-
-void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
-{
-    size_t len = 0;
-
-    while ((len < maxLength) && (source[len] != '\0'))
-    {
-        WritePrintableUsAsciiChar(formatter, source[len]);
-        len++;
-    }
-    NullTerminate(formatter);
+    return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
 }
 
 static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
@@ -200,9 +250,34 @@ static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* format
     }
 }
 
-static inline bool IsPrintableUsAscii(char value)
+void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
 {
-    return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
+    size_t len = 0;
+
+    while ((len < maxLength) && (source[len] != '\0'))
+    {
+        WritePrintableUsAsciiChar(formatter, source[len]);
+        len++;
+    }
+    NullTerminate(formatter);
+}
+
+static inline char DigitToChar(uint32_t value)
+{
+    return (char) ('0' + (value % 10U));
+}
+
+static size_t CountDigits(uint32_t value)
+{
+    size_t count = 1;
+
+    while (value >= 10U)
+    {
+        count++;
+        value /= 10U;
+    }
+
+    return count;
 }
 
 void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)
@@ -259,22 +334,4 @@ const char* SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* for
 size_t SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter)
 {
     return formatter->position;
-}
-
-static inline char DigitToChar(uint32_t value)
-{
-    return (char) ('0' + (value % 10U));
-}
-
-static size_t CountDigits(uint32_t value)
-{
-    size_t count = 1;
-
-    while (value >= 10U)
-    {
-        count++;
-        value /= 10U;
-    }
-
-    return count;
 }

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -453,31 +453,33 @@ void SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter* formatter, uint3
     NullTerminate(formatter);
 }
 
-const char* SolidSyslogFormatter_AsFormattedBuffer(const struct SolidSyslogFormatter* formatter)
+const char* SolidSyslogFormatter_AsFormattedBuffer(struct SolidSyslogFormatter* formatter)
 {
-    TrimTruncatedMultiByteTail((struct SolidSyslogFormatter*) formatter);
+    TrimTruncatedMultiByteTail(formatter);
     return formatter->buffer;
 }
 
 static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter)
 {
-    char*  buffer = formatter->buffer;
-    size_t p      = formatter->position;
+    char*  buffer   = formatter->buffer;
+    size_t p        = formatter->position;
+    size_t trimFrom = p;
 
     if ((p >= 1) && (IsTwoByteLead(buffer[p - 1]) || IsThreeByteLead(buffer[p - 1]) || IsFourByteLead(buffer[p - 1])))
     {
-        buffer[p - 1] = '\0';
+        trimFrom = p - 1;
     }
     else if ((p >= 2) && (IsThreeByteLead(buffer[p - 2]) || IsFourByteLead(buffer[p - 2])))
     {
-        buffer[p - 2] = '\0';
-        buffer[p - 1] = '\0';
+        trimFrom = p - 2;
     }
     else if ((p >= 3) && IsFourByteLead(buffer[p - 3]))
     {
-        buffer[p - 3] = '\0';
-        buffer[p - 2] = '\0';
-        buffer[p - 1] = '\0';
+        trimFrom = p - 3;
+    }
+    for (size_t i = trimFrom; i < p; i++)
+    {
+        buffer[i] = '\0';
     }
 }
 

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -47,6 +47,7 @@ static size_t        CountDigits(uint32_t value);
 static inline size_t Utf8CodepointLength(const char* source);
 static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
+static inline void   WriteReplacementCharacter(struct SolidSyslogFormatter* formatter);
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
@@ -112,21 +113,18 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        const char* copyFrom  = &source[len];
-        size_t      copyCount = Utf8CodepointLength(&source[len]);
+        size_t codepointLength = Utf8CodepointLength(&source[len]);
 
-        if (copyCount > 0)
+        if (codepointLength > 0)
         {
-            len += copyCount;
+            WriteBytes(formatter, &source[len], codepointLength);
+            len += codepointLength;
         }
         else
         {
-            copyFrom  = REPLACEMENT_CHARACTER;
-            copyCount = sizeof(REPLACEMENT_CHARACTER);
+            WriteReplacementCharacter(formatter);
             len += 1;
         }
-
-        WriteBytes(formatter, copyFrom, copyCount);
     }
     NullTerminate(formatter);
 }
@@ -222,6 +220,11 @@ static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
     bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
     bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
     return f4WithCont1Above8F || f5OrHigherLead;
+}
+
+static inline void WriteReplacementCharacter(struct SolidSyslogFormatter* formatter)
+{
+    WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
 }
 
 static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -389,10 +389,13 @@ static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* forma
     else if ((p >= 2) && (IsThreeByteLead(buffer[p - 2]) || IsFourByteLead(buffer[p - 2])))
     {
         buffer[p - 2] = '\0';
+        buffer[p - 1] = '\0';
     }
     else if ((p >= 3) && IsFourByteLead(buffer[p - 3]))
     {
         buffer[p - 3] = '\0';
+        buffer[p - 2] = '\0';
+        buffer[p - 1] = '\0';
     }
 }
 

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -32,6 +32,7 @@ static inline bool   IsFourByteLead(char byte);
 static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongThreeByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongTwoByteLead(char byte);
+static inline bool   IsAsciiCharacter(char value);
 static inline bool   IsPrintableUsAscii(char value);
 static inline bool   IsThreeByteLead(char byte);
 static inline bool   IsTwoByteLead(char byte);
@@ -69,10 +70,19 @@ static inline void NullTerminate(struct SolidSyslogFormatter* formatter)
     }
 }
 
-void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char value)
+void SolidSyslogFormatter_AsciiCharacter(struct SolidSyslogFormatter* formatter, char value)
 {
+    if (!IsAsciiCharacter(value))
+    {
+        value = NON_PRINTABLE_SUBSTITUTE;
+    }
     WriteChar(formatter, value);
     NullTerminate(formatter);
+}
+
+static inline bool IsAsciiCharacter(char value)
+{
+    return (value == ' ') || IsPrintableUsAscii(value);
 }
 
 static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -26,7 +26,11 @@ static const char NON_PRINTABLE_SUBSTITUTE   = '?';
  * byte per Unicode §3.9 best practice for per-byte maximal subpart. */
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
 
-static inline bool   CodepointFits(size_t codepointLength, size_t remaining);
+/* An escape pair on the wire ('\' + char) decodes back to the single
+ * character it was escaping — one byte in the reader's decoder buffer. */
+static const size_t ESCAPED_CHARACTER_DECODED_LENGTH = 1;
+
+static inline bool   CodepointFits(size_t codepointLength, size_t remainingDecodedLength);
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
 static inline bool   IsFourByteLead(char byte);
@@ -139,9 +143,9 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
     NullTerminate(formatter);
 }
 
-static inline bool CodepointFits(size_t codepointLength, size_t remaining)
+static inline bool CodepointFits(size_t codepointLength, size_t remainingDecodedLength)
 {
-    return (codepointLength > 0) && (codepointLength <= remaining);
+    return (codepointLength > 0) && (codepointLength <= remainingDecodedLength);
 }
 
 static inline size_t Utf8CodepointLength(const char* source)
@@ -245,29 +249,38 @@ static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char
     }
 }
 
-void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
+void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxDecodedLength)
 {
-    size_t len = 0;
+    size_t sourcePos     = 0;
+    size_t decodedLength = 0;
 
-    while ((len < maxRawLength) && (source[len] != '\0'))
+    while (source[sourcePos] != '\0')
     {
-        size_t codepointLength = Utf8CodepointLength(&source[len]);
+        size_t codepointLength        = Utf8CodepointLength(&source[sourcePos]);
+        size_t remainingDecodedLength = (decodedLength < maxDecodedLength) ? (maxDecodedLength - decodedLength) : 0;
 
-        if (CodepointFits(codepointLength, maxRawLength - len))
+        if (NeedsEscape(source[sourcePos]) && (remainingDecodedLength >= ESCAPED_CHARACTER_DECODED_LENGTH))
         {
-            if ((codepointLength == 1) && NeedsEscape(source[len]))
-            {
-                /* Escape prefix is an output byte, not a source byte; len
-                 * advances only by the codepoint's own length. */
-                WriteChar(formatter, ESCAPE_PREFIX);
-            }
-            WriteBytes(formatter, &source[len], codepointLength);
-            len += codepointLength;
+            char escaped[] = {ESCAPE_PREFIX, source[sourcePos]};
+            WriteBytes(formatter, escaped, sizeof(escaped));
+            sourcePos++;
+            decodedLength += ESCAPED_CHARACTER_DECODED_LENGTH;
+        }
+        else if (CodepointFits(codepointLength, remainingDecodedLength))
+        {
+            WriteBytes(formatter, &source[sourcePos], codepointLength);
+            sourcePos += codepointLength;
+            decodedLength += codepointLength;
+        }
+        else if (remainingDecodedLength >= sizeof(REPLACEMENT_CHARACTER))
+        {
+            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
+            sourcePos++;
+            decodedLength += sizeof(REPLACEMENT_CHARACTER);
         }
         else
         {
-            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
-            len += 1;
+            break;
         }
     }
     NullTerminate(formatter);

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -30,7 +30,22 @@ static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
  * character it was escaping — one byte in the reader's decoder buffer. */
 static const size_t ESCAPED_CHARACTER_DECODED_LENGTH = 1;
 
+/* Mutable state threaded through the EscapedString writer helpers.
+ * sourcePos walks the source until NUL; decodedLength counts bytes the
+ * reader's decoder would extract; exhausted flips when a writer can't
+ * fit and the loop must terminate. */
+struct EscapedContext
+{
+    struct SolidSyslogFormatter* formatter;
+    const char*                  source;
+    size_t                       sourcePos;
+    size_t                       decodedLength;
+    size_t                       maxDecodedLength;
+    bool                         exhausted;
+};
+
 static inline bool   CodepointFits(size_t codepointLength, size_t remainingDecodedLength);
+static inline bool   Fits(const struct EscapedContext* context, size_t decodedAdvance);
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
 static inline bool   IsFourByteLead(char byte);
@@ -38,6 +53,7 @@ static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongThreeByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongTwoByteLead(char byte);
 static inline bool   IsAsciiCharacter(char value);
+static inline bool   IsExhausted(const struct EscapedContext* context);
 static inline bool   IsPrintableUsAscii(char value);
 static inline bool   IsThreeByteLead(char byte);
 static inline bool   IsTwoByteLead(char byte);
@@ -51,11 +67,16 @@ static inline bool   NeedsEscape(char value);
 static inline char   DigitToChar(uint32_t value);
 static size_t        CountDigits(uint32_t value);
 static inline size_t Utf8CodepointLength(const char* source);
+static inline void   Exhaust(struct EscapedContext* context);
 static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline void   TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
+static inline void   Write(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance);
 static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WriteCodepoint(struct EscapedContext* context);
+static inline void   WriteEscaped(struct EscapedContext* context);
 static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WriteReplacement(struct EscapedContext* context);
 
 struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
 {
@@ -251,36 +272,24 @@ static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char
 
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxDecodedLength)
 {
-    size_t sourcePos     = 0;
-    size_t decodedLength = 0;
+    struct EscapedContext context = {
+        .formatter        = formatter,
+        .source           = source,
+        .sourcePos        = 0,
+        .decodedLength    = 0,
+        .maxDecodedLength = maxDecodedLength,
+        .exhausted        = false,
+    };
 
-    while (source[sourcePos] != '\0')
+    while ((source[context.sourcePos] != '\0') && !IsExhausted(&context))
     {
-        size_t codepointLength        = Utf8CodepointLength(&source[sourcePos]);
-        size_t remainingDecodedLength = (decodedLength < maxDecodedLength) ? (maxDecodedLength - decodedLength) : 0;
-
-        if (NeedsEscape(source[sourcePos]) && (remainingDecodedLength >= ESCAPED_CHARACTER_DECODED_LENGTH))
+        if (NeedsEscape(source[context.sourcePos]))
         {
-            char escaped[] = {ESCAPE_PREFIX, source[sourcePos]};
-            WriteBytes(formatter, escaped, sizeof(escaped));
-            sourcePos++;
-            decodedLength += ESCAPED_CHARACTER_DECODED_LENGTH;
-        }
-        else if (CodepointFits(codepointLength, remainingDecodedLength))
-        {
-            WriteBytes(formatter, &source[sourcePos], codepointLength);
-            sourcePos += codepointLength;
-            decodedLength += codepointLength;
-        }
-        else if (remainingDecodedLength >= sizeof(REPLACEMENT_CHARACTER))
-        {
-            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
-            sourcePos++;
-            decodedLength += sizeof(REPLACEMENT_CHARACTER);
+            WriteEscaped(&context);
         }
         else
         {
-            break;
+            WriteCodepoint(&context);
         }
     }
     NullTerminate(formatter);
@@ -289,6 +298,64 @@ void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, 
 static inline bool NeedsEscape(char value)
 {
     return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
+}
+
+static inline bool IsExhausted(const struct EscapedContext* context)
+{
+    return context->exhausted;
+}
+
+static inline void WriteEscaped(struct EscapedContext* context)
+{
+    if (Fits(context, ESCAPED_CHARACTER_DECODED_LENGTH))
+    {
+        char escaped[] = {ESCAPE_PREFIX, context->source[context->sourcePos]};
+        Write(context, escaped, sizeof(escaped), 1, ESCAPED_CHARACTER_DECODED_LENGTH);
+        return;
+    }
+    Exhaust(context);
+}
+
+static inline bool Fits(const struct EscapedContext* context, size_t decodedAdvance)
+{
+    return (decodedAdvance > 0) && (decodedAdvance <= context->maxDecodedLength - context->decodedLength);
+}
+
+static inline void Write(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance)
+{
+    WriteBytes(context->formatter, bytes, byteCount);
+    context->sourcePos += sourceAdvance;
+    context->decodedLength += decodedAdvance;
+}
+
+static inline void Exhaust(struct EscapedContext* context)
+{
+    context->exhausted = true;
+}
+
+/* Writes the source codepoint at sourcePos if it fits the decoded budget;
+ * otherwise falls back to WriteReplacement (which emits U+FFFD or marks
+ * the context exhausted). Fits also rejects invalid UTF-8 because
+ * Utf8CodepointLength returns 0 for ill-formed sequences. */
+static inline void WriteCodepoint(struct EscapedContext* context)
+{
+    size_t codepointLength = Utf8CodepointLength(&context->source[context->sourcePos]);
+    if (Fits(context, codepointLength))
+    {
+        Write(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
+        return;
+    }
+    WriteReplacement(context);
+}
+
+static inline void WriteReplacement(struct EscapedContext* context)
+{
+    if (Fits(context, sizeof(REPLACEMENT_CHARACTER)))
+    {
+        Write(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
+        return;
+    }
+    Exhaust(context);
 }
 
 void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -232,6 +232,18 @@ static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char
     }
 }
 
+void SolidSyslogFormatter_RawBoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
+{
+    size_t len = 0;
+
+    while ((len < maxLength) && (source[len] != '\0'))
+    {
+        WriteChar(formatter, source[len]);
+        len++;
+    }
+    NullTerminate(formatter);
+}
+
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
 {
     size_t len = 0;

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -351,7 +351,7 @@ void SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter* formatter, uint3
     NullTerminate(formatter);
 }
 
-const char* SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter)
+const char* SolidSyslogFormatter_AsFormattedBuffer(const struct SolidSyslogFormatter* formatter)
 {
     TrimTruncatedMultiByteTail((struct SolidSyslogFormatter*) formatter);
     return formatter->buffer;

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -27,7 +27,6 @@ static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
 
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
-static inline bool   HasCapacityFor(const struct SolidSyslogFormatter* formatter, size_t count);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
 static inline bool   IsFourByteLead(char byte);
 static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
@@ -47,8 +46,8 @@ static inline char   DigitToChar(uint32_t value);
 static size_t        CountDigits(uint32_t value);
 static inline size_t Utf8CodepointLength(const char* source);
 static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
+static inline void   TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
 static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
-static inline void   WriteReplacementCharacter(struct SolidSyslogFormatter* formatter);
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
@@ -114,26 +113,20 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        size_t codepointLength = Utf8CodepointLength(&source[len]);
+        const char* bytes           = REPLACEMENT_CHARACTER;
+        size_t      count           = sizeof(REPLACEMENT_CHARACTER);
+        size_t      advance         = 1;
+        size_t      codepointLength = Utf8CodepointLength(&source[len]);
 
         if ((codepointLength > 0) && (codepointLength <= (maxLength - len)))
         {
-            if (!HasCapacityFor(formatter, codepointLength))
-            {
-                break;
-            }
-            WriteBytes(formatter, &source[len], codepointLength);
-            len += codepointLength;
+            bytes   = &source[len];
+            count   = codepointLength;
+            advance = codepointLength;
         }
-        else
-        {
-            if (!HasCapacityFor(formatter, sizeof(REPLACEMENT_CHARACTER)))
-            {
-                break;
-            }
-            WriteReplacementCharacter(formatter);
-            len += 1;
-        }
+
+        WriteBytes(formatter, bytes, count);
+        len += advance;
     }
     NullTerminate(formatter);
 }
@@ -229,16 +222,6 @@ static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
     bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
     bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
     return f4WithCont1Above8F || f5OrHigherLead;
-}
-
-static inline bool HasCapacityFor(const struct SolidSyslogFormatter* formatter, size_t count)
-{
-    return (formatter->size > 0) && ((formatter->position + count) <= (formatter->size - 1));
-}
-
-static inline void WriteReplacementCharacter(struct SolidSyslogFormatter* formatter)
-{
-    WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
 }
 
 static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
@@ -370,7 +353,27 @@ void SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter* formatter, uint3
 
 const char* SolidSyslogFormatter_AsString(const struct SolidSyslogFormatter* formatter)
 {
+    TrimTruncatedMultiByteTail((struct SolidSyslogFormatter*) formatter);
     return formatter->buffer;
+}
+
+static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter)
+{
+    char*  buffer = formatter->buffer;
+    size_t p      = formatter->position;
+
+    if ((p >= 1) && (IsTwoByteLead(buffer[p - 1]) || IsThreeByteLead(buffer[p - 1]) || IsFourByteLead(buffer[p - 1])))
+    {
+        buffer[p - 1] = '\0';
+    }
+    else if ((p >= 2) && (IsThreeByteLead(buffer[p - 2]) || IsFourByteLead(buffer[p - 2])))
+    {
+        buffer[p - 2] = '\0';
+    }
+    else if ((p >= 3) && IsFourByteLead(buffer[p - 3]))
+    {
+        buffer[p - 3] = '\0';
+    }
 }
 
 size_t SolidSyslogFormatter_Length(const struct SolidSyslogFormatter* formatter)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -26,6 +26,7 @@ static const char NON_PRINTABLE_SUBSTITUTE   = '?';
  * byte per Unicode §3.9 best practice for per-byte maximal subpart. */
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
 
+static inline bool   CodepointFits(size_t codepointLength, size_t remaining);
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
 static inline bool   IsFourByteLead(char byte);
@@ -123,22 +124,25 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        const char* bytes           = REPLACEMENT_CHARACTER;
-        size_t      count           = sizeof(REPLACEMENT_CHARACTER);
-        size_t      advance         = 1;
-        size_t      codepointLength = Utf8CodepointLength(&source[len]);
+        size_t codepointLength = Utf8CodepointLength(&source[len]);
 
-        if ((codepointLength > 0) && (codepointLength <= (maxLength - len)))
+        if (CodepointFits(codepointLength, maxLength - len))
         {
-            bytes   = &source[len];
-            count   = codepointLength;
-            advance = codepointLength;
+            WriteBytes(formatter, &source[len], codepointLength);
+            len += codepointLength;
         }
-
-        WriteBytes(formatter, bytes, count);
-        len += advance;
+        else
+        {
+            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
+            len += 1;
+        }
     }
     NullTerminate(formatter);
+}
+
+static inline bool CodepointFits(size_t codepointLength, size_t remaining)
+{
+    return (codepointLength > 0) && (codepointLength <= remaining);
 }
 
 static inline size_t Utf8CodepointLength(const char* source)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -232,18 +232,6 @@ static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char
     }
 }
 
-void SolidSyslogFormatter_RawBoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
-{
-    size_t len = 0;
-
-    while ((len < maxLength) && (source[len] != '\0'))
-    {
-        WriteChar(formatter, source[len]);
-        len++;
-    }
-    NullTerminate(formatter);
-}
-
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
 {
     size_t len = 0;

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -22,13 +22,19 @@ static const char LOWEST_PRINTABLE_US_ASCII  = '!';
 static const char HIGHEST_PRINTABLE_US_ASCII = '~';
 static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 
+static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
+
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline bool   NeedsEscape(char value);
 static inline bool   IsPrintableUsAscii(char value);
-static inline size_t SkipBadUtf8(const char* source);
+static inline bool   IsValidUtf8SingleByte(char value);
+static inline bool   IsValidUtf8TwoByte(char lead, char continuation);
+static inline bool   IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
+static inline bool   IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
+static inline size_t Utf8CodepointLength(const char* source);
 static inline char   DigitToChar(uint32_t value);
 static size_t        CountDigits(uint32_t value);
 
@@ -75,34 +81,73 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        size_t skipped = SkipBadUtf8(&source[len]);
-        if (skipped > 0)
+        const char* copyFrom = &source[len];
+        size_t      copyCount;
+
+        size_t length = Utf8CodepointLength(&source[len]);
+        if (length > 0)
         {
-            WriteChar(formatter, '\xEF');
-            WriteChar(formatter, '\xBF');
-            WriteChar(formatter, '\xBD');
-            len += skipped;
+            copyCount = length;
+            len += length;
         }
         else
         {
-            WriteChar(formatter, source[len]);
-            len++;
+            copyFrom  = REPLACEMENT_CHARACTER;
+            copyCount = sizeof(REPLACEMENT_CHARACTER);
+            len += 1;
+        }
+
+        for (size_t i = 0; i < copyCount; i++)
+        {
+            WriteChar(formatter, copyFrom[i]);
         }
     }
     NullTerminate(formatter);
 }
 
-static inline size_t SkipBadUtf8(const char* source)
+static inline bool IsValidUtf8SingleByte(char value)
 {
-    size_t skip  = 0;
-    char   value = source[0];
+    return (value & 0x80) == 0x00;
+}
 
-    if (((value & 0xC0) == 0x80) || ((value & 0xFE) == 0xC0) || (value == '\xF5') || ((value & 0xF8) == 0xF8))
+static inline bool IsValidUtf8TwoByte(char lead, char continuation)
+{
+    return ((lead & 0xE0) == 0xC0) && ((lead & 0xFE) != 0xC0) && ((continuation & 0xC0) == 0x80);
+}
+
+static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
+{
+    return ((lead & 0xF0) == 0xE0) && ((continuation1 & 0xC0) == 0x80) && ((continuation2 & 0xC0) == 0x80)
+           && !((lead == '\xE0') && ((continuation1 & 0xE0) == 0x80))
+           && !((lead == '\xED') && ((continuation1 & 0xE0) == 0xA0));
+}
+
+static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
+{
+    return (((lead & 0xFC) == 0xF0) || (lead == '\xF4')) && ((continuation1 & 0xC0) == 0x80) && ((continuation2 & 0xC0) == 0x80) && ((continuation3 & 0xC0) == 0x80)
+           && !((lead == '\xF0') && ((continuation1 & 0xF0) == 0x80))
+           && !((lead == '\xF4') && ((continuation1 & 0xF0) != 0x80));
+}
+
+static inline size_t Utf8CodepointLength(const char* source)
+{
+    if (IsValidUtf8SingleByte(source[0]))
     {
-        skip = 1;
+        return 1;
     }
-
-    return skip;
+    if (IsValidUtf8TwoByte(source[0], source[1]))
+    {
+        return 2;
+    }
+    if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    {
+        return 3;
+    }
+    if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
+    {
+        return 4;
+    }
+    return 0;
 }
 
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -26,9 +26,52 @@ static const char NON_PRINTABLE_SUBSTITUTE   = '?';
  * byte per Unicode §3.9 best practice for per-byte maximal subpart. */
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
 
-static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter)
+static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
+static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
+static inline bool   IsFourByteLead(char byte);
+static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
+static inline bool   IsOverlongThreeByteEncoding(char lead, char continuation1);
+static inline bool   IsOverlongTwoByteLead(char byte);
+static inline bool   IsPrintableUsAscii(char value);
+static inline bool   IsThreeByteLead(char byte);
+static inline bool   IsTwoByteLead(char byte);
+static inline bool   IsUtf16SurrogateEncoding(char lead, char continuation1);
+static inline bool   IsUtf8Continuation(char byte);
+static inline bool   IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
+static inline bool   IsValidUtf8SingleByte(char byte);
+static inline bool   IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
+static inline bool   IsValidUtf8TwoByte(char lead, char continuation1);
+static inline bool   NeedsEscape(char value);
+static inline char   DigitToChar(uint32_t value);
+static size_t        CountDigits(uint32_t value);
+static inline size_t Utf8CodepointLength(const char* source);
+static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
+static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
+static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
+
+struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
 {
-    return (formatter->size > 0) && (formatter->position < formatter->size - 1);
+    struct SolidSyslogFormatter* formatter = (struct SolidSyslogFormatter*) storage;
+    formatter->size                        = bufferSize;
+    formatter->position                    = 0;
+    NullTerminate(formatter);
+    return formatter;
+}
+
+static inline void NullTerminate(struct SolidSyslogFormatter* formatter)
+{
+    if (formatter->size > 0)
+    {
+        formatter->buffer[formatter->position] = '\0';
+    }
+}
+
+void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char value)
+{
+    WriteChar(formatter, value);
+    NullTerminate(formatter);
 }
 
 static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value)
@@ -40,27 +83,9 @@ static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value)
     }
 }
 
-static inline void NullTerminate(struct SolidSyslogFormatter* formatter)
+static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter)
 {
-    if (formatter->size > 0)
-    {
-        formatter->buffer[formatter->position] = '\0';
-    }
-}
-
-struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
-{
-    struct SolidSyslogFormatter* formatter = (struct SolidSyslogFormatter*) storage;
-    formatter->size                        = bufferSize;
-    formatter->position                    = 0;
-    NullTerminate(formatter);
-    return formatter;
-}
-
-void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char value)
-{
-    WriteChar(formatter, value);
-    NullTerminate(formatter);
+    return (formatter->size > 0) && (formatter->position < formatter->size - 1);
 }
 
 /*
@@ -80,107 +105,6 @@ void SolidSyslogFormatter_Character(struct SolidSyslogFormatter* formatter, char
  *   F5-F7              codepoints above U+10FFFF
  *   F8-FF              5+ byte prefix patterns removed by RFC 3629
  */
-
-static inline bool IsUtf8Continuation(char byte)
-{
-    return (byte & 0xC0) == 0x80;
-}
-
-static inline bool IsTwoByteLead(char byte)
-{
-    return (byte & 0xE0) == 0xC0;
-}
-
-static inline bool IsThreeByteLead(char byte)
-{
-    return (byte & 0xF0) == 0xE0;
-}
-
-static inline bool IsFourByteLead(char byte)
-{
-    return (byte & 0xF8) == 0xF0;
-}
-
-static inline bool IsOverlongTwoByteLead(char byte)
-{
-    return (byte & 0xFE) == 0xC0;
-}
-
-static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1)
-{
-    return (lead == '\xE0') && ((continuation1 & 0xE0) == 0x80);
-}
-
-static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1)
-{
-    return (lead == '\xED') && ((continuation1 & 0xE0) == 0xA0);
-}
-
-static inline bool IsOverlongFourByteEncoding(char lead, char continuation1)
-{
-    return (lead == '\xF0') && ((continuation1 & 0xF0) == 0x80);
-}
-
-static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
-{
-    bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
-    bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
-    return f4WithCont1Above8F || f5OrHigherLead;
-}
-
-static inline bool IsValidUtf8SingleByte(char byte)
-{
-    return (byte & 0x80) == 0;
-}
-
-static inline bool IsValidUtf8TwoByte(char lead, char continuation1)
-{
-    return IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) && IsUtf8Continuation(continuation1);
-}
-
-static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
-{
-    return IsThreeByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) &&
-           !IsOverlongThreeByteEncoding(lead, continuation1) && !IsUtf16SurrogateEncoding(lead, continuation1);
-}
-
-static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
-{
-    return IsFourByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) && IsUtf8Continuation(continuation3) &&
-           !IsOverlongFourByteEncoding(lead, continuation1) && !IsAboveUnicodeMaxEncoding(lead, continuation1);
-}
-
-static inline size_t Utf8CodepointLength(const char* source)
-{
-    size_t length = 0;
-
-    if (IsValidUtf8SingleByte(source[0]))
-    {
-        length = 1;
-    }
-    else if (IsValidUtf8TwoByte(source[0], source[1]))
-    {
-        length = 2;
-    }
-    else if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
-    {
-        length = 3;
-    }
-    else if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
-    {
-        length = 4;
-    }
-
-    return length;
-}
-
-static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
-{
-    for (size_t i = 0; i < count; i++)
-    {
-        WriteChar(formatter, bytes[i]);
-    }
-}
 
 void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
 {
@@ -207,18 +131,105 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
     NullTerminate(formatter);
 }
 
-static inline bool NeedsEscape(char value)
+static inline size_t Utf8CodepointLength(const char* source)
 {
-    return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
+    size_t length = 0;
+
+    if (IsValidUtf8SingleByte(source[0]))
+    {
+        length = 1;
+    }
+    else if (IsValidUtf8TwoByte(source[0], source[1]))
+    {
+        length = 2;
+    }
+    else if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    {
+        length = 3;
+    }
+    else if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
+    {
+        length = 4;
+    }
+
+    return length;
 }
 
-static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
+static inline bool IsValidUtf8SingleByte(char byte)
 {
-    if (NeedsEscape(value))
+    return (byte & 0x80) == 0;
+}
+
+static inline bool IsValidUtf8TwoByte(char lead, char continuation1)
+{
+    return IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) && IsUtf8Continuation(continuation1);
+}
+
+static inline bool IsTwoByteLead(char byte)
+{
+    return (byte & 0xE0) == 0xC0;
+}
+
+static inline bool IsOverlongTwoByteLead(char byte)
+{
+    return (byte & 0xFE) == 0xC0;
+}
+
+static inline bool IsUtf8Continuation(char byte)
+{
+    return (byte & 0xC0) == 0x80;
+}
+
+static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
+{
+    return IsThreeByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) &&
+           !IsOverlongThreeByteEncoding(lead, continuation1) && !IsUtf16SurrogateEncoding(lead, continuation1);
+}
+
+static inline bool IsThreeByteLead(char byte)
+{
+    return (byte & 0xF0) == 0xE0;
+}
+
+static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1)
+{
+    return (lead == '\xE0') && ((continuation1 & 0xE0) == 0x80);
+}
+
+static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1)
+{
+    return (lead == '\xED') && ((continuation1 & 0xE0) == 0xA0);
+}
+
+static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
+{
+    return IsFourByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) && IsUtf8Continuation(continuation3) &&
+           !IsOverlongFourByteEncoding(lead, continuation1) && !IsAboveUnicodeMaxEncoding(lead, continuation1);
+}
+
+static inline bool IsFourByteLead(char byte)
+{
+    return (byte & 0xF8) == 0xF0;
+}
+
+static inline bool IsOverlongFourByteEncoding(char lead, char continuation1)
+{
+    return (lead == '\xF0') && ((continuation1 & 0xF0) == 0x80);
+}
+
+static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
+{
+    bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
+    bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
+    return f4WithCont1Above8F || f5OrHigherLead;
+}
+
+static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
+{
+    for (size_t i = 0; i < count; i++)
     {
-        WriteChar(formatter, ESCAPE_PREFIX);
+        WriteChar(formatter, bytes[i]);
     }
-    WriteChar(formatter, value);
 }
 
 void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxRawLength)
@@ -233,21 +244,18 @@ void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, 
     NullTerminate(formatter);
 }
 
-static inline bool IsPrintableUsAscii(char value)
+static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
 {
-    return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
+    if (NeedsEscape(value))
+    {
+        WriteChar(formatter, ESCAPE_PREFIX);
+    }
+    WriteChar(formatter, value);
 }
 
-static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
+static inline bool NeedsEscape(char value)
 {
-    if (IsPrintableUsAscii(value))
-    {
-        WriteChar(formatter, value);
-    }
-    else
-    {
-        WriteChar(formatter, NON_PRINTABLE_SUBSTITUTE);
-    }
+    return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
 }
 
 void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* formatter, const char* source, size_t maxLength)
@@ -262,22 +270,21 @@ void SolidSyslogFormatter_PrintUsAsciiString(struct SolidSyslogFormatter* format
     NullTerminate(formatter);
 }
 
-static inline char DigitToChar(uint32_t value)
+static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
 {
-    return (char) ('0' + (value % 10U));
+    if (IsPrintableUsAscii(value))
+    {
+        WriteChar(formatter, value);
+    }
+    else
+    {
+        WriteChar(formatter, NON_PRINTABLE_SUBSTITUTE);
+    }
 }
 
-static size_t CountDigits(uint32_t value)
+static inline bool IsPrintableUsAscii(char value)
 {
-    size_t count = 1;
-
-    while (value >= 10U)
-    {
-        count++;
-        value /= 10U;
-    }
-
-    return count;
+    return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
 }
 
 void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)
@@ -297,6 +304,24 @@ void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_
         divisor /= 10U;
     }
     NullTerminate(formatter);
+}
+
+static size_t CountDigits(uint32_t value)
+{
+    size_t count = 1;
+
+    while (value >= 10U)
+    {
+        count++;
+        value /= 10U;
+    }
+
+    return count;
+}
+
+static inline char DigitToChar(uint32_t value)
+{
+    return (char) ('0' + (value % 10U));
 }
 
 void SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter* formatter, uint32_t value)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -70,13 +70,14 @@ static inline size_t Utf8CodepointLength(const char* source);
 static inline void   Exhaust(struct EscapedContext* context);
 static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline void   TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
-static inline void   Write(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance);
 static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WriteCodepoint(struct EscapedContext* context);
-static inline void   WriteEscaped(struct EscapedContext* context);
-static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void   WriteReplacement(struct EscapedContext* context);
+/* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- 3 callers in this file pass compile-time constants or codepointLength; param names disambiguate */
+static inline void WriteContext(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance);
+static inline void WriteEscaped(struct EscapedContext* context);
+static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void WriteReplacement(struct EscapedContext* context);
 
 struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
 {
@@ -281,7 +282,7 @@ void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, 
         .exhausted        = false,
     };
 
-    while ((source[context.sourcePos] != '\0') && !IsExhausted(&context))
+    while (!IsExhausted(&context))
     {
         if (NeedsEscape(source[context.sourcePos]))
         {
@@ -302,7 +303,7 @@ static inline bool NeedsEscape(char value)
 
 static inline bool IsExhausted(const struct EscapedContext* context)
 {
-    return context->exhausted;
+    return context->exhausted || (context->source[context->sourcePos] == '\0');
 }
 
 static inline void WriteEscaped(struct EscapedContext* context)
@@ -310,7 +311,7 @@ static inline void WriteEscaped(struct EscapedContext* context)
     if (Fits(context, ESCAPED_CHARACTER_DECODED_LENGTH))
     {
         char escaped[] = {ESCAPE_PREFIX, context->source[context->sourcePos]};
-        Write(context, escaped, sizeof(escaped), 1, ESCAPED_CHARACTER_DECODED_LENGTH);
+        WriteContext(context, escaped, sizeof(escaped), 1, ESCAPED_CHARACTER_DECODED_LENGTH);
         return;
     }
     Exhaust(context);
@@ -321,7 +322,8 @@ static inline bool Fits(const struct EscapedContext* context, size_t decodedAdva
     return (decodedAdvance > 0) && (decodedAdvance <= context->maxDecodedLength - context->decodedLength);
 }
 
-static inline void Write(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance)
+/* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- see forward declaration */
+static inline void WriteContext(struct EscapedContext* context, const char* bytes, size_t byteCount, size_t sourceAdvance, size_t decodedAdvance)
 {
     WriteBytes(context->formatter, bytes, byteCount);
     context->sourcePos += sourceAdvance;
@@ -342,7 +344,7 @@ static inline void WriteCodepoint(struct EscapedContext* context)
     size_t codepointLength = Utf8CodepointLength(&context->source[context->sourcePos]);
     if (Fits(context, codepointLength))
     {
-        Write(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
+        WriteContext(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
         return;
     }
     WriteReplacement(context);
@@ -352,7 +354,7 @@ static inline void WriteReplacement(struct EscapedContext* context)
 {
     if (Fits(context, sizeof(REPLACEMENT_CHARACTER)))
     {
-        Write(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
+        WriteContext(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
         return;
     }
     Exhaust(context);

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -51,7 +51,6 @@ static inline void   NullTerminate(struct SolidSyslogFormatter* formatter);
 static inline void   TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
 static inline void   WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
 static inline void   WriteChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void   WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value);
 static inline void   WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
 
 struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
@@ -252,19 +251,26 @@ void SolidSyslogFormatter_EscapedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxRawLength) && (source[len] != '\0'))
     {
-        WriteEscapedChar(formatter, source[len]);
-        len++;
+        size_t codepointLength = Utf8CodepointLength(&source[len]);
+
+        if (CodepointFits(codepointLength, maxRawLength - len))
+        {
+            if ((codepointLength == 1) && NeedsEscape(source[len]))
+            {
+                /* Escape prefix is an output byte, not a source byte; len
+                 * advances only by the codepoint's own length. */
+                WriteChar(formatter, ESCAPE_PREFIX);
+            }
+            WriteBytes(formatter, &source[len], codepointLength);
+            len += codepointLength;
+        }
+        else
+        {
+            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
+            len += 1;
+        }
     }
     NullTerminate(formatter);
-}
-
-static inline void WriteEscapedChar(struct SolidSyslogFormatter* formatter, char value)
-{
-    if (NeedsEscape(value))
-    {
-        WriteChar(formatter, ESCAPE_PREFIX);
-    }
-    WriteChar(formatter, value);
 }
 
 static inline bool NeedsEscape(char value)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -152,15 +152,15 @@ static inline size_t Utf8CodepointLength(const char* source)
     {
         length = 1;
     }
-    else if (IsValidUtf8TwoByte(source[0], source[1]))
+    else if ((source[1] != '\0') && IsValidUtf8TwoByte(source[0], source[1]))
     {
         length = 2;
     }
-    else if (IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    else if ((source[1] != '\0') && (source[2] != '\0') && IsValidUtf8ThreeByte(source[0], source[1], source[2]))
     {
         length = 3;
     }
-    else if (IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
+    else if ((source[1] != '\0') && (source[2] != '\0') && (source[3] != '\0') && IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
     {
         length = 4;
     }

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -27,6 +27,7 @@ static const char NON_PRINTABLE_SUBSTITUTE   = '?';
 static const char REPLACEMENT_CHARACTER[] = {'\xEF', '\xBF', '\xBD'};
 
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
+static inline bool   HasCapacityFor(const struct SolidSyslogFormatter* formatter, size_t count);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
 static inline bool   IsFourByteLead(char byte);
 static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
@@ -115,13 +116,21 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
     {
         size_t codepointLength = Utf8CodepointLength(&source[len]);
 
-        if (codepointLength > 0)
+        if ((codepointLength > 0) && (codepointLength <= (maxLength - len)))
         {
+            if (!HasCapacityFor(formatter, codepointLength))
+            {
+                break;
+            }
             WriteBytes(formatter, &source[len], codepointLength);
             len += codepointLength;
         }
         else
         {
+            if (!HasCapacityFor(formatter, sizeof(REPLACEMENT_CHARACTER)))
+            {
+                break;
+            }
             WriteReplacementCharacter(formatter);
             len += 1;
         }
@@ -220,6 +229,11 @@ static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
     bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
     bool f5OrHigherLead     = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
     return f4WithCont1Above8F || f5OrHigherLead;
+}
+
+static inline bool HasCapacityFor(const struct SolidSyslogFormatter* formatter, size_t count)
+{
+    return (formatter->size > 0) && ((formatter->position + count) <= (formatter->size - 1));
 }
 
 static inline void WriteReplacementCharacter(struct SolidSyslogFormatter* formatter)

--- a/Core/Source/SolidSyslogOriginSd.c
+++ b/Core/Source/SolidSyslogOriginSd.c
@@ -54,5 +54,5 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     struct SolidSyslogOriginSd*  origin    = (struct SolidSyslogOriginSd*) self;
     struct SolidSyslogFormatter* preformat = SolidSyslogFormatter_FromStorage(origin->formattedStorage);
 
-    SolidSyslogFormatter_BoundedString(formatter, SolidSyslogFormatter_AsString(preformat), SolidSyslogFormatter_Length(preformat));
+    SolidSyslogFormatter_BoundedString(formatter, SolidSyslogFormatter_AsFormattedBuffer(preformat), SolidSyslogFormatter_Length(preformat));
 }

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -128,7 +128,8 @@ static bool ResolveDestination(struct SolidSyslogStreamSender* sender, struct So
 
     sender->config.endpoint(&endpoint);
 
-    return SolidSyslogResolver_Resolve(sender->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), endpoint.port, addr);
+    return SolidSyslogResolver_Resolve(sender->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), endpoint.port,
+                                       addr);
 }
 
 static void Disconnect(struct SolidSyslogSender* self)

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -128,7 +128,7 @@ static bool ResolveDestination(struct SolidSyslogStreamSender* sender, struct So
 
     sender->config.endpoint(&endpoint);
 
-    return SolidSyslogResolver_Resolve(sender->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port, addr);
+    return SolidSyslogResolver_Resolve(sender->config.resolver, SOLIDSYSLOG_TRANSPORT_TCP, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), endpoint.port, addr);
 }
 
 static void Disconnect(struct SolidSyslogSender* self)
@@ -152,7 +152,7 @@ static bool TransmitFramed(struct SolidSyslogStreamSender* sender, const void* b
     SolidSyslogFormatterStorage  prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
     struct SolidSyslogFormatter* prefix = FormatOctetCountingPrefix(prefixStorage, size);
 
-    return SendBytes(sender, SolidSyslogFormatter_AsString(prefix), SolidSyslogFormatter_Length(prefix)) && SendBytes(sender, buffer, size);
+    return SendBytes(sender, SolidSyslogFormatter_AsFormattedBuffer(prefix), SolidSyslogFormatter_Length(prefix)) && SendBytes(sender, buffer, size);
 }
 
 static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -159,7 +159,7 @@ static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatt
 {
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, OCTET_COUNTING_PREFIX_CAPACITY);
     SolidSyslogFormatter_Uint32(f, (uint32_t) messageSize);
-    SolidSyslogFormatter_Character(f, ' ');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
     return f;
 }
 

--- a/Core/Source/SolidSyslogTimeQualitySd.c
+++ b/Core/Source/SolidSyslogTimeQualitySd.c
@@ -43,16 +43,16 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     FormatBoolParam(formatter, PARAM_TZ_KNOWN, sizeof(PARAM_TZ_KNOWN) - 1, q.tzKnown);
     FormatBoolParam(formatter, PARAM_IS_SYNCED, sizeof(PARAM_IS_SYNCED) - 1, q.isSynced);
     FormatSyncAccuracy(formatter, q.syncAccuracyMicroseconds);
-    SolidSyslogFormatter_Character(formatter, ']');
+    SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
 static void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* name, size_t nameLength, bool value)
 {
     SolidSyslogFormatter_BoundedString(formatter, name, nameLength);
-    SolidSyslogFormatter_Character(formatter, '=');
-    SolidSyslogFormatter_Character(formatter, '"');
-    SolidSyslogFormatter_Character(formatter, value ? '1' : '0');
-    SolidSyslogFormatter_Character(formatter, '"');
+    SolidSyslogFormatter_AsciiCharacter(formatter, '=');
+    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
+    SolidSyslogFormatter_AsciiCharacter(formatter, value ? '1' : '0');
+    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
 static void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
@@ -64,5 +64,5 @@ static void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t 
 
     SolidSyslogFormatter_BoundedString(formatter, PARAM_SYNC_ACCURACY, sizeof(PARAM_SYNC_ACCURACY) - 1);
     SolidSyslogFormatter_Uint32(formatter, value);
-    SolidSyslogFormatter_Character(formatter, '"');
+    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -93,7 +93,7 @@ static bool Connect(struct SolidSyslogUdpSender* udp)
 
     udp->config.endpoint(&endpoint);
 
-    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsString(hostFormatter), endpoint.port);
+    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), endpoint.port);
 
     if (!Connected(udp))
     {

--- a/Platform/Posix/Source/SolidSyslogPosixHostname.c
+++ b/Platform/Posix/Source/SolidSyslogPosixHostname.c
@@ -16,6 +16,6 @@ void SolidSyslogPosixHostname_Get(struct SolidSyslogFormatter* formatter)
     if (gethostname(hostname, sizeof(hostname)) == 0)
     {
         hostname[sizeof(hostname) - 1] = '\0';
-        SolidSyslogFormatter_BoundedString(formatter, hostname, sizeof(hostname));
+        SolidSyslogFormatter_RawBoundedString(formatter, hostname, sizeof(hostname));
     }
 }

--- a/Platform/Posix/Source/SolidSyslogPosixHostname.c
+++ b/Platform/Posix/Source/SolidSyslogPosixHostname.c
@@ -16,6 +16,6 @@ void SolidSyslogPosixHostname_Get(struct SolidSyslogFormatter* formatter)
     if (gethostname(hostname, sizeof(hostname)) == 0)
     {
         hostname[sizeof(hostname) - 1] = '\0';
-        SolidSyslogFormatter_RawBoundedString(formatter, hostname, sizeof(hostname));
+        SolidSyslogFormatter_PrintUsAsciiString(formatter, hostname, sizeof(hostname));
     }
 }

--- a/Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c
@@ -28,7 +28,7 @@ static struct SolidSyslogPosixMessageQueueBuffer instance;
 
 static inline const char* QueueName(void)
 {
-    return SolidSyslogFormatter_AsString(SolidSyslogFormatter_FromStorage(instance.nameStorage));
+    return SolidSyslogFormatter_AsFormattedBuffer(SolidSyslogFormatter_FromStorage(instance.nameStorage));
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- distinct semantic meaning; struct wrapper would over-engineer

--- a/Platform/Windows/Source/SolidSyslogWindowsHostname.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsHostname.c
@@ -28,6 +28,6 @@ void SolidSyslogWindowsHostname_Get(struct SolidSyslogFormatter* formatter)
     if (WindowsHostname_GetComputerNameExA(ComputerNamePhysicalDnsHostname, hostname, &size))
     {
         hostname[sizeof(hostname) - 1] = '\0';
-        SolidSyslogFormatter_BoundedString(formatter, hostname, sizeof(hostname));
+        SolidSyslogFormatter_RawBoundedString(formatter, hostname, sizeof(hostname));
     }
 }

--- a/Platform/Windows/Source/SolidSyslogWindowsHostname.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsHostname.c
@@ -28,6 +28,6 @@ void SolidSyslogWindowsHostname_Get(struct SolidSyslogFormatter* formatter)
     if (WindowsHostname_GetComputerNameExA(ComputerNamePhysicalDnsHostname, hostname, &size))
     {
         hostname[sizeof(hostname) - 1] = '\0';
-        SolidSyslogFormatter_RawBoundedString(formatter, hostname, sizeof(hostname));
+        SolidSyslogFormatter_PrintUsAsciiString(formatter, hostname, sizeof(hostname));
     }
 }

--- a/Tests/Example/ExampleAppNameTest.cpp
+++ b/Tests/Example/ExampleAppNameTest.cpp
@@ -22,7 +22,7 @@ TEST_GROUP(ExampleAppName)
 
     [[nodiscard]] const char* formatted() const
     {
-        return SolidSyslogFormatter_AsString(formatter);
+        return SolidSyslogFormatter_AsFormattedBuffer(formatter);
     }
 };
 

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -65,6 +65,56 @@ TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
     CHECK_FORMATTED("hello");
 }
 
+TEST(SolidSyslogFormatter, BoundedStringReplacesInvalidLeadByteWithReplacementChar)
+{
+    formatBoundedString("\x85", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesSmallestContinuationByte)
+{
+    formatBoundedString("\x80", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesOverlongTwoByteEncodingPerByte)
+{
+    /* \xC1\x81 — overlong 2-byte form of U+0041. Per RFC 3629 §10 and Unicode
+     * §3.9, each invalid byte becomes its own U+FFFD substitution. */
+    formatBoundedString("\xC1\x81", 2);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesOverlongLeadC0)
+{
+    /* \xC0 — the other overlong 2-byte lead forbidden by RFC 3629 §4. */
+    formatBoundedString("\xC0", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesInvalidLeadsF5ToFF)
+{
+    /* F5-F7: would encode codepoint > U+10FFFF (outside Unicode range).
+     * F8-FF: 5+ byte prefix patterns, removed by RFC 3629.
+     * \xF5 and \xFF exercise both ends of the range. */
+    formatBoundedString("\xF5\xFF", 2);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesInvalidLeadsInF8ToFFMid)
+{
+    /* Interior of the 5+ byte prefix range — drives a mask that covers F8-FF,
+     * rather than enumerating each value. */
+    formatBoundedString("\xF8\xFE", 2);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
     formatBoundedString("hello", 3);

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -7,8 +7,8 @@
 
 #define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
 
-#define CHECK_FORMATTED(expected)                                     \
-    STRCMP_EQUAL(expected, SolidSyslogFormatter_AsString(formatter)); \
+#define CHECK_FORMATTED(expected)                                              \
+    STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter)); \
     LONGS_EQUAL(strlen(expected), SolidSyslogFormatter_Length(formatter))
 
 #define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
@@ -363,65 +363,65 @@ TEST(SolidSyslogFormatter, LengthAdvancesWithWrites)
     CHECK_LENGTH(5);
 }
 
-TEST(SolidSyslogFormatter, AsStringReturnsFormattedContent)
+TEST(SolidSyslogFormatter, AsFormattedBufferReturnsFormattedContent)
 {
     formatBoundedString("test", 4);
 
     CHECK_FORMATTED("test");
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsTruncatedTwoByteLeadAtBufferTail)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedTwoByteLeadAtBufferTail)
 {
-    /* \xC2 alone is a truncated 2-byte lead. AsString must hide it with a
+    /* \xC2 alone is a truncated 2-byte lead. AsFormattedBuffer must hide it with a
      * NUL so callers never observe invalid UTF-8 at the tail. Length still
      * reports the raw byte count so the gap records what was trimmed. */
     formatCharacter('\xC2');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsTruncatedThreeByteLeadAtBufferTail)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedThreeByteLeadAtBufferTail)
 {
     /* \xE0 alone is a truncated 3-byte lead. */
     formatCharacter('\xE0');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsTruncatedFourByteLeadAtBufferTail)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedFourByteLeadAtBufferTail)
 {
     /* \xF0 alone is a truncated 4-byte lead. */
     formatCharacter('\xF0');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsThreeByteLeadWithOnlyOneContinuation)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsThreeByteLeadWithOnlyOneContinuation)
 {
     /* \xE0\xA0 is a valid 3-byte prefix waiting for its final continuation.
      * Without the third byte the codepoint is truncated and both bytes
-     * must be hidden from AsString. */
+     * must be hidden from AsFormattedBuffer. */
     formatCharacter('\xE0');
     formatCharacter('\xA0');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsFourByteLeadWithOnlyOneContinuation)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyOneContinuation)
 {
     /* \xF0\x90 is the first two bytes of a 4-byte sequence; still truncated. */
     formatCharacter('\xF0');
     formatCharacter('\x90');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, AsStringTrimsFourByteLeadWithOnlyTwoContinuations)
+TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyTwoContinuations)
 {
     /* \xF0\x90\x80 is the first three bytes of a 4-byte sequence; still
      * one continuation short of a complete codepoint. */
@@ -429,7 +429,7 @@ TEST(SolidSyslogFormatter, AsStringTrimsFourByteLeadWithOnlyTwoContinuations)
     formatCharacter('\x90');
     formatCharacter('\x80');
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
 }
 
@@ -581,31 +581,31 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
     CHECK_FORMATTED("abc");
 }
 
-TEST(SolidSyslogFormatter, BoundedStringReplacementHiddenFromAsStringWhenOutputTooSmall)
+TEST(SolidSyslogFormatter, BoundedStringReplacementHiddenFromAsFormattedBufferWhenOutputTooSmall)
 {
     /* Replacement is 3 bytes. A 3-byte buffer provides 2 usable bytes
      * (one reserved for NUL), so U+FFFD cannot be fully written. The
-     * formatter clamps the third byte; AsString trims the truncated
+     * formatter clamps the third byte; AsFormattedBuffer trims the truncated
      * lead so callers see no invalid UTF-8. Length still reflects the
      * raw bytes the formatter absorbed, making the gap observable. */
     CREATE_FORMATTER(3);
 
     formatBoundedString("\xC3", 1);
 
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsStringWhenOutputTooSmall)
+TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsFormattedBufferWhenOutputTooSmall)
 {
     /* After writing 'a', only 1 usable byte remains in the 3-byte
-     * buffer. The 3-byte codepoint clamps after one byte; AsString
+     * buffer. The 3-byte codepoint clamps after one byte; AsFormattedBuffer
      * trims the truncated lead so the visible tail is clean. */
     CREATE_FORMATTER(3);
 
     formatBoundedString("a\xE0\xA0\x80", 4);
 
-    STRCMP_EQUAL("a", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("a", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -35,6 +35,7 @@ TEST_GROUP(SolidSyslogFormatter)
 
     void formatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
     void formatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
+    void formatRawBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_RawBoundedString(formatter, source, maxLength); }
     void formatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
     void formatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
     void formatFourDigit(uint32_t value) const { SolidSyslogFormatter_FourDigit(formatter, value); }
@@ -607,6 +608,24 @@ TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsFormattedBuffe
 
     STRCMP_EQUAL("a", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, RawBoundedStringWritesAsciiVerbatim)
+{
+    formatRawBoundedString("hello", 5);
+
+    CHECK_FORMATTED("hello");
+}
+
+TEST(SolidSyslogFormatter, RawBoundedStringPassesInvalidUtf8ByteThroughUnchanged)
+{
+    /* Distinguishing property from BoundedString: raw passthrough, no
+     * UTF-8 validation, no U+FFFD substitution. \x85 alone is an invalid
+     * UTF-8 byte (stray continuation); RawBoundedString writes it as-is. */
+    formatRawBoundedString("\x85", 1);
+
+    STRCMP_EQUAL("\x85", SolidSyslogFormatter_AsFormattedBuffer(formatter));
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogFormatter, CharacterStopsWhenFull)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -370,6 +370,69 @@ TEST(SolidSyslogFormatter, AsStringReturnsFormattedContent)
     CHECK_FORMATTED("test");
 }
 
+TEST(SolidSyslogFormatter, AsStringTrimsTruncatedTwoByteLeadAtBufferTail)
+{
+    /* \xC2 alone is a truncated 2-byte lead. AsString must hide it with a
+     * NUL so callers never observe invalid UTF-8 at the tail. Length still
+     * reports the raw byte count so the gap records what was trimmed. */
+    formatCharacter('\xC2');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, AsStringTrimsTruncatedThreeByteLeadAtBufferTail)
+{
+    /* \xE0 alone is a truncated 3-byte lead. */
+    formatCharacter('\xE0');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, AsStringTrimsTruncatedFourByteLeadAtBufferTail)
+{
+    /* \xF0 alone is a truncated 4-byte lead. */
+    formatCharacter('\xF0');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, AsStringTrimsThreeByteLeadWithOnlyOneContinuation)
+{
+    /* \xE0\xA0 is a valid 3-byte prefix waiting for its final continuation.
+     * Without the third byte the codepoint is truncated and both bytes
+     * must be hidden from AsString. */
+    formatCharacter('\xE0');
+    formatCharacter('\xA0');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, AsStringTrimsFourByteLeadWithOnlyOneContinuation)
+{
+    /* \xF0\x90 is the first two bytes of a 4-byte sequence; still truncated. */
+    formatCharacter('\xF0');
+    formatCharacter('\x90');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
+}
+
+TEST(SolidSyslogFormatter, AsStringTrimsFourByteLeadWithOnlyTwoContinuations)
+{
+    /* \xF0\x90\x80 is the first three bytes of a 4-byte sequence; still
+     * one continuation short of a complete codepoint. */
+    formatCharacter('\xF0');
+    formatCharacter('\x90');
+    formatCharacter('\x80');
+
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
+}
+
 TEST(SolidSyslogFormatter, ZeroSizeCharacterIsNoOp)
 {
     CREATE_FORMATTER(0);
@@ -518,30 +581,32 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
     CHECK_FORMATTED("abc");
 }
 
-TEST(SolidSyslogFormatter, BoundedStringDropsReplacementWhenOutputTooSmall)
+TEST(SolidSyslogFormatter, BoundedStringReplacementHiddenFromAsStringWhenOutputTooSmall)
 {
     /* Replacement is 3 bytes. A 3-byte buffer provides 2 usable bytes
-     * (one reserved for NUL), so an invalid input's replacement does not
-     * fit. Writing a partial U+FFFD would leave truncated UTF-8 in the
-     * output tail, so the whole replacement is dropped. */
+     * (one reserved for NUL), so U+FFFD cannot be fully written. The
+     * formatter clamps the third byte; AsString trims the truncated
+     * lead so callers see no invalid UTF-8. Length still reflects the
+     * raw bytes the formatter absorbed, making the gap observable. */
     CREATE_FORMATTER(3);
 
     formatBoundedString("\xC3", 1);
 
-    CHECK_FORMATTED("");
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, BoundedStringDropsValidCodepointWhenOutputTooSmall)
+TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsStringWhenOutputTooSmall)
 {
-    /* After writing 'a', only 1 usable byte remains in the 3-byte buffer.
-     * A valid 3-byte codepoint cannot fit, and writing a partial one would
-     * leave truncated UTF-8 at the output tail. The codepoint is dropped
-     * and the loop stops. */
+    /* After writing 'a', only 1 usable byte remains in the 3-byte
+     * buffer. The 3-byte codepoint clamps after one byte; AsString
+     * trims the truncated lead so the visible tail is clean. */
     CREATE_FORMATTER(3);
 
     formatBoundedString("a\xE0\xA0\x80", 4);
 
-    CHECK_FORMATTED("a");
+    STRCMP_EQUAL("a", SolidSyslogFormatter_AsString(formatter));
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogFormatter, CharacterStopsWhenFull)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -115,6 +115,169 @@ TEST(SolidSyslogFormatter, BoundedStringReplacesInvalidLeadsInF8ToFFMid)
     CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD");
 }
 
+TEST(SolidSyslogFormatter, BoundedStringPassesValidTwoByteCodepointThrough)
+{
+    /* \xC2\x80 is the canonical 2-byte encoding of U+0080. Valid UTF-8. */
+    formatBoundedString("\xC2\x80", 2);
+
+    CHECK_FORMATTED("\xC2\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesSecondValidTwoByteCodepointThrough)
+{
+    /* \xC3\xA9 is the canonical 2-byte encoding of U+00E9 (é). Valid UTF-8. */
+    formatBoundedString("\xC3\xA9", 2);
+
+    CHECK_FORMATTED("\xC3\xA9");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesHighestValidTwoByteCodepointThrough)
+{
+    /* \xDF\xBF is the canonical 2-byte encoding of U+07FF, the top of the 2-byte range. */
+    formatBoundedString("\xDF\xBF", 2);
+
+    CHECK_FORMATTED("\xDF\xBF");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesMiddleValidTwoByteCodepointThrough)
+{
+    /* \xCC\x80 is a valid 2-byte codepoint mid-range (U+0300, combining grave accent). */
+    formatBoundedString("\xCC\x80", 2);
+
+    CHECK_FORMATTED("\xCC\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesValidThreeByteCodepointThrough)
+{
+    /* \xE0\xA0\x80 is the canonical 3-byte encoding of U+0800, the smallest
+     * non-overlong 3-byte codepoint. Valid UTF-8. */
+    formatBoundedString("\xE0\xA0\x80", 3);
+
+    CHECK_FORMATTED("\xE0\xA0\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesThreeByteCodepointWithE1LeadThrough)
+{
+    /* \xE1\x80\x80 is the canonical 3-byte encoding of U+1000. Forces the
+     * lead byte check to generalise past \xE0. */
+    formatBoundedString("\xE1\x80\x80", 3);
+
+    CHECK_FORMATTED("\xE1\x80\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesOverlongThreeByteEncodingPerByte)
+{
+    /* \xE0\x80\x80 — overlong 3-byte encoding of U+0000. The E0 lead
+     * requires a continuation in A0-BF; \x80 is below that subrange, so the
+     * sequence is ill-formed and each invalid byte becomes its own U+FFFD. */
+    formatBoundedString("\xE0\x80\x80", 3);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesOverlongThreeByteEncodingAtSubrangeTop)
+{
+    /* \xE0\x9F\x80 — also overlong: \x9F is still below the E0 subrange
+     * lower bound of \xA0. Forces the exclusion to widen beyond a single
+     * hardcoded continuation byte to the full 80-9F range. */
+    formatBoundedString("\xE0\x9F\x80", 3);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesUtf16SurrogateEncodingPerByte)
+{
+    /* \xED\xA0\x80 — UTF-8 encoding of U+D800, a UTF-16 high surrogate.
+     * RFC 3629 §3 forbids encoding surrogates; the ED lead requires a
+     * continuation in 80-9F, not A0-BF. */
+    formatBoundedString("\xED\xA0\x80", 3);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesThreeByteLeadFollowedByAscii)
+{
+    /* \xE1 is a 3-byte lead; the next byte \x40 ('@') is not a valid
+     * continuation (continuations must be 80-BF). Per maximal-subpart rule
+     * the lead alone becomes U+FFFD; the ASCII byte passes through; the
+     * stray \x80 is another U+FFFD. */
+    formatBoundedString("\xE1\x40\x80", 3);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\x40\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesTopOfThreeByteLeadRangeWhenInvalid)
+{
+    /* \xEF is the top of the 3-byte lead range (E0-EF). Here it isn't
+     * followed by a valid continuation, so the lead alone becomes U+FFFD. */
+    formatBoundedString("\xEF\x40\x80", 3);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\x40\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesValidFourByteCodepointThrough)
+{
+    /* \xF0\x90\x80\x80 is the canonical 4-byte encoding of U+10000, the
+     * smallest non-overlong 4-byte codepoint. Valid UTF-8. */
+    formatBoundedString("\xF0\x90\x80\x80", 4);
+
+    CHECK_FORMATTED("\xF0\x90\x80\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringPassesFourByteCodepointWithF1LeadThrough)
+{
+    /* \xF1\x80\x80\x80 is the canonical 4-byte encoding of U+40000. Forces
+     * the 4-byte lead check to generalise past \xF0. */
+    formatBoundedString("\xF1\x80\x80\x80", 4);
+
+    CHECK_FORMATTED("\xF1\x80\x80\x80");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesOverlongFourByteEncodingPerByte)
+{
+    /* \xF0\x80\x80\x80 — overlong 4-byte encoding of U+0000. The F0 lead
+     * requires a continuation in 90-BF; \x80 is below that subrange. */
+    formatBoundedString("\xF0\x80\x80\x80", 4);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesFourByteEncodingBeyondUnicodeRange)
+{
+    /* \xF4\x90\x80\x80 encodes a codepoint beyond U+10FFFF (the top of the
+     * Unicode range). The F4 lead requires cont1 in 80-8F; \x90 is above
+     * that subrange. */
+    formatBoundedString("\xF4\x90\x80\x80", 4);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesF5AsFourByteLead)
+{
+    /* \xF5 is not a valid 4-byte lead — any codepoint with a F5 lead would
+     * exceed U+10FFFF. RFC 3629 §3 restricts 4-byte leads to F0-F4. */
+    formatBoundedString("\xF5\x80\x80\x80", 4);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesF6AsFourByteLead)
+{
+    /* \xF6 is not a valid 4-byte lead either — same reason as F5. */
+    formatBoundedString("\xF6\x80\x80\x80", 4);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesF7AsFourByteLead)
+{
+    /* \xF7 is the top of the would-be 4-byte lead range but is still
+     * outside the valid F0-F4 range. */
+    formatBoundedString("\xF7\x80\x80\x80", 4);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD");
+}
+
 TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
 {
     formatBoundedString("hello", 3);

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -483,6 +483,49 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyTwoContinua
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
 }
 
+TEST(SolidSyslogFormatter, AsFormattedBufferZerosOrphanContinuationWhenThreeByteTrimmedAtPenultimate)
+{
+    /* Trim masks the 3-byte lead with NUL; the orphan continuation that
+     * followed must also be zeroed so callers forwarding (buffer, Length)
+     * to a byte sink never observe stray UTF-8 past the mask. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("\xE0\xA0\x80", 3);
+
+    const char* buffer = SolidSyslogFormatter_AsFormattedBuffer(formatter);
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
+    BYTES_EQUAL('\0', buffer[0]);
+    BYTES_EQUAL('\0', buffer[1]);
+}
+
+TEST(SolidSyslogFormatter, AsFormattedBufferZerosOrphanContinuationWhenFourByteTrimmedAtPenultimate)
+{
+    /* Same rule with a 4-byte codepoint partially clamped to 2 bytes. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("\xF0\x90\x80\x80", 4);
+
+    const char* buffer = SolidSyslogFormatter_AsFormattedBuffer(formatter);
+    LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
+    BYTES_EQUAL('\0', buffer[0]);
+    BYTES_EQUAL('\0', buffer[1]);
+}
+
+TEST(SolidSyslogFormatter, AsFormattedBufferZerosBothOrphanContinuationsWhenFourByteTrimmedAtAntepenultimate)
+{
+    /* 4-byte codepoint clamped after 3 bytes — both trailing continuations
+     * must be zeroed alongside the masked lead. */
+    CREATE_FORMATTER(4);
+
+    formatBoundedString("\xF0\x90\x80\x80", 4);
+
+    const char* buffer = SolidSyslogFormatter_AsFormattedBuffer(formatter);
+    LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
+    BYTES_EQUAL('\0', buffer[0]);
+    BYTES_EQUAL('\0', buffer[1]);
+    BYTES_EQUAL('\0', buffer[2]);
+}
+
 TEST(SolidSyslogFormatter, ZeroSizeAsciiCharacterIsNoOp)
 {
     CREATE_FORMATTER(0);

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -745,7 +745,7 @@ TEST(SolidSyslogFormatter, EscapedStringPassesOrdinaryCharacterThrough)
     CHECK_FORMATTED("a");
 }
 
-TEST(SolidSyslogFormatter, EscapedStringTruncatesAtMaxRawLength)
+TEST(SolidSyslogFormatter, EscapedStringTruncatesAtMaxDecodedLength)
 {
     SolidSyslogFormatter_EscapedString(formatter, "hello", 3);
 
@@ -780,8 +780,12 @@ TEST(SolidSyslogFormatter, EscapedStringEscapesAllThreeSpecialsInOneValue)
     CHECK_FORMATTED("\\\"\\\\\\]");
 }
 
-TEST(SolidSyslogFormatter, EscapedStringMaxRawLengthBoundsInputNotOutput)
+TEST(SolidSyslogFormatter, EscapedStringMaxDecodedLengthBoundsDecoderBufferNotEncodedOutput)
 {
+    /* maxDecodedLength bounds what the reader's decoder would extract
+     * (one byte per unescaped character), not the wire bytes we emit.
+     * Two decoded quotes fit the bound; each expands to a 2-byte escape
+     * pair on the wire, so the output is 4 bytes. */
     SolidSyslogFormatter_EscapedString(formatter, R"(""""")", 2);
 
     CHECK_FORMATTED(R"(\"\")");
@@ -802,12 +806,12 @@ TEST(SolidSyslogFormatter, EscapedStringReplacesInvalidUtf8ByteWithReplacementCh
 {
     /* \xC0 is an invalid 2-byte lead (overlong); EscapedString must
      * substitute it with U+FFFD via the shared UTF-8 core. The surrounding
-     * ASCII rides through unescaped. Proves the invalid-path substitution
-     * is inherited, not a separate implementation. */
+     * ASCII rides through unescaped. The decoded budget must accommodate
+     * the ASCII bytes plus U+FFFD's 3 decoded bytes. */
     SolidSyslogFormatter_EscapedString(formatter,
                                        "a\xC0"
                                        "b",
-                                       3);
+                                       5);
 
     CHECK_FORMATTED("a\xEF\xBF\xBD"
                     "b");
@@ -815,13 +819,38 @@ TEST(SolidSyslogFormatter, EscapedStringReplacesInvalidUtf8ByteWithReplacementCh
 
 TEST(SolidSyslogFormatter, EscapedStringReplacesStragglingMultiByteLeadWhenSourceTruncated)
 {
-    /* maxRawLength caps source at 1 byte, but \xC2 followed by \x80 in
-     * memory would be a valid 2-byte codepoint. The source-bound check in
-     * the shared UTF-8 core demotes the lead to U+FFFD — EscapedString
-     * inherits truncation handling for free. */
-    SolidSyslogFormatter_EscapedString(formatter, "\xC2\x80", 1);
+    /* \xC2 is a 2-byte lead with no continuation available in the source
+     * (NUL-terminator follows). The lead cannot complete a codepoint and
+     * is demoted to U+FFFD — the decoded budget must accommodate the
+     * 3 decoded bytes of the replacement. */
+    SolidSyslogFormatter_EscapedString(formatter, "\xC2", 3);
 
     CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringReplacementClaimsThreeBytesOfDecodedBudget)
+{
+    /* U+FFFD occupies 3 bytes in the reader's decoder buffer. A 4-byte
+     * decoded budget that already holds one ASCII byte can admit the
+     * replacement (1 + 3 = 4), but has no room for a trailing ASCII byte.
+     * This pins both the 3-byte fit check and the += 3 advance for the
+     * replacement branch; a regression to 1 in either would let the
+     * trailing 'b' through. */
+    SolidSyslogFormatter_EscapedString(formatter,
+                                       "a\xC0"
+                                       "b",
+                                       4);
+
+    CHECK_FORMATTED("a\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringBreaksWhenReplacementDoesNotFitDecodedBudget)
+{
+    /* U+FFFD's 3 decoded bytes do not fit a 2-byte decoded budget, so the
+     * replacement cannot be emitted and the loop terminates. */
+    SolidSyslogFormatter_EscapedString(formatter, "\xC0", 2);
+
+    CHECK_FORMATTED("");
 }
 
 TEST(SolidSyslogFormatter, PrintUsAsciiStringWithEmptyInputWritesNothing)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -372,10 +372,13 @@ TEST(SolidSyslogFormatter, AsFormattedBufferReturnsFormattedContent)
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedTwoByteLeadAtBufferTail)
 {
-    /* \xC2 alone is a truncated 2-byte lead. AsFormattedBuffer must hide it with a
-     * NUL so callers never observe invalid UTF-8 at the tail. Length still
-     * reports the raw byte count so the gap records what was trimmed. */
-    formatCharacter('\xC2');
+    /* A 2-byte output buffer (1 usable byte) fills after the lead of a valid
+     * 2-byte codepoint; WriteChar clamps the continuation. AsFormattedBuffer
+     * must mask the stray lead with a NUL so callers see valid UTF-8.
+     * Length still reports the raw byte count so the gap records the trim. */
+    CREATE_FORMATTER(2);
+
+    formatBoundedString("\xC2\x80", 2);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
@@ -383,8 +386,11 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedTwoByteLeadAtBufferTai
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedThreeByteLeadAtBufferTail)
 {
-    /* \xE0 alone is a truncated 3-byte lead. */
-    formatCharacter('\xE0');
+    /* Same pattern with a 3-byte codepoint: the lead slips in, the two
+     * continuations clamp. Trim removes the stray lead. */
+    CREATE_FORMATTER(2);
+
+    formatBoundedString("\xE0\xA0\x80", 3);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
@@ -392,8 +398,10 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedThreeByteLeadAtBufferT
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedFourByteLeadAtBufferTail)
 {
-    /* \xF0 alone is a truncated 4-byte lead. */
-    formatCharacter('\xF0');
+    /* Same pattern with a 4-byte codepoint. */
+    CREATE_FORMATTER(2);
+
+    formatBoundedString("\xF0\x90\x80\x80", 4);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
@@ -401,11 +409,12 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsTruncatedFourByteLeadAtBufferTa
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsThreeByteLeadWithOnlyOneContinuation)
 {
-    /* \xE0\xA0 is a valid 3-byte prefix waiting for its final continuation.
-     * Without the third byte the codepoint is truncated and both bytes
-     * must be hidden from AsFormattedBuffer. */
-    formatCharacter('\xE0');
-    formatCharacter('\xA0');
+    /* A 3-byte buffer (2 usable bytes) lets the 3-byte codepoint's lead
+     * and first continuation through before clamping the last byte.
+     * Trim inspects position-2 and removes the truncated pair. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("\xE0\xA0\x80", 3);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
@@ -413,9 +422,11 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsThreeByteLeadWithOnlyOneContinu
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyOneContinuation)
 {
-    /* \xF0\x90 is the first two bytes of a 4-byte sequence; still truncated. */
-    formatCharacter('\xF0');
-    formatCharacter('\x90');
+    /* Same buffer size with a 4-byte codepoint: two of four bytes get in,
+     * trim inspects position-2 to find the stray 4-byte lead. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("\xF0\x90\x80\x80", 4);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
@@ -423,11 +434,12 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyOneContinua
 
 TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyTwoContinuations)
 {
-    /* \xF0\x90\x80 is the first three bytes of a 4-byte sequence; still
-     * one continuation short of a complete codepoint. */
-    formatCharacter('\xF0');
-    formatCharacter('\x90');
-    formatCharacter('\x80');
+    /* A 4-byte buffer (3 usable bytes) lets three of the four bytes of a
+     * 4-byte codepoint through before clamping. Trim inspects position-3
+     * to find the stray lead. */
+    CREATE_FORMATTER(4);
+
+    formatBoundedString("\xF0\x90\x80\x80", 4);
 
     STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -33,7 +33,7 @@ TEST_GROUP(SolidSyslogFormatter)
         CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
 
-    void formatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
+    void formatAsciiCharacter(char value) const { SolidSyslogFormatter_AsciiCharacter(formatter, value); }
     void formatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
     void formatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
     void formatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
@@ -43,19 +43,57 @@ TEST_GROUP(SolidSyslogFormatter)
 
 // clang-format on
 
-TEST(SolidSyslogFormatter, CharacterWritesIntoBuffer)
+TEST(SolidSyslogFormatter, AsciiCharacterWritesIntoBuffer)
 {
-    formatCharacter('A');
+    formatAsciiCharacter('A');
 
     CHECK_FORMATTED("A");
 }
 
-TEST(SolidSyslogFormatter, TwoCharactersAppendInSequence)
+TEST(SolidSyslogFormatter, TwoAsciiCharactersAppendInSequence)
 {
-    formatCharacter('A');
-    formatCharacter('B');
+    formatAsciiCharacter('A');
+    formatAsciiCharacter('B');
 
     CHECK_FORMATTED("AB");
+}
+
+TEST(SolidSyslogFormatter, AsciiCharacterSubstitutesHighBitByteWithQuestionMark)
+{
+    /* A high-bit byte (like a UTF-8 lead) is not PRINTUSASCII; it must be
+     * replaced with the substitute '?'. This keeps AsciiCharacter safe to
+     * hand to extension points — no way to smuggle non-ASCII in. */
+    formatAsciiCharacter('\xC3');
+
+    CHECK_FORMATTED("?");
+}
+
+TEST(SolidSyslogFormatter, AsciiCharacterSubstitutesControlCharWithQuestionMark)
+{
+    /* C0 control characters (0x01-0x1F) are not acceptable in the header
+     * fields; AsciiCharacter must substitute them. */
+    formatAsciiCharacter('\x01');
+
+    CHECK_FORMATTED("?");
+}
+
+TEST(SolidSyslogFormatter, AsciiCharacterSubstitutesDelWithQuestionMark)
+{
+    /* DEL (0x7F) sits between the printable range and the high-bit
+     * range; it is still non-printable and must substitute. */
+    formatAsciiCharacter('\x7F');
+
+    CHECK_FORMATTED("?");
+}
+
+TEST(SolidSyslogFormatter, AsciiCharacterAcceptsSpace)
+{
+    /* Space (0x20) is outside PRINTUSASCII but must pass through — the
+     * library uses it as the structural separator between syslog header
+     * fields. */
+    formatAsciiCharacter(' ');
+
+    CHECK_FORMATTED(" ");
 }
 
 TEST(SolidSyslogFormatter, BoundedStringWritesStringIntoBuffer)
@@ -314,9 +352,9 @@ TEST(SolidSyslogFormatter, BoundedStringReplacesStragglingFourByteLeadWhenSource
     CHECK_FORMATTED("\xEF\xBF\xBD");
 }
 
-TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
+TEST(SolidSyslogFormatter, BoundedStringAppendsAfterAsciiCharacter)
 {
-    formatCharacter('<');
+    formatAsciiCharacter('<');
     formatBoundedString("hello", 10);
 
     CHECK_FORMATTED("<hello");
@@ -343,9 +381,9 @@ TEST(SolidSyslogFormatter, Uint32FormatsMultipleDigits)
     CHECK_FORMATTED("134");
 }
 
-TEST(SolidSyslogFormatter, Uint32AppendsAfterCharacter)
+TEST(SolidSyslogFormatter, Uint32AppendsAfterAsciiCharacter)
 {
-    formatCharacter('<');
+    formatAsciiCharacter('<');
     formatUint32(42);
 
     CHECK_FORMATTED("<42");
@@ -445,11 +483,11 @@ TEST(SolidSyslogFormatter, AsFormattedBufferTrimsFourByteLeadWithOnlyTwoContinua
     LONGS_EQUAL(3, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, ZeroSizeCharacterIsNoOp)
+TEST(SolidSyslogFormatter, ZeroSizeAsciiCharacterIsNoOp)
 {
     CREATE_FORMATTER(0);
 
-    formatCharacter('A');
+    formatAsciiCharacter('A');
 
     CHECK_LENGTH(0);
 }
@@ -476,7 +514,7 @@ TEST(SolidSyslogFormatter, OneByteBufferHoldsOnlyNullTerminator)
 {
     CREATE_FORMATTER(1);
 
-    formatCharacter('X');
+    formatAsciiCharacter('X');
 
     CHECK_FORMATTED("");
 }
@@ -621,13 +659,13 @@ TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsFormattedBuffe
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
 }
 
-TEST(SolidSyslogFormatter, CharacterStopsWhenFull)
+TEST(SolidSyslogFormatter, AsciiCharacterStopsWhenFull)
 {
     CREATE_FORMATTER(3);
 
-    formatCharacter('A');
-    formatCharacter('B');
-    formatCharacter('C');
+    formatAsciiCharacter('A');
+    formatAsciiCharacter('B');
+    formatAsciiCharacter('C');
 
     CHECK_FORMATTED("AB");
 }

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -35,7 +35,6 @@ TEST_GROUP(SolidSyslogFormatter)
 
     void formatCharacter(char value) const { SolidSyslogFormatter_Character(formatter, value); }
     void formatBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_BoundedString(formatter, source, maxLength); }
-    void formatRawBoundedString(const char* source, size_t maxLength) const { SolidSyslogFormatter_RawBoundedString(formatter, source, maxLength); }
     void formatUint32(uint32_t value) const { SolidSyslogFormatter_Uint32(formatter, value); }
     void formatTwoDigit(uint32_t value) const { SolidSyslogFormatter_TwoDigit(formatter, value); }
     void formatFourDigit(uint32_t value) const { SolidSyslogFormatter_FourDigit(formatter, value); }
@@ -608,24 +607,6 @@ TEST(SolidSyslogFormatter, BoundedStringValidCodepointHiddenFromAsFormattedBuffe
 
     STRCMP_EQUAL("a", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(2, SolidSyslogFormatter_Length(formatter));
-}
-
-TEST(SolidSyslogFormatter, RawBoundedStringWritesAsciiVerbatim)
-{
-    formatRawBoundedString("hello", 5);
-
-    CHECK_FORMATTED("hello");
-}
-
-TEST(SolidSyslogFormatter, RawBoundedStringPassesInvalidUtf8ByteThroughUnchanged)
-{
-    /* Distinguishing property from BoundedString: raw passthrough, no
-     * UTF-8 validation, no U+FFFD substitution. \x85 alone is an invalid
-     * UTF-8 byte (stray continuation); RawBoundedString writes it as-is. */
-    formatRawBoundedString("\x85", 1);
-
-    STRCMP_EQUAL("\x85", SolidSyslogFormatter_AsFormattedBuffer(formatter));
-    LONGS_EQUAL(1, SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogFormatter, CharacterStopsWhenFull)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -285,6 +285,35 @@ TEST(SolidSyslogFormatter, BoundedStringTruncatesAtMaxLength)
     CHECK_FORMATTED("hel");
 }
 
+TEST(SolidSyslogFormatter, BoundedStringReplacesStragglingTwoByteLeadWhenSourceTruncated)
+{
+    /* maxLength caps source at 1 byte, but \xC2 followed by \x80 in memory
+     * would be a valid 2-byte codepoint. Per Unicode §3.9, a lead that
+     * can't complete a codepoint within the input bound becomes a single
+     * U+FFFD; the continuation beyond the cap is never consumed. */
+    formatBoundedString("\xC2\x80", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesStragglingThreeByteLeadWhenSourceTruncated)
+{
+    /* maxLength caps source at 1 byte of an otherwise-valid 3-byte
+     * sequence. The same truncation rule as the 2-byte case applies. */
+    formatBoundedString("\xE0\xA0\x80", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringReplacesStragglingFourByteLeadWhenSourceTruncated)
+{
+    /* maxLength caps source at 1 byte of an otherwise-valid 4-byte
+     * sequence. The same truncation rule applies. */
+    formatBoundedString("\xF0\x90\x80\x80", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
 TEST(SolidSyslogFormatter, BoundedStringAppendsAfterCharacter)
 {
     formatCharacter('<');
@@ -487,6 +516,32 @@ TEST(SolidSyslogFormatter, BoundedStringWritesNothingWhenFull)
     formatBoundedString("xyz", 3);
 
     CHECK_FORMATTED("abc");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringDropsReplacementWhenOutputTooSmall)
+{
+    /* Replacement is 3 bytes. A 3-byte buffer provides 2 usable bytes
+     * (one reserved for NUL), so an invalid input's replacement does not
+     * fit. Writing a partial U+FFFD would leave truncated UTF-8 in the
+     * output tail, so the whole replacement is dropped. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("\xC3", 1);
+
+    CHECK_FORMATTED("");
+}
+
+TEST(SolidSyslogFormatter, BoundedStringDropsValidCodepointWhenOutputTooSmall)
+{
+    /* After writing 'a', only 1 usable byte remains in the 3-byte buffer.
+     * A valid 3-byte codepoint cannot fit, and writing a partial one would
+     * leave truncated UTF-8 at the output tail. The codepoint is dropped
+     * and the loop stops. */
+    CREATE_FORMATTER(3);
+
+    formatBoundedString("a\xE0\xA0\x80", 4);
+
+    CHECK_FORMATTED("a");
 }
 
 TEST(SolidSyslogFormatter, CharacterStopsWhenFull)

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -744,6 +744,43 @@ TEST(SolidSyslogFormatter, EscapedStringMaxRawLengthBoundsInputNotOutput)
     CHECK_FORMATTED(R"(\"\")");
 }
 
+TEST(SolidSyslogFormatter, EscapedStringPassesValidUtf8CodepointsThroughAroundEscapedSpecial)
+{
+    /* \xC2\x80 is a valid 2-byte UTF-8 codepoint. The embedded \" is the
+     * only byte requiring escape; the UTF-8 codepoints on either side ride
+     * through unchanged. Proves the shared UTF-8 core composes with the
+     * single-byte escape decoration. */
+    SolidSyslogFormatter_EscapedString(formatter, "\xC2\x80\"\xC2\x80", 5);
+
+    CHECK_FORMATTED("\xC2\x80\\\"\xC2\x80");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringReplacesInvalidUtf8ByteWithReplacementChar)
+{
+    /* \xC0 is an invalid 2-byte lead (overlong); EscapedString must
+     * substitute it with U+FFFD via the shared UTF-8 core. The surrounding
+     * ASCII rides through unescaped. Proves the invalid-path substitution
+     * is inherited, not a separate implementation. */
+    SolidSyslogFormatter_EscapedString(formatter,
+                                       "a\xC0"
+                                       "b",
+                                       3);
+
+    CHECK_FORMATTED("a\xEF\xBF\xBD"
+                    "b");
+}
+
+TEST(SolidSyslogFormatter, EscapedStringReplacesStragglingMultiByteLeadWhenSourceTruncated)
+{
+    /* maxRawLength caps source at 1 byte, but \xC2 followed by \x80 in
+     * memory would be a valid 2-byte codepoint. The source-bound check in
+     * the shared UTF-8 core demotes the lead to U+FFFD — EscapedString
+     * inherits truncation handling for free. */
+    SolidSyslogFormatter_EscapedString(formatter, "\xC2\x80", 1);
+
+    CHECK_FORMATTED("\xEF\xBF\xBD");
+}
+
 TEST(SolidSyslogFormatter, PrintUsAsciiStringWithEmptyInputWritesNothing)
 {
     SolidSyslogFormatter_PrintUsAsciiString(formatter, "", 0);

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -56,7 +56,7 @@ TEST(SolidSyslogMetaSd, CreateReturnsNonNull)
 TEST(SolidSyslogMetaSd, FirstFormatProducesSequenceId1)
 {
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"1\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogMetaSd, SecondFormatProducesSequenceId2)
@@ -64,7 +64,7 @@ TEST(SolidSyslogMetaSd, SecondFormatProducesSequenceId2)
     format();
     resetFormatter();
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"2\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogMetaSd, ThirdFormatProducesSequenceId3)
@@ -73,7 +73,7 @@ TEST(SolidSyslogMetaSd, ThirdFormatProducesSequenceId3)
     format();
     resetFormatter();
     format();
-    STRCMP_EQUAL("[meta sequenceId=\"3\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[meta sequenceId=\"3\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogMetaSd, FormatAdvancesFormatterLength)
@@ -81,7 +81,7 @@ TEST(SolidSyslogMetaSd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsFormattedBuffer(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogMetaSd, DestroyDoesNotCrash)

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -77,19 +77,19 @@ TEST(SolidSyslogOriginSd, CreateReturnsNonNull)
 TEST(SolidSyslogOriginSd, FormatContainsSoftwareName)
 {
     format();
-    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "software=\"TestSoftware\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsFormattedBuffer(formatter), "software=\"TestSoftware\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, FormatContainsSwVersion)
 {
     format();
-    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "swVersion=\"9.8.7\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsFormattedBuffer(formatter), "swVersion=\"9.8.7\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, FormatProducesCompleteOriginSd)
 {
     format();
-    STRCMP_EQUAL("[origin software=\"TestSoftware\" swVersion=\"9.8.7\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"TestSoftware\" swVersion=\"9.8.7\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, FormatAdvancesFormatterLength)
@@ -97,7 +97,7 @@ TEST(SolidSyslogOriginSd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsFormattedBuffer(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogOriginSd, DifferentValuesProduceDifferentOutput)
@@ -107,7 +107,7 @@ TEST(SolidSyslogOriginSd, DifferentValuesProduceDifferentOutput)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"OtherSoft\" swVersion=\"1.2.3\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"OtherSoft\" swVersion=\"1.2.3\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, SoftwareAtMaxLength)
@@ -117,7 +117,7 @@ TEST(SolidSyslogOriginSd, SoftwareAtMaxLength)
 
     resetFormatter();
     format();
-    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsFormattedBuffer(formatter), "software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, SoftwareTruncatedBeyondMaxLength)
@@ -127,7 +127,7 @@ TEST(SolidSyslogOriginSd, SoftwareTruncatedBeyondMaxLength)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijkl\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, SwVersionAtMaxLength)
@@ -137,7 +137,7 @@ TEST(SolidSyslogOriginSd, SwVersionAtMaxLength)
 
     resetFormatter();
     format();
-    CHECK(strstr(SolidSyslogFormatter_AsString(formatter), "swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"") != nullptr);
+    CHECK(strstr(SolidSyslogFormatter_AsFormattedBuffer(formatter), "swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"") != nullptr);
 }
 
 TEST(SolidSyslogOriginSd, SwVersionTruncatedBeyondMaxLength)
@@ -147,7 +147,7 @@ TEST(SolidSyslogOriginSd, SwVersionTruncatedBeyondMaxLength)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, EmptySoftwareString)
@@ -157,7 +157,7 @@ TEST(SolidSyslogOriginSd, EmptySoftwareString)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, EmptySwVersionString)
@@ -167,7 +167,7 @@ TEST(SolidSyslogOriginSd, EmptySwVersionString)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, NullSoftwareReturnsNull)
@@ -198,7 +198,7 @@ TEST(SolidSyslogOriginSd, SoftwareContainingSpecialsIsEscaped)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"a\\\"b\\\\c\\]d\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"a\\\"b\\\\c\\]d\" swVersion=\"1.0\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, SwVersionContainingSpecialsIsEscaped)
@@ -208,7 +208,7 @@ TEST(SolidSyslogOriginSd, SwVersionContainingSpecialsIsEscaped)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"1\\\"2\\\\3\\]4\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[origin software=\"S\" swVersion=\"1\\\"2\\\\3\\]4\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogOriginSd, WorstCaseFullyEscapedInputFitsPreFormattedStorage)
@@ -221,5 +221,5 @@ TEST(SolidSyslogOriginSd, WorstCaseFullyEscapedInputFitsPreFormattedStorage)
 
     resetFormatter();
     format();
-    STRCMP_EQUAL(originSdWith(escapeEach(software), escapeEach(swVersion)).c_str(), SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL(originSdWith(escapeEach(software), escapeEach(swVersion)).c_str(), SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1047,14 +1047,8 @@ TEST(SolidSyslog, ProcessIdAt129CharsIsTruncatedTo128)
     CHECK_PROCID(expected.c_str());
 }
 
-IGNORE_TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
+TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
 {
-    /* Ignored pending follow-up commit on this branch: ASCII-only fields
-     * (PROCID, APP-NAME, HOSTNAME, MSGID) should not be passed through the
-     * UTF-8 BoundedString sanitiser before PrintUsAsciiString. With per-byte
-     * U+FFFD substitution in BoundedString, a single invalid byte now
-     * expands to three '?' characters here instead of one. Fix is to bypass
-     * BoundedString for ASCII-only fields. */
     StringFake_SetProcessId("a\xC3"
                             "b");
     Log();

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1047,8 +1047,14 @@ TEST(SolidSyslog, ProcessIdAt129CharsIsTruncatedTo128)
     CHECK_PROCID(expected.c_str());
 }
 
-TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
+IGNORE_TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
 {
+    /* Ignored pending follow-up commit on this branch: ASCII-only fields
+     * (PROCID, APP-NAME, HOSTNAME, MSGID) should not be passed through the
+     * UTF-8 BoundedString sanitiser before PrintUsAsciiString. With per-byte
+     * U+FFFD substitution in BoundedString, a single invalid byte now
+     * expands to three '?' characters here instead of one. Fix is to bypass
+     * BoundedString for ASCII-only fields. */
     StringFake_SetProcessId("a\xC3"
                             "b");
     Log();

--- a/Tests/SolidSyslogTimeQualitySdTest.cpp
+++ b/Tests/SolidSyslogTimeQualitySdTest.cpp
@@ -59,7 +59,7 @@ TEST(SolidSyslogTimeQualitySd, CreateReturnsNonNull)
 TEST(SolidSyslogTimeQualitySd, FormatProducesTzKnownAndIsSynced)
 {
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatWithFalseValues)
@@ -67,46 +67,46 @@ TEST(SolidSyslogTimeQualitySd, FormatWithFalseValues)
     stubTimeQuality.tzKnown  = false;
     stubTimeQuality.isSynced = false;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"0\" isSynced=\"0\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"0\" isSynced=\"0\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatIncludesSyncAccuracyWhenNonZero)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 50;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"50\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"50\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, SyncAccuracyOfOneIsSmallestNonOmitValue)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 1;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"1\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"1\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, SyncAccuracyAtMaxUint32)
 {
     stubTimeQuality.syncAccuracyMicroseconds = UINT32_MAX;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"4294967295\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\" syncAccuracy=\"4294967295\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, OmitSyncAccuracyUsesDefinedConstant)
 {
     stubTimeQuality.syncAccuracyMicroseconds = SOLIDSYSLOG_SYNC_ACCURACY_OMIT;
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, CallbackIsInvokedOnEachFormat)
 {
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"1\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 
     stubTimeQuality.isSynced = false;
     resetFormatter();
     format();
-    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"0\"]", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("[timeQuality tzKnown=\"1\" isSynced=\"0\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatAdvancesFormatterLength)
@@ -114,14 +114,14 @@ TEST(SolidSyslogTimeQualitySd, FormatAdvancesFormatterLength)
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
     format();
     CHECK(SolidSyslogFormatter_Length(formatter) > 0);
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsFormattedBuffer(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, FormatAdvancesLengthWithSyncAccuracy)
 {
     stubTimeQuality.syncAccuracyMicroseconds = 50;
     format();
-    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsString(formatter)), SolidSyslogFormatter_Length(formatter));
+    LONGS_EQUAL(strlen(SolidSyslogFormatter_AsFormattedBuffer(formatter)), SolidSyslogFormatter_Length(formatter));
 }
 
 TEST(SolidSyslogTimeQualitySd, DestroyDoesNotCrash)

--- a/Tests/SolidSyslogWindowsHostnameTest.cpp
+++ b/Tests/SolidSyslogWindowsHostnameTest.cpp
@@ -51,7 +51,7 @@ TEST_GROUP(SolidSyslogWindowsHostname)
 
     const char* formatted() const
     {
-        return SolidSyslogFormatter_AsString(formatter);
+        return SolidSyslogFormatter_AsFormattedBuffer(formatter);
     }
 };
 

--- a/Tests/SolidSyslogWindowsProcessIdTest.cpp
+++ b/Tests/SolidSyslogWindowsProcessIdTest.cpp
@@ -34,7 +34,7 @@ TEST_GROUP(SolidSyslogWindowsProcessId)
 
     const char* formatted() const
     {
-        return SolidSyslogFormatter_AsString(formatter);
+        return SolidSyslogFormatter_AsFormattedBuffer(formatter);
     }
 };
 

--- a/Tests/StringFake.c
+++ b/Tests/StringFake.c
@@ -21,7 +21,7 @@ void StringFake_SetHostname(const char* hostname)
 
 void StringFake_GetHostname(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_BoundedString(formatter, fakeHostname, strlen(fakeHostname));
+    SolidSyslogFormatter_RawBoundedString(formatter, fakeHostname, strlen(fakeHostname));
 }
 
 void StringFake_SetAppName(const char* appName)
@@ -31,7 +31,7 @@ void StringFake_SetAppName(const char* appName)
 
 void StringFake_GetAppName(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_BoundedString(formatter, fakeAppName, strlen(fakeAppName));
+    SolidSyslogFormatter_RawBoundedString(formatter, fakeAppName, strlen(fakeAppName));
 }
 
 void StringFake_SetProcessId(const char* procId)
@@ -41,5 +41,5 @@ void StringFake_SetProcessId(const char* procId)
 
 void StringFake_GetProcessId(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_BoundedString(formatter, fakeProcessId, strlen(fakeProcessId));
+    SolidSyslogFormatter_RawBoundedString(formatter, fakeProcessId, strlen(fakeProcessId));
 }

--- a/Tests/StringFake.c
+++ b/Tests/StringFake.c
@@ -21,7 +21,7 @@ void StringFake_SetHostname(const char* hostname)
 
 void StringFake_GetHostname(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_RawBoundedString(formatter, fakeHostname, strlen(fakeHostname));
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, fakeHostname, strlen(fakeHostname));
 }
 
 void StringFake_SetAppName(const char* appName)
@@ -31,7 +31,7 @@ void StringFake_SetAppName(const char* appName)
 
 void StringFake_GetAppName(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_RawBoundedString(formatter, fakeAppName, strlen(fakeAppName));
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, fakeAppName, strlen(fakeAppName));
 }
 
 void StringFake_SetProcessId(const char* procId)
@@ -41,5 +41,5 @@ void StringFake_SetProcessId(const char* procId)
 
 void StringFake_GetProcessId(struct SolidSyslogFormatter* formatter)
 {
-    SolidSyslogFormatter_RawBoundedString(formatter, fakeProcessId, strlen(fakeProcessId));
+    SolidSyslogFormatter_PrintUsAsciiString(formatter, fakeProcessId, strlen(fakeProcessId));
 }

--- a/Tests/StringFakeTest.cpp
+++ b/Tests/StringFakeTest.cpp
@@ -27,7 +27,7 @@ TEST_GROUP(StringFake)
 TEST(StringFake, ReturnsEmptyStringAfterReset)
 {
     StringFake_GetHostname(formatter);
-    STRCMP_EQUAL("", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(0, SolidSyslogFormatter_Length(formatter));
 }
 
@@ -35,6 +35,6 @@ TEST(StringFake, ReturnsConfiguredHostname)
 {
     StringFake_SetHostname("MyHost");
     StringFake_GetHostname(formatter);
-    STRCMP_EQUAL("MyHost", SolidSyslogFormatter_AsString(formatter));
+    STRCMP_EQUAL("MyHost", SolidSyslogFormatter_AsFormattedBuffer(formatter));
     LONGS_EQUAL(6, SolidSyslogFormatter_Length(formatter));
 }

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -138,9 +138,8 @@ non-repudiation and assured delivery.
 
 Requires cryptographic integrity, encryption, and assured delivery with
 non-repudiation. TLS transport has landed and RFC 5424 string-hygiene is
-closed (SD escaping + PRINTUSASCII header-field validation); remaining
-SL4 items are at-rest cryptography and UTF-8 safe truncation of the MSG
-body.
+closed (SD escaping + PRINTUSASCII header-field validation + UTF-8
+formatter primitives); the remaining SL4 item is at-rest cryptography.
 
 | Component | Header | Purpose | Status |
 |---|---|---|---|
@@ -149,7 +148,7 @@ body.
 | Authenticated integrity policy | — | HMAC/AES-CMAC on stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | PRINTUSASCII validation | — | Header field character compliance | Available — non-compliant bytes substituted with `?` via `SolidSyslogFormatter_PrintUsAsciiString` |
-| UTF-8 safe truncation | — | No split multi-byte sequences | Planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
+| UTF-8 validation | — | Formatter primitives uphold RFC 3629; ill-formed input substituted with U+FFFD (Unicode §3.9). MSG-body truncation at the wire-buffer limit remains a SIEM concern. | Available — `SolidSyslogFormatter_BoundedString`, `SolidSyslogFormatter_EscapedString` ([S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) |
 | Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
 
 **What SL4 adds over SL3:**
@@ -165,8 +164,6 @@ body.
 - Cryptographic integrity at rest — HMAC or AES-CMAC replacing CRC-16, making
   stored-record tampering detectable even by a local attacker (CR 2.12, CR 3.9).
 - Encryption at rest — stored records unreadable without key material (CR 3.9).
-- UTF-8 safe truncation on message body — no split multi-byte sequences
-  when MSG is truncated at the wire limit.
 
 **SL4 TLS substrate.** `SolidSyslogTlsStream` — the OpenSSL-backed client-side
 TLS substrate — ships with the SL4 controls that depend on the client:

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -23,12 +23,12 @@ Status key:
 | 6.2.5 | PROCID — max 128 chars, PRINTUSASCII | Supported | Truncated to 128. Non-PRINTUSASCII bytes substituted with `?` |
 | 6.2.6 | MSGID — max 32 chars, PRINTUSASCII | Supported | Truncated to 32. Non-PRINTUSASCII bytes substituted with `?` |
 | 6.3 | STRUCTURED-DATA — SD-ELEMENTs or NILVALUE | Supported | Extensible via `SolidSyslogStructuredData` vtable |
-| 6.3.3 | SD-PARAM value escaping (`]`, `\`, `"`) | Supported | `SolidSyslogFormatter_EscapedString`; `OriginSd` escapes software/swVersion. SD-NAME syntax validation planned — [E14](https://github.com/DavidCozens/solid-syslog/issues/64) |
+| 6.3.3 | SD-PARAM value escaping (`]`, `\`, `"`) | Supported | `SolidSyslogFormatter_EscapedString` — RFC 3629 UTF-8 validated, ill-formed input substituted per-byte with U+FFFD (Unicode §3.9); `OriginSd` escapes software/swVersion. SD-NAME syntax validation planned — [E14](https://github.com/DavidCozens/solid-syslog/issues/64) |
 | 6.3.3 | timeQuality SD — tzKnown, isSynced, syncAccuracy | Supported | `SolidSyslogTimeQualitySd` |
 | 6.3.4 | origin SD — software, swVersion | Supported | `SolidSyslogOriginSd`. `ip` and `enterpriseId` not implemented |
 | 6.3.5 | meta SD — sequenceId | Supported | `SolidSyslogMetaSd`. Starts at 1, increments per message. `sysUpTime` and `language` not implemented |
 | 6.3.5 | meta SD — sequenceId wraps at 2147483647 to 1 | Not yet | Planned — see [sequenceId rules](https://github.com/DavidCozens/solid-syslog/issues/31) |
-| 6.4 | MSG — UTF-8 preferred | Partial | Passes through caller's encoding. No BOM prefix. UTF-8 safe truncation planned — [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121) |
+| 6.4 | MSG — UTF-8 preferred | Supported | RFC 3629 UTF-8 validated at the formatter primitives (`SolidSyslogFormatter_BoundedString`), with ill-formed input substituted per-byte with U+FFFD (Unicode §3.9). No BOM prefix. MSG body truncation at the wire-buffer limit is the SIEM's responsibility (out-of-scope per [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) |
 | 8.1 | Message size — max 2048 recommended | Supported | Default `SOLIDSYSLOG_MAX_MESSAGE_SIZE` = 512. Configurable via CMake |
 | 9 | PRINTUSASCII in header fields (codes 33-126) | Supported | Non-compliant bytes substituted with `?` at format time (HOSTNAME, APP-NAME, PROCID, MSGID) |
 


### PR DESCRIPTION
## Purpose

Closes #121.

RFC 5424 §6.4 MSG content and §6.3.3 PARAM-VALUE are UTF-8. The formatter's write primitives had two classes of latent defect around that contract:

1. **No validation.** `BoundedString` and `EscapedString` passed arbitrary bytes through — a caller supplying ill-formed UTF-8, or a valid codepoint straddling the source bound, produced invalid UTF-8 in the output buffer.
2. **Extension-point footguns.** `Character` accepted any 8-bit value; `AsString` implied a C-string contract but any mid-buffer write of a multi-byte lead could leave a truncated tail that `strlen` would read into.

This PR makes the formatter's public surface uphold RFC 3629 / Unicode §3.9 across the board, and closes the single-byte and raw-write holes at the edges of the API.

## Summary of changes

**UTF-8 validation** (BoundedString and EscapedString):
- Full RFC 3629 classifier for 1/2/3/4-byte codepoints with all exclusions (overlong leads, UTF-16 surrogate range, beyond U+10FFFF, 5+ byte prefixes).
- Invalid bytes and truncated-at-source-bound sequences are replaced per-byte with U+FFFD, matching Unicode §3.9's maximal-subpart guidance.
- EscapedString's loop now shares the same UTF-8 core as BoundedString — the escape prefix decoration for `"` / `\` / `]` is one extra line in the valid branch.

**AsFormattedBuffer (renamed from AsString)**:
- Name reflects the actual contract: a byte buffer, not a C string. MSG content may legitimately contain U+0000; the internal NUL is a defensive marker.
- Adds a trim step so callers never observe a truncated multi-byte lead at the tail (the source-bound clamp can leave one; AsFormattedBuffer replaces it with NUL before handing the pointer back).

**AsciiCharacter (renamed from Character)**:
- Accepts 0x20 (SP) + 0x21-0x7E (PRINTUSASCII). Anything else is substituted with `?`.
- Closes the one-byte-at-a-time injection hole at extension points and direct callers.

**ASCII field callbacks** scrub at source via `PrintUsAsciiString` (was a brief detour via a now-removed `RawBoundedString`). A single invalid byte in HOSTNAME/APP-NAME/PROCID now becomes one `?` instead of three.

**Shared primitives**:
- `CodepointFits(codepointLength, remaining)` predicate.
- `TrimTruncatedMultiByteTail` helper behind `AsFormattedBuffer`.
- `IsAsciiCharacter`, `IsValidUtf8{SingleByte,TwoByte,ThreeByte,FourByte}`, `IsUtf8Continuation`, lead-class predicates (`IsTwoByteLead`, `IsThreeByteLead`, `IsFourByteLead`), and exclusion predicates (`IsOverlongTwoByteLead`, `IsOverlongThreeByteEncoding`, `IsUtf16SurrogateEncoding`, `IsOverlongFourByteEncoding`, `IsAboveUnicodeMaxEncoding`).

**Latent bug fix**: `Utf8CodepointLength` previously read `source[0..3]` unconditionally via argument evaluation, producing reads past the NUL terminator on short C-strings. Caught by sanitize (ASan); fixed with short-circuit NUL checks per branch.

## Breaking public API changes (library pre-1.0)

- `SolidSyslogFormatter_Character` → `SolidSyslogFormatter_AsciiCharacter` with PRINTUSASCII + SP contract and `?` substitution.
- `SolidSyslogFormatter_AsString` → `SolidSyslogFormatter_AsFormattedBuffer`.

All in-tree call sites (Core, Platform, Tests) updated. No external ABI guarantees exist yet.

## Non-goals on this PR

- **Wider rename chore** making every string/char function explicit about its contract (`*BoundedString` → `Utf8BoundedString`, `*PrintUsAsciiString` → an ASCII variant, etc.) — deferred to a separate refactor PR.
- **MSG-body truncation at the main message buffer boundary** remains covered by the existing SIEM-handles-truncation contract from S07.04.
- **`FormatStringField`'s redundant second-pass `PrintUsAsciiString`** after callbacks now scrub at source — idempotent, harmless, cleanup is cosmetic.

## Test evidence

Strict TDD throughout. New coverage pins each behaviour at the test surface:

- 2/3/4-byte UTF-8 validation: valid lead ranges, subrange exclusions (E0 overlong, ED surrogate, F0 overlong, F4 beyond-Unicode, F5-F7 invalid leads).
- Source-bound truncation per codepoint length; matches per-byte U+FFFD for all invalid cases.
- AsFormattedBuffer trim at position-1, position-2, position-3 for each lead class — now driven through the BoundedString small-buffer-clamp path.
- AsciiCharacter substitution: high-bit, control char, DEL, SP acceptance.
- EscapedString UTF-8 composition: valid codepoints surrounding an escaped special; invalid UTF-8 triggers U+FFFD; straggling multi-byte lead at `maxRawLength`.
- PROCID test `ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark` re-enabled and passes.

**Local gate sweep all green**: debug + junit, sanitize + junit, tidy, cppcheck, coverage (100.0% of 1339 lines, 310 functions), clang-format.

## Areas affected

- `Core/Interface/SolidSyslogFormatter.h` — renamed two functions; added docstring for the buffer-not-string contract.
- `Core/Source/SolidSyslogFormatter.c` — net ~+300/-50 lines; new UTF-8 classifier, trim, shared primitives.
- `Core/Source/SolidSyslog.c`, `SolidSyslogStreamSender.c`, `SolidSyslogTimeQualitySd.c`, `SolidSyslogFileStore.c`, `SolidSyslogOriginSd.c`, `SolidSyslogUdpSender.c` — call-site renames.
- `Platform/Posix/Source/SolidSyslogPosixHostname.c`, `Platform/Windows/Source/SolidSyslogWindowsHostname.c`, `Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c` — call-site renames; ASCII callbacks migrated to `PrintUsAsciiString`.
- `Tests/StringFake.c` — ASCII callbacks migrated.
- `Tests/SolidSyslogFormatterTest.cpp` — ~70 new tests driving the UTF-8 + substitution + trim behaviours.
- `Tests/SolidSyslogTest.cpp` — one previously-ignored PROCID test re-enabled.
- `CLAUDE.md` — public-header audiences table updated; new "Function Ordering" section documenting the convention.

## Test plan

- [ ] CI green on all platforms (gcc, clang, MSVC, sanitize, coverage, tidy, cppcheck, format, bdd).
- [ ] CodeRabbit review consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codepoint-aware UTF‑8 formatting with replacement for invalid or truncated sequences; trimmed/zeroed tails for safety.
  * Buffer accessor behavior clarified and adjusted: returned buffer is NUL-terminated for convenience but must be paired with length queries.

* **API Changes**
  * ASCII-character writer renamed and escaping API now treats capacity as a decoded-length budget.

* **Documentation**
  * Added guidance on in-source function ordering and helper placement.

* **Tests**
  * Expanded UTF‑8 and truncation test coverage and adapted tests to updated accessor semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->