### PR TITLE
chore: scope default VS Code build task to SolidSyslogTests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,9 +7,9 @@
         {
             "label": "build and test",
             "type": "shell",
-            "command": "if [ -z \"$BUILD_PRESET\" ]; then behave Bdd/features/; else cmake --build --preset $BUILD_PRESET && ctest --preset $BUILD_PRESET --verbose; fi",
+            "command": "if [ -z \"$BUILD_PRESET\" ]; then behave Bdd/features/; else cmake --build --preset $BUILD_PRESET --target SolidSyslogTests && ctest --preset $BUILD_PRESET --verbose --tests-regex '^SolidSyslogTests$'; fi",
             "windows": {
-                "command": "cmake --preset msvc-debug; if ($?) { cmake --build --preset msvc-debug }; if ($?) { ctest --preset msvc-debug --verbose }"
+                "command": "cmake --preset msvc-debug; if ($?) { cmake --build --preset msvc-debug --target SolidSyslogTests }; if ($?) { ctest --preset msvc-debug --verbose --tests-regex '^SolidSyslogTests$' }"
             },
             "group": {
                 "kind": "build",


### PR DESCRIPTION
## Summary

- Ctrl+Shift+B was running `cmake --build --preset $BUILD_PRESET` followed by `ctest --preset $BUILD_PRESET --verbose`, which built the OpenSSL integration test binary and ran the integration suite alongside the unit suite. The inner-loop shortcut should be unit-only.
- Limit the build to `--target SolidSyslogTests` (only the static lib + fakes + unit test executable build) and the test run to `--tests-regex '^SolidSyslogTests$'`. Same applied to the Windows command for consistency.
- Integration tests are still buildable and runnable on demand (e.g. `cmake --build --preset $BUILD_PRESET` followed by `ctest --preset $BUILD_PRESET`) and continue to run in CI via the `openssl-integration` job.

## Test plan

- [x] `cmake --build --preset debug --target SolidSyslogTests` — only the unit suite + its dependencies build
- [x] `ctest --preset debug --verbose --tests-regex '^SolidSyslogTests$'` — runs SolidSyslogTests only, OpenSslIntegrationTests skipped (1/1 reported, not 2/2)
- [ ] On the Windows side: Ctrl+Shift+B should still complete in roughly the same time but skip the OpenSslIntegration step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code build and test task configuration to target specific test suite execution.

---

**Note:** This release contains no user-facing changes. The modification is internal tooling configuration only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->