### PR TITLE
feat: S12.08 TcpSender error guards (socket, partial write, SO_SNDTIMEO)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,56 @@
 # Dev Log
 
+## 2026-04-26 — S12.08 TcpSender error guards (socket(), partial write, SO_SNDTIMEO)
+
+### Decisions
+- **Fail-fast on any short return from `send()`, no internal retry loop.**
+  Considered the SendAll-with-offset pattern but went simpler: a short return,
+  `EAGAIN`/`EWOULDBLOCK`, or any non-`EINTR` error all surface as `Send` →
+  false. The caller closes and reconnects on the next attempt; store-and-forward
+  replays the whole message on the fresh socket. Trade-off: under a peer that
+  always short-writes (rare on a blocking socket without `O_NONBLOCK`), the
+  message can churn through replay. In return: clean per-call latency upper
+  bound (≤ `SO_SNDTIMEO`), much smaller code surface, easier to port to a new
+  Stream backend.
+- **`SO_SNDTIMEO` set at `Open` (5 s, hard-coded).** Bounds the blocking
+  window of any single `send()`. A wedged peer can no longer make a
+  `SolidSyslog_Service` call hang indefinitely — the timeout fires as
+  `EAGAIN`, propagates as `Send` → false, and S&F handles the rest. The
+  5 s value is recorded as a candidate for a future port-time CMake
+  override (the same shape we'd use for `SOLIDSYSLOG_MAX_MESSAGE_SIZE` on
+  memory-constrained MCUs); for now it lives as an `enum` in the
+  implementation file.
+- **`EINTR` is the only retried errno.** Strictly a portability shim
+  against systems without `SA_RESTART`. Documented inline so it doesn't
+  get deleted as dead code in a future cleanup.
+- **`MSG_NOSIGNAL` already in place.** No SIGPIPE work needed for
+  POSIX/Linux. BSD/macOS would use `SO_NOSIGPIPE`, VxWorks 7 a per-thread
+  mask — out of scope until a concrete porting target appears.
+- **`getaddrinfo` NULL guard (item 1 in the original issue) was already
+  fixed** by an earlier refactor that removed the `BuildAddress` helper.
+  Existing tests `ReturnsFalseWhenGetAddrInfoFails` and
+  `DoesNotFreeAddrInfoWhenGetAddrInfoFails` document the safe path. No
+  code change for this item.
+
+### Deferred
+- **Port-time CMake override mechanism** for `SEND_TIMEOUT_SECONDS` and
+  `SOLIDSYSLOG_MAX_MESSAGE_SIZE`. Both are good candidates; neither has a
+  concrete user need yet. A future story can add the CMake plumbing
+  (`-D` cache variables → preprocessor defines → `enum` defaults guarded
+  by `#ifndef`).
+- **Symmetric tests for the BSD/macOS/VxWorks SIGPIPE matrix.** Not
+  testable without a VxWorks build; would slot under E13 cross-platform
+  CI if/when a VxWorks target is added.
+
+### Open questions for the blog source
+- **What's the right "fast fail vs internal retry" line for embedded
+  transports?** SendAll is correct for streams over reliable lossless
+  links; fast-fail-and-replay is correct when there's a backstop (S&F)
+  and you value latency predictability. The conventional advice is
+  "always SendAll on TCP" — but that advice doesn't account for systems
+  where the transport sits below an event loop with its own retry
+  semantics. SolidSyslog's S&F is exactly that. Worth a paragraph.
+
 ## 2026-04-25 — S07.07 sequenceId rollover and zero-avoidance per RFC 5424 §7.3.1
 
 ### Decisions

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -16,19 +16,26 @@ enum
     SEND_TIMEOUT_SECONDS = 5
 };
 
-static bool             Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
-static bool             Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
-static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size);
-static void             Close(struct SolidSyslogStream* self);
-static void             EnableTcpNoDelay(int fd);
-static void             SetSendTimeout(int fd);
-static inline bool      IsFileDescriptorValid(int fd);
-
 struct SolidSyslogPosixTcpStream
 {
     struct SolidSyslogStream base;
     int                      fd;
 };
+
+static bool             Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
+static bool             Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
+static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size);
+static void             Close(struct SolidSyslogStream* self);
+
+static int         OpenAndConfigureSocket(void);
+static void        EnableTcpNoDelay(int fd);
+static void        SetSendTimeout(int fd);
+static inline bool IsFileDescriptorValid(int fd);
+static bool        ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin);
+static bool        Connect(int fd, const struct sockaddr_in* sin);
+static ssize_t     SendRetryingOnSignal(int fd, const void* buffer, size_t size);
+static bool        WasInterruptedBySignal(void);
+static bool        WroteAllBytes(ssize_t sent, size_t expected);
 
 SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixTcpStream) <= SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE,
                           "SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE is too small for struct SolidSyslogPosixTcpStream");
@@ -59,26 +66,27 @@ void SolidSyslogPosixTcpStream_Destroy(struct SolidSyslogStream* stream)
 
 static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
 {
-    struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
-    const struct sockaddr_in*         sin    = SolidSyslogAddress_AsConstSockaddrIn(addr);
+    struct SolidSyslogPosixTcpStream* stream    = (struct SolidSyslogPosixTcpStream*) self;
+    const struct sockaddr_in*         sin       = SolidSyslogAddress_AsConstSockaddrIn(addr);
+    bool                              connected = false;
 
-    stream->fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (!IsFileDescriptorValid(stream->fd))
+    stream->fd = OpenAndConfigureSocket();
+    if (IsFileDescriptorValid(stream->fd))
     {
-        return false;
+        connected = ConnectOrCloseOnFailure(stream, sin);
     }
-    EnableTcpNoDelay(stream->fd);
-    SetSendTimeout(stream->fd);
-
-    bool connected = connect(stream->fd, (const struct sockaddr*) sin, sizeof(*sin)) == 0;
-
-    if (!connected)
-    {
-        close(stream->fd);
-        stream->fd = INVALID_FD;
-    }
-
     return connected;
+}
+
+static int OpenAndConfigureSocket(void)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (IsFileDescriptorValid(fd))
+    {
+        EnableTcpNoDelay(fd);
+        SetSendTimeout(fd);
+    }
+    return fd;
 }
 
 static void EnableTcpNoDelay(int fd)
@@ -99,18 +107,56 @@ static void SetSendTimeout(int fd)
     setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
 }
 
+static inline bool IsFileDescriptorValid(int fd)
+{
+    return (fd >= 0);
+}
+
+static bool ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin)
+{
+    bool connected = Connect(stream->fd, sin);
+    if (!connected)
+    {
+        close(stream->fd);
+        stream->fd = INVALID_FD;
+    }
+    return connected;
+}
+
+static bool Connect(int fd, const struct sockaddr_in* sin)
+{
+    return (connect(fd, (const struct sockaddr*) sin, sizeof(*sin)) == 0);
+}
+
 static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
-    ssize_t                           sent   = 0;
-    /* Retry only on EINTR — portability shim for kernels without SA_RESTART.
-     * Any other failure (including EAGAIN/EWOULDBLOCK from SO_SNDTIMEO) and
-     * any short return propagates as false; the caller closes and reconnects. */
+    ssize_t                           sent   = SendRetryingOnSignal(stream->fd, buffer, size);
+    return WroteAllBytes(sent, size);
+}
+
+/* Retry only on EINTR — portability shim for kernels without SA_RESTART.
+ * Any other failure (including EAGAIN/EWOULDBLOCK from SO_SNDTIMEO) and
+ * any short return propagate via WroteAllBytes; the caller closes and
+ * reconnects, store-and-forward replays the message on the fresh socket. */
+static ssize_t SendRetryingOnSignal(int fd, const void* buffer, size_t size)
+{
+    ssize_t sent = 0;
     do
     {
-        sent = send(stream->fd, buffer, size, MSG_NOSIGNAL);
-    } while (sent < 0 && errno == EINTR);
-    return sent >= 0 && (size_t) sent == size;
+        sent = send(fd, buffer, size, MSG_NOSIGNAL);
+    } while ((sent < 0) && WasInterruptedBySignal());
+    return sent;
+}
+
+static bool WasInterruptedBySignal(void)
+{
+    return (errno == EINTR);
+}
+
+static bool WroteAllBytes(ssize_t sent, size_t expected)
+{
+    return (sent >= 0) && ((size_t) sent == expected);
 }
 
 static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size)
@@ -127,9 +173,4 @@ static void Close(struct SolidSyslogStream* self)
         close(stream->fd);
         stream->fd = INVALID_FD;
     }
-}
-
-static inline bool IsFileDescriptorValid(int fd)
-{
-    return fd >= 0;
 }

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -3,14 +3,17 @@
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogStreamDefinition.h"
 
+#include <errno.h>
 #include <netinet/tcp.h>
 #include <stddef.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 enum
 {
-    INVALID_FD = -1
+    INVALID_FD           = -1,
+    SEND_TIMEOUT_SECONDS = 5
 };
 
 static bool             Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
@@ -18,6 +21,7 @@ static bool             Send(struct SolidSyslogStream* self, const void* buffer,
 static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size);
 static void             Close(struct SolidSyslogStream* self);
 static void             EnableTcpNoDelay(int fd);
+static void             SetSendTimeout(int fd);
 static inline bool      IsFileDescriptorValid(int fd);
 
 struct SolidSyslogPosixTcpStream
@@ -59,9 +63,13 @@ static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress
     const struct sockaddr_in*         sin    = SolidSyslogAddress_AsConstSockaddrIn(addr);
 
     stream->fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (!IsFileDescriptorValid(stream->fd))
+    {
+        return false;
+    }
     EnableTcpNoDelay(stream->fd);
+    SetSendTimeout(stream->fd);
 
-    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions) -- socket() failure handling deferred to error handling epic
     bool connected = connect(stream->fd, (const struct sockaddr*) sin, sizeof(*sin)) == 0;
 
     if (!connected)
@@ -79,10 +87,30 @@ static void EnableTcpNoDelay(int fd)
     setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
 }
 
+/* Caps blocking time of send() so a wedged peer can't make a single
+ * SolidSyslog_Service() call hang. On expiry, send() returns -1 with
+ * EAGAIN/EWOULDBLOCK, the Send vtable returns false, and the Service
+ * loop closes and reconnects on the next attempt; store-and-forward
+ * replays the message on the fresh socket. Hard-coded for now;
+ * port-time CMake override is a future option. */
+static void SetSendTimeout(int fd)
+{
+    struct timeval timeout = {.tv_sec = SEND_TIMEOUT_SECONDS, .tv_usec = 0};
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+}
+
 static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
-    return send(stream->fd, buffer, size, MSG_NOSIGNAL) >= 0;
+    ssize_t                           sent   = 0;
+    /* Retry only on EINTR — portability shim for kernels without SA_RESTART.
+     * Any other failure (including EAGAIN/EWOULDBLOCK from SO_SNDTIMEO) and
+     * any short return propagates as false; the caller closes and reconnects. */
+    do
+    {
+        sent = send(stream->fd, buffer, size, MSG_NOSIGNAL);
+    } while (sent < 0 && errno == EINTR);
+    return sent >= 0 && (size_t) sent == size;
 }
 
 static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -4,6 +4,7 @@
 #include "SolidSyslogStream.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
+#include <cerrno>
 #include <cstdint>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -81,9 +82,13 @@ TEST(SolidSyslogPosixTcpStream, OpenCallsSocketWithSOCK_STREAM)
 TEST(SolidSyslogPosixTcpStream, OpenEnablesTcpNoDelay)
 {
     SolidSyslogStream_Open(stream, addr);
-    LONGS_EQUAL(1, SocketFake_SetSockOptCallCount());
-    LONGS_EQUAL(IPPROTO_TCP, SocketFake_LastSetSockOptLevel());
-    LONGS_EQUAL(TCP_NODELAY, SocketFake_LastSetSockOptOptname());
+    CHECK_TRUE(SocketFake_HasSetSockOpt(IPPROTO_TCP, TCP_NODELAY));
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenSetsSendTimeout)
+{
+    SolidSyslogStream_Open(stream, addr);
+    CHECK_TRUE(SocketFake_HasSetSockOpt(SOL_SOCKET, SO_SNDTIMEO));
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenCallsConnectWithSocketFd)
@@ -109,6 +114,49 @@ TEST(SolidSyslogPosixTcpStream, OpenReturnsFalseOnConnectFailure)
 {
     SocketFake_SetConnectFails(true);
     CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenReturnsFalseWhenSocketFails)
+{
+    SocketFake_SetSocketFails(true);
+    CHECK_FALSE(SolidSyslogStream_Open(stream, addr));
+}
+
+TEST(SolidSyslogPosixTcpStream, OpenSkipsConnectAndSetsockoptWhenSocketFails)
+{
+    SocketFake_SetSocketFails(true);
+    SolidSyslogStream_Open(stream, addr);
+    LONGS_EQUAL(0, SocketFake_ConnectCallCount());
+    LONGS_EQUAL(0, SocketFake_SetSockOptCallCount());
+}
+
+TEST(SolidSyslogPosixTcpStream, SendReturnsFalseOnShortWrite)
+{
+    SolidSyslogStream_Open(stream, addr);
+    SocketFake_SetSendReturn(3);
+    CHECK_FALSE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendDoesNotRetryAfterShortWrite)
+{
+    SolidSyslogStream_Open(stream, addr);
+    SocketFake_SetSendReturn(3);
+    SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, SocketFake_SendCallCount());
+}
+
+TEST(SolidSyslogPosixTcpStream, SendRetriesOnEintrAndSucceeds)
+{
+    SolidSyslogStream_Open(stream, addr);
+    SocketFake_FailNextSendWithErrno(EINTR);
+    CHECK_TRUE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogPosixTcpStream, SendReturnsFalseOnEagainTimeout)
+{
+    SolidSyslogStream_Open(stream, addr);
+    SocketFake_FailNextSendWithErrno(EAGAIN);
+    CHECK_FALSE(SolidSyslogStream_Send(stream, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
 TEST(SolidSyslogPosixTcpStream, OpenClosesSocketOnConnectFailure)

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -144,9 +144,7 @@ TEST(SolidSyslogStreamSender, FirstSendOpensStreamSocket)
 TEST(SolidSyslogStreamSender, FirstSendSetsTcpNoDelay)
 {
     Send();
-    LONGS_EQUAL(1, SocketFake_SetSockOptCallCount());
-    LONGS_EQUAL(IPPROTO_TCP, SocketFake_LastSetSockOptLevel());
-    LONGS_EQUAL(TCP_NODELAY, SocketFake_LastSetSockOptOptname());
+    CHECK_TRUE(SocketFake_HasSetSockOpt(IPPROTO_TCP, TCP_NODELAY));
 }
 
 // clang-format off
@@ -537,9 +535,10 @@ TEST(SolidSyslogStreamSenderFailure, ReconnectSetsTcpNoDelay)
     Send();
     SocketFake_SetSendFails(false);
     Send();
-    LONGS_EQUAL(2, SocketFake_SetSockOptCallCount());
-    LONGS_EQUAL(IPPROTO_TCP, SocketFake_LastSetSockOptLevel());
-    LONGS_EQUAL(TCP_NODELAY, SocketFake_LastSetSockOptOptname());
+    /* Two opens (initial + reconnect); both must set TCP_NODELAY.
+     * Counted indirectly: TCP_NODELAY appears twice, plus SO_SNDTIMEO twice = 4 total. */
+    LONGS_EQUAL(4, SocketFake_SetSockOptCallCount());
+    CHECK_TRUE(SocketFake_HasSetSockOpt(IPPROTO_TCP, TCP_NODELAY));
 }
 
 TEST(SolidSyslogStreamSenderFailure, ReconnectResolvesDns)

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -1,6 +1,7 @@
 #include "SocketFake.h"
 #include "SafeString.h"
 #include <arpa/inet.h>
+#include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <string.h>
@@ -31,13 +32,17 @@ enum
     SOCKETFAKE_MAX_SEND_CALLS = 8
 };
 
-static bool   sendFails;
-static int    sendFailOnCall;
-static int    sendCallCount;
-static char   sendBufCopy[SOCKETFAKE_MAX_SEND_CALLS][SOCKETFAKE_MAX_BUFFER_SIZE];
-static size_t sendLenCopy[SOCKETFAKE_MAX_SEND_CALLS];
-static int    sendFlagsCopy[SOCKETFAKE_MAX_SEND_CALLS];
-static int    lastSendFd;
+static bool    sendFails;
+static int     sendFailOnCall;
+static int     sendCallCount;
+static bool    sendReturnOverride;
+static ssize_t sendReturnValue;
+static bool    nextSendShouldFailWithErrno;
+static int     nextSendErrno;
+static char    sendBufCopy[SOCKETFAKE_MAX_SEND_CALLS][SOCKETFAKE_MAX_BUFFER_SIZE];
+static size_t  sendLenCopy[SOCKETFAKE_MAX_SEND_CALLS];
+static int     sendFlagsCopy[SOCKETFAKE_MAX_SEND_CALLS];
+static int     lastSendFd;
 
 static bool               connectFails;
 static int                connectCallCount;
@@ -45,9 +50,16 @@ static int                lastConnectFd;
 static struct sockaddr_in lastConnectAddr;
 static char               lastConnectAddrString[INET_ADDRSTRLEN];
 
+enum
+{
+    SOCKETFAKE_MAX_SETSOCKOPT_CALLS = 8
+};
+
 static int setSockOptCallCount;
 static int lastSetSockOptLevel;
 static int lastSetSockOptOptname;
+static int setSockOptLevels[SOCKETFAKE_MAX_SETSOCKOPT_CALLS];
+static int setSockOptOptnames[SOCKETFAKE_MAX_SETSOCKOPT_CALLS];
 
 static int closeCallCount;
 static int lastClosedFd;
@@ -71,17 +83,21 @@ static int                freeAddrInfoCallCount;
 
 void SocketFake_Reset(void)
 {
-    sendtoFails     = false;
-    sendtoCallCount = 0;
-    lastBufCopy[0]  = '\0';
-    lastLen         = 0;
-    lastFlags       = 0;
-    lastAddr        = (struct sockaddr_in) {0};
-    lastAddrLen     = 0;
-    lastSendtoFd    = -1;
-    sendFails       = false;
-    sendFailOnCall  = -1;
-    sendCallCount   = 0;
+    sendtoFails                 = false;
+    sendtoCallCount             = 0;
+    lastBufCopy[0]              = '\0';
+    lastLen                     = 0;
+    lastFlags                   = 0;
+    lastAddr                    = (struct sockaddr_in) {0};
+    lastAddrLen                 = 0;
+    lastSendtoFd                = -1;
+    sendFails                   = false;
+    sendFailOnCall              = -1;
+    sendCallCount               = 0;
+    sendReturnOverride          = false;
+    sendReturnValue             = 0;
+    nextSendShouldFailWithErrno = false;
+    nextSendErrno               = 0;
     for (int i = 0; i < SOCKETFAKE_MAX_SEND_CALLS; i++)
     {
         sendBufCopy[i][0] = '\0';
@@ -97,20 +113,25 @@ void SocketFake_Reset(void)
     setSockOptCallCount      = 0;
     lastSetSockOptLevel      = 0;
     lastSetSockOptOptname    = 0;
-    socketFails              = false;
-    socketCallCount          = 0;
-    socketFd                 = -1;
-    lastSocketDomain         = 0;
-    lastSocketType           = 0;
-    closeCallCount           = 0;
-    lastClosedFd             = -1;
-    recvCallCount            = 0;
-    recvReturn               = 0;
-    lastRecvFd               = -1;
-    lastRecvBuf              = NULL;
-    lastRecvLen              = 0;
-    lastRecvFlags            = 0;
-    lastAddrString[0]        = '\0';
+    for (int i = 0; i < SOCKETFAKE_MAX_SETSOCKOPT_CALLS; i++)
+    {
+        setSockOptLevels[i]   = 0;
+        setSockOptOptnames[i] = 0;
+    }
+    socketFails       = false;
+    socketCallCount   = 0;
+    socketFd          = -1;
+    lastSocketDomain  = 0;
+    lastSocketType    = 0;
+    closeCallCount    = 0;
+    lastClosedFd      = -1;
+    recvCallCount     = 0;
+    recvReturn        = 0;
+    lastRecvFd        = -1;
+    lastRecvBuf       = NULL;
+    lastRecvLen       = 0;
+    lastRecvFlags     = 0;
+    lastAddrString[0] = '\0';
 
     getAddrInfoFails            = false;
     getAddrInfoCallCount        = 0;
@@ -224,6 +245,18 @@ void SocketFake_FailSendOnCall(int callNumber)
     sendFailOnCall = callNumber;
 }
 
+void SocketFake_SetSendReturn(ssize_t value)
+{
+    sendReturnOverride = true;
+    sendReturnValue    = value;
+}
+
+void SocketFake_FailNextSendWithErrno(int errnoValue)
+{
+    nextSendShouldFailWithErrno = true;
+    nextSendErrno               = errnoValue;
+}
+
 /* send accessors */
 
 int SocketFake_SendCallCount(void)
@@ -308,6 +341,19 @@ int SocketFake_LastSetSockOptLevel(void)
 int SocketFake_LastSetSockOptOptname(void)
 {
     return lastSetSockOptOptname;
+}
+
+bool SocketFake_HasSetSockOpt(int level, int optname)
+{
+    int recorded = setSockOptCallCount < SOCKETFAKE_MAX_SETSOCKOPT_CALLS ? setSockOptCallCount : SOCKETFAKE_MAX_SETSOCKOPT_CALLS;
+    for (int i = 0; i < recorded; i++)
+    {
+        if (setSockOptLevels[i] == level && setSockOptOptnames[i] == optname)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 /* close accessors */
@@ -442,7 +488,21 @@ ssize_t send(int sockfd, const void* buf, size_t len, int flags)
     }
     bool failThisCall = sendFails || (sendFailOnCall == sendCallCount);
     sendCallCount++;
-    return failThisCall ? (ssize_t) -1 : (ssize_t) len;
+    if (nextSendShouldFailWithErrno)
+    {
+        errno                       = nextSendErrno;
+        nextSendShouldFailWithErrno = false;
+        return (ssize_t) -1;
+    }
+    if (failThisCall)
+    {
+        return (ssize_t) -1;
+    }
+    if (sendReturnOverride)
+    {
+        return sendReturnValue;
+    }
+    return (ssize_t) len;
 }
 
 // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) -- POSIX API; parameter names differ from glibc internal names
@@ -463,6 +523,11 @@ int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t
     (void) sockfd;
     (void) optval;
     (void) optlen;
+    if (setSockOptCallCount < SOCKETFAKE_MAX_SETSOCKOPT_CALLS)
+    {
+        setSockOptLevels[setSockOptCallCount]   = level;
+        setSockOptOptnames[setSockOptCallCount] = optname;
+    }
     setSockOptCallCount++;
     lastSetSockOptLevel   = level;
     lastSetSockOptOptname = optname;

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -83,6 +83,9 @@ static int                freeAddrInfoCallCount;
 
 void SocketFake_Reset(void)
 {
+    /* Reset errno so a stale value from a prior test (notably EINTR set via
+     * FailNextSendWithErrno) cannot leak into the next test's retry loop. */
+    errno                       = 0;
     sendtoFails                 = false;
     sendtoCallCount             = 0;
     lastBufCopy[0]              = '\0';
@@ -496,6 +499,9 @@ ssize_t send(int sockfd, const void* buf, size_t len, int flags)
     }
     if (failThisCall)
     {
+        /* Set a non-retryable errno so the production EINTR-retry loop
+         * cannot wedge if errno happened to be EINTR from a prior test. */
+        errno = EIO;
         return (ssize_t) -1;
     }
     if (sendReturnOverride)

--- a/Tests/Support/SocketFake.h
+++ b/Tests/Support/SocketFake.h
@@ -37,6 +37,8 @@ EXTERN_C_BEGIN
     /* send configuration */
     void SocketFake_SetSendFails(bool fails);
     void SocketFake_FailSendOnCall(int callNumber);
+    void SocketFake_SetSendReturn(ssize_t value);
+    void SocketFake_FailNextSendWithErrno(int errnoValue);
 
     /* send accessors */
     int         SocketFake_SendCallCount(void);
@@ -55,9 +57,10 @@ EXTERN_C_BEGIN
     const char* SocketFake_LastConnectAddrAsString(void);
 
     /* setsockopt accessors */
-    int SocketFake_SetSockOptCallCount(void);
-    int SocketFake_LastSetSockOptLevel(void);
-    int SocketFake_LastSetSockOptOptname(void);
+    int  SocketFake_SetSockOptCallCount(void);
+    int  SocketFake_LastSetSockOptLevel(void);
+    int  SocketFake_LastSetSockOptOptname(void);
+    bool SocketFake_HasSetSockOpt(int level, int optname);
 
     /* close accessors */
     int SocketFake_CloseCallCount(void);

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -282,5 +282,5 @@ signal that does not depend on the transport layer being lossless. Cross-referen
 | CR 2.11 Timestamps | `SolidSyslogClockFunction`, `SolidSyslogTimeQualitySd` | Injected clock with quality metadata |
 | CR 2.12 Non-repudiation | `SolidSyslogMetaSd` (sequenceId), `SolidSyslogCrc16Policy`, `SolidSyslogTlsStream` mTLS | Sequence gaps detectable by SIEM; mTLS cryptographically identifies the sender |
 | CR 3.9 Audit information protection | `SolidSyslogCrc16Policy` (at rest, SL3), `SolidSyslogTlsStream` (in transit, SL4) | TLS substrate hardened by [S03.08](https://github.com/DavidCozens/solid-syslog/issues/172) and [S03.09](https://github.com/DavidCozens/solid-syslog/issues/173); cryptographic integrity and encryption at rest remain in [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
-| SR 6.1 Audit log accessibility | `SolidSyslog_Service`, sender vtable | Non-blocking Log, background Service |
+| SR 6.1 Audit log accessibility | `SolidSyslog_Service`, sender vtable | Non-blocking Log; Service performs the blocking I/O on its own thread, bounded per attempt by the TCP transport's `SO_SNDTIMEO` (5 s — see [`SolidSyslogPosixTcpStream.c`](../Platform/Posix/Source/SolidSyslogPosixTcpStream.c)) |
 | SR 6.2 Continuous monitoring | TCP/TLS transport, store-and-forward | Assured delivery via replay on reconnect |

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -54,7 +54,7 @@ Status key:
 | 3.5 | Session closure handling | Supported | On send failure the stream is closed; the next Send transparently reconnects (S3.4) |
 | 3.5 | Handle receiver-initiated close | Supported | Detected via send failure path — same reconnect-on-next-Send mechanism (S3.4) |
 | 3.5 | Address rotation without app restart | Supported | App bumps `endpointVersion`; sender Disconnects and reconnects on next Send (S3.4) |
-| — | Partial write handling (send returns short) | Not yet | Planned — [S12.8](https://github.com/DavidCozens/solid-syslog/issues/119) |
+| — | Partial write handling (send returns short) | Supported | A short return from `send()` is treated as failure: `Send` returns false, the caller closes and reconnects on the next attempt, store-and-forward replays the message on the fresh socket. `SO_SNDTIMEO` is set at socket open (5 s, hard-coded — see `Platform/Posix/Source/SolidSyslogPosixTcpStream.c`) so a wedged peer can't make a single `SolidSyslog_Service` call hang indefinitely. `EINTR` is the only retried errno (portability shim for kernels without `SA_RESTART`); `EAGAIN`/`EWOULDBLOCK` (timeout) and any other error propagate as failure. |
 
 ## RFC 5425 — TLS Transport Mapping for Syslog
 
@@ -74,5 +74,5 @@ Status key:
 |---|---|---|---|---|---|
 | RFC 5424 | 17 | 17 | 0 | 0 | 0 |
 | RFC 5426 | 6 | 3 | 1 | 0 | 2 |
-| RFC 6587 | 6 | 2 | 2 | 2 | 0 |
+| RFC 6587 | 8 | 7 | 0 | 0 | 1 |
 | RFC 5425 | 7 | 6 | 1 | 0 | 0 |


### PR DESCRIPTION
Closes #119

## Summary

Three error edges in `PosixTcpStream` tightened, with `SO_SNDTIMEO` added so a wedged TCP peer can't make a single `SolidSyslog_Service` call hang indefinitely. Item 1 from the original scope (`getaddrinfo` NULL guard) was already fixed by an earlier refactor — see [issue comment](https://github.com/DavidCozens/solid-syslog/issues/119#issuecomment-4321790269).

- **socket() failure guard.** If `socket()` returns -1, `Open` returns false and skips the downstream `connect()`/`setsockopt()` calls. Removes the long-standing `NOLINT(clang-analyzer-unix.StdCLibraryFunctions)`.
- **Partial write handling.** A short return from `send()` is treated as failure (no `SendAll`-with-offset loop). `Send` returns false; the caller closes and reconnects on the next attempt; store-and-forward replays the whole message on the fresh socket. Cleaner latency bound, smaller code surface, S&F is the safety net.
- **`SO_SNDTIMEO` at Open.** Hard-coded 5 s. `EAGAIN`/`EWOULDBLOCK` from timeout firing propagates via the same error path as any other `-1`. Recorded as a candidate for a future port-time CMake override.
- **`EINTR` retry shim.** The only retried errno, strictly for portability against kernels without `SA_RESTART`. Documented inline.

`MSG_NOSIGNAL` was already in place; no SIGPIPE work needed for POSIX/Linux. BSD/macOS/VxWorks portability deferred until a real porting target appears.

`docs/rfc-compliance.md` row 57 flips from "Not yet" to "Supported"; the RFC 6587 summary count is brought back in sync (was drifting like the RFC 5424 row was before — same kind of fix as #207). `docs/iec62443.md` SR 6.1 row clarifies the bounded blocking note. DEVLOG entry added.

`SocketFake` gains three scriptable knobs:
- `SetSendReturn(ssize_t)` — script next `send()` return value (drives short-write test)
- `FailNextSendWithErrno(int)` — fail next `send()` with `-1` + chosen errno (drives EINTR + EAGAIN tests)
- `HasSetSockOpt(level, optname)` — order-independent search across recorded `setsockopt` calls

Existing `OpenEnablesTcpNoDelay`, `FirstSendSetsTcpNoDelay`, `ReconnectSetsTcpNoDelay` migrated to `HasSetSockOpt` now that there are two `setsockopt` calls per Open.

## Test plan

- [x] `cmake --preset debug && cmake --build --preset debug && ./build/debug/Tests/SolidSyslogTests` — 857 tests, 853 ran, 1202 checks, 0 failures
- [x] `cmake --preset sanitize && cmake --build --preset sanitize && ctest --preset sanitize` — clean (ASan + UBSan)
- [x] `cmake --preset coverage && cmake --build --preset coverage --target coverage` — 100% line coverage retained
- [x] `cmake --preset tidy && cmake --build --preset tidy` — clang-tidy clean
- [x] `cmake --preset cppcheck && cmake --build --preset cppcheck` — cppcheck clean
- [x] clang-format dry-run clean
- [ ] CI: format, build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, bdd, windows-build-and-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP send timeout (5 seconds) to prevent indefinite blocking on socket operations.

* **Bug Fixes**
  * Improved error handling for TCP sends: now fails on short writes, timeout conditions, and non-`EINTR` errors; retries only on `EINTR`.
  * Enhanced socket validation during open to fail fast on invalid file descriptors.

* **Documentation**
  * Updated RFC 6587 and IEC 62443 compliance matrices to reflect send timeout and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->