### PR TITLE
docs: refresh CI checks list and public header audience table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,15 @@ All changes to `main` must go via a pull request — direct pushes are blocked b
 **Merge strategy:** Squash merge only. This keeps a linear history on `main` and means the PR title
 becomes the single commit message — so the PR title must follow Conventional Commits format (see below).
 
-**Before raising a PR:**
-- All CI checks must pass: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test
+**Before raising a PR — run locally:**
+- build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format
+- Windows, BDD, and OpenSSL integration jobs are CI's responsibility — running them locally would slow development too much
 - Commits on the branch can be informal (work-in-progress messages are fine)
 - The PR title is what matters — it becomes the permanent commit message on `main`
 
 **Branch protection rules (configured on GitHub):**
 - Direct pushes to `main` are blocked
-- PRs require all status checks to pass before merging: build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test
+- PRs require all status checks to pass before merging: build-and-test, openssl-integration, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, windows-build-and-test, bdd, bdd-windows
 - Squash merge only — other merge strategies are disabled
 - Branches are deleted automatically after merge
 
@@ -302,7 +303,10 @@ boundary that makes the code testable and portable to embedded targets.
 
 ### Public header audiences (Interface Segregation)
 
-Headers in `Core/Interface/` are split by audience — each user includes only what they need:
+Public headers are split by audience — each user includes only what they need. Most headers
+live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*` and
+`SolidSyslogWindows*` rows below) live under `Platform/Posix/Interface/` and
+`Platform/Windows/Interface/` respectively.
 
 | Header | Audience | Provides |
 |---|---|---|
@@ -314,13 +318,21 @@ Headers in `Core/Interface/` are split by audience — each user includes only w
 | `SolidSyslogEndpoint.h` | System setup code that supplies destination host/port (and version on changes) | `SolidSyslogEndpoint`, `SolidSyslogEndpointFunction`, `SolidSyslogEndpointVersionFunction`, `SOLIDSYSLOG_MAX_HOST_SIZE` |
 | `SolidSyslogSender.h` | Any code holding a sender handle | `SolidSyslogSender_Send`, `SolidSyslogSender_Disconnect` |
 | `SolidSyslogSenderDefinition.h` | Sender implementors (extension point) | `SolidSyslogSender` vtable struct (`Send`, `Disconnect`) |
+| `SolidSyslogTransport.h` | Any code selecting a transport | `SolidSyslogTransport` enum (`UDP`, `TCP`) |
 | `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(resolver, transport, host, port, *out)` |
+| `SolidSyslogResolverDefinition.h` | Resolver implementors (extension point) | `SolidSyslogResolver` vtable struct (`Resolve`) |
+| `SolidSyslogDatagram.h` | Sender implementors using datagram transport | `SolidSyslogDatagram_Open`, `_SendTo`, `_Close` |
+| `SolidSyslogDatagramDefinition.h` | Datagram implementors (extension point) | `SolidSyslogDatagram` vtable struct (`Open`, `SendTo`, `Close`) |
+| `SolidSyslogStream.h` | Sender implementors using stream transport | `SolidSyslogStream_Open`, `_Send`, `_Read`, `_Close`, `SolidSyslogSsize` |
+| `SolidSyslogStreamDefinition.h` | Stream implementors (extension point) | `SolidSyslogStream` vtable struct (`Open`, `Send`, `Read`, `Close`) |
 | `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy`, `SOLIDSYSLOG_UDP_DEFAULT_PORT` |
 | `SolidSyslogStreamSender.h` | System setup code using octet-framed transport (RFC 6587) over any Stream — `SolidSyslogPosixTcpStream` (TCP), `SolidSyslogTlsStream` (TLS; OpenSSL reference integration), or a caller-supplied Stream backend | `SolidSyslogStreamSenderConfig` (resolver, stream, endpoint, endpointVersion), `SolidSyslogStreamSender_Create`, `_Destroy` |
 | `SolidSyslogSwitchingSender.h` | System setup code composing multiple inner senders | `SolidSyslogSwitchingSenderConfig` (senders, senderCount, selector), `SolidSyslogSwitchingSenderSelector`, `SolidSyslogSwitchingSender_Create`, `_Destroy` |
+| `SolidSyslogBuffer.h` | Library internals consuming a buffer (Service algorithm) | `SolidSyslogBuffer_Write`, `_Read` |
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |
+| `SolidSyslogStore.h` | Library internals consuming a store (Service algorithm) | `SolidSyslogStore_Write`, `_ReadNextUnsent`, `_MarkSent`, `_HasUnsent`, `_IsHalted` |
 | `SolidSyslogStoreDefinition.h` | Store implementors (extension point) | `SolidSyslogStore` vtable struct |
 | `SolidSyslogNullStore.h` | System setup code (no store-and-forward) | `SolidSyslogNullStore_Create`, `_Destroy` |
 | `SolidSyslogFileDefinition.h` | File implementors (extension point) | `SolidSyslogFile` vtable struct |

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -48,7 +48,7 @@ Status key:
 | Section | Requirement | Status | Notes |
 |---|---|---|---|
 | 3.2 | Sender initiates TCP connection | Supported | `SolidSyslogStreamSender` connects lazily on first send (S03.04) |
-| 3.2 | Default port 601 | Supported | `SOLIDSYSLOG_TCP_DEFAULT_PORT = 601` per IANA assignment |
+| 3.2 | Default port 601 | Supported | `SOLIDSYSLOG_TCP_DEFAULT_PORT = 601` per IANA assignment (defined in `Platform/Posix/Interface/SolidSyslogPosixTcpStream.h`) |
 | 3.4.1 | Octet counting framing | Supported | `MSG-LEN SP MSG` prefix on every send |
 | 3.4.2 | Non-transparent framing (LF trailer) | Not supported | Octet counting is the recommended method |
 | 3.5 | Session closure handling | Supported | On send failure the stream is closed; the next Send transparently reconnects (S3.4) |


### PR DESCRIPTION
## Summary

Drift fixes from a sanity check across the project's `.md` files.

- **CLAUDE.md — CI checks section.** Split the list into "run locally before raising a PR" (the build/test/quality jobs that fit normal dev flow) and "branch protection" (the full set of required status checks). The local list trims Windows / BDD / OpenSSL integration since those aren't local-runnable in normal flow. The branch-protection list now correctly includes `openssl-integration` and `bdd-windows`.
- **CLAUDE.md — Public header audience table.** Added missing rows for headers that exist but were undocumented:
  - `SolidSyslogTransport.h`
  - `SolidSyslogResolverDefinition.h`
  - `SolidSyslogDatagram.h` + `SolidSyslogDatagramDefinition.h`
  - `SolidSyslogStream.h` + `SolidSyslogStreamDefinition.h`
  - `SolidSyslogBuffer.h`
  - `SolidSyslogStore.h`

  Also clarified that `SolidSyslogPosix*` / `SolidSyslogWindows*` rows live under `Platform/<os>/Interface/`, not `Core/Interface/`.
- **docs/rfc-compliance.md.** Noted that `SOLIDSYSLOG_TCP_DEFAULT_PORT` is defined in `Platform/Posix/Interface/SolidSyslogPosixTcpStream.h`, not Core, so readers don't go looking in the wrong place.

## Test plan

- [ ] CI passes — docs-only change, but format/lint jobs should still be green.
- [ ] Header table rows match what's actually exported (spot-check a couple of newly added rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR workflow documentation with refined branch protection requirements.
  * Enhanced public API header documentation with clarifications on platform-specific interfaces and abstraction headers.
  * Improved RFC 6587 compliance documentation with source code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->