### PR TITLE
ci: rename jobs to <category>-<platform>-<toolchain> scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,45 +591,45 @@ jobs:
                 "tools": [
                   {
                     "id": "junit",
-                    "name": "Unit Tests (GCC)",
+                    "name": "build-linux-gcc",
                     "pattern": "**/junit-build-linux-gcc/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "Unit Tests (Clang)",
+                    "name": "build-linux-clang",
                     "pattern": "**/junit-build-linux-clang/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "Unit Tests (Sanitize)",
+                    "name": "sanitize-linux-gcc",
                     "pattern": "**/junit-sanitize-linux-gcc/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "Integration Tests (OpenSSL)",
+                    "name": "integration-linux-openssl",
                     "pattern": "**/junit-integration-linux-openssl/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "BDD Tests (Linux)",
+                    "name": "bdd-linux-syslog-ng",
                     "pattern": "**/junit-bdd-linux-syslog-ng/TESTS-*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "BDD Tests (Windows)",
+                    "name": "bdd-windows-otel",
                     "pattern": "**/junit-bdd-windows-otel/TESTS-*.xml"
                   },
                   {
                     "id": "junit",
-                    "name": "Unit Tests (MSVC)",
+                    "name": "build-windows-msvc",
                     "pattern": "**/junit-build-windows-msvc/cpputest_*.xml"
                   }
                 ]
               },
               "analysis": [
                 {
-                  "name": "clang-tidy",
-                  "id": "clang-tidy",
+                  "name": "analyze-tidy",
+                  "id": "analyze-tidy",
                   "tools": [
                     {
                       "id": "clang-tidy",
@@ -638,8 +638,8 @@ jobs:
                   ]
                 },
                 {
-                  "name": "cppcheck",
-                  "id": "cppcheck",
+                  "name": "analyze-cppcheck",
+                  "id": "analyze-cppcheck",
                   "tools": [
                     {
                       "id": "cppcheck",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
+  build-linux-gcc:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-gcc
+          name: junit-build-linux-gcc
           path: build/debug/cpputest_*.xml
           retention-days: 1
 
@@ -61,7 +61,7 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  openssl-integration:
+  integration-linux-openssl:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,11 +98,11 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-openssl-integration
+          name: junit-integration-linux-openssl
           path: build/debug/cpputest_*.xml
           retention-days: 1
 
-  clang-build-and-test:
+  build-linux-clang:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,11 +136,11 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-clang
+          name: junit-build-linux-clang
           path: build/clang-debug/cpputest_*.xml
           retention-days: 1
 
-  sanitize:
+  sanitize-linux-gcc:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -174,11 +174,11 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-sanitize
+          name: junit-sanitize-linux-gcc
           path: build/sanitize/cpputest_*.xml
           retention-days: 1
 
-  coverage:
+  coverage-linux-gcc:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -246,7 +246,7 @@ jobs:
           path: build/coverage/coverage_report/
 
   deploy-coverage-pages:
-    needs: coverage
+    needs: coverage-linux-gcc
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -261,7 +261,7 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
-  tidy:
+  analyze-tidy:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/davidcozens/cpputest:sha-18f19e1
@@ -289,7 +289,7 @@ jobs:
           path: build/tidy/clang-tidy-output.txt
           retention-days: 1
 
-  format:
+  analyze-format:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/davidcozens/cpputest:sha-18f19e1
@@ -307,7 +307,7 @@ jobs:
           find Core/Interface Core/Source Tests Example -name '*.c' -o -name '*.cpp' -o -name '*.h' \
             | xargs clang-format --dry-run --Werror
 
-  cppcheck:
+  analyze-cppcheck:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/davidcozens/cpputest:sha-18f19e1
@@ -347,7 +347,7 @@ jobs:
           path: build/cppcheck/cppcheck-report.xml
           retention-days: 1
 
-  windows-build-and-test:
+  build-windows-msvc:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -387,7 +387,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-msvc
+          name: junit-build-windows-msvc
           path: build/msvc-debug/cpputest_*.xml
           retention-days: 1
 
@@ -399,8 +399,8 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  bdd-windows:
-    needs: windows-build-and-test
+  bdd-windows-otel:
+    needs: build-windows-msvc
     runs-on: windows-2025
     permissions:
       contents: read
@@ -489,7 +489,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-bdd-windows
+          name: junit-bdd-windows-otel
           path: Bdd/junit/TESTS-*.xml
           retention-days: 1
 
@@ -501,8 +501,8 @@ jobs:
           echo "--- otelcol.err ---"
           cat Bdd/output/otelcol.err || true
 
-  bdd:
-    needs: build-and-test
+  bdd-linux-syslog-ng:
+    needs: build-linux-gcc
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -539,7 +539,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-bdd
+          name: junit-bdd-linux-syslog-ng
           path: Bdd/junit/TESTS-*.xml
           retention-days: 1
 
@@ -547,9 +547,9 @@ jobs:
         if: failure()
         run: docker compose -f ci/docker-compose.bdd.yml logs --no-color
 
-  quality-summary:
+  summary:
     if: always() && github.event_name == 'pull_request'
-    needs: [build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, bdd, windows-build-and-test, bdd-windows, openssl-integration]
+    needs: [build-linux-gcc, build-linux-clang, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, bdd-linux-syslog-ng, build-windows-msvc, bdd-windows-otel, integration-linux-openssl]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -592,37 +592,37 @@ jobs:
                   {
                     "id": "junit",
                     "name": "Unit Tests (GCC)",
-                    "pattern": "**/junit-gcc/cpputest_*.xml"
+                    "pattern": "**/junit-build-linux-gcc/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "Unit Tests (Clang)",
-                    "pattern": "**/junit-clang/cpputest_*.xml"
+                    "pattern": "**/junit-build-linux-clang/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "Unit Tests (Sanitize)",
-                    "pattern": "**/junit-sanitize/cpputest_*.xml"
+                    "pattern": "**/junit-sanitize-linux-gcc/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "Integration Tests (OpenSSL)",
-                    "pattern": "**/junit-openssl-integration/cpputest_*.xml"
+                    "pattern": "**/junit-integration-linux-openssl/cpputest_*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "BDD Tests (Linux)",
-                    "pattern": "**/junit-bdd/TESTS-*.xml"
+                    "pattern": "**/junit-bdd-linux-syslog-ng/TESTS-*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "BDD Tests (Windows)",
-                    "pattern": "**/junit-bdd-windows/TESTS-*.xml"
+                    "pattern": "**/junit-bdd-windows-otel/TESTS-*.xml"
                   },
                   {
                     "id": "junit",
                     "name": "Unit Tests (MSVC)",
-                    "pattern": "**/junit-msvc/cpputest_*.xml"
+                    "pattern": "**/junit-build-windows-msvc/cpputest_*.xml"
                   }
                 ]
               },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,14 +18,14 @@ All changes to `main` must go via a pull request — direct pushes are blocked b
 becomes the single commit message — so the PR title must follow Conventional Commits format (see below).
 
 **Before raising a PR — run locally:**
-- build-and-test, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format
+- build-linux-gcc, build-linux-clang, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format
 - Windows, BDD, and OpenSSL integration jobs are CI's responsibility — running them locally would slow development too much
 - Commits on the branch can be informal (work-in-progress messages are fine)
 - The PR title is what matters — it becomes the permanent commit message on `main`
 
 **Branch protection rules (configured on GitHub):**
 - Direct pushes to `main` are blocked
-- PRs require all status checks to pass before merging: build-and-test, openssl-integration, clang-build-and-test, sanitize, coverage, tidy, cppcheck, format, windows-build-and-test, bdd, bdd-windows
+- PRs require all status checks to pass before merging: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel
 - Squash merge only — other merge strategies are disabled
 - Branches are deleted automatically after merge
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,19 +4,23 @@ GitHub Actions runs all jobs in parallel on every push and pull request to `main
 
 ## Jobs
 
+Job names follow the pattern `<category>-<platform>-<toolchain-or-feature>` so additional
+compilers and BDD targets (e.g. an ARM cross-compile or FreeRTOS QEMU oracle) slot in
+without renaming what's already there.
+
 | Job | Preset | Notes |
 |---|---|---|
-| `build-and-test` | `debug` | Test results annotated on PR |
-| `clang-build-and-test` | `clang-debug` | Second compiler check using Clang 19 |
-| `sanitize` | `sanitize` | ASan + UBSan — test results annotated on PR |
-| `coverage` | `coverage` | Summary in Actions UI; HTML report deployed to GitHub Pages on merge to `main` |
-| `tidy` | `tidy` | clang-tidy — pass/fail with errors in job log |
-| `cppcheck` | `cppcheck` | cppcheck static analysis |
-| `format` | — | clang-format dry-run; fails if any file needs reformatting |
-| `windows-build-and-test` | `msvc-debug` | MSVC build on `windows-latest`; CppUTest via vcpkg; test results annotated on PR |
-| `openssl-integration` | `debug` | Runs the in-process TLS integration tests against libssl (no network oracle) |
-| `bdd` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave), Linux runner |
-| `bdd-windows` | — | Windows-eligible BDD scenarios driven against an OTel Collector oracle |
+| `build-linux-gcc` | `debug` | Test results annotated on PR |
+| `build-linux-clang` | `clang-debug` | Second compiler check using Clang 19 |
+| `build-windows-msvc` | `msvc-debug` | MSVC build on `windows-latest`; CppUTest via vcpkg; test results annotated on PR |
+| `sanitize-linux-gcc` | `sanitize` | ASan + UBSan — test results annotated on PR |
+| `coverage-linux-gcc` | `coverage` | Summary in Actions UI; HTML report deployed to GitHub Pages on merge to `main` |
+| `analyze-tidy` | `tidy` | clang-tidy — pass/fail with errors in job log |
+| `analyze-cppcheck` | `cppcheck` | cppcheck static analysis |
+| `analyze-format` | — | clang-format dry-run; fails if any file needs reformatting |
+| `integration-linux-openssl` | `debug` | Runs the in-process TLS integration tests against libssl (no network oracle) |
+| `bdd-linux-syslog-ng` | — | End-to-end BDD test via Docker Compose (syslog-ng + Behave), Linux runner |
+| `bdd-windows-otel` | — | Windows-eligible BDD scenarios driven against an OTel Collector oracle |
 
 ## Branch protection
 

--- a/docs/cloning-template.md
+++ b/docs/cloning-template.md
@@ -111,8 +111,9 @@ In the GitHub repository settings, under **Pages**:
 - Set **Source** to `GitHub Actions`
 
 Without this, the `deploy-coverage-pages` job will fail on every push to `main`.
-The seven CI check jobs (`build-and-test`, `clang-build-and-test`, `sanitize`, `coverage`,
-`tidy`, `cppcheck`, `format`) are independent of Pages and will pass regardless.
+The CI check jobs (`build-linux-gcc`, `build-linux-clang`, `sanitize-linux-gcc`,
+`coverage-linux-gcc`, `analyze-tidy`, `analyze-cppcheck`, `analyze-format`) are independent
+of Pages and will pass regardless.
 
 > **Note:** GitHub Pages deployment requires a public repository, or a paid GitHub plan
 > (Pro, Team, or Enterprise) for private repositories. On a free plan with a private repo,
@@ -145,7 +146,7 @@ gh api repos/OWNER/REPO/actions/permissions/workflow \
 
 In the GitHub repository settings, under **Branches** → **Add branch protection rule** for `main`:
 - Require a pull request before merging
-- Require all status checks to pass: `build-and-test`, `clang-build-and-test`, `sanitize`, `coverage`, `tidy`, `cppcheck`, `format`
+- Require all status checks to pass: `build-linux-gcc`, `build-linux-clang`, `build-windows-msvc`, `sanitize-linux-gcc`, `coverage-linux-gcc`, `analyze-tidy`, `analyze-cppcheck`, `analyze-format`, `integration-linux-openssl`, `bdd-linux-syslog-ng`, `bdd-windows-otel`
 - Require squash merge only
 - Enable automatic branch deletion after merge
 
@@ -158,7 +159,7 @@ gh api repos/OWNER/REPO/branches/main/protection \
 {
   "required_status_checks": {
     "strict": false,
-    "contexts": ["build-and-test", "clang-build-and-test", "sanitize", "coverage", "tidy", "cppcheck", "format"]
+    "contexts": ["build-linux-gcc", "build-linux-clang", "build-windows-msvc", "sanitize-linux-gcc", "coverage-linux-gcc", "analyze-tidy", "analyze-cppcheck", "analyze-format", "integration-linux-openssl", "bdd-linux-syslog-ng", "bdd-windows-otel"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -5,7 +5,7 @@
 | Image | Tag | Used by |
 |---|---|---|
 | `ghcr.io/davidcozens/cpputest` | `sha-18f19e1` | devcontainer (`gcc` service), all CI jobs except clang |
-| `ghcr.io/davidcozens/cpputest-clang` | `sha-0385cea` | `clang` compose service, `clang-build-and-test` CI job |
+| `ghcr.io/davidcozens/cpputest-clang` | `sha-0385cea` | `clang` compose service, `build-linux-clang` CI job |
 | `balabit/syslog-ng` | `latest` | `syslog-ng` service — BDD test oracle |
 | `ghcr.io/davidcozens/behave` | `sha-3faff14` | `behave` service — Debian trixie + Python 3.12 + Behave for BDD scenarios |
 


### PR DESCRIPTION
## Summary

Establishes a regular naming pattern for CI jobs so adding new compilers (e.g. an ARM cross-compile) and new BDD targets (e.g. FreeRTOS QEMU) slot in without renaming what's already there. Categories also group neatly in the GitHub Actions UI's alphabetical sort.

### Renames

| Old | New |
|---|---|
| `build-and-test` | `build-linux-gcc` |
| `clang-build-and-test` | `build-linux-clang` |
| `windows-build-and-test` | `build-windows-msvc` |
| `sanitize` | `sanitize-linux-gcc` |
| `coverage` | `coverage-linux-gcc` |
| `tidy` | `analyze-tidy` |
| `cppcheck` | `analyze-cppcheck` |
| `format` | `analyze-format` |
| `openssl-integration` | `integration-linux-openssl` |
| `bdd` | `bdd-linux-syslog-ng` |
| `bdd-windows` | `bdd-windows-otel` |
| `quality-summary` | `summary` |
| `deploy-coverage-pages` | (unchanged — already fits) |

JUnit artifact names also follow the new scheme (`junit-<job-name>`) so they pair predictably with the producing job. Internal `needs:` references and the `summary` job's pattern matchers updated in lockstep.

Doc references updated in `CLAUDE.md`, `docs/ci.md`, `docs/containers.md`, `docs/cloning-template.md`.

## Branch protection coordination

The required-status-checks list on `main` still references the old names. The PR's CI runs will report under the **new** names and won't satisfy the old required checks, so the PR can't merge until the protection rule is updated.

Recommended sequence (admin action):
1. Wait for this PR's CI to go green under the new names.
2. In branch-protection settings, replace the old required-check list with the new names: `build-linux-gcc`, `build-linux-clang`, `build-windows-msvc`, `sanitize-linux-gcc`, `coverage-linux-gcc`, `analyze-tidy`, `analyze-cppcheck`, `analyze-format`, `integration-linux-openssl`, `bdd-linux-syslog-ng`, `bdd-windows-otel`.
3. Merge this PR (squash, per project convention).

There's a brief window where main's protection list mentions checks that no PR will run anymore — fine for a single-developer project as long as no other PR is mid-flight. If concerned, the temporary workaround is to keep both old and new names in the required list during the merge window, then drop the old names afterward.

## Test plan

- [ ] CI passes — every job runs under its new name.
- [ ] `summary` job aggregates correctly (depends on all renamed jobs by their new names).
- [ ] No old job name remains anywhere (`grep -rn` after the rename came back clean).
- [ ] Branch-protection list updated before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)