### PR TITLE
feat: S13.16 SolidSyslogWindowsFile — file abstraction using <io.h>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,7 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogCrc16Policy.h` | System setup code using CRC-16 integrity | `SolidSyslogCrc16Policy_Create`, `_Destroy` |
 | `SolidSyslogCrc16.h` | Any code needing CRC-16 computation | `SolidSyslogCrc16_Compute` |
 | `SolidSyslogPosixFile.h` | System setup code using POSIX file I/O | `SolidSyslogPosixFile_Create`, `_Destroy` |
+| `SolidSyslogWindowsFile.h` | System setup code using Windows file I/O (MSVC `<io.h>`) | `SolidSyslogWindowsFile_Create`, `_Destroy` |
 | `SolidSyslogPosixClock.h` | System setup code using POSIX clock | `SolidSyslogPosixClock_GetTimestamp` |
 | `SolidSyslogPosixHostname.h` | String callback implementor using POSIX hostname | `SolidSyslogPosixHostname_Get` (writes into `SolidSyslogFormatter*`) |
 | `SolidSyslogPosixProcessId.h` | String callback implementor using POSIX process ID | `SolidSyslogPosixProcessId_Get` (writes into `SolidSyslogFormatter*`) |

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,52 @@
 # Dev Log
 
+## 2026-04-26 — S13.16 WindowsFile — file abstraction using `<io.h>`
+
+### Decisions
+- **MSVC `<io.h>` underscore wrappers, not Win32 `CreateFile`/`ReadFile`.**
+  `<io.h>` keeps the same `int fd` model and `INVALID_FD = -1` sentinel
+  that `SolidSyslogPosixFile` uses, so the two impls read line-for-line
+  alongside each other. Win32 native (HANDLE, `INVALID_HANDLE_VALUE`,
+  overlapped I/O signature differences) would have produced a much
+  larger diff with no behavioural gain — the file abstraction is
+  blocking + sequential by design.
+- **`_O_BINARY` is mandatory.** Without it the MSVC CRT translates
+  `0x0A` → `0x0D 0x0A` on write and strips `0x0D` on read. That would
+  silently corrupt `SolidSyslogFileStore` data the moment a frame
+  contained either byte. Added a regression test
+  (`BinaryRoundTripPreservesNewlineBytes`) that writes a payload
+  containing `0x0A` and `0x0D` and asserts byte-for-byte round-trip.
+- **`_sopen_s` over `_open`.** Plain `_open` triggers MSVC C4996
+  (deprecation in favour of safe-CRT variants) and the project's
+  banned-API policy forbids re-introducing `_CRT_SECURE_NO_WARNINGS`.
+  `_sopen_s(&fd, path, oflag, _SH_DENYNO, pmode)` is the non-deprecated
+  equivalent; `_SH_DENYNO` matches POSIX `open()`'s default of no share
+  restriction. `_close`, `_read`, `_write`, `_lseeki64`, `_chsize_s`,
+  `_access`, `_unlink` do not trigger C4996 and are used directly.
+- **Tests hit the real filesystem.** Same approach as
+  `SolidSyslogPosixFileTest`. No UT_PTR_SET seam, no fake — just open,
+  write, read, seek, truncate, exists, delete against a path under
+  `GetTempPathA`. The MSVC POSIX-compat layer is what production uses
+  in anger, so exercising the real CRT is the truthful test.
+
+### Deferred
+- **`SolidSyslogFileStore` wiring on Windows** — needs a threaded
+  buffer to be useful end-to-end (single-task example would not
+  exercise S&F). Story for that lands once the Windows threaded buffer
+  is in place.
+- **`_chsize_s` / `_lseeki64` return-value checks.** `SolidSyslogPosixFile`
+  ignores the return values of `ftruncate` / `lseek` likewise; matching
+  the same risk profile keeps the impls symmetric. If a future story
+  adds error reporting to the `SolidSyslogFile` vtable both impls get
+  upgraded together.
+- **Cross-platform unification under a shared `SolidSyslogFile` impl.**
+  Considered briefly — both impls would need conditional includes and
+  the underscore-prefix divergence would litter the source. The
+  per-platform impls are cleaner.
+
+### Open questions
+- None.
+
 ## 2026-04-26 — S13.09 WinsockTcpStream — Windows TCP transport
 
 ### Decisions

--- a/Platform/Windows/CMakeLists.txt
+++ b/Platform/Windows/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 if(HAVE_WINDOWS_PLATFORM)
     target_sources(${PROJECT_NAME} PRIVATE
         Source/SolidSyslogWindowsClock.c
+        Source/SolidSyslogWindowsFile.c
         Source/SolidSyslogWindowsHostname.c
         Source/SolidSyslogWindowsProcessId.c
     )

--- a/Platform/Windows/Interface/SolidSyslogWindowsFile.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsFile.h
@@ -1,0 +1,25 @@
+#ifndef SOLIDSYSLOGWINDOWSFILE_H
+#define SOLIDSYSLOGWINDOWSFILE_H
+
+#include "SolidSyslogFile.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    enum
+    {
+        SOLIDSYSLOG_WINDOWS_FILE_SIZE = sizeof(intptr_t) * 11
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_WINDOWS_FILE_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogWindowsFileStorage;
+
+    struct SolidSyslogFile* SolidSyslogWindowsFile_Create(SolidSyslogWindowsFileStorage * storage);
+    void                    SolidSyslogWindowsFile_Destroy(struct SolidSyslogFile * file);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSFILE_H */

--- a/Platform/Windows/Source/SolidSyslogWindowsFile.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsFile.c
@@ -1,0 +1,147 @@
+#include "SolidSyslogWindowsFile.h"
+#include "SolidSyslogFileDefinition.h"
+#include "SolidSyslogMacros.h"
+
+#include <fcntl.h>
+#include <io.h>
+#include <share.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+/* _O_BINARY disables the MSVC CRT's CR/LF translation on read/write so
+ * arbitrary binary content (e.g. SolidSyslogFileStore frames) round-trips
+ * unchanged. Without it the CRT substitutes 0x0D 0x0A for 0x0A on write
+ * and the inverse on read, corrupting any byte that happens to fall on
+ * those values. */
+#define DEFAULT_OPEN_FLAGS (_O_RDWR | _O_CREAT | _O_BINARY)
+#define DEFAULT_FILE_PERMISSIONS (_S_IREAD | _S_IWRITE)
+
+enum
+{
+    INVALID_FD             = -1,
+    ACCESS_EXISTENCE_CHECK = 0 /* equivalent to POSIX F_OK; <io.h> does not define an alias */
+};
+
+static bool   Open(struct SolidSyslogFile* self, const char* path);
+static void   Close(struct SolidSyslogFile* self);
+static bool   IsOpen(struct SolidSyslogFile* self);
+static bool   Read(struct SolidSyslogFile* self, void* buf, size_t count);
+static bool   Write(struct SolidSyslogFile* self, const void* buf, size_t count);
+static void   SeekTo(struct SolidSyslogFile* self, size_t offset);
+static size_t Size(struct SolidSyslogFile* self);
+static void   Truncate(struct SolidSyslogFile* self);
+static bool   Exists(struct SolidSyslogFile* self, const char* path);
+static bool   Delete(struct SolidSyslogFile* self, const char* path);
+
+struct SolidSyslogWindowsFile
+{
+    struct SolidSyslogFile base;
+    int                    fd;
+};
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogWindowsFile) <= sizeof(SolidSyslogWindowsFileStorage),
+                          "SOLIDSYSLOG_WINDOWS_FILE_SIZE is too small for struct SolidSyslogWindowsFile");
+
+static const struct SolidSyslogWindowsFile DEFAULT_INSTANCE = {
+    {Open, Close, IsOpen, Read, Write, SeekTo, Size, Truncate, Exists, Delete},
+    INVALID_FD,
+};
+
+static const struct SolidSyslogWindowsFile DESTROYED_INSTANCE = {
+    {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
+    INVALID_FD,
+};
+
+struct SolidSyslogFile* SolidSyslogWindowsFile_Create(SolidSyslogWindowsFileStorage* storage)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) storage;
+    *windows                               = DEFAULT_INSTANCE;
+    return &windows->base;
+}
+
+void SolidSyslogWindowsFile_Destroy(struct SolidSyslogFile* file)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) file;
+
+    if (windows->fd != INVALID_FD)
+    {
+        _close(windows->fd);
+    }
+
+    *windows = DESTROYED_INSTANCE;
+}
+
+static bool Open(struct SolidSyslogFile* self, const char* path)
+{
+    /* _sopen_s is the non-deprecated MSVC equivalent of POSIX open(): the
+     * plain _open triggers C4996 (Microsoft's safe-CRT preference) and
+     * _CRT_SECURE_NO_WARNINGS is forbidden by the project's banned-API
+     * policy. _SH_DENYNO matches POSIX open()'s default of no share mode. */
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    errno_t                        err     = _sopen_s(&windows->fd, path, DEFAULT_OPEN_FLAGS, _SH_DENYNO, DEFAULT_FILE_PERMISSIONS);
+    if (err != 0)
+    {
+        windows->fd = INVALID_FD;
+    }
+    return windows->fd != INVALID_FD;
+}
+
+static void Close(struct SolidSyslogFile* self)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+
+    if (windows->fd != INVALID_FD)
+    {
+        _close(windows->fd);
+        windows->fd = INVALID_FD;
+    }
+}
+
+static bool IsOpen(struct SolidSyslogFile* self)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    return windows->fd != INVALID_FD;
+}
+
+static bool Read(struct SolidSyslogFile* self, void* buf, size_t count)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    return _read(windows->fd, buf, (unsigned int) count) == (int) count;
+}
+
+static bool Write(struct SolidSyslogFile* self, const void* buf, size_t count)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    return _write(windows->fd, buf, (unsigned int) count) == (int) count;
+}
+
+static void SeekTo(struct SolidSyslogFile* self, size_t offset)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    _lseeki64(windows->fd, (__int64) offset, SEEK_SET);
+}
+
+static size_t Size(struct SolidSyslogFile* self)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    __int64                        size    = _lseeki64(windows->fd, 0, SEEK_END);
+    return (size >= 0) ? (size_t) size : 0;
+}
+
+static void Truncate(struct SolidSyslogFile* self)
+{
+    struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
+    _chsize_s(windows->fd, 0);
+}
+
+static bool Exists(struct SolidSyslogFile* self, const char* path)
+{
+    (void) self;
+    return _access(path, ACCESS_EXISTENCE_CHECK) == 0;
+}
+
+static bool Delete(struct SolidSyslogFile* self, const char* path)
+{
+    (void) self;
+    return _unlink(path) == 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 if(HAVE_WINDOWS_PLATFORM)
     list(APPEND TEST_SOURCES
         SolidSyslogWindowsClockTest.cpp
+        SolidSyslogWindowsFileTest.cpp
         SolidSyslogWindowsHostnameTest.cpp
         SolidSyslogWindowsProcessIdTest.cpp
     )

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -1,0 +1,143 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogWindowsFile.h"
+
+#include <cstdio>
+#include <string>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+// clang-format off
+
+static std::string MakeTempPath(const char* filename)
+{
+    char  tempDir[MAX_PATH] = {};
+    DWORD len               = GetTempPathA(MAX_PATH, tempDir);
+    return std::string(tempDir, len) + filename;
+}
+
+TEST_GROUP(SolidSyslogWindowsFile)
+{
+    SolidSyslogWindowsFileStorage storage = {};
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogFile* file = nullptr;
+    std::string testPath;
+
+    void setup() override
+    {
+        testPath = MakeTempPath("test_windows_file.dat");
+        std::remove(testPath.c_str());
+        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
+        file = SolidSyslogWindowsFile_Create(&storage);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogWindowsFile_Destroy(file);
+        std::remove(testPath.c_str());
+    }
+
+    void OpenTestFile() const
+    {
+        CHECK_TRUE(SolidSyslogFile_Open(file, testPath.c_str()));
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWindowsFile, CreateReturnsNonNull)
+{
+    CHECK_TRUE(file != nullptr);
+}
+
+TEST(SolidSyslogWindowsFile, CreateReturnsHandleInsideCallerSuppliedStorage)
+{
+    SolidSyslogWindowsFileStorage localStorage{};
+    struct SolidSyslogFile*       localFile = SolidSyslogWindowsFile_Create(&localStorage);
+    POINTERS_EQUAL(&localStorage, localFile);
+    SolidSyslogWindowsFile_Destroy(localFile);
+}
+
+TEST(SolidSyslogWindowsFile, IsOpenReturnsFalseBeforeOpen)
+{
+    CHECK_FALSE(SolidSyslogFile_IsOpen(file));
+}
+
+TEST(SolidSyslogWindowsFile, OpenReturnsTrue)
+{
+    OpenTestFile();
+}
+
+TEST(SolidSyslogWindowsFile, OpenSetsIsOpen)
+{
+    OpenTestFile();
+    CHECK_TRUE(SolidSyslogFile_IsOpen(file));
+}
+
+TEST(SolidSyslogWindowsFile, CloseResetsIsOpen)
+{
+    OpenTestFile();
+    SolidSyslogFile_Close(file);
+    CHECK_FALSE(SolidSyslogFile_IsOpen(file));
+}
+
+TEST(SolidSyslogWindowsFile, WriteAndReadRoundTrip)
+{
+    OpenTestFile();
+    CHECK_TRUE(SolidSyslogFile_Write(file, "hello", 5));
+    SolidSyslogFile_SeekTo(file, 0);
+
+    char buf[16] = {};
+    CHECK_TRUE(SolidSyslogFile_Read(file, buf, 5));
+    MEMCMP_EQUAL("hello", buf, 5);
+}
+
+TEST(SolidSyslogWindowsFile, SizeReturnsFileSize)
+{
+    OpenTestFile();
+    LONGS_EQUAL(0, SolidSyslogFile_Size(file));
+    CHECK_TRUE(SolidSyslogFile_Write(file, "hello", 5));
+    LONGS_EQUAL(5, SolidSyslogFile_Size(file));
+}
+
+TEST(SolidSyslogWindowsFile, TruncateClearsFile)
+{
+    OpenTestFile();
+    CHECK_TRUE(SolidSyslogFile_Write(file, "hello", 5));
+    SolidSyslogFile_Truncate(file);
+    LONGS_EQUAL(0, SolidSyslogFile_Size(file));
+}
+
+TEST(SolidSyslogWindowsFile, BinaryRoundTripPreservesNewlineBytes)
+{
+    /* Without _O_BINARY the MSVC CRT would substitute 0x0D 0x0A for 0x0A on
+     * write and strip 0x0D on read. This test catches a regression where the
+     * flag is dropped or replaced with _O_TEXT. */
+    OpenTestFile();
+    const unsigned char payload[] = {0x01, 0x0A, 0x0D, 0x0A, 0xFF};
+    CHECK_TRUE(SolidSyslogFile_Write(file, payload, sizeof(payload)));
+    SolidSyslogFile_SeekTo(file, 0);
+
+    unsigned char roundTrip[sizeof(payload)] = {};
+    CHECK_TRUE(SolidSyslogFile_Read(file, roundTrip, sizeof(roundTrip)));
+    MEMCMP_EQUAL(payload, roundTrip, sizeof(payload));
+    LONGS_EQUAL(sizeof(payload), SolidSyslogFile_Size(file));
+}
+
+TEST(SolidSyslogWindowsFile, OpenWithInvalidPathReturnsFalse)
+{
+    CHECK_FALSE(SolidSyslogFile_Open(file, "C:\\nonexistent_dir_solidsyslog_test\\file.dat"));
+}
+
+TEST(SolidSyslogWindowsFile, DeleteRemovesFile)
+{
+    OpenTestFile();
+    SolidSyslogFile_Close(file);
+    CHECK_TRUE(SolidSyslogFile_Delete(file, testPath.c_str()));
+    CHECK_FALSE(SolidSyslogFile_Exists(file, testPath.c_str()));
+}
+
+TEST(SolidSyslogWindowsFile, DeleteReturnsFalseForNonexistentFile)
+{
+    CHECK_FALSE(SolidSyslogFile_Delete(file, MakeTempPath("nonexistent_windows_file.dat").c_str()));
+}


### PR DESCRIPTION
## Summary

- New `SolidSyslogWindowsFile` — Windows impl of the `SolidSyslogFile` vtable, mirroring `SolidSyslogPosixFile` line-for-line. Same `int fd` model, same `INVALID_FD = -1` sentinel, same vtable instance pattern.
- Differences confined to MSVC's `<io.h>` CRT names: `_sopen_s` (not the C4996-deprecated `_open`), `_close`, `_read`, `_write`, `_lseeki64`, `_chsize_s`, `_access`, `_unlink`. `_SH_DENYNO` matches POSIX `open()`'s default share mode.
- `_O_BINARY` is mandatory and tested explicitly: without it the MSVC CRT translates `0x0A` → `0x0D 0x0A` on write and strips `0x0D` on read, which would silently corrupt `SolidSyslogFileStore` frames. New regression test `BinaryRoundTripPreservesNewlineBytes` writes a payload containing both bytes and asserts byte-for-byte round-trip.
- Tests hit the real filesystem at a path resolved via `GetTempPathA` — same approach as `SolidSyslogPosixFileTest`. No UT_PTR_SET seam.

## Test plan

- [x] `msvc-debug` build green locally — 612 tests, 610 ran, 0 failures (was 599 before; +13 new).
- [x] Linux gates green via devcontainer: `debug` (gcc), `clang-debug`, `sanitize`, `tidy`, `cppcheck`, `coverage` (100% lines / 100% functions on the Posix side; the new Windows code is gated behind `HAVE_WINDOWS_PLATFORM` and isn't compiled there).
- [x] `clang-format --dry-run --Werror` clean across `Core/Interface Core/Source Platform Tests Example`.

## Out of scope

- `SolidSyslogFileStore` wiring on Windows — needs a threaded buffer to be useful end-to-end (single-task example wouldn't exercise S&F). Future story.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)