### PR TITLE
docs: add summary to required-checks list in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ becomes the single commit message — so the PR title must follow Conventional C
 
 **Branch protection rules (configured on GitHub):**
 - Direct pushes to `main` are blocked
-- PRs require all status checks to pass before merging: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel
+- PRs require all status checks to pass before merging: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel, summary
 - Squash merge only — other merge strategies are disabled
 - Branches are deleted automatically after merge
 


### PR DESCRIPTION
## Summary

- Adds `summary` (the Quality Summary aggregation job) to CLAUDE.md's branch-protection required-checks list, aligning the doc with the live setting after today's protection update.

## Context

After the rename PR #212 (`build-and-test` → `build-linux-gcc` etc.) the CLAUDE.md required-checks list was already up to date with the new names. Today's branch-protection change added `summary` to the required contexts so it gates merges on PRs (it was already running on every PR, just not gating). This brings the doc in line.

## Test plan

- [x] No code change; just one line in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced branch protection rules by adding an additional required status check to strengthen code quality assurance processes before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->