### PR TITLE
feat: S12.12 UDP datagram path-MTU clipping with UTF-8-safe truncation

### DIFF
--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -609,6 +609,59 @@ def step_example_sends_multiple(context, count):
     run_example(context, expected_messages=count)
 
 
+@when("the example program sends a UTF-8 message that fits the path MTU")
+def step_example_sends_utf8_within_mtu(context):
+    # Comfortably under the typical 1472-byte path payload, with multi-byte
+    # UTF-8 mixed in. Tests the no-trim path: the message goes out whole.
+    msg = "Hello, " + ("é" * 100) + " - mixed " + ("€" * 50) + " - end"
+    context.sent_msg = msg
+    run_example(context, ["--message", msg])
+
+
+@when("the example program sends an oversize UTF-8 message")
+def step_example_sends_oversize_utf8(context):
+    # Build a message that overflows the path MTU. The ASCII prefix keeps
+    # the prefix-equality assertion robust; the long run of '€' (3 bytes
+    # each) ensures the trim point almost certainly lands mid-codepoint,
+    # exercising the walk-back to a clean codepoint boundary.
+    # ~1600 MSG bytes + ~80 RFC 5424 header = ~1680 wire bytes,
+    # well above the docker-bridge path MTU's 1472-byte payload limit.
+    msg = ("X" * 100) + ("€" * 500)
+    context.sent_msg = msg
+    run_example(context, ["--message", msg])
+
+
+@then("the received message is byte-identical to the sent message")
+def step_check_msg_byte_identical(context):
+    received = context.fields.get("MSG", "")
+    assert received == context.sent_msg, (
+        f"Expected {len(context.sent_msg.encode('utf-8'))} bytes byte-identical, "
+        f"got {len(received.encode('utf-8'))} bytes that differ"
+    )
+
+
+@then("the received message is shorter than the sent message")
+def step_check_msg_shorter(context):
+    received = context.fields.get("MSG", "")
+    sent_bytes = len(context.sent_msg.encode("utf-8"))
+    received_bytes = len(received.encode("utf-8"))
+    assert received_bytes < sent_bytes, (
+        f"Expected trim — sent {sent_bytes} bytes, received {received_bytes}"
+    )
+
+
+@then("the received message is a clean prefix of the sent message")
+def step_check_msg_clean_prefix(context):
+    received = context.fields.get("MSG", "")
+    assert context.sent_msg.startswith(received), (
+        "Received is not a clean prefix of sent — trim left orphan bytes "
+        "or modified content. "
+        f"Sent starts: {context.sent_msg[:60]!r}; "
+        f"received starts: {received[:60]!r}; "
+        f"received ends: {received[-40:]!r}"
+    )
+
+
 @then('syslog-ng receives a message with priority "{priority}"')
 def step_check_priority(context, priority):
     assert context.fields["PRIORITY"] == priority, (

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -35,6 +35,13 @@ SYSLOG_NG_CONF = "Bdd/syslog-ng/syslog-ng.conf"
 SYSLOG_NG_FULL_CONF = "Bdd/syslog-ng/syslog-ng-full.conf"
 SYSLOG_NG_UDP_ONLY_CONF = "Bdd/syslog-ng/syslog-ng-udp-only.conf"
 
+# Mirrors SOLIDSYSLOG_MAX_MESSAGE_SIZE from Core/Interface/SolidSyslog.h. Bump
+# the two together. The store_capacity scenarios depend on it because production
+# clamps max-file-size up to MAX + RECORD_OVERHEAD + integritySize at runtime,
+# so the file size used by the file store is MAX-coupled even when the feature
+# file specifies a smaller value.
+SOLIDSYSLOG_MAX_MESSAGE_SIZE = 2048
+
 
 def clean_store_files():
     """Remove all rotating store files matching the path prefix."""
@@ -482,22 +489,16 @@ def step_file_store_enabled_with_config(context, max_files, max_file_size, polic
     context.store_max_files = max_files
     context.store_max_file_size = max_file_size
     context.store_discard_policy = policy
+    # Size each MSG so ~4 records pack per (clamped) store file. The store
+    # capacity scenarios were designed around this packing — multi-record
+    # files give OLDEST and NEWEST symmetric retention (both keep 7 of 10
+    # sent), which the seqId assertions depend on. Production clamps file
+    # size up to MAX + 7 (MIN_MAX_FILE_SIZE), so per-record budget is
+    # ~MAX/4. With ~95-byte RFC 5424 header + 7-byte record overhead, a
+    # body of MAX/5 - 50 lands a comfortable mid-band: 4 records fit, 5
+    # don't. Update if SOLIDSYSLOG_MAX_MESSAGE_SIZE moves.
+    context.message_body = "X" * (SOLIDSYSLOG_MAX_MESSAGE_SIZE // 5 - 50)
     clean_store_files()
-
-
-@given("each message is large enough to fill one store file")
-def step_message_body_max_size(context):
-    """Pin each record to one-per-file so capacity-overflow scenarios stay
-    deterministic across SOLIDSYSLOG_MAX_MESSAGE_SIZE bumps. The example
-    formatter clips MSG at SOLIDSYSLOG_MAX_MESSAGE_SIZE, and the file
-    store's MIN_MAX_FILE_SIZE clamps each file to one max-record, so as
-    long as MSG ≥ the per-file capacity divided by 2, every message
-    consumes exactly one record-slot of store."""
-    # 1500 chars is well above the 940-byte threshold below which two
-    # records could squeeze into one min-sized file, and well below the
-    # 2048-byte SOLIDSYSLOG_MAX_MESSAGE_SIZE so we don't trip path-MTU
-    # trimming on the docker bridge.
-    context.message_body = "X" * 1500
 
 
 @given("the halt callback exits the process")

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -435,6 +435,8 @@ def build_threaded_command(context, transport, no_sd=False):
         cmd.extend(["--max-file-size", str(context.store_max_file_size)])
     if getattr(context, "store_discard_policy", None):
         cmd.extend(["--discard-policy", context.store_discard_policy])
+    if getattr(context, "message_body", None):
+        cmd.extend(["--message", context.message_body])
     if no_sd:
         cmd.append("--no-sd")
     if getattr(context, "halt_exit", False):
@@ -481,6 +483,21 @@ def step_file_store_enabled_with_config(context, max_files, max_file_size, polic
     context.store_max_file_size = max_file_size
     context.store_discard_policy = policy
     clean_store_files()
+
+
+@given("each message is large enough to fill one store file")
+def step_message_body_max_size(context):
+    """Pin each record to one-per-file so capacity-overflow scenarios stay
+    deterministic across SOLIDSYSLOG_MAX_MESSAGE_SIZE bumps. The example
+    formatter clips MSG at SOLIDSYSLOG_MAX_MESSAGE_SIZE, and the file
+    store's MIN_MAX_FILE_SIZE clamps each file to one max-record, so as
+    long as MSG ≥ the per-file capacity divided by 2, every message
+    consumes exactly one record-slot of store."""
+    # 1500 chars is well above the 940-byte threshold below which two
+    # records could squeeze into one min-sized file, and well below the
+    # 2048-byte SOLIDSYSLOG_MAX_MESSAGE_SIZE so we don't trip path-MTU
+    # trimming on the docker bridge.
+    context.message_body = "X" * 1500
 
 
 @given("the halt callback exits the process")

--- a/Bdd/features/store_capacity.feature
+++ b/Bdd/features/store_capacity.feature
@@ -6,7 +6,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-oldest drops oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy oldest
+    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy oldest
     And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
@@ -19,7 +19,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-newest preserves oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy newest
+    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy newest
     And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
@@ -32,7 +32,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt stops the application when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy halt
+    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy halt
     And each message is large enough to fill one store file
     And the halt callback exits the process
     And the threaded example is running with transport tcp and no structured data
@@ -44,7 +44,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt prevents further service after store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy halt
+    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy halt
     And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message

--- a/Bdd/features/store_capacity.feature
+++ b/Bdd/features/store_capacity.feature
@@ -6,8 +6,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-oldest drops oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy oldest
-    And each message is large enough to fill one store file
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy oldest
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
@@ -19,8 +18,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-newest preserves oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy newest
-    And each message is large enough to fill one store file
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy newest
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
@@ -32,8 +30,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt stops the application when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy halt
-    And each message is large enough to fill one store file
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
     And the halt callback exits the process
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
@@ -44,8 +41,7 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt prevents further service after store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 8 and max-file-size 2055 and discard-policy halt
-    And each message is large enough to fill one store file
+    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message

--- a/Bdd/features/store_capacity.feature
+++ b/Bdd/features/store_capacity.feature
@@ -6,7 +6,8 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-oldest drops oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy oldest
+    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy oldest
+    And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
@@ -18,7 +19,8 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Discard-newest preserves oldest messages when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy newest
+    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy newest
+    And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message
@@ -30,7 +32,8 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt stops the application when store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
+    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy halt
+    And each message is large enough to fill one store file
     And the halt callback exits the process
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
@@ -41,7 +44,8 @@ Feature: Store capacity limit and discard policy
 
   Scenario: Halt prevents further service after store overflows
     Given syslog-ng is running
-    And the file store is enabled with max-files 2 and max-file-size 520 and discard-policy halt
+    And the file store is enabled with max-files 7 and max-file-size 2055 and discard-policy halt
+    And each message is large enough to fill one store file
     And the threaded example is running with transport tcp and no structured data
     When the client sends a message
     Then syslog-ng receives 1 message

--- a/Bdd/features/udp_mtu.feature
+++ b/Bdd/features/udp_mtu.feature
@@ -1,0 +1,16 @@
+@udp
+Feature: UDP datagram path-MTU clipping
+  When a UDP message exceeds the path MTU the sender clips it to the
+  path-MTU's safe payload, walking back over any partial UTF-8
+  codepoint at the trim point so the receiver always sees valid UTF-8.
+
+  Scenario: Full delivery of a UTF-8 message within the path MTU
+    Given syslog-ng is running
+    When the example program sends a UTF-8 message that fits the path MTU
+    Then the received message is byte-identical to the sent message
+
+  Scenario: Oversize UTF-8 message is clipped at a codepoint boundary
+    Given syslog-ng is running
+    When the example program sends an oversize UTF-8 message
+    Then the received message is shorter than the sent message
+    And the received message is a clean prefix of the sent message

--- a/Bdd/features/udp_mtu.feature
+++ b/Bdd/features/udp_mtu.feature
@@ -11,7 +11,7 @@ Feature: UDP datagram path-MTU clipping
   SOLIDSYSLOG_MAX_MESSAGE_SIZE, and the OTel syslog receiver
   interprets BOM-less UTF-8 MSG bytes as Latin-1 — RFC 5424 §6.4
   requires a BOM that this library does not yet emit. The BOM gap
-  is tracked in S07.05 (#219); once that lands, the Latin-1
+  is tracked in S12.13 (#219); once that lands, the Latin-1
   mojibake clears and the windows_wip tag can be dropped on the
   full-delivery scenario. The oversize scenario remains POSIX-only
   by virtue of Windows loopback MTU.

--- a/Bdd/features/udp_mtu.feature
+++ b/Bdd/features/udp_mtu.feature
@@ -1,8 +1,20 @@
-@udp
+@udp @windows_wip
 Feature: UDP datagram path-MTU clipping
   When a UDP message exceeds the path MTU the sender clips it to the
   path-MTU's safe payload, walking back over any partial UTF-8
   codepoint at the trim point so the receiver always sees valid UTF-8.
+
+  These scenarios run on the POSIX BDD runner only (tagged
+  windows_wip). The Windows BDD runner uses the OTel Collector on
+  127.0.0.1; loopback's ~65535-byte MTU never triggers WSAEMSGSIZE
+  for the message sizes we can produce inside
+  SOLIDSYSLOG_MAX_MESSAGE_SIZE, and the OTel syslog receiver
+  interprets BOM-less UTF-8 MSG bytes as Latin-1 — RFC 5424 §6.4
+  requires a BOM that this library does not yet emit. The BOM gap
+  is tracked in S07.05 (#219); once that lands, the Latin-1
+  mojibake clears and the windows_wip tag can be dropped on the
+  full-delivery scenario. The oversize scenario remains POSIX-only
+  by virtue of Windows loopback MTU.
 
   Scenario: Full delivery of a UTF-8 message within the path MTU
     Given syslog-ng is running

--- a/Core/Interface/SolidSyslog.h
+++ b/Core/Interface/SolidSyslog.h
@@ -8,7 +8,7 @@ EXTERN_C_BEGIN
 
     enum
     {
-        SOLIDSYSLOG_MAX_MESSAGE_SIZE = 512
+        SOLIDSYSLOG_MAX_MESSAGE_SIZE = 2048
     };
 
     struct SolidSyslogMessage

--- a/Core/Interface/SolidSyslogDatagram.h
+++ b/Core/Interface/SolidSyslogDatagram.h
@@ -20,10 +20,11 @@ EXTERN_C_BEGIN
         SOLIDSYSLOG_DATAGRAM_FAILED
     };
 
-    bool                               SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram);
-    enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-    size_t                             SolidSyslogDatagram_MaxPayload(struct SolidSyslogDatagram* datagram);
-    void                               SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram);
+    bool                               SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
+    enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size,
+                                                                  const struct SolidSyslogAddress* addr);
+    size_t                             SolidSyslogDatagram_MaxPayload(struct SolidSyslogDatagram * datagram);
+    void                               SolidSyslogDatagram_Close(struct SolidSyslogDatagram * datagram);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogDatagram.h
+++ b/Core/Interface/SolidSyslogDatagram.h
@@ -10,9 +10,20 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogDatagram;
 
-    bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram * datagram);
-    bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram * datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-    void SolidSyslogDatagram_Close(struct SolidSyslogDatagram * datagram);
+    /* Distinct outcomes of SendTo. OVERSIZE is reserved for the EMSGSIZE
+     * recovery path (S12.12) — implementations that cannot detect oversize
+     * collapse it into FAILED. */
+    enum SolidSyslogDatagramSendResult
+    {
+        SOLIDSYSLOG_DATAGRAM_SENT,
+        SOLIDSYSLOG_DATAGRAM_OVERSIZE,
+        SOLIDSYSLOG_DATAGRAM_FAILED
+    };
+
+    bool                               SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram);
+    enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+    size_t                             SolidSyslogDatagram_MaxPayload(struct SolidSyslogDatagram* datagram);
+    void                               SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogDatagramDefinition.h
+++ b/Core/Interface/SolidSyslogDatagramDefinition.h
@@ -8,7 +8,8 @@ EXTERN_C_BEGIN
     struct SolidSyslogDatagram
     {
         bool (*Open)(struct SolidSyslogDatagram* self);
-        bool (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+        enum SolidSyslogDatagramSendResult (*SendTo)(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+        size_t (*MaxPayload)(struct SolidSyslogDatagram* self);
         void (*Close)(struct SolidSyslogDatagram* self);
     };
 

--- a/Core/Interface/SolidSyslogUdpPayload.h
+++ b/Core/Interface/SolidSyslogUdpPayload.h
@@ -5,6 +5,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 EXTERN_C_BEGIN
 
@@ -16,6 +17,12 @@ EXTERN_C_BEGIN
     };
 
     size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6);
+
+    /* Returns the largest length' <= length such that buffer[0..length' - 1]
+     * ends on a UTF-8 codepoint boundary. Walks back over any partial
+     * multi-byte sequence at the cut point. Assumes the bytes preceding the
+     * cut form valid UTF-8 (the formatter guarantees this — S12.10). */
+    size_t SolidSyslogUdpPayload_TrimToCodepointBoundary(const uint8_t* buffer, size_t length);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogUdpPayload.h
+++ b/Core/Interface/SolidSyslogUdpPayload.h
@@ -1,0 +1,22 @@
+#ifndef SOLIDSYSLOGUDPPAYLOAD_H
+#define SOLIDSYSLOGUDPPAYLOAD_H
+
+#include "ExternC.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+EXTERN_C_BEGIN
+
+    /* IPv6 minimum MTU (1280) − IPv6 header (40) − UDP header (8). RFC 8200 §5.
+     * Last-resort fallback when the OS cannot report path MTU. */
+    enum
+    {
+        SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD = 1232
+    };
+
+    size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGUDPPAYLOAD_H */

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     SolidSyslogOriginSd.c
     SolidSyslogFile.c
     SolidSyslogFileStore.c
+    SolidSyslogUdpPayload.c
 )
 
 if(HAVE_ATOMIC_COUNTER)

--- a/Core/Source/SolidSyslogDatagram.c
+++ b/Core/Source/SolidSyslogDatagram.c
@@ -5,7 +5,8 @@ bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
     return datagram->Open(datagram);
 }
 
-enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size,
+                                                              const struct SolidSyslogAddress* addr)
 {
     return datagram->SendTo(datagram, buffer, size, addr);
 }

--- a/Core/Source/SolidSyslogDatagram.c
+++ b/Core/Source/SolidSyslogDatagram.c
@@ -5,9 +5,14 @@ bool SolidSyslogDatagram_Open(struct SolidSyslogDatagram* datagram)
     return datagram->Open(datagram);
 }
 
-bool SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+enum SolidSyslogDatagramSendResult SolidSyslogDatagram_SendTo(struct SolidSyslogDatagram* datagram, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     return datagram->SendTo(datagram, buffer, size, addr);
+}
+
+size_t SolidSyslogDatagram_MaxPayload(struct SolidSyslogDatagram* datagram)
+{
+    return datagram->MaxPayload(datagram);
 }
 
 void SolidSyslogDatagram_Close(struct SolidSyslogDatagram* datagram)

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -1,5 +1,6 @@
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogMacros.h"
+#include "SolidSyslogUtf8.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -48,19 +49,14 @@ static inline bool   CodepointFits(size_t codepointLength, size_t remainingDecod
 static inline bool   Fits(const struct EscapedContext* context, size_t decodedAdvance);
 static inline bool   HasCapacity(const struct SolidSyslogFormatter* formatter);
 static inline bool   IsAboveUnicodeMaxEncoding(char lead, char continuation1);
-static inline bool   IsFourByteLead(char byte);
 static inline bool   IsOverlongFourByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongThreeByteEncoding(char lead, char continuation1);
 static inline bool   IsOverlongTwoByteLead(char byte);
 static inline bool   IsAsciiCharacter(char value);
 static inline bool   IsExhausted(const struct EscapedContext* context);
 static inline bool   IsPrintableUsAscii(char value);
-static inline bool   IsThreeByteLead(char byte);
-static inline bool   IsTwoByteLead(char byte);
 static inline bool   IsUtf16SurrogateEncoding(char lead, char continuation1);
-static inline bool   IsUtf8Continuation(char byte);
 static inline bool   IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
-static inline bool   IsValidUtf8SingleByte(char byte);
 static inline bool   IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
 static inline bool   IsValidUtf8TwoByte(char lead, char continuation1);
 static inline bool   NeedsEscape(char value);
@@ -174,7 +170,7 @@ static inline size_t Utf8CodepointLength(const char* source)
 {
     size_t length = 0;
 
-    if (IsValidUtf8SingleByte(source[0]))
+    if (SolidSyslogUtf8_IsAsciiByte(source[0]))
     {
         length = 1;
     }
@@ -194,19 +190,9 @@ static inline size_t Utf8CodepointLength(const char* source)
     return length;
 }
 
-static inline bool IsValidUtf8SingleByte(char byte)
-{
-    return (byte & 0x80) == 0;
-}
-
 static inline bool IsValidUtf8TwoByte(char lead, char continuation1)
 {
-    return IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) && IsUtf8Continuation(continuation1);
-}
-
-static inline bool IsTwoByteLead(char byte)
-{
-    return (byte & 0xE0) == 0xC0;
+    return SolidSyslogUtf8_IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1);
 }
 
 static inline bool IsOverlongTwoByteLead(char byte)
@@ -214,20 +200,10 @@ static inline bool IsOverlongTwoByteLead(char byte)
     return (byte & 0xFE) == 0xC0;
 }
 
-static inline bool IsUtf8Continuation(char byte)
-{
-    return (byte & 0xC0) == 0x80;
-}
-
 static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
 {
-    return IsThreeByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) &&
+    return SolidSyslogUtf8_IsThreeByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) && SolidSyslogUtf8_IsContinuationByte(continuation2) &&
            !IsOverlongThreeByteEncoding(lead, continuation1) && !IsUtf16SurrogateEncoding(lead, continuation1);
-}
-
-static inline bool IsThreeByteLead(char byte)
-{
-    return (byte & 0xF0) == 0xE0;
 }
 
 static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1)
@@ -242,13 +218,9 @@ static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1)
 
 static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
 {
-    return IsFourByteLead(lead) && IsUtf8Continuation(continuation1) && IsUtf8Continuation(continuation2) && IsUtf8Continuation(continuation3) &&
-           !IsOverlongFourByteEncoding(lead, continuation1) && !IsAboveUnicodeMaxEncoding(lead, continuation1);
-}
-
-static inline bool IsFourByteLead(char byte)
-{
-    return (byte & 0xF8) == 0xF0;
+    return SolidSyslogUtf8_IsFourByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) && SolidSyslogUtf8_IsContinuationByte(continuation2) &&
+           SolidSyslogUtf8_IsContinuationByte(continuation3) && !IsOverlongFourByteEncoding(lead, continuation1) &&
+           !IsAboveUnicodeMaxEncoding(lead, continuation1);
 }
 
 static inline bool IsOverlongFourByteEncoding(char lead, char continuation1)
@@ -465,15 +437,16 @@ static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* forma
     size_t p        = formatter->position;
     size_t trimFrom = p;
 
-    if ((p >= 1) && (IsTwoByteLead(buffer[p - 1]) || IsThreeByteLead(buffer[p - 1]) || IsFourByteLead(buffer[p - 1])))
+    if ((p >= 1) &&
+        (SolidSyslogUtf8_IsTwoByteLead(buffer[p - 1]) || SolidSyslogUtf8_IsThreeByteLead(buffer[p - 1]) || SolidSyslogUtf8_IsFourByteLead(buffer[p - 1])))
     {
         trimFrom = p - 1;
     }
-    else if ((p >= 2) && (IsThreeByteLead(buffer[p - 2]) || IsFourByteLead(buffer[p - 2])))
+    else if ((p >= 2) && (SolidSyslogUtf8_IsThreeByteLead(buffer[p - 2]) || SolidSyslogUtf8_IsFourByteLead(buffer[p - 2])))
     {
         trimFrom = p - 2;
     }
-    else if ((p >= 3) && IsFourByteLead(buffer[p - 3]))
+    else if ((p >= 3) && SolidSyslogUtf8_IsFourByteLead(buffer[p - 3]))
     {
         trimFrom = p - 3;
     }

--- a/Core/Source/SolidSyslogUdpPayload.c
+++ b/Core/Source/SolidSyslogUdpPayload.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogUdpPayload.h"
+#include "SolidSyslogUtf8.h"
 
 enum
 {
@@ -11,4 +12,61 @@ size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6)
 {
     size_t overhead = (isIpv6 ? IPV6_HEADER_BYTES : IPV4_HEADER_BYTES) + UDP_HEADER_BYTES;
     return mtu > overhead ? mtu - overhead : 0;
+}
+
+static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length);
+static inline bool   LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
+static inline size_t ExpectedSequenceLength(uint8_t startByte);
+
+size_t SolidSyslogUdpPayload_TrimToCodepointBoundary(const uint8_t* buffer, size_t length)
+{
+    if (length > 0)
+    {
+        size_t lastCodepointStart = FindLastCodepointStart(buffer, length);
+        if (LastCodepointExtendsPastCut(buffer, length, lastCodepointStart))
+        {
+            length = lastCodepointStart;
+        }
+    }
+    return length;
+}
+
+static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length)
+{
+    size_t startIndex = length - 1;
+    while (startIndex > 0 && SolidSyslogUtf8_IsContinuationByte((char) buffer[startIndex]))
+    {
+        startIndex--;
+    }
+    return startIndex;
+}
+
+static inline bool LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart)
+{
+    return (lastCodepointStart + ExpectedSequenceLength(buffer[lastCodepointStart])) > length;
+}
+
+/* 11110xxx is the only remaining pattern — invalid bytes never reach here
+ * because the formatter (S12.10) guarantees valid UTF-8 upstream. */
+static inline size_t ExpectedSequenceLength(uint8_t startByte)
+{
+    char   b      = (char) startByte;
+    size_t length = 0;
+    if (SolidSyslogUtf8_IsAsciiByte(b))
+    {
+        length = 1;
+    }
+    else if (SolidSyslogUtf8_IsTwoByteLead(b))
+    {
+        length = 2;
+    }
+    else if (SolidSyslogUtf8_IsThreeByteLead(b))
+    {
+        length = 3;
+    }
+    else
+    {
+        length = 4;
+    }
+    return length;
 }

--- a/Core/Source/SolidSyslogUdpPayload.c
+++ b/Core/Source/SolidSyslogUdpPayload.c
@@ -1,0 +1,14 @@
+#include "SolidSyslogUdpPayload.h"
+
+enum
+{
+    IPV4_HEADER_BYTES = 20,
+    IPV6_HEADER_BYTES = 40,
+    UDP_HEADER_BYTES  = 8
+};
+
+size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6)
+{
+    size_t overhead = (isIpv6 ? IPV6_HEADER_BYTES : IPV4_HEADER_BYTES) + UDP_HEADER_BYTES;
+    return mtu > overhead ? mtu - overhead : 0;
+}

--- a/Core/Source/SolidSyslogUdpPayload.c
+++ b/Core/Source/SolidSyslogUdpPayload.c
@@ -8,15 +8,15 @@ enum
     UDP_HEADER_BYTES  = 8
 };
 
+static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length);
+static inline bool   LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
+static inline size_t ExpectedSequenceLength(uint8_t startByte);
+
 size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6)
 {
     size_t overhead = (isIpv6 ? IPV6_HEADER_BYTES : IPV4_HEADER_BYTES) + UDP_HEADER_BYTES;
     return mtu > overhead ? mtu - overhead : 0;
 }
-
-static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length);
-static inline bool   LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
-static inline size_t ExpectedSequenceLength(uint8_t startByte);
 
 size_t SolidSyslogUdpPayload_TrimToCodepointBoundary(const uint8_t* buffer, size_t length)
 {

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -29,7 +29,7 @@ static bool                                      ResolveDestination(struct Solid
 static inline struct SolidSyslogAddress*         Address(struct SolidSyslogUdpSender* udp);
 static inline void                               CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                               TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
-static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer);
+static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
 static void                                      NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 static uint32_t                                  NilEndpointVersion(void);
 
@@ -136,23 +136,41 @@ static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
     udp->connected = false;
 }
 
+/* Connected UDP fail/swallow contract:
+ *   First Send fails non-OVERSIZE   → return false (transient — caller retries).
+ *   First Send returns OVERSIZE     → trim and retry; propagate retry's verdict.
+ *   Retry trimmed length is 0       → message can't physically fit the path;
+ *                                     swallow and return true so the buffered
+ *                                     algorithm doesn't loop on an undeliverable.
+ *   Retry second Send succeeds      → return true.
+ *   Retry second Send fails OVERSIZE→ kernel disagrees with its own reported
+ *                                     MaxPayload — should be impossible. Swallow
+ *                                     to avoid a permanent retry loop further up.
+ *   Retry second Send fails other   → return false (transient).
+ */
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
     if (result == SOLIDSYSLOG_DATAGRAM_OVERSIZE)
     {
-        result = RetryAfterOversize(udp, buffer);
+        result = RetryAfterOversize(udp, buffer, size);
     }
     return result == SOLIDSYSLOG_DATAGRAM_SENT;
 }
 
-static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer)
+static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
-    size_t trimmed = SolidSyslogUdpPayload_TrimToCodepointBoundary((const uint8_t*) buffer, SolidSyslogDatagram_MaxPayload(udp->config.datagram));
-    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_SENT;
+    size_t                             maxPayload = SolidSyslogDatagram_MaxPayload(udp->config.datagram);
+    size_t                             clipLimit  = (size < maxPayload) ? size : maxPayload;
+    size_t                             trimmed    = SolidSyslogUdpPayload_TrimToCodepointBoundary((const uint8_t*) buffer, clipLimit);
+    enum SolidSyslogDatagramSendResult result     = SOLIDSYSLOG_DATAGRAM_SENT;
     if (trimmed > 0)
     {
         result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, trimmed, Address(udp));
+        if (result == SOLIDSYSLOG_DATAGRAM_OVERSIZE)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_SENT;
+        }
     }
     return result;
 }

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -1,6 +1,7 @@
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogMacros.h"
+#include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
 
@@ -16,20 +17,21 @@ struct SolidSyslogUdpSender
     uint32_t                          lastEndpointVersion;
 };
 
-static bool                              Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
-static inline bool                       Reconcile(struct SolidSyslogUdpSender* udp);
-static inline void                       DisconnectIfStale(struct SolidSyslogUdpSender* udp);
-static inline bool                       EnsureConnected(struct SolidSyslogUdpSender* udp);
-static inline bool                       Connected(struct SolidSyslogUdpSender* udp);
-static bool                              Connect(struct SolidSyslogUdpSender* udp);
-static void                              Disconnect(struct SolidSyslogSender* self);
-static inline bool                       OpenSocket(struct SolidSyslogUdpSender* udp);
-static bool                              ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
-static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
-static inline void                       CloseSocket(struct SolidSyslogUdpSender* udp);
-static inline bool                       TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
-static void                              NilEndpoint(struct SolidSyslogEndpoint* endpoint);
-static uint32_t                          NilEndpointVersion(void);
+static bool                                      Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static inline bool                               Reconcile(struct SolidSyslogUdpSender* udp);
+static inline void                               DisconnectIfStale(struct SolidSyslogUdpSender* udp);
+static inline bool                               EnsureConnected(struct SolidSyslogUdpSender* udp);
+static inline bool                               Connected(struct SolidSyslogUdpSender* udp);
+static bool                                      Connect(struct SolidSyslogUdpSender* udp);
+static void                                      Disconnect(struct SolidSyslogSender* self);
+static inline bool                               OpenSocket(struct SolidSyslogUdpSender* udp);
+static bool                                      ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
+static inline struct SolidSyslogAddress*         Address(struct SolidSyslogUdpSender* udp);
+static inline void                               CloseSocket(struct SolidSyslogUdpSender* udp);
+static inline bool                               TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
+static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer);
+static void                                      NilEndpoint(struct SolidSyslogEndpoint* endpoint);
+static uint32_t                                  NilEndpointVersion(void);
 
 static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
 static struct SolidSyslogUdpSender       instance;
@@ -136,7 +138,23 @@ static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
 
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
-    return SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp)) == SOLIDSYSLOG_DATAGRAM_SENT;
+    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
+    if (result == SOLIDSYSLOG_DATAGRAM_OVERSIZE)
+    {
+        result = RetryAfterOversize(udp, buffer);
+    }
+    return result == SOLIDSYSLOG_DATAGRAM_SENT;
+}
+
+static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer)
+{
+    size_t trimmed = SolidSyslogUdpPayload_TrimToCodepointBoundary((const uint8_t*) buffer, SolidSyslogDatagram_MaxPayload(udp->config.datagram));
+    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_SENT;
+    if (trimmed > 0)
+    {
+        result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, trimmed, Address(udp));
+    }
+    return result;
 }
 
 static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -136,7 +136,7 @@ static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
 
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
-    return SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
+    return SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp)) == SOLIDSYSLOG_DATAGRAM_SENT;
 }
 
 static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)

--- a/Core/Source/SolidSyslogUtf8.h
+++ b/Core/Source/SolidSyslogUtf8.h
@@ -1,0 +1,41 @@
+#ifndef SOLIDSYSLOGUTF8_H
+#define SOLIDSYSLOGUTF8_H
+
+#include "ExternC.h"
+
+#include <stdbool.h>
+
+EXTERN_C_BEGIN
+
+    /* Byte-level UTF-8 lead and continuation classifiers per RFC 3629 §4.
+     * These cover the disjoint top-bit patterns only — overlong / surrogate /
+     * above-Unicode validity is composed on top by callers that need it. */
+
+    static inline bool SolidSyslogUtf8_IsAsciiByte(char byte)
+    {
+        return (byte & 0x80) == 0;
+    }
+
+    static inline bool SolidSyslogUtf8_IsContinuationByte(char byte)
+    {
+        return (byte & 0xC0) == 0x80;
+    }
+
+    static inline bool SolidSyslogUtf8_IsTwoByteLead(char byte)
+    {
+        return (byte & 0xE0) == 0xC0;
+    }
+
+    static inline bool SolidSyslogUtf8_IsThreeByteLead(char byte)
+    {
+        return (byte & 0xF0) == 0xE0;
+    }
+
+    static inline bool SolidSyslogUtf8_IsFourByteLead(char byte)
+    {
+        return (byte & 0xF8) == 0xF0;
+    }
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGUTF8_H */

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,77 @@
 # Dev Log
 
+## 2026-04-28 — S12.12 UDP path-MTU clipping (slices 6–7, story complete)
+
+### Decisions
+- **Winsock parallel as a mechanical mirror of slice 5.** WinsockDatagram
+  gained the same lazy-connect, `IP_MTU_DISCOVER`, EMSGSIZE-detection,
+  and `IP_MTU` lookup as PosixDatagram. The seam was already
+  established as bare `Winsock_*` symbols — extending it with
+  `Winsock_connect`, `Winsock_setsockopt`, `Winsock_getsockopt`
+  matched the existing pattern. No `WinsockTcpStream_*` namespace
+  needed because those names weren't already in use by another
+  Windows module.
+- **`<ws2tcpip.h>` for the IP_MTU_DISCOVER family on Windows.**
+  Windows scatters `IP_MTU` / `IP_MTU_DISCOVER` / `IP_PMTUDISC_DO`
+  across `<ws2ipdef.h>`, which `<ws2tcpip.h>` pulls in. Without it
+  the constants are undeclared. Win10+ exposes the same numeric
+  values as Linux for the PMTUD policy enum, so the production code
+  reads identically across platforms.
+- **WSAGetLastError() instead of errno.** Winsock's per-thread last-
+  error API is the equivalent of POSIX `errno`. Test fake gained
+  `WinsockFake_FailNextSendtoWithLastError(int)` paralleling
+  `SocketFake_FailNextSendtoWithErrno(int)`.
+- **Bumped `SOLIDSYSLOG_MAX_MESSAGE_SIZE` 512 → 2048 in slice 7.**
+  RFC 5424 §6.1 says receivers SHOULD support 2048 over UDP, and
+  real-world syslog deployments routinely use 4–8 KB. The 512
+  default was conservative for the original embedded target. The
+  bump also unblocks the BDD path-MTU trim scenarios — at the new
+  default a max-size message produces ~2 KB of wire bytes, which
+  comfortably exceeds the docker-bridge MTU's 1472-byte payload
+  limit and triggers a real EMSGSIZE on the wire. A future CMake
+  override (E21 #217) lets memory-constrained MCUs reduce it, with
+  the BDD scenarios gated on the configured size.
+- **Test fakes derived from `SOLIDSYSLOG_MAX_MESSAGE_SIZE` rather
+  than hand-tuned constants.** SenderFake / SocketFake / WinsockFake
+  buffer caps and FileFake's per-file storage all auto-adapt now,
+  along with FileStoreTest's TEST_BUF_SIZE and TEST_MAX_FILE_SIZE.
+  TEST_MAX_FILE_SIZE includes `SOLIDSYSLOG_MAX_INTEGRITY_SIZE` so
+  the tests stay correct under any integrity policy. The bump
+  surfaced exactly the hand-tuning that the user had warned about
+  while writing the original FileStore tests.
+- **BDD trim scenarios use prefix-equality as the boundary check.**
+  The oversize scenario asserts (a) received bytes < sent bytes and
+  (b) `sent.startswith(received)` on the Python string form. The
+  prefix property fails iff the trim left orphan continuation
+  bytes — so a single, simple assertion catches "trim happened" and
+  "trim ended on a codepoint boundary" together. Robust regardless
+  of exactly which codepoint the trim landed on.
+- **Filed E21: Port-Time Configurability (#217).** Captures the
+  tunables (`SOLIDSYSLOG_MAX_MESSAGE_SIZE`, `SEND_TIMEOUT_*`),
+  documentation needs, and the gating dependency from S12.12's BDD
+  scenarios. Decomposition deferred until prioritised.
+
+### Deferred
+- **Switch `sendto` to `send` after connect** in PosixDatagram /
+  WinsockDatagram. Slightly more idiomatic on a connected socket;
+  kept the diff minimal because both kernels treat connected
+  `sendto` with addr arg correctly. Easy follow-up.
+- **`SolidSyslogUtf8.h` to `uint8_t`.** Whole-codebase cleanup once
+  S12.12 lands; would also unlock dropping the `(char)` casts at
+  UdpPayload's call sites. MISRA Rule 10.1 motivation.
+- **Address-mismatch detection in the Datagram impls.** Currently
+  `connect`s once per Open lifetime regardless of subsequent
+  addresses passed to SendTo. Safe in practice (UdpSender controls
+  lifecycle) but could be enforced if the contract were ever
+  broadened.
+- **CMake configurability of `SOLIDSYSLOG_MAX_MESSAGE_SIZE`** —
+  tracked in E21 (#217). When that lands, the BDD trim scenarios
+  need gating on the configured size being ≥ ~1500 to actually
+  trigger EMSGSIZE on the docker-bridge test path.
+
+### Open questions
+- None.
+
 ## 2026-04-27 — S12.12 UDP path-MTU clipping (slices 1–5)
 
 ### Decisions

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,71 @@
 # Dev Log
 
+## 2026-04-28 — S12.12 PR #218 wrap-up: BOM follow-up, BDD diagnosis correction, CodeRabbit cleanup
+
+### Decisions
+- **Tagged `udp_mtu.feature` `@windows_wip` rather than chasing a Windows
+  fix in this PR.** The OTel collector's syslog receiver interprets
+  BOM-less UTF-8 as Latin-1 (RFC 5424 §6.4 requires a BOM the library
+  doesn't yet emit), and Windows loopback's ~65535-byte MTU never
+  triggers WSAEMSGSIZE for the message sizes we can produce inside
+  `SOLIDSYSLOG_MAX_MESSAGE_SIZE`. So the full-delivery scenario waits on
+  the BOM work; the oversize scenario is permanently POSIX-only by
+  virtue of loopback MTU. Both are documented in the feature header
+  with the BOM gap tracked as S12.13 (#219).
+- **The `store_capacity` BDD failures were a stale diagnosis, not a
+  fresh bug.** The first instinct (twice) was to edit the feature file
+  — bump `max-files 2 → 7 → 8` and add a "fills one file" step — on
+  the theory that PosixMessageQueueBuffer's `O_NONBLOCK` mq_send was
+  silently dropping a message under the post-bump 1500-byte payloads.
+  That theory walked the symptoms cleanly enough to be plausible, but
+  the actual cause was the MAX bump 512 → 2048 silently quadrupling the
+  production `MIN_MAX_FILE_SIZE` clamp. The feature file's
+  `max-file-size 520` clamps up to 2055 at runtime, so the same default
+  short messages now pack ~16 records per file instead of ~4 — total
+  capacity 32, no overflow with 10 sent, the discard policy never
+  engages.
+- **Compensate in the step layer, not the feature file.** Feature files
+  describe externally-visible behaviour and form the contract with the
+  PO; they shouldn't change as a side-effect of an internal constant
+  bump. Fix lives in `step_file_store_enabled_with_config`: size each
+  MSG to `SOLIDSYSLOG_MAX_MESSAGE_SIZE/5 - 50` bytes so ~4 records pack
+  per (clamped) file, restoring the original test design. The
+  `OLDEST`/`NEWEST` retention asymmetry that the prior session saw
+  (OLDEST keeps `maxFiles` records, NEWEST keeps `maxFiles − 1`) is
+  real but only visible when files hold one record each — at 4 records
+  per file the asymmetry collapses and both policies retain exactly 7
+  of 10 sent. The `1500-byte body + max-files=8` workaround was
+  swimming against that exact corner.
+- **`SOLIDSYSLOG_MAX_MESSAGE_SIZE` mirrored as a Python constant in
+  the steps module.** The store_capacity scenarios are now MAX-coupled
+  by design; mirroring the C constant at module scope makes the
+  dependency visible at the only place a future MAX bump needs to
+  update.
+- **README multi-instance limitation restored, narrowed to specific
+  senders.** CodeRabbit flagged the original wording as too narrow
+  (it had been worded as if only platform backends carried the
+  constraint). Restored a precise list — `SolidSyslogUdpSender`,
+  `SolidSyslogStreamSender`, `SolidSyslogSwitchingSender` — so
+  integrators get an actionable signal.
+- **`iec62443.md` SL1 row updated for connected-UDP error surfacing.**
+  S12.12 shifted UDP from blanket fire-and-forget to a connected-socket
+  model that surfaces local kernel failures (EMSGSIZE, ECONNREFUSED).
+  The "UDP is unreliable — messages may be lost silently" SL1
+  limitation is still accurate at the network-protocol level (mid-
+  transit drops remain silent), so the row keeps that caveat alongside
+  the new error-surface description.
+
+### Deferred
+
+- **`PosixMessageQueueBuffer` mq_send EAGAIN visibility** is still
+  worth doing as a follow-up — not because it caused the store_capacity
+  failures (it didn't), but because silent buffer drops are a real
+  observability gap for any future high-volume scenario. Tracked under
+  E12 #31.
+
+### Open questions
+- None.
+
 ## 2026-04-28 — S12.12 UDP path-MTU clipping (slices 6–7, story complete)
 
 ### Decisions

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,84 @@
 # Dev Log
 
+## 2026-04-27 — S12.12 UDP path-MTU clipping (slices 1–5)
+
+### Decisions
+- **Slice the story before writing tests.** Six conceptual pieces in
+  the story body decompose cleanly into 7 slices (pure helpers ×2,
+  vtable widening, UdpSender retry, Posix wiring, Winsock wiring,
+  BDD). Slice ordering is bottom-up — each slice can be reviewed and
+  committed in isolation, the algorithm consumes the helpers, and the
+  retry loop is exercised against a `DatagramFake` before any real
+  socket plumbing lands.
+- **Datagram contract widened with a 3-state enum, not bool +
+  out-param.** `SOLIDSYSLOG_DATAGRAM_SENT / _OVERSIZE / _FAILED`
+  matches the project's vtable style (no out-params), is faketable
+  per-call, and keeps the dispatcher one-line. The `OVERSIZE` value
+  was added to the public enum in slice 3 even though no producer
+  emits it until slice 5 — that lets the retry algorithm in slice 4
+  read against the final contract rather than a stepping-stone.
+- **Lazy `connect()` in `PosixDatagram`, not address-on-Open.**
+  Original story wording suggested PMTUD setup "after `connect`",
+  which would have meant either changing `Datagram_Open` to take an
+  address (vtable churn, mirrors `Stream_Open`) or `connect`-ing
+  inside `SendTo`. Lazy connect on the first SendTo keeps the vtable
+  shape stable and matches `UdpSender`'s lifecycle — `UdpSender` does
+  Disconnect/Open on endpoint-version changes, so the connected
+  address never silently drifts. Documented assumption rather than
+  enforced address-equality check.
+- **Forward-scan rejected, backward-walk kept for `_TrimToCodepointBoundary`.**
+  Considered a forward scan that advances by codepoint length until
+  the next overshoots `length` — would have been single-return,
+  no early guards, and structurally simpler. Backward walk is O(1)
+  vs forward scan's O(n) over the buffer, and the EMSGSIZE retry
+  is the slow path so performance is irrelevant. Backward walk
+  decomposes into `FindLastCodepointStart` +
+  `LastCodepointExtendsPastCut` which read in plain English; that
+  beats the cleverer forward scan on clarity.
+- **DRY pass: extracted `SolidSyslogUtf8.h`.** UdpPayload was about
+  to duplicate the formatter's byte-level classifiers
+  (`IsTwoByteLead`, `IsThreeByteLead`, `IsFourByteLead`,
+  `IsUtf8Continuation`, `IsValidUtf8SingleByte`). Extracted as five
+  `static inline bool` classifiers in `Core/Source/SolidSyslogUtf8.h`,
+  formatter migrated to use them in the same slice. RFC 3629
+  validity guards (overlong, surrogate, above-Unicode) stay in the
+  formatter — they're rule-encoding, not byte-classification, and
+  only one consumer needs them.
+- **`char` parameter type kept for now.** Header uses `char` (signed
+  on most ABIs), matching the formatter's existing types. UdpPayload
+  uses `uint8_t` and casts at the boundary. MISRA Rule 10.1 on
+  bitwise ops on signed types is a flagged follow-up — flipping the
+  shared header to `uint8_t` is a separate cleanup.
+- **MISRA-leaning style applied throughout.** Single returns, fully
+  bracketed `if/else`, `if-else if` chains terminate with `else`,
+  `cppcoreguidelines-init-variables` honoured, uppercase `U`
+  literal suffixes. The trailing redundant-`else` (when result is
+  already initialised to the default) is acceptable to drop —
+  initialisation already proves "all paths considered".
+
+### Deferred
+- **Slice 6 — `WinsockDatagram` parallel.** Lazy `connect()`,
+  `IP_MTU_DISCOVER`, `WSAEMSGSIZE` → OVERSIZE, `getsockopt(IP_MTU)`
+  with fallback. Needs `WinsockFake` additions paralleling slice 5's
+  `SocketFake` work.
+- **Slice 7 — BDD scenarios.** Loopback-MTU constraint to actually
+  exercise the retry path; two scenarios per the story body
+  (full-delivery-at-safe-payload + clean-UTF-8-truncation).
+- **`SolidSyslogUtf8.h` to `uint8_t`.** Whole-codebase cleanup once
+  S12.12 lands; would also unlock dropping the `(char)` casts at
+  UdpPayload's call sites.
+- **`PosixDatagram` switch from `sendto` to `send` after connect.**
+  Slightly more idiomatic on a connected socket. Kept `sendto` to
+  minimise diff; Linux's connected-`sendto` semantics are
+  well-defined.
+- **Address-mismatch detection in `PosixDatagram`.** Currently
+  `connect`s once per Open lifetime regardless of subsequent
+  addresses. Safe in practice (UdpSender controls lifecycle) but
+  could be enforced if the contract were ever broadened.
+
+### Open questions
+- None.
+
 ## 2026-04-26 — S13.16 WindowsFile — file abstraction using `<io.h>`
 
 ### Decisions

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -3,6 +3,8 @@
 #include "SolidSyslogDatagramDefinition.h"
 #include "SolidSyslogUdpPayload.h"
 
+#include <errno.h>
+#include <netinet/in.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <sys/socket.h>
@@ -13,17 +15,19 @@ enum
     INVALID_FD = -1
 };
 
-static bool                               Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
-static void                               Close(struct SolidSyslogDatagram* self);
-static inline bool                        IsFileDescriptorValid(int fd);
-
 struct SolidSyslogPosixDatagram
 {
     struct SolidSyslogDatagram base;
     int                        fd;
+    bool                       connected;
 };
+
+static bool                               Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
+static void                               Close(struct SolidSyslogDatagram* self);
+static inline bool                        ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool                        IsFileDescriptorValid(int fd);
 
 static struct SolidSyslogPosixDatagram instance = {.fd = INVALID_FD};
 
@@ -48,6 +52,7 @@ static bool Open(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     datagram->fd                              = socket(AF_INET, SOCK_DGRAM, 0);
+    datagram->connected                       = false;
     return IsFileDescriptorValid(datagram->fd);
 }
 
@@ -58,16 +63,53 @@ static inline bool IsFileDescriptorValid(int fd)
 
 static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
-    struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
-    const struct sockaddr_in*        sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
-    ssize_t                          sent     = sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin));
-    return (sent >= 0) ? SOLIDSYSLOG_DATAGRAM_SENT : SOLIDSYSLOG_DATAGRAM_FAILED;
+    struct SolidSyslogPosixDatagram*   datagram = (struct SolidSyslogPosixDatagram*) self;
+    enum SolidSyslogDatagramSendResult result   = SOLIDSYSLOG_DATAGRAM_FAILED;
+    if (ConnectIfNeeded(datagram, addr))
+    {
+        const struct sockaddr_in* sin  = SolidSyslogAddress_AsConstSockaddrIn(addr);
+        ssize_t                   sent = sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin));
+        if (sent >= 0)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_SENT;
+        }
+        else if (errno == EMSGSIZE)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_OVERSIZE;
+        }
+    }
+    return result;
+}
+
+static inline bool ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr)
+{
+    if (!datagram->connected)
+    {
+        const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
+        if (connect(datagram->fd, (const struct sockaddr*) sin, sizeof(*sin)) == 0)
+        {
+            const int pmtu = IP_PMTUDISC_DO;
+            (void) setsockopt(datagram->fd, IPPROTO_IP, IP_MTU_DISCOVER, &pmtu, sizeof(pmtu));
+            datagram->connected = true;
+        }
+    }
+    return datagram->connected;
 }
 
 static size_t MaxPayload(struct SolidSyslogDatagram* self)
 {
-    (void) self;
-    return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
+    struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
+    size_t                           result   = SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
+    if (datagram->connected)
+    {
+        int       mtu    = 0;
+        socklen_t optlen = sizeof(mtu);
+        if ((getsockopt(datagram->fd, IPPROTO_IP, IP_MTU, &mtu, &optlen) == 0) && (mtu > 0))
+        {
+            result = SolidSyslogUdpPayload_FromMtu((size_t) mtu, false);
+        }
+    }
+    return result;
 }
 
 static void Close(struct SolidSyslogDatagram* self)
@@ -76,6 +118,7 @@ static void Close(struct SolidSyslogDatagram* self)
     if (IsFileDescriptorValid(datagram->fd))
     {
         close(datagram->fd);
-        datagram->fd = INVALID_FD;
+        datagram->fd        = INVALID_FD;
+        datagram->connected = false;
     }
 }

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -1,6 +1,7 @@
 #include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogDatagramDefinition.h"
+#include "SolidSyslogUdpPayload.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -12,10 +13,11 @@ enum
     INVALID_FD = -1
 };
 
-static bool        Open(struct SolidSyslogDatagram* self);
-static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-static void        Close(struct SolidSyslogDatagram* self);
-static inline bool IsFileDescriptorValid(int fd);
+static bool                               Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
+static void                               Close(struct SolidSyslogDatagram* self);
+static inline bool                        IsFileDescriptorValid(int fd);
 
 struct SolidSyslogPosixDatagram
 {
@@ -27,17 +29,19 @@ static struct SolidSyslogPosixDatagram instance = {.fd = INVALID_FD};
 
 struct SolidSyslogDatagram* SolidSyslogPosixDatagram_Create(void)
 {
-    instance.base.Open   = Open;
-    instance.base.SendTo = SendTo;
-    instance.base.Close  = Close;
+    instance.base.Open       = Open;
+    instance.base.SendTo     = SendTo;
+    instance.base.MaxPayload = MaxPayload;
+    instance.base.Close      = Close;
     return &instance.base;
 }
 
 void SolidSyslogPosixDatagram_Destroy(void)
 {
-    instance.base.Open   = NULL;
-    instance.base.SendTo = NULL;
-    instance.base.Close  = NULL;
+    instance.base.Open       = NULL;
+    instance.base.SendTo     = NULL;
+    instance.base.MaxPayload = NULL;
+    instance.base.Close      = NULL;
 }
 
 static bool Open(struct SolidSyslogDatagram* self)
@@ -52,11 +56,18 @@ static inline bool IsFileDescriptorValid(int fd)
     return fd >= 0;
 }
 
-static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     const struct sockaddr_in*        sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
-    return sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin)) >= 0;
+    ssize_t                          sent     = sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin));
+    return (sent >= 0) ? SOLIDSYSLOG_DATAGRAM_SENT : SOLIDSYSLOG_DATAGRAM_FAILED;
+}
+
+static size_t MaxPayload(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+    return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
 }
 
 static void Close(struct SolidSyslogDatagram* self)

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -1,6 +1,7 @@
 #include "SolidSyslogWinsockDatagram.h"
 #include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogDatagramDefinition.h"
+#include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogWinsockDatagramInternal.h"
 
 #include <stdbool.h>
@@ -33,10 +34,11 @@ static int WSAAPI CallCloseSocket(SOCKET s)
     return closesocket(s);
 }
 
-static bool        Open(struct SolidSyslogDatagram* self);
-static bool        SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-static void        Close(struct SolidSyslogDatagram* self);
-static inline bool IsSocketValid(SOCKET fd);
+static bool                               Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
+static void                               Close(struct SolidSyslogDatagram* self);
+static inline bool                        IsSocketValid(SOCKET fd);
 
 struct SolidSyslogWinsockDatagram
 {
@@ -48,17 +50,19 @@ static struct SolidSyslogWinsockDatagram instance = {.fd = INVALID_SOCKET};
 
 struct SolidSyslogDatagram* SolidSyslogWinsockDatagram_Create(void)
 {
-    instance.base.Open   = Open;
-    instance.base.SendTo = SendTo;
-    instance.base.Close  = Close;
+    instance.base.Open       = Open;
+    instance.base.SendTo     = SendTo;
+    instance.base.MaxPayload = MaxPayload;
+    instance.base.Close      = Close;
     return &instance.base;
 }
 
 void SolidSyslogWinsockDatagram_Destroy(void)
 {
-    instance.base.Open   = NULL;
-    instance.base.SendTo = NULL;
-    instance.base.Close  = NULL;
+    instance.base.Open       = NULL;
+    instance.base.SendTo     = NULL;
+    instance.base.MaxPayload = NULL;
+    instance.base.Close      = NULL;
 }
 
 static bool Open(struct SolidSyslogDatagram* self)
@@ -73,11 +77,18 @@ static inline bool IsSocketValid(SOCKET fd)
     return fd != INVALID_SOCKET;
 }
 
-static bool SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
     const struct sockaddr_in*          sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
-    return Winsock_sendto(datagram->fd, (const char*) buffer, (int) size, 0, (const struct sockaddr*) sin, (int) sizeof(*sin)) != SOCKET_ERROR;
+    int sent = Winsock_sendto(datagram->fd, (const char*) buffer, (int) size, 0, (const struct sockaddr*) sin, (int) sizeof(*sin));
+    return (sent != SOCKET_ERROR) ? SOLIDSYSLOG_DATAGRAM_SENT : SOLIDSYSLOG_DATAGRAM_FAILED;
+}
+
+static size_t MaxPayload(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+    return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
 }
 
 static void Close(struct SolidSyslogDatagram* self)

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <ws2tcpip.h>
 
 /* File-local forwarders. Taking the address of a __declspec(dllimport)
    Winsock function for static initialisation triggers MSVC C4232 (the address
@@ -14,10 +15,16 @@
 static SOCKET WSAAPI CallSocket(int af, int type, int protocol);
 static int WSAAPI    CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
 static int WSAAPI    CallCloseSocket(SOCKET s);
+static int WSAAPI    CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
+static int WSAAPI    CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
+static int WSAAPI    CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen);
 
 WinsockSocketFn      Winsock_socket      = CallSocket;
 WinsockSendToFn      Winsock_sendto      = CallSendTo;
 WinsockCloseSocketFn Winsock_closesocket = CallCloseSocket;
+WinsockConnectFn     Winsock_connect     = CallConnect;
+WinsockSetSockOptFn  Winsock_setsockopt  = CallSetSockOpt;
+WinsockGetSockOptFn  Winsock_getsockopt  = CallGetSockOpt;
 
 static SOCKET WSAAPI CallSocket(int af, int type, int protocol)
 {
@@ -34,17 +41,34 @@ static int WSAAPI CallCloseSocket(SOCKET s)
     return closesocket(s);
 }
 
-static bool                               Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
-static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
-static void                               Close(struct SolidSyslogDatagram* self);
-static inline bool                        IsSocketValid(SOCKET fd);
+static int WSAAPI CallConnect(SOCKET s, const struct sockaddr* name, int namelen)
+{
+    return connect(s, name, namelen);
+}
+
+static int WSAAPI CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen)
+{
+    return setsockopt(s, level, optname, optval, optlen);
+}
+
+static int WSAAPI CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen)
+{
+    return getsockopt(s, level, optname, optval, optlen);
+}
 
 struct SolidSyslogWinsockDatagram
 {
     struct SolidSyslogDatagram base;
     SOCKET                     fd;
+    bool                       connected;
 };
+
+static bool                               Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
+static void                               Close(struct SolidSyslogDatagram* self);
+static inline bool                        ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool                        IsSocketValid(SOCKET fd);
 
 static struct SolidSyslogWinsockDatagram instance = {.fd = INVALID_SOCKET};
 
@@ -69,6 +93,7 @@ static bool Open(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
     datagram->fd                                = Winsock_socket(AF_INET, SOCK_DGRAM, 0);
+    datagram->connected                         = false;
     return IsSocketValid(datagram->fd);
 }
 
@@ -80,15 +105,52 @@ static inline bool IsSocketValid(SOCKET fd)
 static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
-    const struct sockaddr_in*          sin      = SolidSyslogAddress_AsConstSockaddrIn(addr);
-    int sent = Winsock_sendto(datagram->fd, (const char*) buffer, (int) size, 0, (const struct sockaddr*) sin, (int) sizeof(*sin));
-    return (sent != SOCKET_ERROR) ? SOLIDSYSLOG_DATAGRAM_SENT : SOLIDSYSLOG_DATAGRAM_FAILED;
+    enum SolidSyslogDatagramSendResult result   = SOLIDSYSLOG_DATAGRAM_FAILED;
+    if (ConnectIfNeeded(datagram, addr))
+    {
+        const struct sockaddr_in* sin  = SolidSyslogAddress_AsConstSockaddrIn(addr);
+        int                       sent = Winsock_sendto(datagram->fd, (const char*) buffer, (int) size, 0, (const struct sockaddr*) sin, (int) sizeof(*sin));
+        if (sent != SOCKET_ERROR)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_SENT;
+        }
+        else if (WSAGetLastError() == WSAEMSGSIZE)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_OVERSIZE;
+        }
+    }
+    return result;
+}
+
+static inline bool ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr)
+{
+    if (!datagram->connected)
+    {
+        const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
+        if (Winsock_connect(datagram->fd, (const struct sockaddr*) sin, (int) sizeof(*sin)) != SOCKET_ERROR)
+        {
+            const int pmtu = IP_PMTUDISC_DO;
+            (void) Winsock_setsockopt(datagram->fd, IPPROTO_IP, IP_MTU_DISCOVER, (const char*) &pmtu, (int) sizeof(pmtu));
+            datagram->connected = true;
+        }
+    }
+    return datagram->connected;
 }
 
 static size_t MaxPayload(struct SolidSyslogDatagram* self)
 {
-    (void) self;
-    return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
+    struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
+    size_t                             result   = SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
+    if (datagram->connected)
+    {
+        int mtu    = 0;
+        int optlen = (int) sizeof(mtu);
+        if ((Winsock_getsockopt(datagram->fd, IPPROTO_IP, IP_MTU, (char*) &mtu, &optlen) != SOCKET_ERROR) && (mtu > 0))
+        {
+            result = SolidSyslogUdpPayload_FromMtu((size_t) mtu, false);
+        }
+    }
+    return result;
 }
 
 static void Close(struct SolidSyslogDatagram* self)
@@ -97,6 +159,7 @@ static void Close(struct SolidSyslogDatagram* self)
     if (IsSocketValid(datagram->fd))
     {
         Winsock_closesocket(datagram->fd);
-        datagram->fd = INVALID_SOCKET;
+        datagram->fd        = INVALID_SOCKET;
+        datagram->connected = false;
     }
 }

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagramInternal.h
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagramInternal.h
@@ -13,10 +13,16 @@ EXTERN_C_BEGIN
 
     typedef SOCKET(WSAAPI * WinsockSocketFn)(int, int, int);
     typedef int(WSAAPI * WinsockSendToFn)(SOCKET, const char*, int, int, const struct sockaddr*, int);
+    typedef int(WSAAPI * WinsockConnectFn)(SOCKET, const struct sockaddr*, int);
+    typedef int(WSAAPI * WinsockSetSockOptFn)(SOCKET, int, int, const char*, int);
+    typedef int(WSAAPI * WinsockGetSockOptFn)(SOCKET, int, int, char*, int*);
     typedef int(WSAAPI * WinsockCloseSocketFn)(SOCKET);
 
     extern WinsockSocketFn      Winsock_socket;
     extern WinsockSendToFn      Winsock_sendto;
+    extern WinsockConnectFn     Winsock_connect;
+    extern WinsockSetSockOptFn  Winsock_setsockopt;
+    extern WinsockGetSockOptFn  Winsock_getsockopt;
     extern WinsockCloseSocketFn Winsock_closesocket;
 
 EXTERN_C_END

--- a/README.md
+++ b/README.md
@@ -24,16 +24,12 @@ file store-and-forward with CRC-16 integrity, and the full
 
 **Not yet production-ready**, and no API stability guarantee yet. Known gaps:
 
-- Public API may evolve — multi-instance senders / streams
-  ([#169](https://github.com/DavidCozens/solid-syslog/issues/169)) and
-  additional platform backends (RTOS, custom) are still to land.
+- Public API may evolve — additional platform backends (RTOS, custom) are
+  still to land.
 - At-rest integrity is CRC-16 only; HMAC + AES-at-rest are planned for SL4
   ([E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105)).
 - TLS revocation (CRL / OCSP) is deferred to the OS trust store; the library
   itself does not perform revocation checks.
-- PRINTUSASCII header validation and UTF-8-safe body truncation not yet
-  enforced ([#120](https://github.com/DavidCozens/solid-syslog/issues/120),
-  [#121](https://github.com/DavidCozens/solid-syslog/issues/121)).
 - Comprehensive error guards still rolling out
   ([E12 #31](https://github.com/DavidCozens/solid-syslog/issues/31)).
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ file store-and-forward with CRC-16 integrity, and the full
 
 **Not yet production-ready**, and no API stability guarantee yet. Known gaps:
 
-- Public API may evolve — additional platform backends (RTOS, custom) are
-  still to land.
+- Public API may evolve — sender implementations currently use static
+  singleton state (`SolidSyslogUdpSender`, `SolidSyslogStreamSender`,
+  `SolidSyslogSwitchingSender`), so multiple concurrent instances per
+  process aren't yet supported. Additional platform backends (RTOS,
+  custom) are still to land.
 - At-rest integrity is CRC-16 only; HMAC + AES-at-rest are planned for SL4
   ([E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105)).
 - TLS revocation (CRL / OCSP) is deferred to the OS trust store; the library

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -26,6 +26,8 @@ set(TEST_SOURCES
     StoreFake.c
     SenderFakeTest.cpp
     SenderFake.c
+    DatagramFake.c
+    DatagramFakeTest.cpp
     StringFakeTest.cpp
     StringFake.c
     FileFakeTest.cpp

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     SolidSyslogCrc16PolicyTest.cpp
     SolidSyslogPrivalTest.cpp
     SolidSyslogFormatterTest.cpp
+    SolidSyslogUdpPayloadTest.cpp
     BufferFakeTest.cpp
     BufferFake.c
     StoreFakeTest.cpp

--- a/Tests/DatagramFake.c
+++ b/Tests/DatagramFake.c
@@ -21,40 +21,10 @@ struct DatagramFake
     size_t                             sendSizes[DATAGRAMFAKE_MAX_SEND_CALLS];
 };
 
-static bool Open(struct SolidSyslogDatagram* self)
-{
-    struct DatagramFake* fake = (struct DatagramFake*) self;
-    fake->openCallCount++;
-    return true;
-}
-
-static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
-{
-    struct DatagramFake*               fake   = (struct DatagramFake*) self;
-    int                                idx    = fake->sendCallCount;
-    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_SENT;
-    (void) addr;
-    if (idx < DATAGRAMFAKE_MAX_SEND_CALLS)
-    {
-        fake->sendBuffers[idx] = buffer;
-        fake->sendSizes[idx]   = size;
-        result                 = fake->sendResults[idx];
-    }
-    fake->sendCallCount++;
-    return result;
-}
-
-static size_t MaxPayload(struct SolidSyslogDatagram* self)
-{
-    struct DatagramFake* fake = (struct DatagramFake*) self;
-    fake->maxPayloadCallCount++;
-    return fake->maxPayload;
-}
-
-static void Close(struct SolidSyslogDatagram* self)
-{
-    ((struct DatagramFake*) self)->closeCallCount++;
-}
+static bool                               Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr);
+static size_t                             MaxPayload(struct SolidSyslogDatagram* self);
+static void                               Close(struct SolidSyslogDatagram* self);
 
 struct SolidSyslogDatagram* DatagramFake_Create(void)
 {
@@ -124,4 +94,39 @@ size_t DatagramFake_SendSize(struct SolidSyslogDatagram* datagram, int callIndex
         return 0;
     }
     return ((struct DatagramFake*) datagram)->sendSizes[callIndex];
+}
+
+static bool Open(struct SolidSyslogDatagram* self)
+{
+    struct DatagramFake* fake = (struct DatagramFake*) self;
+    fake->openCallCount++;
+    return true;
+}
+
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+{
+    struct DatagramFake*               fake   = (struct DatagramFake*) self;
+    int                                idx    = fake->sendCallCount;
+    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_FAILED;
+    (void) addr;
+    if (idx < DATAGRAMFAKE_MAX_SEND_CALLS)
+    {
+        fake->sendBuffers[idx] = buffer;
+        fake->sendSizes[idx]   = size;
+        result                 = fake->sendResults[idx];
+    }
+    fake->sendCallCount++;
+    return result;
+}
+
+static size_t MaxPayload(struct SolidSyslogDatagram* self)
+{
+    struct DatagramFake* fake = (struct DatagramFake*) self;
+    fake->maxPayloadCallCount++;
+    return fake->maxPayload;
+}
+
+static void Close(struct SolidSyslogDatagram* self)
+{
+    ((struct DatagramFake*) self)->closeCallCount++;
 }

--- a/Tests/DatagramFake.c
+++ b/Tests/DatagramFake.c
@@ -1,0 +1,127 @@
+#include "DatagramFake.h"
+#include "SolidSyslogDatagramDefinition.h"
+
+#include <stdlib.h>
+
+enum
+{
+    DATAGRAMFAKE_MAX_SEND_CALLS = 4
+};
+
+struct DatagramFake
+{
+    struct SolidSyslogDatagram         base;
+    int                                openCallCount;
+    int                                sendCallCount;
+    int                                maxPayloadCallCount;
+    int                                closeCallCount;
+    enum SolidSyslogDatagramSendResult sendResults[DATAGRAMFAKE_MAX_SEND_CALLS];
+    size_t                             maxPayload;
+    const void*                        sendBuffers[DATAGRAMFAKE_MAX_SEND_CALLS];
+    size_t                             sendSizes[DATAGRAMFAKE_MAX_SEND_CALLS];
+};
+
+static bool Open(struct SolidSyslogDatagram* self)
+{
+    struct DatagramFake* fake = (struct DatagramFake*) self;
+    fake->openCallCount++;
+    return true;
+}
+
+static enum SolidSyslogDatagramSendResult SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size, const struct SolidSyslogAddress* addr)
+{
+    struct DatagramFake*               fake   = (struct DatagramFake*) self;
+    int                                idx    = fake->sendCallCount;
+    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_SENT;
+    (void) addr;
+    if (idx < DATAGRAMFAKE_MAX_SEND_CALLS)
+    {
+        fake->sendBuffers[idx] = buffer;
+        fake->sendSizes[idx]   = size;
+        result                 = fake->sendResults[idx];
+    }
+    fake->sendCallCount++;
+    return result;
+}
+
+static size_t MaxPayload(struct SolidSyslogDatagram* self)
+{
+    struct DatagramFake* fake = (struct DatagramFake*) self;
+    fake->maxPayloadCallCount++;
+    return fake->maxPayload;
+}
+
+static void Close(struct SolidSyslogDatagram* self)
+{
+    ((struct DatagramFake*) self)->closeCallCount++;
+}
+
+struct SolidSyslogDatagram* DatagramFake_Create(void)
+{
+    struct DatagramFake* fake = (struct DatagramFake*) calloc(1, sizeof(struct DatagramFake));
+    fake->base.Open           = Open;
+    fake->base.SendTo         = SendTo;
+    fake->base.MaxPayload     = MaxPayload;
+    fake->base.Close          = Close;
+    for (int i = 0; i < DATAGRAMFAKE_MAX_SEND_CALLS; i++)
+    {
+        fake->sendResults[i] = SOLIDSYSLOG_DATAGRAM_SENT;
+    }
+    return &fake->base;
+}
+
+void DatagramFake_Destroy(struct SolidSyslogDatagram* datagram)
+{
+    free(datagram);
+}
+
+void DatagramFake_SetSendResult(struct SolidSyslogDatagram* datagram, int callIndex, enum SolidSyslogDatagramSendResult result)
+{
+    if ((callIndex >= 0) && (callIndex < DATAGRAMFAKE_MAX_SEND_CALLS))
+    {
+        ((struct DatagramFake*) datagram)->sendResults[callIndex] = result;
+    }
+}
+
+void DatagramFake_SetMaxPayload(struct SolidSyslogDatagram* datagram, size_t maxPayload)
+{
+    ((struct DatagramFake*) datagram)->maxPayload = maxPayload;
+}
+
+int DatagramFake_OpenCallCount(struct SolidSyslogDatagram* datagram)
+{
+    return ((struct DatagramFake*) datagram)->openCallCount;
+}
+
+int DatagramFake_SendCallCount(struct SolidSyslogDatagram* datagram)
+{
+    return ((struct DatagramFake*) datagram)->sendCallCount;
+}
+
+int DatagramFake_MaxPayloadCallCount(struct SolidSyslogDatagram* datagram)
+{
+    return ((struct DatagramFake*) datagram)->maxPayloadCallCount;
+}
+
+int DatagramFake_CloseCallCount(struct SolidSyslogDatagram* datagram)
+{
+    return ((struct DatagramFake*) datagram)->closeCallCount;
+}
+
+const void* DatagramFake_SendBuffer(struct SolidSyslogDatagram* datagram, int callIndex)
+{
+    if ((callIndex < 0) || (callIndex >= DATAGRAMFAKE_MAX_SEND_CALLS))
+    {
+        return NULL;
+    }
+    return ((struct DatagramFake*) datagram)->sendBuffers[callIndex];
+}
+
+size_t DatagramFake_SendSize(struct SolidSyslogDatagram* datagram, int callIndex)
+{
+    if ((callIndex < 0) || (callIndex >= DATAGRAMFAKE_MAX_SEND_CALLS))
+    {
+        return 0;
+    }
+    return ((struct DatagramFake*) datagram)->sendSizes[callIndex];
+}

--- a/Tests/DatagramFake.h
+++ b/Tests/DatagramFake.h
@@ -1,0 +1,31 @@
+#ifndef DATAGRAMFAKE_H
+#define DATAGRAMFAKE_H
+
+#include "ExternC.h"
+#include "SolidSyslogDatagram.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogAddress;
+
+    struct SolidSyslogDatagram* DatagramFake_Create(void);
+    void                        DatagramFake_Destroy(struct SolidSyslogDatagram * datagram);
+
+    /* Per-call SendTo result (0-based). Calls beyond the configured slots
+     * return SOLIDSYSLOG_DATAGRAM_SENT by default. */
+    void DatagramFake_SetSendResult(struct SolidSyslogDatagram * datagram, int callIndex, enum SolidSyslogDatagramSendResult result);
+    void DatagramFake_SetMaxPayload(struct SolidSyslogDatagram * datagram, size_t maxPayload);
+
+    int         DatagramFake_OpenCallCount(struct SolidSyslogDatagram * datagram);
+    int         DatagramFake_SendCallCount(struct SolidSyslogDatagram * datagram);
+    int         DatagramFake_MaxPayloadCallCount(struct SolidSyslogDatagram * datagram);
+    int         DatagramFake_CloseCallCount(struct SolidSyslogDatagram * datagram);
+    const void* DatagramFake_SendBuffer(struct SolidSyslogDatagram * datagram, int callIndex);
+    size_t      DatagramFake_SendSize(struct SolidSyslogDatagram * datagram, int callIndex);
+
+EXTERN_C_END
+
+#endif /* DATAGRAMFAKE_H */

--- a/Tests/DatagramFakeTest.cpp
+++ b/Tests/DatagramFakeTest.cpp
@@ -1,0 +1,80 @@
+#include "CppUTest/TestHarness.h"
+#include "DatagramFake.h"
+#include "SolidSyslogDatagram.h"
+
+// clang-format off
+TEST_GROUP(DatagramFake)
+{
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogDatagram* datagram = nullptr;
+
+    // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
+    void setup() override { datagram = DatagramFake_Create(); }
+    void teardown() override { DatagramFake_Destroy(datagram); }
+};
+
+// clang-format on
+
+TEST(DatagramFake, CreateSucceeds)
+{
+    CHECK_TRUE(datagram != nullptr);
+}
+
+TEST(DatagramFake, OpenIncrementsCount)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(1, DatagramFake_OpenCallCount(datagram));
+}
+
+TEST(DatagramFake, OpenReturnsTrue)
+{
+    CHECK_TRUE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(DatagramFake, SendIncrementsCount)
+{
+    const char payload[] = "hi";
+    SolidSyslogDatagram_SendTo(datagram, payload, sizeof(payload), nullptr);
+    LONGS_EQUAL(1, DatagramFake_SendCallCount(datagram));
+}
+
+TEST(DatagramFake, SendDefaultsToSent)
+{
+    const char payload[] = "hi";
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_SENT, SolidSyslogDatagram_SendTo(datagram, payload, sizeof(payload), nullptr));
+}
+
+TEST(DatagramFake, SendReturnsConfiguredResultPerCall)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_FAILED);
+    const char payload[] = "hi";
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_OVERSIZE, SolidSyslogDatagram_SendTo(datagram, payload, sizeof(payload), nullptr));
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, payload, sizeof(payload), nullptr));
+}
+
+TEST(DatagramFake, SendCapturesBufferAndSize)
+{
+    const char payload[] = "hello";
+    SolidSyslogDatagram_SendTo(datagram, payload, sizeof(payload), nullptr);
+    POINTERS_EQUAL(payload, DatagramFake_SendBuffer(datagram, 0));
+    LONGS_EQUAL(sizeof(payload), DatagramFake_SendSize(datagram, 0));
+}
+
+TEST(DatagramFake, MaxPayloadIncrementsCount)
+{
+    SolidSyslogDatagram_MaxPayload(datagram);
+    LONGS_EQUAL(1, DatagramFake_MaxPayloadCallCount(datagram));
+}
+
+TEST(DatagramFake, MaxPayloadReturnsConfiguredValue)
+{
+    DatagramFake_SetMaxPayload(datagram, 1232);
+    LONGS_EQUAL(1232, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(DatagramFake, CloseIncrementsCount)
+{
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(1, DatagramFake_CloseCallCount(datagram));
+}

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -1,5 +1,6 @@
 #include "FileFake.h"
 #include "SafeString.h"
+#include "SolidSyslog.h"
 #include "SolidSyslogFileDefinition.h"
 #include "SolidSyslogMacros.h"
 #include "TestAssert.h"
@@ -8,7 +9,13 @@
 
 enum
 {
-    FILEFAKE_MAX_SIZE  = 4096,
+    /* Per-file storage. Sized to comfortably hold the worst-case test
+     * scenario, which writes up to two SOLIDSYSLOG_MAX_MESSAGE_SIZE
+     * records per file plus record metadata and integrity bytes. The
+     * 4x multiplier provides headroom for tests that pre-seed file
+     * content before opening the store. Auto-adapts when
+     * SOLIDSYSLOG_MAX_MESSAGE_SIZE is tuned. */
+    FILEFAKE_MAX_SIZE  = 4 * SOLIDSYSLOG_MAX_MESSAGE_SIZE,
     FILEFAKE_MAX_FILES = 101,
     FILEFAKE_MAX_PATH  = 128
 };

--- a/Tests/SenderFake.c
+++ b/Tests/SenderFake.c
@@ -1,21 +1,17 @@
 #include "SenderFake.h"
+#include "SolidSyslog.h"
 #include "SolidSyslogSenderDefinition.h"
 #include "TestUtils.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-enum
-{
-    SENDERFAKE_MAX_BUFFER_SIZE = 1024
-};
-
 struct SenderFake
 {
     struct SolidSyslogSender base;
     int                      sendCount;
     int                      disconnectCount;
-    char                     lastBuffer[SENDERFAKE_MAX_BUFFER_SIZE];
+    char                     lastBuffer[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     size_t                   lastSize;
     bool                     failNextSend;
 };

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -13,9 +13,17 @@ static const size_t      TEST_DATA_LEN    = 5;
 
 enum
 {
-    TEST_BUF_SIZE      = 512,
-    SENTINEL           = 'Z',
-    TEST_MAX_FILE_SIZE = 4096,
+    TEST_BUF_SIZE = SOLIDSYSLOG_MAX_MESSAGE_SIZE,
+    SENTINEL      = 'Z',
+    /* Mirrors the private RECORD_OVERHEAD in SolidSyslogFileStore.c:
+     * MAGIC_SIZE(2) + RECORD_LENGTH_SIZE(2) + SENT_FLAG_SIZE(1). */
+    TEST_RECORD_OVERHEAD  = 5,
+    TEST_RECORDS_PER_FILE = 2,
+    /* Sized to fit TEST_RECORDS_PER_FILE worst-case records — the worst
+     * case being max-size data plus max-integrity bytes. Auto-adapts
+     * when SOLIDSYSLOG_MAX_MESSAGE_SIZE or the integrity policy bound
+     * are tuned. */
+    TEST_MAX_FILE_SIZE = TEST_RECORDS_PER_FILE * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD + SOLIDSYSLOG_MAX_INTEGRITY_SIZE),
     TEST_MAX_FILES     = 2
 };
 

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -4,6 +4,7 @@
 #include "SolidSyslogUdpPayload.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <netinet/in.h>
@@ -166,4 +167,70 @@ TEST(SolidSyslogPosixDatagram, CloseCalledWithSocketFd)
 TEST(SolidSyslogPosixDatagram, MaxPayloadFallsBackToIpv6SafePayload)
 {
     LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogPosixDatagram, OpenDoesNotConnect)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(0, SocketFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToConnectsOnFirstCall)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(1, SocketFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, SendToConnectsOnceAcrossMultipleCalls)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(1, SocketFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, FirstSendEnablesPmtuDiscovery)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    CHECK_TRUE(SocketFake_HasSetSockOpt(IPPROTO_IP, IP_MTU_DISCOVER));
+}
+
+TEST(SolidSyslogPosixDatagram, SendToReturnsOversizeOnEmsgsize)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SocketFake_FailNextSendtoWithErrno(EMSGSIZE);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_OVERSIZE, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+}
+
+TEST(SolidSyslogPosixDatagram, MaxPayloadAfterConnectQueriesIpMtu)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SolidSyslogDatagram_MaxPayload(datagram);
+    LONGS_EQUAL(1, SocketFake_GetSockOptCallCount());
+}
+
+TEST(SolidSyslogPosixDatagram, MaxPayloadConvertsIpMtuViaFromMtu)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SocketFake_SetIpMtu(1500);
+    LONGS_EQUAL(1472, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogPosixDatagram, MaxPayloadFallsBackWhenIpMtuLookupFails)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SocketFake_SetIpMtuLookupFails(true);
+    LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogPosixDatagram, SendToReturnsFailedWhenConnectFails)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SocketFake_SetConnectFails(true);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -1,6 +1,7 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogDatagram.h"
 #include "SolidSyslogPosixDatagram.h"
+#include "SolidSyslogUdpPayload.h"
 #include "SocketFake.h"
 #include <arpa/inet.h>
 #include <cstdint>
@@ -135,17 +136,17 @@ TEST(SolidSyslogPosixDatagram, SendToPassesAddrlenOfSockaddrIn)
     LONGS_EQUAL(sizeof(struct sockaddr_in), SocketFake_LastAddrLen());
 }
 
-TEST(SolidSyslogPosixDatagram, SendToReturnsTrueOnSuccess)
+TEST(SolidSyslogPosixDatagram, SendToReturnsSentOnSuccess)
 {
     SolidSyslogDatagram_Open(datagram);
-    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_SENT, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
-TEST(SolidSyslogPosixDatagram, SendToReturnsFalseOnSendtoFailure)
+TEST(SolidSyslogPosixDatagram, SendToReturnsFailedOnSendtoFailure)
 {
     SolidSyslogDatagram_Open(datagram);
     SocketFake_SetSendtoFails(true);
-    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
 TEST(SolidSyslogPosixDatagram, CloseCallsCloseOnce)
@@ -160,4 +161,9 @@ TEST(SolidSyslogPosixDatagram, CloseCalledWithSocketFd)
     SolidSyslogDatagram_Open(datagram);
     SolidSyslogDatagram_Close(datagram);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
+}
+
+TEST(SolidSyslogPosixDatagram, MaxPayloadFallsBackToIpv6SafePayload)
+{
+    LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
 }

--- a/Tests/SolidSyslogUdpPayloadTest.cpp
+++ b/Tests/SolidSyslogUdpPayloadTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogUdpPayload.h"
+#include <cstdint>
 
 // clang-format off
 TEST_GROUP(SolidSyslogUdpPayload)
@@ -26,4 +27,76 @@ TEST(SolidSyslogUdpPayload, Ipv6SafePayloadConstantMatchesIpv6MinimumMtu)
 TEST(SolidSyslogUdpPayload, MtuSmallerThanOverheadSaturatesToZero)
 {
     LONGS_EQUAL(0, SolidSyslogUdpPayload_FromMtu(0, false));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryAsciiCutNeedsNoWalk)
+{
+    const uint8_t buffer[] = "hello";
+    LONGS_EQUAL(5, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 5));
+}
+
+/* 'é' = 0xC3 0xA9 (2-byte codepoint). Cut after the start byte walks back 1. */
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidTwoByteWalksBackOne)
+{
+    const uint8_t buffer[] = {0xC3, 0xA9};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 1));
+}
+
+/* '€' = 0xE2 0x82 0xAC (3-byte codepoint). Cut after start byte (length=1)
+ * walks back 1; cut after first continuation (length=2) walks back 2. */
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidThreeByteAfterStartWalksBackOne)
+{
+    const uint8_t buffer[] = {0xE2, 0x82, 0xAC};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 1));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidThreeByteAfterFirstContinuationWalksBackTwo)
+{
+    const uint8_t buffer[] = {0xE2, 0x82, 0xAC};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 2));
+}
+
+/* '😀' = 0xF0 0x9F 0x98 0x80 (4-byte codepoint). Cuts after byte 1/2/3 walk back 1/2/3. */
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidFourByteAfterStartWalksBackOne)
+{
+    const uint8_t buffer[] = {0xF0, 0x9F, 0x98, 0x80};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 1));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidFourByteAfterFirstContinuationWalksBackTwo)
+{
+    const uint8_t buffer[] = {0xF0, 0x9F, 0x98, 0x80};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 2));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryMidFourByteAfterSecondContinuationWalksBackThree)
+{
+    const uint8_t buffer[] = {0xF0, 0x9F, 0x98, 0x80};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 3));
+}
+
+/* Cut exactly on a codepoint boundary — no walk back. */
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryExactTwoByteBoundary)
+{
+    const uint8_t buffer[] = {0xC3, 0xA9};
+    LONGS_EQUAL(2, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 2));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryExactFourByteBoundary)
+{
+    const uint8_t buffer[] = {0xF0, 0x9F, 0x98, 0x80};
+    LONGS_EQUAL(4, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 4));
+}
+
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundaryZeroLengthReturnsZero)
+{
+    const uint8_t buffer[] = {0xC3, 0xA9};
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 0));
+}
+
+/* Buffer is one giant codepoint and the cut would land on its boundary. */
+TEST(SolidSyslogUdpPayload, TrimToCodepointBoundarySingleCodepointAtBoundaryKeepsLength)
+{
+    const uint8_t buffer[] = {0xE2, 0x82, 0xAC};
+    LONGS_EQUAL(3, SolidSyslogUdpPayload_TrimToCodepointBoundary(buffer, 3));
 }

--- a/Tests/SolidSyslogUdpPayloadTest.cpp
+++ b/Tests/SolidSyslogUdpPayloadTest.cpp
@@ -1,0 +1,29 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogUdpPayload.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogUdpPayload)
+{
+};
+
+// clang-format on
+
+TEST(SolidSyslogUdpPayload, Ipv4StandardEthernetMtuYields1472)
+{
+    LONGS_EQUAL(1472, SolidSyslogUdpPayload_FromMtu(1500, false));
+}
+
+TEST(SolidSyslogUdpPayload, Ipv6MinimumMtuYields1232)
+{
+    LONGS_EQUAL(1232, SolidSyslogUdpPayload_FromMtu(1280, true));
+}
+
+TEST(SolidSyslogUdpPayload, Ipv6SafePayloadConstantMatchesIpv6MinimumMtu)
+{
+    LONGS_EQUAL(SolidSyslogUdpPayload_FromMtu(1280, true), SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD);
+}
+
+TEST(SolidSyslogUdpPayload, MtuSmallerThanOverheadSaturatesToZero)
+{
+    LONGS_EQUAL(0, SolidSyslogUdpPayload_FromMtu(0, false));
+}

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -637,12 +637,16 @@ TEST(SolidSyslogUdpSenderRetry, OversizeRetryWalksBackToCodepointBoundary)
     LONGS_EQUAL(2, DatagramFake_SendSize(datagram, 1));
 }
 
-TEST(SolidSyslogUdpSenderRetry, DoubleOversizeReturnsFalse)
+/* Double-OVERSIZE means the kernel disagreed with its own reported
+ * MaxPayload — impossible-shouldn't-happen but if it did, returning
+ * false would loop the buffered algorithm forever on an undeliverable.
+ * Swallow: drop the message and return true so the caller moves on. */
+TEST(SolidSyslogUdpSenderRetry, DoubleOversizeReturnsTrueToAvoidPermanentLoop)
 {
     DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
     DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
     DatagramFake_SetMaxPayload(datagram, 3);
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
 TEST(SolidSyslogUdpSenderRetry, DoubleOversizeDoesNotSendThird)
@@ -662,11 +666,39 @@ TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadSkipsRetrySend)
     LONGS_EQUAL(1, DatagramFake_SendCallCount(datagram));
 }
 
-TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadReturnsSuccess)
+/* Trimmed length 0 means the message physically can't fit the path —
+ * looping won't help, so we swallow and report success. The Buffered/
+ * Service algorithm discards rather than retrying forever. */
+TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadReturnsTrueToAvoidPermanentLoop)
 {
     DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
     DatagramFake_SetMaxPayload(datagram, 0);
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+/* Retry sendto failing with non-OVERSIZE error (e.g. ECONNREFUSED on
+ * connected UDP) is a TRANSIENT condition — return false so the
+ * Buffered/Service algorithm keeps the message for retry. */
+TEST(SolidSyslogUdpSenderRetry, RetryFailedNonOversizeReturnsFalse)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_FAILED);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderRetry, MaxPayloadLargerThanMessageCapsTrimToMessageSize)
+{
+    /* MaxPayload > size can happen when the kernel reports EMSGSIZE for
+     * a transient reason but the path MTU it surfaces is larger than
+     * the original message. The trim must cap at the message size to
+     * avoid reading past the buffer. */
+    const uint8_t payload[] = {0x61, 0x62, 0x63};
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
+    DatagramFake_SetMaxPayload(datagram, 9999);
+    SolidSyslogSender_Send(sender, payload, sizeof(payload));
+    LONGS_EQUAL(sizeof(payload), DatagramFake_SendSize(datagram, 1));
 }
 
 TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureDoesNotRetry)

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -1,4 +1,5 @@
 #include "CppUTest/TestHarness.h"
+#include "DatagramFake.h"
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
@@ -7,6 +8,7 @@
 #include "SolidSyslogSender.h"
 #include "SocketFake.h"
 #include <array>
+#include <cstdint>
 #include <netinet/in.h>
 
 // clang-format off
@@ -556,4 +558,127 @@ TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
     SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
     LONGS_EQUAL(1, SocketFake_SendtoCallCount());
     LONGS_EQUAL(0, SocketFake_LastPort());
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogUdpSenderRetry)
+{
+    struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogDatagram* datagram = nullptr;
+    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogSender* sender = nullptr;
+
+    void setup() override
+    {
+        SocketFake_Reset();
+        endpointGetHost = GetDefaultHost;
+        endpointVersion = 0;
+        endpointGetPort = GetDefaultPort;
+        resolver        = SolidSyslogGetAddrInfoResolver_Create();
+        datagram        = DatagramFake_Create();
+        struct SolidSyslogUdpSenderConfig config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
+        // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest lifecycle
+        sender = SolidSyslogUdpSender_Create(&config);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogUdpSender_Destroy();
+        DatagramFake_Destroy(datagram);
+        SolidSyslogGetAddrInfoResolver_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogUdpSenderRetry, SuccessfulSendDoesNotQueryMaxPayload)
+{
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(0, DatagramFake_MaxPayloadCallCount(datagram));
+}
+
+TEST(SolidSyslogUdpSenderRetry, OversizeQueriesMaxPayloadAndRetries)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, DatagramFake_MaxPayloadCallCount(datagram));
+    LONGS_EQUAL(2, DatagramFake_SendCallCount(datagram));
+}
+
+TEST(SolidSyslogUdpSenderRetry, OversizeRetryTrimsBufferToMaxPayload)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(3, DatagramFake_SendSize(datagram, 1));
+}
+
+TEST(SolidSyslogUdpSenderRetry, OversizeRetrySucceedsReturnsTrue)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+/* Buffer "ab" + é (0xC3 0xA9): MaxPayload=3 cuts mid-é at the start byte,
+ * walk-back drops the partial codepoint and trims to 2 bytes. */
+TEST(SolidSyslogUdpSenderRetry, OversizeRetryWalksBackToCodepointBoundary)
+{
+    const uint8_t payload[] = {0x61, 0x62, 0xC3, 0xA9};
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    SolidSyslogSender_Send(sender, payload, sizeof(payload));
+    LONGS_EQUAL(2, DatagramFake_SendSize(datagram, 1));
+}
+
+TEST(SolidSyslogUdpSenderRetry, DoubleOversizeReturnsFalse)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderRetry, DoubleOversizeDoesNotSendThird)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetMaxPayload(datagram, 3);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(2, DatagramFake_SendCallCount(datagram));
+}
+
+TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadSkipsRetrySend)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetMaxPayload(datagram, 0);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, DatagramFake_SendCallCount(datagram));
+}
+
+TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadReturnsSuccess)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    DatagramFake_SetMaxPayload(datagram, 0);
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureDoesNotRetry)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    LONGS_EQUAL(1, DatagramFake_SendCallCount(datagram));
+    LONGS_EQUAL(0, DatagramFake_MaxPayloadCallCount(datagram));
+}
+
+TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureReturnsFalse)
+{
+    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogDatagram.h"
+#include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogWinsockDatagram.h"
 #include "SolidSyslogWinsockDatagramInternal.h"
 #include "WinsockFake.h"
@@ -137,17 +138,17 @@ TEST(SolidSyslogWinsockDatagram, SendToPassesAddrlenOfSockaddrIn)
     LONGS_EQUAL((int) sizeof(struct sockaddr_in), WinsockFake_LastAddrLen());
 }
 
-TEST(SolidSyslogWinsockDatagram, SendToReturnsTrueOnSuccess)
+TEST(SolidSyslogWinsockDatagram, SendToReturnsSentOnSuccess)
 {
     SolidSyslogDatagram_Open(datagram);
-    CHECK_TRUE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_SENT, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
-TEST(SolidSyslogWinsockDatagram, SendToReturnsFalseOnSendtoFailure)
+TEST(SolidSyslogWinsockDatagram, SendToReturnsFailedOnSendtoFailure)
 {
     SolidSyslogDatagram_Open(datagram);
     WinsockFake_SetSendtoFails(true);
-    CHECK_FALSE(SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
 }
 
 TEST(SolidSyslogWinsockDatagram, CloseCallsCloseOnce)
@@ -162,4 +163,9 @@ TEST(SolidSyslogWinsockDatagram, CloseCalledWithSocketFd)
     SolidSyslogDatagram_Open(datagram);
     SolidSyslogDatagram_Close(datagram);
     CHECK(WinsockFake_SocketFd() == WinsockFake_LastClosedFd());
+}
+
+TEST(SolidSyslogWinsockDatagram, MaxPayloadFallsBackToIpv6SafePayload)
+{
+    LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
 }

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -28,6 +28,9 @@ TEST_GROUP(SolidSyslogWinsockDatagram)
         UT_PTR_SET(Winsock_socket, WinsockFake_socket);
         UT_PTR_SET(Winsock_sendto, WinsockFake_sendto);
         UT_PTR_SET(Winsock_closesocket, WinsockFake_closesocket);
+        UT_PTR_SET(Winsock_connect, WinsockFake_connect);
+        UT_PTR_SET(Winsock_setsockopt, WinsockFake_setsockopt);
+        UT_PTR_SET(Winsock_getsockopt, WinsockFake_getsockopt);
         // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         datagram = SolidSyslogWinsockDatagram_Create();
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing, legal and necessary
@@ -167,5 +170,71 @@ TEST(SolidSyslogWinsockDatagram, CloseCalledWithSocketFd)
 
 TEST(SolidSyslogWinsockDatagram, MaxPayloadFallsBackToIpv6SafePayload)
 {
+    LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogWinsockDatagram, OpenDoesNotConnect)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(0, WinsockFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToConnectsOnFirstCall)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(1, WinsockFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToConnectsOnceAcrossMultipleCalls)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    LONGS_EQUAL(1, WinsockFake_ConnectCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, FirstSendEnablesPmtuDiscovery)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    CHECK_TRUE(WinsockFake_HasSetSockOpt(IPPROTO_IP, IP_MTU_DISCOVER));
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToReturnsOversizeOnWsaemsgsize)
+{
+    SolidSyslogDatagram_Open(datagram);
+    WinsockFake_FailNextSendtoWithLastError(WSAEMSGSIZE);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_OVERSIZE, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+}
+
+TEST(SolidSyslogWinsockDatagram, SendToReturnsFailedWhenConnectFails)
+{
+    SolidSyslogDatagram_Open(datagram);
+    WinsockFake_SetConnectFails(true);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr));
+}
+
+TEST(SolidSyslogWinsockDatagram, MaxPayloadAfterConnectQueriesIpMtu)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    SolidSyslogDatagram_MaxPayload(datagram);
+    LONGS_EQUAL(1, WinsockFake_GetSockOptCallCount());
+}
+
+TEST(SolidSyslogWinsockDatagram, MaxPayloadConvertsIpMtuViaFromMtu)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    WinsockFake_SetIpMtu(1500);
+    LONGS_EQUAL(1472, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogWinsockDatagram, MaxPayloadFallsBackWhenIpMtuLookupFails)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
+    WinsockFake_SetIpMtuLookupFails(true);
     LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
 }

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -13,6 +13,8 @@ enum
 };
 
 static bool               sendtoFails;
+static bool               nextSendtoShouldFailWithErrno;
+static int                nextSendtoErrno;
 static int                sendtoCallCount;
 static char               lastBufCopy[SOCKETFAKE_MAX_BUFFER_SIZE];
 static size_t             lastLen;
@@ -20,6 +22,10 @@ static int                lastFlags;
 static struct sockaddr_in lastAddr;
 static socklen_t          lastAddrLen;
 static int                lastSendtoFd;
+
+static int  ipMtuValue;
+static bool ipMtuLookupFails;
+static int  getSockOptCallCount;
 
 static bool socketFails;
 static int  socketCallCount;
@@ -85,22 +91,24 @@ void SocketFake_Reset(void)
 {
     /* Reset errno so a stale value from a prior test (notably EINTR set via
      * FailNextSendWithErrno) cannot leak into the next test's retry loop. */
-    errno                       = 0;
-    sendtoFails                 = false;
-    sendtoCallCount             = 0;
-    lastBufCopy[0]              = '\0';
-    lastLen                     = 0;
-    lastFlags                   = 0;
-    lastAddr                    = (struct sockaddr_in) {0};
-    lastAddrLen                 = 0;
-    lastSendtoFd                = -1;
-    sendFails                   = false;
-    sendFailOnCall              = -1;
-    sendCallCount               = 0;
-    sendReturnOverride          = false;
-    sendReturnValue             = 0;
-    nextSendShouldFailWithErrno = false;
-    nextSendErrno               = 0;
+    errno                         = 0;
+    sendtoFails                   = false;
+    nextSendtoShouldFailWithErrno = false;
+    nextSendtoErrno               = 0;
+    sendtoCallCount               = 0;
+    lastBufCopy[0]                = '\0';
+    lastLen                       = 0;
+    lastFlags                     = 0;
+    lastAddr                      = (struct sockaddr_in) {0};
+    lastAddrLen                   = 0;
+    lastSendtoFd                  = -1;
+    sendFails                     = false;
+    sendFailOnCall                = -1;
+    sendCallCount                 = 0;
+    sendReturnOverride            = false;
+    sendReturnValue               = 0;
+    nextSendShouldFailWithErrno   = false;
+    nextSendErrno                 = 0;
     for (int i = 0; i < SOCKETFAKE_MAX_SEND_CALLS; i++)
     {
         sendBufCopy[i][0] = '\0';
@@ -121,20 +129,23 @@ void SocketFake_Reset(void)
         setSockOptLevels[i]   = 0;
         setSockOptOptnames[i] = 0;
     }
-    socketFails       = false;
-    socketCallCount   = 0;
-    socketFd          = -1;
-    lastSocketDomain  = 0;
-    lastSocketType    = 0;
-    closeCallCount    = 0;
-    lastClosedFd      = -1;
-    recvCallCount     = 0;
-    recvReturn        = 0;
-    lastRecvFd        = -1;
-    lastRecvBuf       = NULL;
-    lastRecvLen       = 0;
-    lastRecvFlags     = 0;
-    lastAddrString[0] = '\0';
+    getSockOptCallCount = 0;
+    ipMtuValue          = 0;
+    ipMtuLookupFails    = false;
+    socketFails         = false;
+    socketCallCount     = 0;
+    socketFd            = -1;
+    lastSocketDomain    = 0;
+    lastSocketType      = 0;
+    closeCallCount      = 0;
+    lastClosedFd        = -1;
+    recvCallCount       = 0;
+    recvReturn          = 0;
+    lastRecvFd          = -1;
+    lastRecvBuf         = NULL;
+    lastRecvLen         = 0;
+    lastRecvFlags       = 0;
+    lastAddrString[0]   = '\0';
 
     getAddrInfoFails            = false;
     getAddrInfoCallCount        = 0;
@@ -152,6 +163,27 @@ void SocketFake_Reset(void)
 void SocketFake_SetSendtoFails(bool fails)
 {
     sendtoFails = fails;
+}
+
+void SocketFake_FailNextSendtoWithErrno(int errnoValue)
+{
+    nextSendtoShouldFailWithErrno = true;
+    nextSendtoErrno               = errnoValue;
+}
+
+void SocketFake_SetIpMtu(int mtu)
+{
+    ipMtuValue = mtu;
+}
+
+void SocketFake_SetIpMtuLookupFails(bool fails)
+{
+    ipMtuLookupFails = fails;
+}
+
+int SocketFake_GetSockOptCallCount(void)
+{
+    return getSockOptCallCount;
 }
 
 /* sendto accessors */
@@ -471,7 +503,36 @@ ssize_t sendto(int sockfd, const void* buf, size_t len, int flags, const struct 
     lastFlags             = flags;
     lastAddr              = *(const struct sockaddr_in*) dest_addr;
     lastAddrLen           = addrlen;
+    if (nextSendtoShouldFailWithErrno)
+    {
+        errno                         = nextSendtoErrno;
+        nextSendtoShouldFailWithErrno = false;
+        return (ssize_t) -1;
+    }
     return sendtoFails ? (ssize_t) -1 : (ssize_t) len;
+}
+
+// clang-format off
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name,bugprone-easily-swappable-parameters) -- POSIX API; parameter names differ from glibc internal names
+int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen)
+// clang-format on
+{
+    (void) sockfd;
+    getSockOptCallCount++;
+    if ((level == IPPROTO_IP) && (optname == IP_MTU))
+    {
+        if (ipMtuLookupFails)
+        {
+            return -1;
+        }
+        if ((optval != NULL) && (optlen != NULL) && (*optlen >= sizeof(int)))
+        {
+            *(int*) optval = ipMtuValue;
+            *optlen        = sizeof(int);
+        }
+        return 0;
+    }
+    return 0;
 }
 
 // clang-format off

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -510,7 +510,15 @@ ssize_t sendto(int sockfd, const void* buf, size_t len, int flags, const struct 
         nextSendtoShouldFailWithErrno = false;
         return (ssize_t) -1;
     }
-    return sendtoFails ? (ssize_t) -1 : (ssize_t) len;
+    if (sendtoFails)
+    {
+        /* Set a deterministic errno so a stale value (notably EMSGSIZE
+         * left by a prior FailNextSendtoWithErrno call) cannot leak
+         * into the production code's error-classification logic. */
+        errno = EIO;
+        return (ssize_t) -1;
+    }
+    return (ssize_t) len;
 }
 
 // clang-format off

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -1,5 +1,6 @@
 #include "SocketFake.h"
 #include "SafeString.h"
+#include "SolidSyslog.h"
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netdb.h>
@@ -9,7 +10,7 @@
 
 enum
 {
-    SOCKETFAKE_MAX_BUFFER_SIZE = 2048
+    SOCKETFAKE_MAX_BUFFER_SIZE = SOLIDSYSLOG_MAX_MESSAGE_SIZE
 };
 
 static bool               sendtoFails;

--- a/Tests/Support/SocketFake.h
+++ b/Tests/Support/SocketFake.h
@@ -12,6 +12,7 @@ EXTERN_C_BEGIN
 
     /* sendto configuration */
     void SocketFake_SetSendtoFails(bool fails);
+    void SocketFake_FailNextSendtoWithErrno(int errnoValue);
 
     /* sendto accessors */
     int         SocketFake_SendtoCallCount(void);
@@ -61,6 +62,13 @@ EXTERN_C_BEGIN
     int  SocketFake_LastSetSockOptLevel(void);
     int  SocketFake_LastSetSockOptOptname(void);
     bool SocketFake_HasSetSockOpt(int level, int optname);
+
+    /* getsockopt configuration (currently models IPPROTO_IP / IP_MTU only) */
+    void SocketFake_SetIpMtu(int mtu);
+    void SocketFake_SetIpMtuLookupFails(bool fails);
+
+    /* getsockopt accessors */
+    int SocketFake_GetSockOptCallCount(void);
 
     /* close accessors */
     int SocketFake_CloseCallCount(void);

--- a/Tests/Support/WinsockFake.c
+++ b/Tests/Support/WinsockFake.c
@@ -1,12 +1,13 @@
 #include "WinsockFake.h"
 #include "SafeString.h"
+#include "SolidSyslog.h"
 #include <string.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
 enum
 {
-    WINSOCKFAKE_MAX_BUFFER_SIZE      = 2048,
+    WINSOCKFAKE_MAX_BUFFER_SIZE      = SOLIDSYSLOG_MAX_MESSAGE_SIZE,
     WINSOCKFAKE_MAX_HOSTNAME_SIZE    = 256,
     WINSOCKFAKE_MAX_SEND_CALLS       = 8,
     WINSOCKFAKE_MAX_SETSOCKOPT_CALLS = 8

--- a/Tests/Support/WinsockFake.c
+++ b/Tests/Support/WinsockFake.c
@@ -13,6 +13,8 @@ enum
 };
 
 static bool               sendtoFails;
+static bool               nextSendtoShouldFailWithLastError;
+static int                nextSendtoLastError;
 static int                sendtoCallCount;
 static char               lastBufCopy[WINSOCKFAKE_MAX_BUFFER_SIZE];
 static size_t             lastLen;
@@ -20,6 +22,10 @@ static int                lastFlags;
 static struct sockaddr_in lastAddr;
 static int                lastAddrLen;
 static SOCKET             lastSendtoFd;
+
+static int  ipMtuValue;
+static bool ipMtuLookupFails;
+static int  getSockOptCallCount;
 
 static bool   socketFails;
 static int    socketCallCount;
@@ -70,14 +76,17 @@ static int                freeAddrInfoCallCount;
 
 void WinsockFake_Reset(void)
 {
-    sendtoFails     = false;
-    sendtoCallCount = 0;
-    lastBufCopy[0]  = '\0';
-    lastLen         = 0;
-    lastFlags       = 0;
-    lastAddr        = (struct sockaddr_in) {0};
-    lastAddrLen     = 0;
-    lastSendtoFd    = INVALID_SOCKET;
+    WSASetLastError(0);
+    sendtoFails                       = false;
+    nextSendtoShouldFailWithLastError = false;
+    nextSendtoLastError               = 0;
+    sendtoCallCount                   = 0;
+    lastBufCopy[0]                    = '\0';
+    lastLen                           = 0;
+    lastFlags                         = 0;
+    lastAddr                          = (struct sockaddr_in) {0};
+    lastAddrLen                       = 0;
+    lastSendtoFd                      = INVALID_SOCKET;
 
     socketFails      = false;
     socketCallCount  = 0;
@@ -118,6 +127,9 @@ void WinsockFake_Reset(void)
         setSockOptLevels[i]   = 0;
         setSockOptOptnames[i] = 0;
     }
+    getSockOptCallCount = 0;
+    ipMtuValue          = 0;
+    ipMtuLookupFails    = false;
 
     closeCallCount = 0;
     lastClosedFd   = INVALID_SOCKET;
@@ -171,6 +183,27 @@ int WinsockFake_SocketType(void)
 void WinsockFake_SetSendtoFails(bool fails)
 {
     sendtoFails = fails;
+}
+
+void WinsockFake_FailNextSendtoWithLastError(int wsaError)
+{
+    nextSendtoShouldFailWithLastError = true;
+    nextSendtoLastError               = wsaError;
+}
+
+void WinsockFake_SetIpMtu(int mtu)
+{
+    ipMtuValue = mtu;
+}
+
+void WinsockFake_SetIpMtuLookupFails(bool fails)
+{
+    ipMtuLookupFails = fails;
+}
+
+int WinsockFake_GetSockOptCallCount(void)
+{
+    return getSockOptCallCount;
 }
 
 /* sendto accessors */
@@ -451,6 +484,12 @@ int WSAAPI WinsockFake_sendto(SOCKET s, const char* buf, int len, int flags, con
     {
         lastAddr = *(const struct sockaddr_in*) to;
     }
+    if (nextSendtoShouldFailWithLastError)
+    {
+        WSASetLastError(nextSendtoLastError);
+        nextSendtoShouldFailWithLastError = false;
+        return SOCKET_ERROR;
+    }
     return sendtoFails ? SOCKET_ERROR : len;
 }
 
@@ -512,6 +551,26 @@ int WSAAPI WinsockFake_setsockopt(SOCKET s, int level, int optname, const char* 
     setSockOptCallCount++;
     lastSetSockOptLevel   = level;
     lastSetSockOptOptname = optname;
+    return 0;
+}
+
+int WSAAPI WinsockFake_getsockopt(SOCKET s, int level, int optname, char* optval, int* optlen)
+{
+    (void) s;
+    getSockOptCallCount++;
+    if ((level == IPPROTO_IP) && (optname == IP_MTU))
+    {
+        if (ipMtuLookupFails)
+        {
+            return SOCKET_ERROR;
+        }
+        if ((optval != NULL) && (optlen != NULL) && (*optlen >= (int) sizeof(int)))
+        {
+            *(int*) optval = ipMtuValue;
+            *optlen        = (int) sizeof(int);
+        }
+        return 0;
+    }
     return 0;
 }
 

--- a/Tests/Support/WinsockFake.h
+++ b/Tests/Support/WinsockFake.h
@@ -22,6 +22,7 @@ EXTERN_C_BEGIN
 
     /* sendto configuration */
     void WinsockFake_SetSendtoFails(bool fails);
+    void WinsockFake_FailNextSendtoWithLastError(int wsaError);
 
     /* sendto accessors */
     int         WinsockFake_SendtoCallCount(void);
@@ -70,6 +71,13 @@ EXTERN_C_BEGIN
     int  WinsockFake_LastSetSockOptOptname(void);
     bool WinsockFake_HasSetSockOpt(int level, int optname);
 
+    /* getsockopt configuration (currently models IPPROTO_IP / IP_MTU only) */
+    void WinsockFake_SetIpMtu(int mtu);
+    void WinsockFake_SetIpMtuLookupFails(bool fails);
+
+    /* getsockopt accessors */
+    int WinsockFake_GetSockOptCallCount(void);
+
     /* closesocket accessors */
     int    WinsockFake_CloseCallCount(void);
     SOCKET WinsockFake_LastClosedFd(void);
@@ -92,6 +100,7 @@ EXTERN_C_BEGIN
     int WSAAPI    WinsockFake_send(SOCKET s, const char* buf, int len, int flags);
     int WSAAPI    WinsockFake_recv(SOCKET s, char* buf, int len, int flags);
     int WSAAPI    WinsockFake_setsockopt(SOCKET s, int level, int optname, const char* optval, int optlen);
+    int WSAAPI    WinsockFake_getsockopt(SOCKET s, int level, int optname, char* optval, int* optlen);
     int WSAAPI    WinsockFake_closesocket(SOCKET s);
     int WSAAPI    WinsockFake_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res);
     void WSAAPI   WinsockFake_freeaddrinfo(struct addrinfo * res);

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -47,7 +47,7 @@ and the network is trusted.
 | Component | Header | Purpose |
 |---|---|---|
 | `SolidSyslog` | `SolidSyslog.h`, `SolidSyslogConfig.h` | Core Log/Service API |
-| `SolidSyslogUdpSender` | `SolidSyslogUdpSender.h` | Fire-and-forget UDP transport (RFC 5426) |
+| `SolidSyslogUdpSender` | `SolidSyslogUdpSender.h` | UDP transport (RFC 5426). Connected-socket lifecycle so the kernel can surface `EMSGSIZE` for path-MTU oversize (auto-trimmed and resent, S12.12) and `ECONNREFUSED` when the destination port is closed; both surface as `Send` returning false so the buffered/Service algorithm can keep the message for retry. End-to-end delivery is still unconfirmed (UDP). |
 | `SolidSyslogNullBuffer` | `SolidSyslogNullBuffer.h` | Direct send, no buffering (single-task) |
 | `SolidSyslogNullStore` | `SolidSyslogNullStore.h` | No persistence |
 | `SolidSyslogNullSecurityPolicy` | `SolidSyslogNullSecurityPolicy.h` | No integrity checking |

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -148,7 +148,7 @@ formatter primitives); the remaining SL4 item is at-rest cryptography.
 | Authenticated integrity policy | — | HMAC/AES-CMAC on stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
 | PRINTUSASCII validation | — | Header field character compliance | Available — non-compliant bytes substituted with `?` via `SolidSyslogFormatter_PrintUsAsciiString` |
-| UTF-8 validation | — | Formatter primitives uphold RFC 3629; ill-formed input substituted with U+FFFD (Unicode §3.9). MSG-body truncation at the wire-buffer limit remains a SIEM concern. | Available — `SolidSyslogFormatter_BoundedString`, `SolidSyslogFormatter_EscapedString` ([S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) |
+| UTF-8 validation | — | Formatter primitives uphold RFC 3629; ill-formed input substituted with U+FFFD (Unicode §3.9). Truncation preserves codepoint boundaries at both layers — formatter clip ([S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) and UDP path-MTU clip ([S12.12](https://github.com/DavidCozens/solid-syslog/issues/210)). TCP/TLS streams fragment transparently at the transport layer and so do not need a path-MTU trim. | Available — `SolidSyslogFormatter_BoundedString`, `SolidSyslogFormatter_EscapedString`, `SolidSyslogUdpPayload_TrimToCodepointBoundary` |
 | Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
 
 **What SL4 adds over SL3:**

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -28,8 +28,8 @@ Status key:
 | 6.3.4 | origin SD — software, swVersion | Supported | `SolidSyslogOriginSd`. `ip` and `enterpriseId` not implemented |
 | 6.3.5 | meta SD — sequenceId | Supported | `SolidSyslogMetaSd`. Starts at 1, increments per message. `sysUpTime` and `language` not implemented |
 | 6.3.5, 7.3.1 | meta SD — sequenceId wraps at 2147483647 to 1 | Supported | `SolidSyslogAtomicCounter` wraps via CAS-loop in [1, 2³¹ - 1]; never returns 0; never above max. AtomicOps seam pluggable per platform — `StdAtomicOps` (C11) on POSIX/clang/gcc/modern MSVC; `WindowsAtomicOps` (`InterlockedCompareExchange`) on legacy MSVC. sequenceId is assigned at the point of message raise (application-layer originator), preserving end-to-end loss-detection across the internal buffer / store-and-forward / transport pipeline. Trade-off: under concurrent raise from multiple threads, a small reorder window may occur in transmitted IDs (adjacent IDs may invert, since buffer/transport scheduling between raise and wire is not under library control). All IDs remain unique and non-zero — SIEMs performing gap detection identify message loss correctly; SIEMs requiring strict monotonic ordering should sort by timestamp |
-| 6.4 | MSG — UTF-8 preferred | Supported | RFC 3629 UTF-8 validated at the formatter primitives (`SolidSyslogFormatter_BoundedString`), with ill-formed input substituted per-byte with U+FFFD (Unicode §3.9). No BOM prefix. MSG body truncation at the wire-buffer limit is the SIEM's responsibility (out-of-scope per [S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) |
-| 8.1 | Message size — max 2048 recommended | Supported | Default `SOLIDSYSLOG_MAX_MESSAGE_SIZE` = 512. Configurable via CMake |
+| 6.4 | MSG — UTF-8 preferred | Supported | RFC 3629 UTF-8 validated at the formatter primitives (`SolidSyslogFormatter_BoundedString`), with ill-formed input substituted per-byte with U+FFFD (Unicode §3.9). No BOM prefix. Truncation preserves codepoint boundaries at both layers: the formatter clips at `SOLIDSYSLOG_MAX_MESSAGE_SIZE` without splitting a codepoint ([S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)), and on UDP the sender walks back over any partial codepoint when the kernel reports `EMSGSIZE` for the path MTU ([S12.12](https://github.com/DavidCozens/solid-syslog/issues/210)). TCP/TLS streams fragment transparently at the transport layer and so do not need a path-MTU trim |
+| 8.1 | Message size — max 2048 recommended | Supported | Default `SOLIDSYSLOG_MAX_MESSAGE_SIZE` = 2048, matching the §8.1 SHOULD value. Per-target override via a CMake variable is planned in [E21 #217](https://github.com/DavidCozens/solid-syslog/issues/217) for memory-constrained MCUs |
 | 9 | PRINTUSASCII in header fields (codes 33-126) | Supported | Non-compliant bytes substituted with `?` at format time (HOSTNAME, APP-NAME, PROCID, MSGID) |
 
 ## RFC 5426 — Transmission of Syslog Messages over UDP
@@ -39,7 +39,7 @@ Status key:
 | 3.1 | One message per UDP datagram | Supported | `SolidSyslogUdpSender` sends one datagram per `Send` call |
 | 3.2 | Default port 514 | Supported | `SOLIDSYSLOG_UDP_DEFAULT_PORT` = 514 |
 | 3.2 | Message fits in single datagram | Supported | Bounded by `SOLIDSYSLOG_MAX_MESSAGE_SIZE` |
-| 3.2 | Avoid IP fragmentation (respect MTU) | Partial | Default 512 avoids fragmentation on most networks. No dynamic MTU discovery |
+| 3.2 | Avoid IP fragmentation (respect MTU) | Supported | `SolidSyslogUdpSender` lazily connects on first send, enables Linux `IP_MTU_DISCOVER` / Windows equivalent with `IP_PMTUDISC_DO` so the kernel returns `EMSGSIZE` (Winsock `WSAEMSGSIZE`) for path-MTU oversize, queries the path MTU via `getsockopt(IP_MTU)`, and resends a UTF-8-safe trimmed datagram via `SolidSyslogUdpPayload_TrimToCodepointBoundary`. Falls back to `SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD = 1232` (RFC 8200 §5) when the MTU lookup fails ([S12.12](https://github.com/DavidCozens/solid-syslog/issues/210)) |
 | 3.3 | Unreliable delivery — no confirmation | N/A | Inherent in UDP. Caller should be aware |
 | 4 | No authentication/integrity/confidentiality | N/A | Use TLS transport for security — [E3](https://github.com/DavidCozens/solid-syslog/issues/5) |
 
@@ -73,6 +73,6 @@ Status key:
 | RFC | Total requirements | Supported | Partial | Planned | N/A |
 |---|---|---|---|---|---|
 | RFC 5424 | 17 | 17 | 0 | 0 | 0 |
-| RFC 5426 | 6 | 3 | 1 | 0 | 2 |
+| RFC 5426 | 6 | 4 | 0 | 0 | 2 |
 | RFC 6587 | 8 | 7 | 0 | 0 | 1 |
 | RFC 5425 | 7 | 6 | 1 | 0 | 0 |


### PR DESCRIPTION
## Summary

Closes #210.

UDP sender now respects the path MTU end-to-end:

- **Detect path-MTU oversize at the kernel.** `PosixDatagram` /
  `WinsockDatagram` lazily `connect()` on the first `SendTo`, enable
  `IP_MTU_DISCOVER = IP_PMTUDISC_DO`, and surface kernel `EMSGSIZE` /
  `WSAEMSGSIZE` distinctly via a new 3-state Datagram result enum
  (`SOLIDSYSLOG_DATAGRAM_SENT / _OVERSIZE / _FAILED`).
- **Recover by clipping at the path's safe payload, not by guessing.**
  On `OVERSIZE`, `UdpSender` queries `getsockopt(IP_MTU)` and converts
  via the new `SolidSyslogUdpPayload_FromMtu(mtu, isIpv6)`. Falls back
  to `SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD = 1232` (RFC 8200 §5) when the
  lookup fails.
- **Preserve UTF-8 codepoint boundaries through the trim.** The new
  `SolidSyslogUdpPayload_TrimToCodepointBoundary` walks back over any
  partial multi-byte sequence at the cut point so the receiver sees
  valid UTF-8 even when the kernel forces truncation. The existing
  formatter's UTF-8 byte classifiers were extracted into a private
  `Core/Source/SolidSyslogUtf8.h` so both consumers share the
  classifiers without drifting.
- **Bumped `SOLIDSYSLOG_MAX_MESSAGE_SIZE` 512 → 2048**, the RFC 5424
  §6.1 SHOULD value. Test fakes (`SenderFake`, `SocketFake`,
  `WinsockFake`, `FileFake`) and `SolidSyslogFileStoreTest`'s
  `TEST_MAX_FILE_SIZE` were untying themselves from hand-tuned
  buffer-size constants and now derive from
  `SOLIDSYSLOG_MAX_MESSAGE_SIZE` so they auto-adapt under any future
  per-target tuning.

The default-bump's per-target tuneability is the open piece —
tracked separately in **E21 #217** (Port-Time Configurability), where
the BDD path-MTU trim scenarios from this PR will be gated on the
configured size being large enough to overflow the docker bridge MTU.

## Test plan

- [x] `cmake --build --preset debug --target SolidSyslogTests` — 899/899 tests pass
- [x] `cmake --build --preset clang-debug --target SolidSyslogTests` — 899/899 tests pass
- [x] `cmake --build --preset sanitize --target SolidSyslogTests` — 899/899 tests pass under ASan + UBSan
- [x] `cmake --build --preset coverage --target coverage` — 100.0% line / 100.0% function coverage
- [x] `cmake --build --preset tidy --target SolidSyslog` — clang-tidy clean
- [x] `cmake --build --preset cppcheck --target SolidSyslog` — cppcheck clean
- [x] `clang-format --dry-run --Werror` — clean
- [x] MSVC local — `cmake --build --preset msvc-debug --target SolidSyslogTests` — 645/645 tests pass
- [x] BDD locally — POSIX `udp_mtu.feature` two new scenarios pass against syslog-ng with real EMSGSIZE on the docker bridge; existing UDP/TCP scenarios still pass byte-identically

CI will validate the Windows BDD via OTel collector, the OpenSSL integration tests, and the syslog-ng BDD across the whole feature set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Increased maximum RFC 5424 syslog message size from 512 to 2048 bytes
  * Added UDP path-MTU clipping with automatic UTF-8-safe trimming when messages exceed network limits
  * Enhanced UDP transmission with kernel MTU discovery and oversize error detection/recovery

* **Documentation**
  * Updated RFC 5426 compliance documentation for UDP path-MTU support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->