### PR TITLE
chore: add SOLIDSYSLOG_TLS_DEFAULT_PORT = 6514 per RFC 5425 §4.2

### DIFF
--- a/Core/Interface/SolidSyslogTransport.h
+++ b/Core/Interface/SolidSyslogTransport.h
@@ -4,7 +4,8 @@
 enum
 {
     SOLIDSYSLOG_UDP_DEFAULT_PORT = 514, /* RFC 5426 */
-    SOLIDSYSLOG_TCP_DEFAULT_PORT = 601  /* RFC 6587 §3.2 / IANA assignment for syslog over TCP */
+    SOLIDSYSLOG_TCP_DEFAULT_PORT = 601, /* RFC 6587 §3.2 / IANA assignment for syslog over TCP */
+    SOLIDSYSLOG_TLS_DEFAULT_PORT = 6514 /* RFC 5425 §4.2 / IANA syslog-tls */
 };
 
 enum SolidSyslogTransport

--- a/Example/Common/ExampleTlsConfig.c
+++ b/Example/Common/ExampleTlsConfig.c
@@ -1,12 +1,8 @@
 #include "ExampleTlsConfig.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogTransport.h"
 
 #include <stdint.h>
-
-enum
-{
-    EXAMPLE_TLS_PORT = 6514 /* RFC 5425 */
-};
 
 /* Test CA for BDD. Paths are relative to the working directory the example is
  * launched from (/workspaces/SolidSyslog in the BDD container). */
@@ -19,7 +15,7 @@ const char* ExampleTlsConfig_GetHost(void)
 
 uint16_t ExampleTlsConfig_GetPort(void)
 {
-    return (uint16_t) EXAMPLE_TLS_PORT;
+    return (uint16_t) SOLIDSYSLOG_TLS_DEFAULT_PORT;
 }
 
 const char* ExampleTlsConfig_GetCaBundlePath(void)

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -3,6 +3,7 @@
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogStream.h"
 #include "SolidSyslogTlsStream.h"
+#include "SolidSyslogTransport.h"
 #include "StreamFake.h"
 #include <openssl/ssl.h>
 
@@ -819,4 +820,9 @@ TEST(SolidSyslogTlsStream, OpenPassesCtxFromNewToCheckPrivateKey)
     stream                     = SolidSyslogTlsStream_Create(&streamStorage, &config);
     SolidSyslogStream_Open(stream, addr);
     POINTERS_EQUAL(OpenSslFake_LastCtxReturned(), OpenSslFake_LastCheckPrivateKeyCtxArg());
+}
+
+TEST(SolidSyslogTlsStream, DefaultPortMatchesRfc5425)
+{
+    LONGS_EQUAL(6514, SOLIDSYSLOG_TLS_DEFAULT_PORT);
 }

--- a/docs/rfc-compliance.md
+++ b/docs/rfc-compliance.md
@@ -61,7 +61,7 @@ Status key:
 | Section | Requirement | Status | Notes |
 |---|---|---|---|
 | 4.1 | TLS over TCP | Supported | `SolidSyslogTlsStream` wraps a TCP `Stream` (typically `SolidSyslogPosixTcpStream`) |
-| 4.2 | Default port 6514 | Partial | Caller-supplied via endpoint callback; no `SOLIDSYSLOG_TLS_DEFAULT_PORT` constant shipped. The Threaded example uses 6514 |
+| 4.2 | Default port 6514 | Supported | `SOLIDSYSLOG_TLS_DEFAULT_PORT` constant in `SolidSyslogTransport.h`, alongside the UDP and TCP defaults. Caller-supplied via the endpoint callback so multi-port deployments can override |
 | 5.1 | Server certificate validation | Supported | `SSL_VERIFY_PEER` + `SSL_CTX_load_verify_locations` + `SSL_set1_host` hostname check |
 | 5.2 | Mutual TLS (client certificate) | Supported | Optional `clientCertChainPath` / `clientKeyPath` on `SolidSyslogTlsStreamConfig`; `SSL_CTX_check_private_key` confirms pairing |
 | 5.3 | TLS 1.2+ cipher suites | Supported | `SSL_CTX_set_min_proto_version(TLS1_2_VERSION)` pinned; caller-supplied `cipherList` via `SSL_CTX_set_cipher_list` |


### PR DESCRIPTION
## Summary

- Adds `SOLIDSYSLOG_TLS_DEFAULT_PORT = 6514` to [Core/Interface/SolidSyslogTransport.h](Core/Interface/SolidSyslogTransport.h) alongside the existing UDP (514) and TCP (601) defaults.
- Flips the §4.2 row in [docs/rfc-compliance.md](docs/rfc-compliance.md) from `Partial` to `Supported` — closing the last remaining "Partial" cell across the RFC tables.
- One unit test pinning the value against RFC 5425, mirroring the existing `DefaultPortMatchesRfc6587` test on the TCP side.

Caller-supplied port via the endpoint callback is unchanged, so multi-port deployments can still override.

## Test plan

- [ ] CI green
- [ ] 100% coverage maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced TLS default port support (6514) per RFC 5425 specification, enabling standardized secure syslog communications with reduced configuration overhead.

* **Tests**
  * Added test coverage to validate TLS default port configuration accuracy and compliance.

* **Documentation**
  * Updated RFC 5425 compliance documentation to reflect full TLS default port support while maintaining flexibility for custom port configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->