### PR TITLE
feat: S13.17 embed UTF-8 activeCodePage manifest in Windows example

### DIFF
--- a/Bdd/features/udp_mtu.feature
+++ b/Bdd/features/udp_mtu.feature
@@ -4,21 +4,14 @@ Feature: UDP datagram path-MTU clipping
   path-MTU's safe payload, walking back over any partial UTF-8
   codepoint at the trim point so the receiver always sees valid UTF-8.
 
-  Both scenarios are POSIX-only on the Windows BDD runner, but for
-  different reasons:
+  The oversize scenario is POSIX-only (tagged windows_wip): the
+  Windows BDD runner uses the OTel Collector on 127.0.0.1, and
+  loopback's ~65535-byte MTU never triggers WSAEMSGSIZE for any
+  message inside SOLIDSYSLOG_MAX_MESSAGE_SIZE, so the EMSGSIZE retry
+  path can't actually fire. Full delivery runs on both runners now
+  that S13.17 (#221) embedded a UTF-8 activeCodePage manifest in
+  SolidSyslogExample.exe so multi-byte argv survives the MSVC CRT.
 
-    - Full delivery (windows_wip): SolidSyslogExample.exe receives its
-      --message argv in the Windows active code page rather than UTF-8,
-      so multi-byte UTF-8 bodies arrive at SolidSyslog_Log already
-      mojibake'd and the formatter substitutes U+FFFD per Unicode §3.9.
-      Tracked in S13.17 (#221); once that lands, drop this tag.
-    - Oversize (windows_wip): the OTel runner is on 127.0.0.1 and
-      loopback's ~65535-byte MTU never triggers WSAEMSGSIZE for any
-      message inside SOLIDSYSLOG_MAX_MESSAGE_SIZE, so the EMSGSIZE
-      retry path can't actually fire. This one stays POSIX-only by
-      virtue of the Windows-loopback MTU.
-
-  @windows_wip
   Scenario: Full delivery of a UTF-8 message within the path MTU
     Given syslog-ng is running
     When the example program sends a UTF-8 message that fits the path MTU

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -55,4 +55,9 @@ elseif(SOLIDSYSLOG_WINSOCK AND HAVE_WINDOWS_PLATFORM)
         ${CMAKE_CURRENT_SOURCE_DIR}/Windows
         ${CMAKE_CURRENT_SOURCE_DIR}/Common
     )
+    # Merge the activeCodePage="UTF-8" manifest fragment into the linker's
+    # auto-generated manifest so the MSVC CRT decodes argv as UTF-8 (S13.17 #221).
+    target_link_options(SolidSyslogWindowsExample PRIVATE
+        "/MANIFESTINPUT:${CMAKE_CURRENT_SOURCE_DIR}/Windows/SolidSyslogWindowsExample.manifest"
+    )
 endif()

--- a/Example/Windows/SolidSyslogWindowsExample.manifest
+++ b/Example/Windows/SolidSyslogWindowsExample.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## Summary

- Embeds a Windows 10 1903+ activeCodePage manifest fragment in `SolidSyslogExample.exe` so the MSVC CRT decodes argv as UTF-8 instead of the system code page.
- Wired via `/MANIFESTINPUT` so the linker's auto-generated manifest (`trustInfo` / `requestedExecutionLevel`) is preserved and our fragment is merged in.
- Drops `@windows_wip` from the udp_mtu full-delivery scenario. Oversize stays POSIX-only (Windows loopback MTU never triggers WSAEMSGSIZE — separate concern).

## Why

S12.13's diagnostic dump showed the wire frame correctly carrying the §6.4 UTF-8 BOM but the MSG body full of `U+FFFD` (EF BF BD) replacement codepoints — 100 of them where `é` should have been, 50 where `€` should have been. The library's UTF-8 validator was correctly substituting per Unicode §3.9; the corruption happened upstream in the CRT's argv decode.

## Local validation

Built `SolidSyslogExample.exe` via the `msvc-debug` preset on the local Windows host, extracted the embedded manifest with `mt.exe -inputresource`, and confirmed the merged result contains both the default `<requestedExecutionLevel>` and our `<activeCodePage>UTF-8</activeCodePage>` tag.

## Test plan

- [ ] CI green
- [ ] `bdd-windows-otel` passes the udp_mtu full-delivery scenario byte-identical against the OTel oracle
- [ ] All Linux gates remain green (the `.manifest` only compiles on the MSVC branch)

Closes #221