### PR TITLE
feat: S13.10 SingleTask TCP delivery validated on both BDD runners

### DIFF
--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -600,6 +600,11 @@ def step_example_sends_message(context):
     run_example(context)
 
 
+@when("the example program sends a syslog message with transport {transport}")
+def step_example_sends_with_transport(context, transport):
+    run_example(context, ["--transport", transport])
+
+
 @when("the threaded example sends a syslog message")
 def step_threaded_sends_message(context):
     run_threaded_example(context)

--- a/Bdd/features/tcp_singletask.feature
+++ b/Bdd/features/tcp_singletask.feature
@@ -1,0 +1,14 @@
+@tcp
+Feature: TCP message delivery (single-task example)
+  The single-task example sends messages via TCP transport with RFC
+  6587 octet-counting framing. Companion to the @buffered
+  tcp_transport.feature (which exercises the threaded example) — this
+  one is the runner-agnostic version: it runs on bdd-linux-syslog-ng
+  via syslog-ng's TCP listener and on bdd-windows-otel via the OTel
+  Collector's TCP receiver. Together they validate Windows TCP
+  end-to-end (S13.10).
+
+  Scenario: Single-task message delivered over TCP
+    Given syslog-ng is running
+    When the example program sends a syslog message with transport tcp
+    Then syslog-ng receives a message with priority "134"

--- a/Bdd/otel/config.yaml
+++ b/Bdd/otel/config.yaml
@@ -10,9 +10,13 @@
 # listens on the same port via both transports.
 
 receivers:
-  syslog:
+  # Each syslog receiver instance accepts exactly one of udp: or tcp:, so we
+  # spin two named instances and feed both into the same pipeline.
+  syslog/udp:
     udp:
       listen_address: "127.0.0.1:5514"
+    protocol: rfc5424
+  syslog/tcp:
     tcp:
       listen_address: "127.0.0.1:5514"
     protocol: rfc5424
@@ -30,5 +34,5 @@ service:
       level: warn
   pipelines:
     logs:
-      receivers: [syslog]
+      receivers: [syslog/udp, syslog/tcp]
       exporters: [file]

--- a/Bdd/otel/config.yaml
+++ b/Bdd/otel/config.yaml
@@ -20,6 +20,11 @@ receivers:
     tcp:
       listen_address: "127.0.0.1:5514"
     protocol: rfc5424
+    # The library frames TCP messages with RFC 6587 §3.4.1 octet-counting
+    # (`<len> <space> <message>`); without this flag the syslog receiver
+    # passes the raw frame to the rfc5424 parser, which rejects the digits
+    # before `<`. Mirrors what syslog-ng does by default on the Linux side.
+    enable_octet_counting: true
 
 exporters:
   file:

--- a/Bdd/otel/config.yaml
+++ b/Bdd/otel/config.yaml
@@ -1,13 +1,19 @@
 # OpenTelemetry Collector Contrib config — Windows BDD oracle.
-# Receives RFC 5424 syslog over UDP on 127.0.0.1:5514 and writes each
-# parsed log record as a JSON line to Bdd/output/received.jsonl.
+# Receives RFC 5424 syslog over UDP and TCP on 127.0.0.1:5514 and writes
+# each parsed log record as a JSON line to Bdd/output/received.jsonl.
 #
 # Used by the bdd-windows runner as a Windows-native replacement for
 # syslog-ng (no WSL/Wine/Docker needed).
+#
+# UDP and TCP share port 5514 — they're separate sockets, so the
+# kernel keeps them apart. Mirrors the Linux syslog-ng setup which
+# listens on the same port via both transports.
 
 receivers:
   syslog:
     udp:
+      listen_address: "127.0.0.1:5514"
+    tcp:
       listen_address: "127.0.0.1:5514"
     protocol: rfc5424
 

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -29,11 +29,6 @@ if(SOLIDSYSLOG_POSIX OR SOLIDSYSLOG_WINSOCK)
         SolidSyslogResolver.c
         SolidSyslogDatagram.c
         SolidSyslogUdpSender.c
-    )
-endif()
-
-if(SOLIDSYSLOG_POSIX)
-    list(APPEND SOURCES
         SolidSyslogStreamSender.c
     )
 endif()

--- a/Example/SingleTask/SolidSyslogExample.c
+++ b/Example/SingleTask/SolidSyslogExample.c
@@ -2,22 +2,30 @@
 #include "ExampleAppName.h"
 #include "ExampleCommandLine.h"
 #include "ExampleInteractive.h"
+#include "ExampleTcpConfig.h"
 #include "ExampleUdpConfig.h"
 #include "SolidSyslog.h"
-#include "SolidSyslogGetAddrInfoResolver.h"
-#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogConfig.h"
+#include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogMetaSd.h"
-#include "SolidSyslogOriginSd.h"
-#include "SolidSyslogStdAtomicOps.h"
-#include "SolidSyslogTimeQualitySd.h"
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogNullStore.h"
+#include "SolidSyslogOriginSd.h"
 #include "SolidSyslogPosixClock.h"
+#include "SolidSyslogPosixDatagram.h"
 #include "SolidSyslogPosixHostname.h"
 #include "SolidSyslogPosixProcessId.h"
+#include "SolidSyslogPosixTcpStream.h"
+#include "SolidSyslogStdAtomicOps.h"
+#include "SolidSyslogStreamSender.h"
+#include "SolidSyslogTimeQualitySd.h"
 #include "SolidSyslogUdpSender.h"
+
+#include <string.h>
+
+static SolidSyslogPosixTcpStreamStorage tcpStreamStorage;
+static SolidSyslogStreamSenderStorage   tcpSenderStorage;
 
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 {
@@ -36,11 +44,34 @@ int SolidSyslogExample_Run(int argc, char* argv[])
         return 1;
     }
 
-    struct SolidSyslogResolver*       resolver  = SolidSyslogGetAddrInfoResolver_Create();
-    struct SolidSyslogDatagram*       datagram  = SolidSyslogPosixDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig = {
-        .resolver = resolver, .datagram = datagram, .endpoint = ExampleUdpConfig_GetEndpoint, .endpointVersion = ExampleUdpConfig_GetEndpointVersion};
-    struct SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&udpConfig);
+    struct SolidSyslogResolver* resolver = SolidSyslogGetAddrInfoResolver_Create();
+    struct SolidSyslogDatagram* datagram = NULL;
+    struct SolidSyslogStream*   stream   = NULL;
+    struct SolidSyslogSender*   sender   = NULL;
+    bool                        useTcp   = (options.transport != NULL) && (strcmp(options.transport, "tcp") == 0);
+
+    if (useTcp)
+    {
+        stream                                         = SolidSyslogPosixTcpStream_Create(&tcpStreamStorage);
+        struct SolidSyslogStreamSenderConfig tcpConfig = {
+            .resolver        = resolver,
+            .stream          = stream,
+            .endpoint        = ExampleTcpConfig_GetEndpoint,
+            .endpointVersion = ExampleTcpConfig_GetEndpointVersion,
+        };
+        sender = SolidSyslogStreamSender_Create(&tcpSenderStorage, &tcpConfig);
+    }
+    else
+    {
+        datagram                                    = SolidSyslogPosixDatagram_Create();
+        struct SolidSyslogUdpSenderConfig udpConfig = {
+            .resolver        = resolver,
+            .datagram        = datagram,
+            .endpoint        = ExampleUdpConfig_GetEndpoint,
+            .endpointVersion = ExampleUdpConfig_GetEndpointVersion,
+        };
+        sender = SolidSyslogUdpSender_Create(&udpConfig);
+    }
     struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();
     struct SolidSyslogAtomicCounter*  counter     = SolidSyslogAtomicCounter_Create(SolidSyslogStdAtomicOps_Create());
@@ -80,8 +111,16 @@ int SolidSyslogExample_Run(int argc, char* argv[])
     SolidSyslogStdAtomicOps_Destroy();
     SolidSyslogNullStore_Destroy();
     SolidSyslogNullBuffer_Destroy();
-    SolidSyslogUdpSender_Destroy();
-    SolidSyslogPosixDatagram_Destroy();
+    if (useTcp)
+    {
+        SolidSyslogStreamSender_Destroy(sender);
+        SolidSyslogPosixTcpStream_Destroy(stream);
+    }
+    else
+    {
+        SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
+    }
     SolidSyslogGetAddrInfoResolver_Destroy();
 
     return 0;

--- a/Example/Windows/ExampleWindowsCommandLine.c
+++ b/Example/Windows/ExampleWindowsCommandLine.c
@@ -7,6 +7,7 @@ void ExampleWindowsCommandLine_Parse(int argc, char* argv[], struct WindowsExamp
 {
     options->facility  = SOLIDSYSLOG_FACILITY_LOCAL0;
     options->severity  = SOLIDSYSLOG_SEVERITY_INFO;
+    options->transport = SOLIDSYSLOG_TRANSPORT_UDP;
     options->messageId = NULL;
     options->msg       = NULL;
 
@@ -27,6 +28,10 @@ void ExampleWindowsCommandLine_Parse(int argc, char* argv[], struct WindowsExamp
         else if (((i + 1) < argc) && (strcmp(argv[i], "--message") == 0))
         {
             options->msg = argv[++i];
+        }
+        else if (((i + 1) < argc) && (strcmp(argv[i], "--transport") == 0))
+        {
+            options->transport = (strcmp(argv[++i], "tcp") == 0) ? SOLIDSYSLOG_TRANSPORT_TCP : SOLIDSYSLOG_TRANSPORT_UDP;
         }
     }
 }

--- a/Example/Windows/ExampleWindowsCommandLine.h
+++ b/Example/Windows/ExampleWindowsCommandLine.h
@@ -3,6 +3,7 @@
 
 #include "ExternC.h"
 #include "SolidSyslogPrival.h"
+#include "SolidSyslogTransport.h"
 
 EXTERN_C_BEGIN
 
@@ -10,15 +11,17 @@ EXTERN_C_BEGIN
     {
         enum SolidSyslog_Facility facility;
         enum SolidSyslog_Severity severity;
+        enum SolidSyslogTransport transport;
         const char*               messageId;
         const char*               msg;
     };
 
     /* Minimal CLI parser — recognises --facility N, --severity N, --msgid X,
-       --message X, all optional. Unknown flags and flags missing their
-       argument are silently ignored. Defaults match the SingleTask example:
-       local0 / info / no msgid / no body. getopt is not available on MSVC
-       and pulling in a vcpkg getopt for four flags would be overkill. */
+       --message X, --transport udp|tcp, all optional. Unknown flags and
+       flags missing their argument are silently ignored. Defaults match the
+       SingleTask example: local0 / info / udp / no msgid / no body. getopt
+       is not available on MSVC and pulling in a vcpkg getopt for five flags
+       would be overkill. */
     void ExampleWindowsCommandLine_Parse(int argc, char* argv[], struct WindowsExampleOptions* options);
 
 EXTERN_C_END

--- a/Example/Windows/SolidSyslogWindowsExample.c
+++ b/Example/Windows/SolidSyslogWindowsExample.c
@@ -12,6 +12,8 @@
 #include "SolidSyslogNullStore.h"
 #include "SolidSyslogOriginSd.h"
 #include "SolidSyslogTimeQualitySd.h"
+#include "SolidSyslogStreamSender.h"
+#include "SolidSyslogTransport.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogWindowsAtomicOps.h"
 #include "SolidSyslogWindowsClock.h"
@@ -19,6 +21,7 @@
 #include "SolidSyslogWindowsProcessId.h"
 #include "SolidSyslogWinsockDatagram.h"
 #include "SolidSyslogWinsockResolver.h"
+#include "SolidSyslogWinsockTcpStream.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -26,8 +29,14 @@
 
 enum
 {
-    EXAMPLE_UDP_PORT = 5514
+    /* Unprivileged mirror of SOLIDSYSLOG_UDP_DEFAULT_PORT (514) /
+       SOLIDSYSLOG_TCP_DEFAULT_PORT (601). The BDD oracle listens on both
+       UDP and TCP at 5514. */
+    EXAMPLE_PORT = 5514
 };
+
+static SolidSyslogWinsockTcpStreamStorage tcpStreamStorage;
+static SolidSyslogStreamSenderStorage     tcpSenderStorage;
 
 static const char* GetHost(void)
 {
@@ -36,7 +45,7 @@ static const char* GetHost(void)
 
 static int GetPort(void)
 {
-    return EXAMPLE_UDP_PORT;
+    return EXAMPLE_PORT;
 }
 
 static void GetEndpoint(struct SolidSyslogEndpoint* endpoint)
@@ -70,14 +79,29 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     struct WindowsExampleOptions options;
     ExampleWindowsCommandLine_Parse(argc, argv, &options);
 
-    struct SolidSyslogResolver*       resolver  = SolidSyslogWinsockResolver_Create();
-    struct SolidSyslogDatagram*       datagram  = SolidSyslogWinsockDatagram_Create();
-    struct SolidSyslogUdpSenderConfig udpConfig = {.resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint, .endpointVersion = GetEndpointVersion};
-    struct SolidSyslogSender*         sender    = SolidSyslogUdpSender_Create(&udpConfig);
-    struct SolidSyslogBuffer*         buffer    = SolidSyslogNullBuffer_Create(sender);
-    struct SolidSyslogStore*          store     = SolidSyslogNullStore_Create();
-    struct SolidSyslogAtomicCounter*  counter   = SolidSyslogAtomicCounter_Create(SolidSyslogWindowsAtomicOps_Create());
-    struct SolidSyslogStructuredData* metaSd    = SolidSyslogMetaSd_Create(counter);
+    struct SolidSyslogResolver* resolver = SolidSyslogWinsockResolver_Create();
+    struct SolidSyslogDatagram* datagram = NULL;
+    struct SolidSyslogStream*   stream   = NULL;
+    struct SolidSyslogSender*   sender   = NULL;
+
+    if (options.transport == SOLIDSYSLOG_TRANSPORT_TCP)
+    {
+        stream                                         = SolidSyslogWinsockTcpStream_Create(&tcpStreamStorage);
+        struct SolidSyslogStreamSenderConfig tcpConfig = {
+            .resolver = resolver, .stream = stream, .endpoint = GetEndpoint, .endpointVersion = GetEndpointVersion};
+        sender = SolidSyslogStreamSender_Create(&tcpSenderStorage, &tcpConfig);
+    }
+    else
+    {
+        datagram                                    = SolidSyslogWinsockDatagram_Create();
+        struct SolidSyslogUdpSenderConfig udpConfig = {
+            .resolver = resolver, .datagram = datagram, .endpoint = GetEndpoint, .endpointVersion = GetEndpointVersion};
+        sender = SolidSyslogUdpSender_Create(&udpConfig);
+    }
+    struct SolidSyslogBuffer*         buffer      = SolidSyslogNullBuffer_Create(sender);
+    struct SolidSyslogStore*          store       = SolidSyslogNullStore_Create();
+    struct SolidSyslogAtomicCounter*  counter     = SolidSyslogAtomicCounter_Create(SolidSyslogWindowsAtomicOps_Create());
+    struct SolidSyslogStructuredData* metaSd      = SolidSyslogMetaSd_Create(counter);
     struct SolidSyslogStructuredData* timeQuality = SolidSyslogTimeQualitySd_Create(GetTimeQuality);
     struct SolidSyslogStructuredData* originSd    = SolidSyslogOriginSd_Create("SolidSyslogExample", "0.7.0");
 
@@ -113,8 +137,16 @@ int SolidSyslogWindowsExample_Run(int argc, char* argv[])
     SolidSyslogWindowsAtomicOps_Destroy();
     SolidSyslogNullStore_Destroy();
     SolidSyslogNullBuffer_Destroy();
-    SolidSyslogUdpSender_Destroy();
-    SolidSyslogWinsockDatagram_Destroy();
+    if (options.transport == SOLIDSYSLOG_TRANSPORT_TCP)
+    {
+        SolidSyslogStreamSender_Destroy(sender);
+        SolidSyslogWinsockTcpStream_Destroy(stream);
+    }
+    else
+    {
+        SolidSyslogUdpSender_Destroy();
+        SolidSyslogWinsockDatagram_Destroy();
+    }
     SolidSyslogWinsockResolver_Destroy();
 
     WSACleanup();

--- a/Tests/Example/CMakeLists.txt
+++ b/Tests/Example/CMakeLists.txt
@@ -23,6 +23,7 @@ if(SOLIDSYSLOG_POSIX)
         ${CMAKE_SOURCE_DIR}/Example/SingleTask/SolidSyslogExample.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleCommandLine.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleServiceThread.c
+        ${CMAKE_SOURCE_DIR}/Example/Common/ExampleTcpConfig.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleUdpConfig.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleInteractive.c
         ${CMAKE_SOURCE_DIR}/Example/Common/ExampleSwitchConfig.c

--- a/Tests/Example/ExampleWindowsCommandLineTest.cpp
+++ b/Tests/Example/ExampleWindowsCommandLineTest.cpp
@@ -86,6 +86,24 @@ TEST(ExampleWindowsCommandLine, MessageFlagSetsMsg)
     STRCMP_EQUAL("system started", options.msg);
 }
 
+TEST(ExampleWindowsCommandLine, DefaultTransportIsUdp)
+{
+    char  arg0[] = "test";
+    char* argv[] = {arg0, nullptr};
+    Parse(1, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_TRANSPORT_UDP, options.transport);
+}
+
+TEST(ExampleWindowsCommandLine, TransportFlagSetsTcp)
+{
+    char  arg0[] = "test";
+    char  arg1[] = "--transport";
+    char  arg2[] = "tcp";
+    char* argv[] = {arg0, arg1, arg2, nullptr};
+    Parse(3, argv);
+    LONGS_EQUAL(SOLIDSYSLOG_TRANSPORT_TCP, options.transport);
+}
+
 TEST(ExampleWindowsCommandLine, AllFlagsTogether)
 {
     char  arg0[] = "test";


### PR DESCRIPTION
## Summary

- Adds a TCP receiver to the OTel BDD oracle config so the Windows runner can accept TCP syslog.
- Wires `--transport tcp` into both SingleTask examples (POSIX + Windows). Each branches between `SolidSyslogUdpSender` over a Datagram and `SolidSyslogStreamSender` over a TcpStream. Mirrors the Threaded example's existing transport switch.
- New `Bdd/features/tcp_singletask.feature` with a single scenario tagged `@tcp` only (no `@buffered`) so both `bdd-linux-syslog-ng` and `bdd-windows-otel` exercise it end-to-end.
- New step `the example program sends a syslog message with transport {transport}` parallels the existing threaded variant.
- Two new TDD-driven unit tests for `ExampleWindowsCommandLine_Parse` (default-is-UDP, `--transport tcp` flips it).
- `Core/Source/CMakeLists.txt`: `SolidSyslogStreamSender.c` was POSIX-only when `PosixTcpStream` was the only Stream backend. Move it into the OR-with-WINSOCK block — StreamSender itself is platform-agnostic.

## Test plan

- [ ] CI green
- [ ] `bdd-linux-syslog-ng` passes the new scenario via syslog-ng's `s_tcp` listener
- [ ] `bdd-windows-otel` passes the new scenario via the OTel TCP receiver
- [ ] Existing UDP scenarios stay green on both runners
- [ ] 100% coverage maintained

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP transport support for syslog message delivery as an alternative to UDP.
  * Introduced `--transport` command-line option to select transport at runtime (UDP/TCP).

* **Tests**
  * New test scenarios validate TCP-based syslog message delivery on both Linux and Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->