### PR TITLE
chore: rewrite iec62443 around per-CR mapping, recipes by SL

### DIFF
--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -14,157 +14,45 @@ requirements at each Security Level (SL).
 | SL3 | Sophisticated attack with moderate resources | IACS-specific skills, moderate motivation |
 | SL4 | State-level attack with extensive resources | Nation-state, dedicated team, advanced tools |
 
-## Relevant IEC 62443 Requirements
+## Control Implementation
 
-The following Foundational Requirements (FR) and Component Requirements (CR)
-from IEC 62443-3-3 and IEC 62443-4-2 are addressed by an audit logging library:
+The IEC 62443 Component Requirements (CR) and System Requirements (SR) below
+are the audit-logging-relevant subset of IEC 62443-4-2 and IEC 62443-3-3. Each
+row maps a control to (a) the SL at which IEC requires it, (b) the SolidSyslog
+components that satisfy it at any SL the integrator chooses to ship them, and
+(c) any current capability gaps.
 
-| Requirement | Description | SL1 | SL2 | SL3 | SL4 |
-|---|---|---|---|---|---|
-| CR 1.5 | Authenticator management | — | — | — | Required |
-| CR 1.8 | Public key infrastructure certificates | — | — | — | Required |
-| CR 2.8 | Auditable events | Required | Required | Required | Required |
-| CR 2.9 | Audit storage capacity | — | Required | Required | Required |
-| CR 2.10 | Response to audit processing failures | — | — | Required | Required |
-| CR 2.11 | Timestamps | Required | Required | Required | Required |
-| CR 2.12 | Non-repudiation | — | — | Required | Required |
-| CR 3.9 | Audit information protection | — | Required | Required | Required |
-| SR 6.1 | Audit log accessibility | Required | Required | Required | Required |
-| SR 6.2 | Continuous monitoring | — | Required | Required | Required |
+The components are not bound to specific Security Levels — any of them can be
+linked at any SL. The SL distinction is which controls a deployment must
+address, not which components it may use. See [Setup recipes by SL](#setup-recipes-by-sl)
+at the end of this document for recommended starter component sets.
 
-CR 1.5 and CR 1.8 are included because SL4 mutual TLS uses a client certificate
-as the device's authenticator to the SIEM. They are not relevant at SL1–SL3
-where server-auth TLS (or no TLS) is the chosen posture.
+| CR / SR | Description | Required at | Components & configuration | Gaps |
+|---|---|---|---|---|
+| CR 1.5 | Authenticator management | SL4 | `SolidSyslogTlsStream` mTLS — caller supplies `clientCertChainPath` / `clientKeyPath`; `SSL_CTX_check_private_key` validates the key/cert pair before any bytes hit the wire. Rotation by file replacement plus reconnect (natural reconnect or explicit `SolidSyslogSender_Disconnect`) | Library ships no default authenticators; at-rest key protection (filesystem permissions, HSM) is the integrator's responsibility |
+| CR 1.8 | Public key infrastructure certificates | SL4 | `SolidSyslogTlsStream` — `caBundlePath` loads trust anchors via `SSL_CTX_load_verify_locations`; `SSL_VERIFY_PEER` pinned on the CTX; hostname verification via `SSL_set1_host`. CTX rebuilt on every `Open` so file replacement + reconnect refreshes trust anchors | Revocation (CRL / OCSP) deferred to the OS trust store per [S03.08 ADR](https://github.com/DavidCozens/solid-syslog/issues/172); enrolment is the caller's PKI process |
+| CR 2.8 | Auditable events | SL1+ | `SolidSyslog_Log` formats events per RFC 5424 via `SolidSyslogFormatter`. Structured data attached via `SolidSyslogMetaSd` / `SolidSyslogTimeQualitySd` / `SolidSyslogOriginSd`, or caller-supplied SD. Application defines what to log | None |
+| CR 2.9 | Audit storage capacity | SL2+ | `SolidSyslogFileStore` — rotating files, configurable `max-files` and `max-file-size`, configurable discard policy (`oldest` / `newest` / `halt`). Backed by `SolidSyslogPosixFile` (POSIX) or `SolidSyslogWindowsFile` (Windows). Size to the deployment's outage budget | None |
+| CR 2.10 | Response to audit processing failures | SL3+ | `SolidSyslogStoreFullCallback` (halt policy) and the discard-policy enum. Caller picks the policy that fits the deployment's audit-loss tolerance | None |
+| CR 2.11 | Timestamps | SL1+ | Caller-injected `SolidSyslogClockFunction` — `SolidSyslogPosixClock_GetTimestamp` (POSIX) or `SolidSyslogWindowsClock_GetTimestamp` (Windows). Quality metadata via `SolidSyslogTimeQualitySd` (`tzKnown` / `isSynced` / `syncAccuracy`) | None |
+| CR 2.12 | Non-repudiation | SL3+ | At the wire: `SolidSyslogTlsStream` mTLS cryptographically identifies the sender (SL4 deployments). End-to-end loss detection: `SolidSyslogMetaSd` sequenceId, gap detection at the SIEM. At rest: `SolidSyslogCrc16Policy` records integrity | At-rest CRC-16 is non-cryptographic — a local attacker can rewrite records and recompute the CRC. HMAC / AES-CMAC planned — [E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105) |
+| CR 3.9 | Audit information protection | SL2+ | In transit: `SolidSyslogTlsStream` (TLS 1.2+, AEAD ciphers, hostname verification, optional mTLS). At rest: `SolidSyslogCrc16Policy` for tamper detection | At-rest cryptographic integrity / encryption planned — [E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105) |
+| SR 6.1 | Audit log accessibility | SL1+ | `SolidSyslog_Log` is non-blocking — `SolidSyslogNullBuffer` for immediate send, `SolidSyslogPosixMessageQueueBuffer` for deferred. `SolidSyslog_Service` performs the blocking I/O on the integrator's chosen thread, bounded per attempt by `SO_SNDTIMEO` (5 s — see [`SolidSyslogPosixTcpStream.c`](../Platform/Posix/Source/SolidSyslogPosixTcpStream.c) and [`SolidSyslogWinsockTcpStream.c`](../Platform/Windows/Source/SolidSyslogWinsockTcpStream.c)) | None |
+| SR 6.2 | Continuous monitoring | SL2+ | TCP / TLS delivery confirmation via `SolidSyslogStreamSender`. Replay across outages via `SolidSyslogFileStore` store-and-forward. SIEM-side gap detection via `SolidSyslogMetaSd` sequenceId | None |
 
-## Component Selection by Security Level
+CR 1.5 and CR 1.8 are listed only at SL4 because IEC 62443 requires them only
+when the device authenticates itself cryptographically — at SL1–SL3 the
+posture is server-auth TLS or no TLS.
 
-### SL1 — Basic Audit Logging
+A **comprehensive error-guard pass** ([E12 #31](https://github.com/DavidCozens/solid-syslog/issues/31))
+is in progress across the library. Not a single CR but supports the
+IEC 62443-4-1 secure development lifecycle baseline that underpins SL3+
+deployments.
 
-Minimum viable logging. Events are formatted per RFC 5424 and transmitted
-immediately. Suitable for environments where logging is a compliance checkbox
-and the network is trusted.
+### SL4 TLS substrate
 
-| Component | Header | Purpose |
-|---|---|---|
-| `SolidSyslog` | `SolidSyslog.h`, `SolidSyslogConfig.h` | Core Log/Service API |
-| `SolidSyslogUdpSender` | `SolidSyslogUdpSender.h` | UDP transport (RFC 5426). Connected-socket lifecycle so the kernel can surface `EMSGSIZE` for path-MTU oversize (auto-trimmed and resent, S12.12) and `ECONNREFUSED` when the destination port is closed; both surface as `Send` returning false so the buffered/Service algorithm can keep the message for retry. End-to-end delivery is still unconfirmed (UDP). |
-| `SolidSyslogNullBuffer` | `SolidSyslogNullBuffer.h` | Direct send, no buffering (single-task) |
-| `SolidSyslogNullStore` | `SolidSyslogNullStore.h` | No persistence |
-| `SolidSyslogNullSecurityPolicy` | `SolidSyslogNullSecurityPolicy.h` | No integrity checking |
-| `SolidSyslogFormatter` | `SolidSyslogFormatter.h` | Bounded buffer formatting with overflow protection |
-
-**What this gives you:**
-- RFC 5424 compliant syslog messages (CR 2.8)
-- Timestamps via injected clock function (CR 2.11)
-- Facility/severity classification (CR 2.8)
-- No dynamic memory allocation — stack-only operation
-- Bounded formatting — all buffer writes go through a single overflow-protected
-  write point
-
-**Limitations at SL1:**
-- UDP is unreliable — messages may be lost silently
-- No clock quality metadata
-- No message ordering guarantees
-- No persistence across network outages
-
-### SL2 — Reliable Logging with Identity
-
-Adds reliable transport, asynchronous buffering, event source identification,
-and message ordering. Suitable for environments where audit logs must survive
-brief disruptions and events must be attributable to a specific source.
-
-| Component | Header | Purpose |
-|---|---|---|
-| *All SL1 components* | | |
-| `SolidSyslogStreamSender` | `SolidSyslogStreamSender.h` | Reliable octet-framed transport (RFC 6587) over a Stream — `SolidSyslogPosixTcpStream` (POSIX) or `SolidSyslogWinsockTcpStream` (Windows) at SL2, `SolidSyslogTlsStream` at SL4 |
-| `SolidSyslogPosixMessageQueueBuffer` | `SolidSyslogPosixMessageQueueBuffer.h` | Async buffering (thread-safe) |
-| `SolidSyslogPosixClock` | `SolidSyslogPosixClock.h` | System clock timestamps |
-| `SolidSyslogPosixHostname` | `SolidSyslogPosixHostname.h` | POSIX hostname identification |
-| `SolidSyslogPosixProcessId` | `SolidSyslogPosixProcessId.h` | Process identification |
-| `SolidSyslogMetaSd` | `SolidSyslogMetaSd.h` | sequenceId for message ordering |
-| `SolidSyslogTimeQualitySd` | `SolidSyslogTimeQualitySd.h` | Clock synchronisation metadata |
-| `SolidSyslogAtomicCounter` | `SolidSyslogAtomicCounter.h` | Thread-safe sequence counter |
-
-**What this adds over SL1:**
-- TCP delivery confirmation — messages are not silently lost (SR 6.2)
-- Source identification — hostname, app name, process ID in every message (CR 2.8)
-- Message ordering — sequenceId detects gaps and reordering (SR 6.2)
-- Clock quality — tzKnown, isSynced, syncAccuracy metadata (CR 2.11)
-- Asynchronous logging — Log() does not block on network I/O (SR 6.1)
-
-**Limitations at SL2:**
-- Messages lost during extended network outages (no store-and-forward)
-- No integrity protection on stored or in-flight data
-- No software origin metadata
-
-### SL3 — Protected Logging with Store-and-Forward
-
-Adds persistent storage, integrity protection, and software identification.
-Events survive network outages and power cycles. Integrity checking detects
-tampering with stored records. Suitable for environments requiring
-non-repudiation and assured delivery.
-
-| Component | Header | Purpose |
-|---|---|---|
-| *All SL2 components* | | |
-| `SolidSyslogFileStore` | `SolidSyslogFileStore.h` | Persistent store-and-forward |
-| `SolidSyslogCrc16Policy` | `SolidSyslogCrc16Policy.h` | CRC-16 integrity on stored records |
-| `SolidSyslogOriginSd` | `SolidSyslogOriginSd.h` | Software name and version metadata |
-| `SolidSyslogPosixFile` | `SolidSyslogPosixFile.h` | POSIX file I/O for store |
-
-**What this adds over SL2:**
-- Store-and-forward — events buffered to rotating files during network outage,
-  replayed on reconnection (CR 2.9, CR 2.10)
-- Integrity protection — CRC-16 on every stored record detects corruption or
-  tampering (CR 3.9, CR 2.12)
-- Corruption recovery — damaged records are skipped, valid records preserved
-- Configurable storage capacity — max files, max file size, discard policy
-- Halt-on-full policy — optional callback when storage is exhausted, preventing
-  silent data loss (CR 2.10)
-- Software origin — `[origin software="..." swVersion="..."]` structured data
-  identifies the generating application (CR 2.12)
-- sequenceId non-repudiation — SIEM can detect missing events via sequence gaps
-  (CR 2.12)
-
-**Limitations at SL3:**
-- CRC-16 detects accidental corruption but is not cryptographically secure —
-  an attacker with local access could modify records and recompute the CRC
-- No encryption at rest — stored records are plaintext
-- No TLS — in-flight data is not encrypted
-
-### SL4 — High-Assurance Logging
-
-Requires cryptographic integrity, encryption, and assured delivery with
-non-repudiation. TLS transport has landed and RFC 5424 string-hygiene is
-closed (SD escaping + PRINTUSASCII header-field validation + UTF-8
-formatter primitives); the remaining SL4 item is at-rest cryptography.
-
-| Component | Header | Purpose | Status |
-|---|---|---|---|
-| *All SL3 components* | | | Available |
-| `SolidSyslogTlsStream` | `SolidSyslogTlsStream.h` | OpenSSL-backed TLS 1.2+ transport (RFC 5425): server cert validation, hostname verification, cipher pinning, optional mutual TLS, rotation on reconnect | Available |
-| Authenticated integrity policy | — | HMAC/AES-CMAC on stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
-| Encryption at rest | — | AES encryption of stored records | Planned — [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
-| PRINTUSASCII validation | — | Header field character compliance | Available — non-compliant bytes substituted with `?` via `SolidSyslogFormatter_PrintUsAsciiString` |
-| UTF-8 validation | — | Formatter primitives uphold RFC 3629; ill-formed input substituted with U+FFFD (Unicode §3.9). MSG bodies are prefixed with the RFC 5424 §6.4 UTF-8 BOM, with caller-supplied BOMs normalised to one ([S12.13](https://github.com/DavidCozens/solid-syslog/issues/219)). Truncation preserves codepoint boundaries at both layers — formatter clip ([S12.10](https://github.com/DavidCozens/solid-syslog/issues/121)) and UDP path-MTU clip ([S12.12](https://github.com/DavidCozens/solid-syslog/issues/210)). TCP/TLS streams fragment transparently at the transport layer and so do not need a path-MTU trim. | Available — `SolidSyslogFormatter_BoundedString`, `SolidSyslogFormatter_EscapedString`, `SolidSyslogFormatter_Bom`, `SolidSyslogUdpPayload_TrimToCodepointBoundary` |
-| Comprehensive error guards | — | NULL guards, resource leak protection | In progress — [E12](https://github.com/DavidCozens/solid-syslog/issues/31) |
-
-**What SL4 adds over SL3:**
-- TLS transport — encrypted, authenticated delivery to SIEM via
-  `SolidSyslogTlsStream` plugged into `SolidSyslogStreamSender` (CR 3.9).
-- Mutual TLS — device-to-SIEM authentication via client cert + key, with
-  `SSL_CTX_check_private_key` confirming the pairing before any bytes hit the
-  wire (CR 1.5, CR 2.12).
-- Cert rotation — `SSL_CTX` rebuilt on every `Open`, so file replacement +
-  reconnect refreshes authenticators and trust anchors (CR 1.5, CR 1.8).
-
-**Still to come at SL4:**
-- Cryptographic integrity at rest — HMAC or AES-CMAC replacing CRC-16, making
-  stored-record tampering detectable even by a local attacker (CR 2.12, CR 3.9).
-- Encryption at rest — stored records unreadable without key material (CR 3.9).
-
-**SL4 TLS substrate.** `SolidSyslogTlsStream` — the OpenSSL-backed client-side
-TLS substrate — ships with the SL4 controls that depend on the client:
+`SolidSyslogTlsStream` — the OpenSSL-backed client-side TLS substrate — ships
+with the SL4 controls that depend on the client:
 
 - **Hostname verification.** `SolidSyslogTlsStreamConfig.serverName` is
   forwarded to both SNI (`SSL_set_tlsext_host_name`) and the cert check
@@ -263,22 +151,47 @@ the collector can alert on missing sequence numbers without polling the device.
 `sequenceId` is assigned at the point of message raise (application-layer
 originator), so gaps observed by the SIEM reflect any drop in the full audit
 pipeline — internal buffer, store-and-forward, and transport — not just
-transport-level loss. This contributes to FR 3 (system integrity) and CR 6.1
+transport-level loss. This contributes to FR 3 (system integrity) and SR 6.1
 (audit log accessibility) by giving the SIEM a single end-to-end loss-detection
 signal that does not depend on the transport layer being lossless. Cross-reference:
 [RFC 5424 §7.3.1 in the compliance matrix](rfc-compliance.md#rfc-5424--the-syslog-protocol).
 
-## Traceability Matrix
+## Setup recipes by SL
 
-| IEC 62443 Requirement | SolidSyslog Component | Notes |
-|---|---|---|
-| CR 1.5 Authenticator management | `SolidSyslogTlsStream` — mTLS client cert + key loaded from caller-supplied paths; rotation via file replacement + reconnect | Library ships no default authenticators (vacuous (b)). (d) at-rest key protection — filesystem permissions / HSM — is the integrator's responsibility |
-| CR 1.8 PKI certificates | `SolidSyslogTlsStream` — libssl chain validation (`SSL_VERIFY_PEER`), hostname verification (`SSL_set1_host`), update via reconnect | Revocation (CRL / OCSP) deferred to OS trust store per S03.08 ADR; enrolment is the caller's PKI process |
-| CR 2.8 Auditable events | `SolidSyslog_Log`, RFC 5424 formatting | Application defines what to log |
-| CR 2.9 Audit storage capacity | `SolidSyslogFileStore` (SL3+) | Configurable max files and file size |
-| CR 2.10 Response to audit failures | `SolidSyslogStoreFullCallback`, halt policy | Callback on storage full, optional halt |
-| CR 2.11 Timestamps | `SolidSyslogClockFunction`, `SolidSyslogTimeQualitySd` | Injected clock with quality metadata |
-| CR 2.12 Non-repudiation | `SolidSyslogMetaSd` (sequenceId), `SolidSyslogCrc16Policy`, `SolidSyslogTlsStream` mTLS | Sequence gaps detectable by SIEM; mTLS cryptographically identifies the sender |
-| CR 3.9 Audit information protection | `SolidSyslogCrc16Policy` (at rest, SL3), `SolidSyslogTlsStream` (in transit, SL4) | TLS substrate hardened by [S03.08](https://github.com/DavidCozens/solid-syslog/issues/172) and [S03.09](https://github.com/DavidCozens/solid-syslog/issues/173); cryptographic integrity and encryption at rest remain in [E17](https://github.com/DavidCozens/solid-syslog/issues/105) |
-| SR 6.1 Audit log accessibility | `SolidSyslog_Service`, sender vtable | Non-blocking Log; Service performs the blocking I/O on its own thread, bounded per attempt by the TCP transport's `SO_SNDTIMEO` (5 s — see [`SolidSyslogPosixTcpStream.c`](../Platform/Posix/Source/SolidSyslogPosixTcpStream.c) and [`SolidSyslogWinsockTcpStream.c`](../Platform/Windows/Source/SolidSyslogWinsockTcpStream.c)) |
-| SR 6.2 Continuous monitoring | TCP/TLS transport, store-and-forward | Assured delivery via replay on reconnect |
+Recommended starter component sets for each Security Level. The components
+listed are sufficient to address the controls IEC requires at that level —
+nothing prevents an SL1 deployment from linking SL3-style components if the
+threat model demands it. See [Control Implementation](#control-implementation)
+above for the canonical CR-to-component mapping.
+
+### SL1 — basic audit logging
+
+- `SolidSyslog`, `SolidSyslogConfig` — core API.
+- `SolidSyslogFormatter` — bounded buffer formatting.
+- A clock — `SolidSyslogPosixClock_GetTimestamp` (POSIX) or `SolidSyslogWindowsClock_GetTimestamp` (Windows).
+- A sender — `SolidSyslogUdpSender` (RFC 5426 UDP) or `SolidSyslogStreamSender` over a TCP `Stream` (RFC 6587).
+- A buffer — `SolidSyslogNullBuffer` (single-task) or `SolidSyslogPosixMessageQueueBuffer` (threaded).
+- A store — `SolidSyslogNullStore` is sufficient at SL1 (no persistence required).
+- A security policy — `SolidSyslogNullSecurityPolicy` is sufficient.
+
+### SL2 — adds storage and continuous monitoring
+
+- All SL1 components.
+- TCP transport (`SolidSyslogStreamSender` over `SolidSyslogPosixTcpStream` / `SolidSyslogWinsockTcpStream`) so the sender sees delivery confirmation (SR 6.2).
+- `SolidSyslogFileStore` so messages survive network outages (CR 2.9), with `max-files` × `max-file-size` sized to the deployment's outage budget.
+- `SolidSyslogMetaSd` sequenceId so the SIEM can detect gaps independently of the transport layer (SR 6.2).
+- `SolidSyslogTimeQualitySd` clock-quality metadata (CR 2.11).
+
+### SL3 — adds non-repudiation and audit-failure response
+
+- All SL2 components.
+- `SolidSyslogCrc16Policy` for at-rest tamper detection (CR 2.12, CR 3.9).
+- A discard-policy choice (`oldest` / `newest` / `halt`) and, if `halt` is selected, a `SolidSyslogStoreFullCallback` so the application can react when storage is exhausted (CR 2.10).
+- `SolidSyslogOriginSd` software / version metadata to identify the generating application.
+
+### SL4 — adds cryptographic identity and audit information protection
+
+- All SL3 components.
+- `SolidSyslogTlsStream` instead of plain TCP, configured with `caBundlePath`, `serverName`, and (for mutual-auth deployments) `clientCertChainPath` / `clientKeyPath` (CR 1.5, CR 1.8, CR 3.9 in transit).
+- A `cipherList` appropriate to the deployment's threat model — e.g. `"ECDHE+AESGCM:ECDHE+CHACHA20"` for TLS 1.2 AEAD with forward secrecy.
+- *Planned* — cryptographic at-rest integrity policy ([E17 #105](https://github.com/DavidCozens/solid-syslog/issues/105)) closes the remaining at-rest gap on CR 2.12 / CR 3.9.


### PR DESCRIPTION
## Summary

Restructures `docs/iec62443.md` around a single per-CR control table — each row identifies (a) the SL at which IEC requires the control, (b) the SolidSyslog components that satisfy it at any level the integrator picks, and (c) any current capability gap. A thin "Setup recipes by SL" section at the end gives the practical starter component bundle for each SL.

## Why

The previous shape had two structural problems:

- Components were presented as bundled into SL-specific component sets ("SL2 components", "SL3 components"), so `SolidSyslogFileStore` looked unavailable at SL2 even though the integrator can link it at any level. The "Limitations at SL2: messages lost during extended outages" cell directly contradicted the IEC requirements table at the top, which lists CR 2.9 as required at SL2.
- The Traceability Matrix at the bottom duplicated the SL-by-SL component tables in the middle, with neither presenting the control-to-component mapping authoritatively.

The rewrite separates capability (per-CR) from recommendations (recipes by SL).

## Stats

- 286 → 197 lines.
- "Architecture for Security", "Deployment Considerations", and the SL4 TLS substrate deep-dive preserved verbatim.
- Pre-existing typo in the SIEM-integration paragraph fixed (`CR 6.1` → `SR 6.1`).

## Test plan

- [ ] CI green (`analyze-format` is the only meaningful gate; everything else is a no-op for docs)