### PR TITLE
refactor: TimeQualitySd / MetaSd helpers static inline + single-exit

### DIFF
--- a/Core/Source/SolidSyslogMetaSd.c
+++ b/Core/Source/SolidSyslogMetaSd.c
@@ -13,10 +13,10 @@ struct SolidSyslogMetaSd
     SolidSyslogStringFunction        getLanguage;
 };
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
-static void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
-static void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static void        Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static inline void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
 
 static struct SolidSyslogMetaSd instance;
 
@@ -53,38 +53,32 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
-static void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
-    if (meta->counter == NULL)
+    if (meta->counter != NULL)
     {
-        return;
+        SolidSyslogFormatter_BoundedString(formatter, SEQUENCE_ID_SD, sizeof(SEQUENCE_ID_SD) - 1);
+        SolidSyslogFormatter_Uint32(formatter, SolidSyslogAtomicCounter_Increment(meta->counter));
+        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
     }
-
-    SolidSyslogFormatter_BoundedString(formatter, SEQUENCE_ID_SD, sizeof(SEQUENCE_ID_SD) - 1);
-    SolidSyslogFormatter_Uint32(formatter, SolidSyslogAtomicCounter_Increment(meta->counter));
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
-static void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
-    if (meta->getSysUpTime == NULL)
+    if (meta->getSysUpTime != NULL)
     {
-        return;
+        SolidSyslogFormatter_BoundedString(formatter, SYS_UP_TIME_SD, sizeof(SYS_UP_TIME_SD) - 1);
+        SolidSyslogFormatter_Uint32(formatter, meta->getSysUpTime());
+        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
     }
-
-    SolidSyslogFormatter_BoundedString(formatter, SYS_UP_TIME_SD, sizeof(SYS_UP_TIME_SD) - 1);
-    SolidSyslogFormatter_Uint32(formatter, meta->getSysUpTime());
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
-static void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
-    if (meta->getLanguage == NULL)
+    if (meta->getLanguage != NULL)
     {
-        return;
+        SolidSyslogFormatter_BoundedString(formatter, LANGUAGE_SD, sizeof(LANGUAGE_SD) - 1);
+        meta->getLanguage(formatter);
+        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
     }
-
-    SolidSyslogFormatter_BoundedString(formatter, LANGUAGE_SD, sizeof(LANGUAGE_SD) - 1);
-    meta->getLanguage(formatter);
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }

--- a/Core/Source/SolidSyslogTimeQualitySd.c
+++ b/Core/Source/SolidSyslogTimeQualitySd.c
@@ -8,9 +8,9 @@ struct SolidSyslogTimeQualitySd
     SolidSyslogTimeQualityFunction   getTimeQuality;
 };
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* name, size_t nameLength, bool value);
-static void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value);
+static void        Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static inline void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* name, size_t nameLength, bool value);
+static inline void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value);
 
 static struct SolidSyslogTimeQualitySd instance;
 
@@ -46,7 +46,7 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
-static void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* name, size_t nameLength, bool value)
+static inline void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* name, size_t nameLength, bool value)
 {
     SolidSyslogFormatter_BoundedString(formatter, name, nameLength);
     SolidSyslogFormatter_AsciiCharacter(formatter, '=');
@@ -55,14 +55,12 @@ static void FormatBoolParam(struct SolidSyslogFormatter* formatter, const char* 
     SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
-static void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
+static inline void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    if (value == SOLIDSYSLOG_SYNC_ACCURACY_OMIT)
+    if (value != SOLIDSYSLOG_SYNC_ACCURACY_OMIT)
     {
-        return;
+        SolidSyslogFormatter_BoundedString(formatter, PARAM_SYNC_ACCURACY, sizeof(PARAM_SYNC_ACCURACY) - 1);
+        SolidSyslogFormatter_Uint32(formatter, value);
+        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
     }
-
-    SolidSyslogFormatter_BoundedString(formatter, PARAM_SYNC_ACCURACY, sizeof(PARAM_SYNC_ACCURACY) - 1);
-    SolidSyslogFormatter_Uint32(formatter, value);
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }


### PR DESCRIPTION
## Summary

Cleanup of two pre-existing style violations the user reaffirmed during S07.05:

- Extracted readability helpers in production C should be `static inline` per CLAUDE.md ("helpers are usually static inline"). They are extracted for clarity, not for behavioural separation, so `inline` is the correct compiler hint.
- Bodies should follow the project MISRA single-exit leaning rather than using early-return guard clauses.

`SolidSyslogTimeQualitySd.c`:

- `FormatBoolParam`: `static void` → `static inline void` (no body change; was already single-exit).
- `FormatSyncAccuracy`: `static void` → `static inline void`; early-return guard `if (value == OMIT) { return; }` rewritten as a wrapping `if (value != OMIT) { … }` so the function has a single implicit exit at the closing brace.

`SolidSyslogMetaSd.c`:

- `EmitSequenceId` / `EmitSysUpTime` / `EmitLanguage`: same pattern. All three picked up `static inline` and switched from early-return guards to wrapped if-blocks.

Forward declarations updated to match. All bodies and effective behaviour are unchanged — pure refactor for codebase consistency. `OriginSd` helpers (added in S07.05) already follow this pattern; this PR aligns the older SDs.

The `project_misra_early_return_audit` memory entry that tracked this can be removed once this lands.

## Test plan

- [ ] CI green: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format
- [ ] CI green: integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel
- [ ] Coverage stays at 100% lines / 100% functions
- [ ] Local validation: 947 tests pass on gcc + clang + ASan/UBSan; coverage 100% (1559/1559 lines, 349/349 functions); tidy/cppcheck/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)