### PR TITLE
docs: add Callback Conventions section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,39 @@ Names should be self-documenting — prefer clarity over brevity.
 
 ---
 
+## Callback Conventions
+
+The library is migrating away from singleton instances toward integrator-injected storage and
+context-pointer callbacks. The migration is **opportunistic per-class** — not a sweep — so older
+context-less callbacks (`SolidSyslogClockFunction`, `SolidSyslogStringFunction`,
+`SolidSyslogStoreFullCallback`, etc.) keep their current shape until the class that owns them is
+next touched.
+
+**For new callbacks:**
+
+- The function pointer takes a `void* context` parameter.
+- The config struct exposes a paired context field. When several callbacks form a logical
+  feature, share one context field (e.g. `thresholdContext` shared between the threshold
+  function and the threshold-crossed callback).
+- Treat the context as opaque from the integrator's side — the library passes it through unchanged.
+
+**For existing callbacks:**
+
+- Migrate at the same time as a refactor or significant modification of the owning class. For
+  example, `SolidSyslogStoreFullCallback` migrates inside the FileStore split (S18.01), not in a
+  separate sweep PR.
+
+**Storage injection:**
+
+- Mirrors the `SolidSyslogFormatterStorage` pattern. The public header exposes an opaque storage
+  type and a `SOLIDSYSLOG_<TYPE>_STORAGE_SIZE` macro; `_Create` takes a pointer to caller-allocated
+  storage of that size. No `malloc` anywhere in the library.
+- Internal sub-components (e.g. RecordStore and BlockSequence inside FileStore) nest inside the
+  parent's storage blob. Their types stay in `Core/Source/` and never appear in public headers,
+  so integrator and example code physically cannot reach them.
+
+---
+
 ## Function Ordering
 
 Within a source file, functions are ordered top-down so the reader sees the lifecycle and public API


### PR DESCRIPTION
## Summary

- Adds a new **Callback Conventions** section to `CLAUDE.md` between *Code Style* and *Function Ordering*.
- Captures the resolved direction from the S05.09 / E18 refinement session: new callbacks take `void* context` paired with a config-struct context field; existing context-less callbacks migrate opportunistically when their owning class is next touched; storage injection follows the `SolidSyslogFormatterStorage` opaque-blob pattern.
- Notes that internal sub-components (e.g. RecordStore / BlockSequence inside FileStore) nest in the parent's storage blob and stay in `Core/Source/`, which the CMake target structure makes unreachable from integrator and example code — encapsulation enforced by the build, not just convention.

## Why now

The first stories under this convention are queued: S05.09 #111, S18.01 #234, and the rest of E18 #112. Landing the convention as its own small docs PR keeps subsequent code PRs focused on implementation rather than introducing the rule and applying it in the same change.

## Test plan

- [x] Docs-only change — no code, no tests, no CI gates affected beyond the standard checks.
- [ ] Reviewer skim the new section reads sensibly and matches the existing CLAUDE.md tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to clarify callback parameter requirements and context-sharing patterns for callback APIs.
  * Documented storage-allocation guidelines and migration strategy for API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->