### PR TITLE
refactor(filestore): split into RecordStore + BlockSequence layers (S18.01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,12 +333,12 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |
-| `SolidSyslogStore.h` | Library internals consuming a store (Service algorithm) | `SolidSyslogStore_Write`, `_ReadNextUnsent`, `_MarkSent`, `_HasUnsent`, `_IsHalted` |
-| `SolidSyslogStoreDefinition.h` | Store implementors (extension point) | `SolidSyslogStore` vtable struct |
+| `SolidSyslogStore.h` | Library internals consuming a store (Service algorithm) and integrator code querying capacity | `SolidSyslogStore_Write`, `_ReadNextUnsent`, `_MarkSent`, `_HasUnsent`, `_IsHalted`, `_GetTotalBytes`, `_GetUsedBytes` |
+| `SolidSyslogStoreDefinition.h` | Store implementors (extension point) | `SolidSyslogStore` vtable struct (`Write`, `ReadNextUnsent`, `MarkSent`, `HasUnsent`, `IsHalted`, `GetTotalBytes`, `GetUsedBytes`) |
 | `SolidSyslogNullStore.h` | System setup code (no store-and-forward) | `SolidSyslogNullStore_Create`, `_Destroy` |
 | `SolidSyslogFileDefinition.h` | File implementors (extension point) | `SolidSyslogFile` vtable struct |
 | `SolidSyslogFile.h` | Any code using the file abstraction | `SolidSyslogFile_Open`, `_Close`, `_IsOpen`, `_Read`, `_Write`, `_SeekTo`, `_Size`, `_Truncate` |
-| `SolidSyslogFileStore.h` | System setup code using file-based store | `SolidSyslogFileStore_Create`, `_Destroy`, `SOLIDSYSLOG_HALT`, `SolidSyslogStoreFullCallback` |
+| `SolidSyslogFileStore.h` | System setup code using file-based store | `SolidSyslogFileStoreStorage`, `SOLIDSYSLOG_FILESTORE_STORAGE_SIZE`, `SolidSyslogFileStoreConfig` (with `storeFullContext`), `SolidSyslogFileStore_Create(storage, config)`, `_Destroy(store)`, `SolidSyslogDiscardPolicy` (`SOLIDSYSLOG_DISCARD_OLDEST` / `_NEWEST` / `_HALT`), `SolidSyslogStoreFullCallback(void* context)` |
 | `SolidSyslogSecurityPolicyDefinition.h` | SecurityPolicy implementors (extension point) | `SolidSyslogSecurityPolicy` vtable struct, `SOLIDSYSLOG_MAX_INTEGRITY_SIZE` |
 | `SolidSyslogNullSecurityPolicy.h` | System setup code (no integrity checking) | `SolidSyslogNullSecurityPolicy_Create`, `_Destroy` |
 | `SolidSyslogCrc16Policy.h` | System setup code using CRC-16 integrity | `SolidSyslogCrc16Policy_Create`, `_Destroy` |

--- a/Core/Interface/SolidSyslogFileStore.h
+++ b/Core/Interface/SolidSyslogFileStore.h
@@ -1,14 +1,15 @@
 #ifndef SOLIDSYSLOGFILESTORE_H
 #define SOLIDSYSLOGFILESTORE_H
 
+#include "SolidSyslog.h"
 #include "SolidSyslogFile.h"
+#include "SolidSyslogSecurityPolicyDefinition.h"
 #include "SolidSyslogStore.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 EXTERN_C_BEGIN
-
-    struct SolidSyslogSecurityPolicy;
 
     enum SolidSyslogDiscardPolicy
     {
@@ -31,8 +32,18 @@ EXTERN_C_BEGIN
         SolidSyslogStoreFullCallback      onStoreFull;
     };
 
-    struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config);
-    void                     SolidSyslogFileStore_Destroy(void);
+    enum
+    {
+        SOLIDSYSLOG_FILESTORE_STORAGE_SIZE = (sizeof(intptr_t) * 32) + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE + 16
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_FILESTORE_STORAGE_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogFileStoreStorage;
+
+    struct SolidSyslogStore* SolidSyslogFileStore_Create(SolidSyslogFileStoreStorage * storage, const struct SolidSyslogFileStoreConfig* config);
+    void                     SolidSyslogFileStore_Destroy(struct SolidSyslogStore * store);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogFileStore.h
+++ b/Core/Interface/SolidSyslogFileStore.h
@@ -18,7 +18,7 @@ EXTERN_C_BEGIN
         SOLIDSYSLOG_HALT
     };
 
-    typedef void (*SolidSyslogStoreFullCallback)(void); // NOLINT(modernize-redundant-void-arg) -- required in C
+    typedef void (*SolidSyslogStoreFullCallback)(void* context);
 
     struct SolidSyslogFileStoreConfig
     {
@@ -30,6 +30,7 @@ EXTERN_C_BEGIN
         enum SolidSyslogDiscardPolicy     discardPolicy;
         struct SolidSyslogSecurityPolicy* securityPolicy;
         SolidSyslogStoreFullCallback      onStoreFull;
+        void*                             storeFullContext;
     };
 
     enum

--- a/Core/Interface/SolidSyslogStore.h
+++ b/Core/Interface/SolidSyslogStore.h
@@ -9,11 +9,13 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogStore;
 
-    bool SolidSyslogStore_Write(struct SolidSyslogStore * store, const void* data, size_t size);
-    bool SolidSyslogStore_ReadNextUnsent(struct SolidSyslogStore * store, void* data, size_t maxSize, size_t* bytesRead);
-    void SolidSyslogStore_MarkSent(struct SolidSyslogStore * store);
-    bool SolidSyslogStore_HasUnsent(struct SolidSyslogStore * store);
-    bool SolidSyslogStore_IsHalted(struct SolidSyslogStore * store);
+    bool   SolidSyslogStore_Write(struct SolidSyslogStore * store, const void* data, size_t size);
+    bool   SolidSyslogStore_ReadNextUnsent(struct SolidSyslogStore * store, void* data, size_t maxSize, size_t* bytesRead);
+    void   SolidSyslogStore_MarkSent(struct SolidSyslogStore * store);
+    bool   SolidSyslogStore_HasUnsent(struct SolidSyslogStore * store);
+    bool   SolidSyslogStore_IsHalted(struct SolidSyslogStore * store);
+    size_t SolidSyslogStore_GetTotalBytes(struct SolidSyslogStore * store);
+    size_t SolidSyslogStore_GetUsedBytes(struct SolidSyslogStore * store);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogStoreDefinition.h
+++ b/Core/Interface/SolidSyslogStoreDefinition.h
@@ -12,6 +12,8 @@ EXTERN_C_BEGIN
         void (*MarkSent)(struct SolidSyslogStore* self);
         bool (*HasUnsent)(struct SolidSyslogStore* self);
         bool (*IsHalted)(struct SolidSyslogStore* self);
+        size_t (*GetTotalBytes)(struct SolidSyslogStore* self);
+        size_t (*GetUsedBytes)(struct SolidSyslogStore* self);
     };
 
 EXTERN_C_END

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -87,18 +87,18 @@ bool BlockSequence_Open(struct BlockSequence* blockSequence)
     SolidSyslogFormatterStorage writeNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
     const char*                 writeName = FormatFilename(blockSequence, writeNameStorage, blockSequence->writeSequence);
 
-    if (!SolidSyslogFile_Open(blockSequence->writeFile, writeName))
+    bool opened = SolidSyslogFile_Open(blockSequence->writeFile, writeName);
+
+    if (opened)
     {
-        return false;
+        SolidSyslogFormatterStorage readNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+        const char*                 readName = FormatFilename(blockSequence, readNameStorage, blockSequence->readSequence);
+        SolidSyslogFile_Open(blockSequence->readFile, readName);
+
+        blockSequence->writePosition = SolidSyslogFile_Size(blockSequence->writeFile);
     }
 
-    SolidSyslogFormatterStorage readNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char*                 readName = FormatFilename(blockSequence, readNameStorage, blockSequence->readSequence);
-    SolidSyslogFile_Open(blockSequence->readFile, readName);
-
-    blockSequence->writePosition = SolidSyslogFile_Size(blockSequence->writeFile);
-
-    return true;
+    return opened;
 }
 
 static void ScanForExistingFiles(struct BlockSequence* blockSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -68,6 +68,7 @@ void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockS
     blockSequence->discardPolicy    = config->discardPolicy;
     blockSequence->onStoreFull      = config->onStoreFull;
     blockSequence->halted           = false;
+    blockSequence->atCapacity       = false;
     blockSequence->oldestSequence   = 0;
     blockSequence->readSequence     = 0;
     blockSequence->writeSequence    = 0;
@@ -185,6 +186,8 @@ static inline bool StoreIsFull(const struct BlockSequence* blockSequence)
 
 static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
 {
+    blockSequence->atCapacity = true;
+
     if (blockSequence->discardPolicy == SOLIDSYSLOG_HALT)
     {
         blockSequence->halted = true;
@@ -311,4 +314,20 @@ bool BlockSequence_HasUnsent(const struct BlockSequence* blockSequence)
 bool BlockSequence_IsHalted(const struct BlockSequence* blockSequence)
 {
     return blockSequence->halted;
+}
+
+size_t BlockSequence_TotalBytes(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->maxFiles * blockSequence->maxFileSize;
+}
+
+size_t BlockSequence_UsedBytes(const struct BlockSequence* blockSequence)
+{
+    if (blockSequence->atCapacity)
+    {
+        return BlockSequence_TotalBytes(blockSequence);
+    }
+
+    size_t closedBlocks = FileCount(blockSequence) - 1;
+    return (closedBlocks * blockSequence->maxFileSize) + blockSequence->writePosition;
 }

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -302,14 +302,14 @@ void BlockSequence_AdvanceToNextReadFile(struct BlockSequence* blockSequence)
     SwitchReadFile(blockSequence, NextSequence(blockSequence->readSequence));
 }
 
-bool BlockSequence_ReadingOlderFile(const struct BlockSequence* blockSequence)
+bool BlockSequence_IsReadingOlderFile(const struct BlockSequence* blockSequence)
 {
     return blockSequence->readSequence != blockSequence->writeSequence;
 }
 
 bool BlockSequence_HasUnsent(const struct BlockSequence* blockSequence)
 {
-    return BlockSequence_ReadingOlderFile(blockSequence) || (blockSequence->readCursor < blockSequence->writePosition);
+    return BlockSequence_IsReadingOlderFile(blockSequence) || (blockSequence->readCursor < blockSequence->writePosition);
 }
 
 bool BlockSequence_IsHalted(const struct BlockSequence* blockSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -67,6 +67,7 @@ void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockS
     blockSequence->maxFiles         = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
     blockSequence->discardPolicy    = config->discardPolicy;
     blockSequence->onStoreFull      = config->onStoreFull;
+    blockSequence->storeFullContext = config->storeFullContext;
     blockSequence->halted           = false;
     blockSequence->atCapacity       = false;
     blockSequence->oldestSequence   = 0;
@@ -194,7 +195,7 @@ static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
 
         if (blockSequence->onStoreFull != NULL)
         {
-            blockSequence->onStoreFull();
+            blockSequence->onStoreFull(blockSequence->storeFullContext);
         }
     }
 }

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -1,0 +1,314 @@
+#include "BlockSequence.h"
+
+#include "SolidSyslogFormatter.h"
+
+enum
+{
+    MIN_MAX_FILES    = 2,
+    MAX_MAX_FILES    = 99,
+    SEQUENCE_MODULUS = 100,
+    MAX_PATH_SIZE    = 128
+};
+
+static const char FILE_EXTENSION[] = ".log";
+
+enum
+{
+    SEQUENCE_DIGITS   = 2,
+    FILENAME_SUFFIX   = SEQUENCE_DIGITS + sizeof(FILE_EXTENSION) - 1,
+    MAX_PREFIX_LENGTH = MAX_PATH_SIZE - FILENAME_SUFFIX - 1
+};
+
+static inline const char* FormatFilename(const struct BlockSequence* blockSequence, SolidSyslogFormatterStorage* storage, uint8_t sequence)
+{
+    struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, MAX_PATH_SIZE);
+
+    SolidSyslogFormatter_BoundedString(f, blockSequence->pathPrefix, MAX_PREFIX_LENGTH);
+    SolidSyslogFormatter_TwoDigit(f, sequence);
+    SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
+
+    return SolidSyslogFormatter_AsFormattedBuffer(f);
+}
+
+static inline uint8_t NextSequence(uint8_t current)
+{
+    return (uint8_t) ((current + 1) % SEQUENCE_MODULUS);
+}
+
+static inline size_t FileCount(const struct BlockSequence* blockSequence)
+{
+    return (size_t) ((blockSequence->writeSequence - blockSequence->oldestSequence + SEQUENCE_MODULUS) % SEQUENCE_MODULUS) + 1;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value, min, max have distinct semantics
+static inline size_t ClampToRange(size_t value, size_t min, size_t max)
+{
+    size_t result = value;
+
+    if (result < min)
+    {
+        result = min;
+    }
+
+    if (result > max)
+    {
+        result = max;
+    }
+
+    return result;
+}
+
+void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockSequenceConfig* config)
+{
+    blockSequence->readFile         = config->readFile;
+    blockSequence->writeFile        = config->writeFile;
+    blockSequence->pathPrefix       = config->pathPrefix;
+    blockSequence->maxFileSize      = config->maxFileSize;
+    blockSequence->maxFiles         = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
+    blockSequence->discardPolicy    = config->discardPolicy;
+    blockSequence->onStoreFull      = config->onStoreFull;
+    blockSequence->halted           = false;
+    blockSequence->oldestSequence   = 0;
+    blockSequence->readSequence     = 0;
+    blockSequence->writeSequence    = 0;
+    blockSequence->readCursor       = 0;
+    blockSequence->writePosition    = 0;
+    blockSequence->writeFileCorrupt = false;
+}
+
+static void ScanForExistingFiles(struct BlockSequence* blockSequence);
+
+bool BlockSequence_Open(struct BlockSequence* blockSequence)
+{
+    ScanForExistingFiles(blockSequence);
+
+    SolidSyslogFormatterStorage writeNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+    const char*                 writeName = FormatFilename(blockSequence, writeNameStorage, blockSequence->writeSequence);
+
+    if (!SolidSyslogFile_Open(blockSequence->writeFile, writeName))
+    {
+        return false;
+    }
+
+    SolidSyslogFormatterStorage readNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+    const char*                 readName = FormatFilename(blockSequence, readNameStorage, blockSequence->readSequence);
+    SolidSyslogFile_Open(blockSequence->readFile, readName);
+
+    blockSequence->writePosition = SolidSyslogFile_Size(blockSequence->writeFile);
+
+    return true;
+}
+
+static void ScanForExistingFiles(struct BlockSequence* blockSequence)
+{
+    enum
+    {
+        MAX_SEQUENCE = 100
+    };
+
+    bool foundFirst = false;
+
+    for (int seq = 0; seq < MAX_SEQUENCE; seq++)
+    {
+        SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+        const char*                 name = FormatFilename(blockSequence, nameStorage, (uint8_t) seq);
+
+        if (SolidSyslogFile_Exists(blockSequence->writeFile, name))
+        {
+            if (!foundFirst)
+            {
+                blockSequence->oldestSequence = (uint8_t) seq;
+                blockSequence->readSequence   = (uint8_t) seq;
+                foundFirst                    = true;
+            }
+
+            blockSequence->writeSequence = (uint8_t) seq;
+        }
+    }
+}
+
+static inline bool IsWriteFileOpen(const struct BlockSequence* blockSequence)
+{
+    return (blockSequence->writeFile != NULL) && SolidSyslogFile_IsOpen(blockSequence->writeFile);
+}
+
+static inline bool IsReadFileOpen(const struct BlockSequence* blockSequence)
+{
+    return (blockSequence->readFile != NULL) && SolidSyslogFile_IsOpen(blockSequence->readFile);
+}
+
+void BlockSequence_Close(struct BlockSequence* blockSequence)
+{
+    if (IsWriteFileOpen(blockSequence))
+    {
+        SolidSyslogFile_Close(blockSequence->writeFile);
+    }
+
+    if (IsReadFileOpen(blockSequence))
+    {
+        SolidSyslogFile_Close(blockSequence->readFile);
+    }
+}
+
+static inline bool FileIsFull(const struct BlockSequence* blockSequence, size_t recordSize);
+static inline bool StoreIsFull(const struct BlockSequence* blockSequence);
+static inline void NotifyStoreFull(struct BlockSequence* blockSequence);
+static bool        RotateToNextFile(struct BlockSequence* blockSequence);
+
+bool BlockSequence_PrepareForWrite(struct BlockSequence* blockSequence, size_t recordSize, bool* readFileChanged)
+{
+    bool spaceAvailable = true;
+    *readFileChanged    = false;
+
+    if (FileIsFull(blockSequence, recordSize) && StoreIsFull(blockSequence))
+    {
+        NotifyStoreFull(blockSequence);
+        spaceAvailable = false;
+    }
+    else if (FileIsFull(blockSequence, recordSize))
+    {
+        *readFileChanged = RotateToNextFile(blockSequence);
+    }
+
+    return spaceAvailable;
+}
+
+static inline bool FileIsFull(const struct BlockSequence* blockSequence, size_t recordSize)
+{
+    return blockSequence->writeFileCorrupt || (blockSequence->writePosition + recordSize) > blockSequence->maxFileSize;
+}
+
+static inline bool StoreIsFull(const struct BlockSequence* blockSequence)
+{
+    return (FileCount(blockSequence) >= blockSequence->maxFiles) && (blockSequence->discardPolicy != SOLIDSYSLOG_DISCARD_OLDEST);
+}
+
+static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
+{
+    if (blockSequence->discardPolicy == SOLIDSYSLOG_HALT)
+    {
+        blockSequence->halted = true;
+
+        if (blockSequence->onStoreFull != NULL)
+        {
+            blockSequence->onStoreFull();
+        }
+    }
+}
+
+static bool        DiscardOldestFile(struct BlockSequence* blockSequence);
+static void        DeleteOldestFile(struct BlockSequence* blockSequence);
+static void        ResetReadToOldestFile(struct BlockSequence* blockSequence);
+static inline void SwitchReadFile(struct BlockSequence* blockSequence, uint8_t newSequence);
+
+static bool RotateToNextFile(struct BlockSequence* blockSequence)
+{
+    SolidSyslogFile_Close(blockSequence->writeFile);
+    blockSequence->writeSequence    = NextSequence(blockSequence->writeSequence);
+    blockSequence->writePosition    = 0;
+    blockSequence->writeFileCorrupt = false;
+    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+    const char*                 name = FormatFilename(blockSequence, nameStorage, blockSequence->writeSequence);
+    SolidSyslogFile_Open(blockSequence->writeFile, name);
+
+    bool readFileChanged = false;
+
+    if (FileCount(blockSequence) > blockSequence->maxFiles)
+    {
+        readFileChanged = DiscardOldestFile(blockSequence);
+    }
+
+    return readFileChanged;
+}
+
+static bool DiscardOldestFile(struct BlockSequence* blockSequence)
+{
+    bool readingOldestFile = (blockSequence->readSequence == blockSequence->oldestSequence);
+
+    DeleteOldestFile(blockSequence);
+
+    if (readingOldestFile)
+    {
+        ResetReadToOldestFile(blockSequence);
+    }
+
+    return readingOldestFile;
+}
+
+static void DeleteOldestFile(struct BlockSequence* blockSequence)
+{
+    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+    const char*                 name = FormatFilename(blockSequence, nameStorage, blockSequence->oldestSequence);
+    SolidSyslogFile_Delete(blockSequence->writeFile, name);
+    blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
+}
+
+static void ResetReadToOldestFile(struct BlockSequence* blockSequence)
+{
+    SwitchReadFile(blockSequence, blockSequence->oldestSequence);
+}
+
+static inline void SwitchReadFile(struct BlockSequence* blockSequence, uint8_t newSequence)
+{
+    SolidSyslogFile_Close(blockSequence->readFile);
+    blockSequence->readSequence = newSequence;
+    blockSequence->readCursor   = 0;
+    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
+    const char*                 name = FormatFilename(blockSequence, nameStorage, blockSequence->readSequence);
+    SolidSyslogFile_Open(blockSequence->readFile, name);
+}
+
+struct SolidSyslogFile* BlockSequence_WriteFile(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->writeFile;
+}
+
+size_t BlockSequence_WritePosition(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->writePosition;
+}
+
+void BlockSequence_NoteRecordWritten(struct BlockSequence* blockSequence, size_t recordSize)
+{
+    blockSequence->writePosition += recordSize;
+}
+
+void BlockSequence_MarkWriteFileCorrupt(struct BlockSequence* blockSequence)
+{
+    blockSequence->writeFileCorrupt = true;
+}
+
+struct SolidSyslogFile* BlockSequence_ReadFile(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readFile;
+}
+
+size_t BlockSequence_ReadCursor(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readCursor;
+}
+
+void BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cursor)
+{
+    blockSequence->readCursor = cursor;
+}
+
+void BlockSequence_AdvanceToNextReadFile(struct BlockSequence* blockSequence)
+{
+    SwitchReadFile(blockSequence, NextSequence(blockSequence->readSequence));
+}
+
+bool BlockSequence_ReadingOlderFile(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readSequence != blockSequence->writeSequence;
+}
+
+bool BlockSequence_HasUnsent(const struct BlockSequence* blockSequence)
+{
+    return BlockSequence_ReadingOlderFile(blockSequence) || (blockSequence->readCursor < blockSequence->writePosition);
+}
+
+bool BlockSequence_IsHalted(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->halted;
+}

--- a/Core/Source/BlockSequence.h
+++ b/Core/Source/BlockSequence.h
@@ -54,7 +54,7 @@ struct SolidSyslogFile* BlockSequence_ReadFile(const struct BlockSequence* block
 size_t                  BlockSequence_ReadCursor(const struct BlockSequence* blockSequence);
 void                    BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cursor);
 void                    BlockSequence_AdvanceToNextReadFile(struct BlockSequence* blockSequence);
-bool                    BlockSequence_ReadingOlderFile(const struct BlockSequence* blockSequence);
+bool                    BlockSequence_IsReadingOlderFile(const struct BlockSequence* blockSequence);
 
 bool   BlockSequence_HasUnsent(const struct BlockSequence* blockSequence);
 bool   BlockSequence_IsHalted(const struct BlockSequence* blockSequence);

--- a/Core/Source/BlockSequence.h
+++ b/Core/Source/BlockSequence.h
@@ -29,6 +29,7 @@ struct BlockSequence
     enum SolidSyslogDiscardPolicy discardPolicy;
     SolidSyslogStoreFullCallback  onStoreFull;
     bool                          halted;
+    bool                          atCapacity;
     uint8_t                       oldestSequence;
     uint8_t                       readSequence;
     uint8_t                       writeSequence;
@@ -53,7 +54,9 @@ void                    BlockSequence_SetReadCursor(struct BlockSequence* blockS
 void                    BlockSequence_AdvanceToNextReadFile(struct BlockSequence* blockSequence);
 bool                    BlockSequence_ReadingOlderFile(const struct BlockSequence* blockSequence);
 
-bool BlockSequence_HasUnsent(const struct BlockSequence* blockSequence);
-bool BlockSequence_IsHalted(const struct BlockSequence* blockSequence);
+bool   BlockSequence_HasUnsent(const struct BlockSequence* blockSequence);
+bool   BlockSequence_IsHalted(const struct BlockSequence* blockSequence);
+size_t BlockSequence_TotalBytes(const struct BlockSequence* blockSequence);
+size_t BlockSequence_UsedBytes(const struct BlockSequence* blockSequence);
 
 #endif /* SOLIDSYSLOG_BLOCKSEQUENCE_H */

--- a/Core/Source/BlockSequence.h
+++ b/Core/Source/BlockSequence.h
@@ -17,6 +17,7 @@ struct BlockSequenceConfig
     size_t                        maxFiles;
     enum SolidSyslogDiscardPolicy discardPolicy;
     SolidSyslogStoreFullCallback  onStoreFull;
+    void*                         storeFullContext;
 };
 
 struct BlockSequence
@@ -28,6 +29,7 @@ struct BlockSequence
     size_t                        maxFiles;
     enum SolidSyslogDiscardPolicy discardPolicy;
     SolidSyslogStoreFullCallback  onStoreFull;
+    void*                         storeFullContext;
     bool                          halted;
     bool                          atCapacity;
     uint8_t                       oldestSequence;

--- a/Core/Source/BlockSequence.h
+++ b/Core/Source/BlockSequence.h
@@ -1,0 +1,59 @@
+#ifndef SOLIDSYSLOG_BLOCKSEQUENCE_H
+#define SOLIDSYSLOG_BLOCKSEQUENCE_H
+
+#include "SolidSyslogFile.h"
+#include "SolidSyslogFileStore.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct BlockSequenceConfig
+{
+    struct SolidSyslogFile*       readFile;
+    struct SolidSyslogFile*       writeFile;
+    const char*                   pathPrefix;
+    size_t                        maxFileSize;
+    size_t                        maxFiles;
+    enum SolidSyslogDiscardPolicy discardPolicy;
+    SolidSyslogStoreFullCallback  onStoreFull;
+};
+
+struct BlockSequence
+{
+    struct SolidSyslogFile*       readFile;
+    struct SolidSyslogFile*       writeFile;
+    const char*                   pathPrefix;
+    size_t                        maxFileSize;
+    size_t                        maxFiles;
+    enum SolidSyslogDiscardPolicy discardPolicy;
+    SolidSyslogStoreFullCallback  onStoreFull;
+    bool                          halted;
+    uint8_t                       oldestSequence;
+    uint8_t                       readSequence;
+    uint8_t                       writeSequence;
+    size_t                        readCursor;
+    size_t                        writePosition;
+    bool                          writeFileCorrupt;
+};
+
+void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockSequenceConfig* config);
+bool BlockSequence_Open(struct BlockSequence* blockSequence);
+void BlockSequence_Close(struct BlockSequence* blockSequence);
+
+bool                    BlockSequence_PrepareForWrite(struct BlockSequence* blockSequence, size_t recordSize, bool* readFileChanged);
+struct SolidSyslogFile* BlockSequence_WriteFile(const struct BlockSequence* blockSequence);
+size_t                  BlockSequence_WritePosition(const struct BlockSequence* blockSequence);
+void                    BlockSequence_NoteRecordWritten(struct BlockSequence* blockSequence, size_t recordSize);
+void                    BlockSequence_MarkWriteFileCorrupt(struct BlockSequence* blockSequence);
+
+struct SolidSyslogFile* BlockSequence_ReadFile(const struct BlockSequence* blockSequence);
+size_t                  BlockSequence_ReadCursor(const struct BlockSequence* blockSequence);
+void                    BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cursor);
+void                    BlockSequence_AdvanceToNextReadFile(struct BlockSequence* blockSequence);
+bool                    BlockSequence_ReadingOlderFile(const struct BlockSequence* blockSequence);
+
+bool BlockSequence_HasUnsent(const struct BlockSequence* blockSequence);
+bool BlockSequence_IsHalted(const struct BlockSequence* blockSequence);
+
+#endif /* SOLIDSYSLOG_BLOCKSEQUENCE_H */

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     SolidSyslogOriginSd.c
     SolidSyslogFile.c
     SolidSyslogFileStore.c
+    RecordStore.c
     SolidSyslogUdpPayload.c
 )
 

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     SolidSyslogFile.c
     SolidSyslogFileStore.c
     RecordStore.c
+    BlockSequence.c
     SolidSyslogUdpPayload.c
 )
 

--- a/Core/Source/RecordStore.c
+++ b/Core/Source/RecordStore.c
@@ -1,0 +1,302 @@
+#include "RecordStore.h"
+
+#include "SolidSyslogFile.h"
+
+#include <string.h>
+
+enum
+{
+    MAGIC_SIZE         = 2,
+    MAGIC_BYTE_0       = 0xA5,
+    MAGIC_BYTE_1       = 0x5A,
+    RECORD_LENGTH_SIZE = 2,
+    SENT_FLAG_SIZE     = 1,
+    SENT_FLAG_UNSENT   = 0xFF,
+    SENT_FLAG_SENT     = 0x00
+};
+
+static inline uint8_t* MagicAddress(struct RecordStore* recordStore)
+{
+    return recordStore->buffer;
+}
+
+static inline uint8_t* LengthAddress(struct RecordStore* recordStore)
+{
+    return recordStore->buffer + MAGIC_SIZE;
+}
+
+static inline uint8_t* MessageAddress(struct RecordStore* recordStore)
+{
+    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE;
+}
+
+static inline uint8_t* IntegrityChecksumAddress(struct RecordStore* recordStore, size_t dataSize)
+{
+    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize;
+}
+
+static inline uint8_t* IntegrityRegionAddress(struct RecordStore* recordStore)
+{
+    return MagicAddress(recordStore);
+}
+
+static inline uint16_t IntegrityRegionSize(size_t dataSize)
+{
+    return (uint16_t) (MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize);
+}
+
+static inline uint8_t* SentFlagAddress(struct RecordStore* recordStore, size_t dataSize)
+{
+    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize + recordStore->securityPolicy->integritySize;
+}
+
+static inline size_t SentFlagFileOffset(const struct RecordStore* recordStore, size_t recordStart, uint16_t dataLength)
+{
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + recordStore->securityPolicy->integritySize;
+}
+
+static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength)
+{
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
+}
+
+void RecordStore_Init(struct RecordStore* recordStore, struct SolidSyslogSecurityPolicy* securityPolicy)
+{
+    recordStore->securityPolicy         = securityPolicy;
+    recordStore->hasReadRecord          = false;
+    recordStore->lastSentFlagFileOffset = 0;
+}
+
+size_t RecordStore_RecordSize(const struct RecordStore* recordStore, uint16_t dataLength)
+{
+    return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + recordStore->securityPolicy->integritySize + SENT_FLAG_SIZE;
+}
+
+static inline void AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size);
+
+bool RecordStore_Append(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t position, const void* data, size_t dataSize)
+{
+    AssembleRecord(recordStore, data, dataSize);
+
+    SolidSyslogFile_SeekTo(file, position);
+
+    return SolidSyslogFile_Write(file, recordStore->buffer, RecordStore_RecordSize(recordStore, (uint16_t) dataSize));
+}
+
+static inline void AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size)
+{
+    MagicAddress(recordStore)[0] = MAGIC_BYTE_0;
+    MagicAddress(recordStore)[1] = MAGIC_BYTE_1;
+
+    uint16_t length = (uint16_t) size;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(LengthAddress(recordStore), &length, RECORD_LENGTH_SIZE);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(MessageAddress(recordStore), data, size);
+
+    recordStore->securityPolicy->ComputeIntegrity(IntegrityRegionAddress(recordStore), IntegrityRegionSize(size), IntegrityChecksumAddress(recordStore, size));
+
+    *SentFlagAddress(recordStore, size) = SENT_FLAG_UNSENT;
+}
+
+static bool        ReadAndValidateRecord(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t* length);
+static inline void CopyRecordData(struct RecordStore* recordStore, uint16_t length, void* dst, size_t maxSize, size_t* bytesRead);
+static inline void RememberCurrentRecord(struct RecordStore* recordStore, size_t offset, uint16_t length);
+
+bool RecordStore_Read(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, void* dst, size_t maxSize, size_t* bytesRead)
+{
+    uint16_t length = 0;
+    bool     read   = false;
+
+    *bytesRead = 0;
+
+    if (ReadAndValidateRecord(recordStore, file, offset, &length))
+    {
+        CopyRecordData(recordStore, length, dst, maxSize, bytesRead);
+        RememberCurrentRecord(recordStore, offset, length);
+        read = *bytesRead > 0;
+    }
+
+    return read;
+}
+
+static inline bool ReadFromFile(struct SolidSyslogFile* file, void* buf, size_t count);
+static inline bool ReadRecordHeader(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset);
+static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* length);
+static inline bool ReadRecordBody(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t length);
+static inline bool ReadIntegrityChecksum(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t recordStart, uint16_t dataLength);
+static inline bool VerifyIntegrity(struct RecordStore* recordStore, uint16_t length);
+
+static bool ReadAndValidateRecord(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t* length)
+{
+    return ReadRecordHeader(recordStore, file, offset) && ValidateHeader(recordStore, length) && ReadRecordBody(recordStore, file, offset, *length) &&
+           ReadIntegrityChecksum(recordStore, file, offset, *length) && VerifyIntegrity(recordStore, *length);
+}
+
+static inline bool ReadFromFile(struct SolidSyslogFile* file, void* buf, size_t count)
+{
+    return SolidSyslogFile_Read(file, buf, count);
+}
+
+static inline bool ReadRecordHeader(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset)
+{
+    SolidSyslogFile_SeekTo(file, offset);
+    return ReadFromFile(file, IntegrityRegionAddress(recordStore), MAGIC_SIZE + RECORD_LENGTH_SIZE);
+}
+
+static inline bool IsMagicValid(struct RecordStore* recordStore)
+{
+    return (MagicAddress(recordStore)[0] == MAGIC_BYTE_0) && (MagicAddress(recordStore)[1] == MAGIC_BYTE_1);
+}
+
+static inline uint16_t RecordLength(struct RecordStore* recordStore)
+{
+    uint16_t length = 0;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(&length, LengthAddress(recordStore), RECORD_LENGTH_SIZE);
+    return length;
+}
+
+static inline bool IsValidLength(uint16_t length)
+{
+    return length <= SOLIDSYSLOG_MAX_MESSAGE_SIZE;
+}
+
+static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* length)
+{
+    bool valid = IsMagicValid(recordStore);
+
+    if (valid)
+    {
+        *length = RecordLength(recordStore);
+        valid   = IsValidLength(*length);
+    }
+
+    return valid;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- offset is a file position, length is a data size; distinct semantics
+static inline bool ReadRecordBody(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t length)
+{
+    SolidSyslogFile_SeekTo(file, offset + MAGIC_SIZE + RECORD_LENGTH_SIZE);
+    return ReadFromFile(file, MessageAddress(recordStore), length);
+}
+
+static inline bool ReadIntegrityChecksum(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t recordStart, uint16_t dataLength)
+{
+    SolidSyslogFile_SeekTo(file, IntegrityChecksumFileOffset(recordStart, dataLength));
+    return ReadFromFile(file, IntegrityChecksumAddress(recordStore, dataLength), recordStore->securityPolicy->integritySize);
+}
+
+static inline bool VerifyIntegrity(struct RecordStore* recordStore, uint16_t length)
+{
+    return recordStore->securityPolicy->VerifyIntegrity(IntegrityRegionAddress(recordStore), IntegrityRegionSize(length),
+                                                        IntegrityChecksumAddress(recordStore, length));
+}
+
+static inline size_t BoundedSize(uint16_t length, size_t maxSize)
+{
+    return (length < maxSize) ? length : maxSize;
+}
+
+static inline void CopyRecordData(struct RecordStore* recordStore, uint16_t length, void* dst, size_t maxSize, size_t* bytesRead)
+{
+    size_t copySize = BoundedSize(length, maxSize);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
+    memcpy(dst, MessageAddress(recordStore), copySize);
+    *bytesRead = copySize;
+}
+
+static inline void RememberCurrentRecord(struct RecordStore* recordStore, size_t offset, uint16_t length)
+{
+    recordStore->lastSentFlagFileOffset = SentFlagFileOffset(recordStore, offset, length);
+    recordStore->hasReadRecord          = true;
+}
+
+static inline bool WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogFile* file);
+
+bool RecordStore_MarkLastReadAsSent(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t* nextCursor)
+{
+    bool marked = false;
+
+    if (recordStore->hasReadRecord && WriteSentFlag(recordStore, file))
+    {
+        *nextCursor                = recordStore->lastSentFlagFileOffset + SENT_FLAG_SIZE;
+        recordStore->hasReadRecord = false;
+        marked                     = true;
+    }
+
+    return marked;
+}
+
+static inline bool WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogFile* file)
+{
+    uint8_t flag = SENT_FLAG_SENT;
+
+    SolidSyslogFile_SeekTo(file, recordStore->lastSentFlagFileOffset);
+    return SolidSyslogFile_Write(file, &flag, SENT_FLAG_SIZE);
+}
+
+void RecordStore_ForgetLastRead(struct RecordStore* recordStore)
+{
+    recordStore->hasReadRecord = false;
+}
+
+static bool        AdvancePastSentRecord(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t* cursor, size_t fileSize, bool* corrupt);
+static inline bool ReadSentFlag(struct SolidSyslogFile* file, size_t sentFlagOffset, uint8_t* flag);
+static inline bool IsRecordSent(const struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t recordStart, uint16_t length);
+static inline void SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length);
+
+size_t RecordStore_FindFirstUnsent(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t fileSize, bool* corrupt)
+{
+    size_t cursor   = 0;
+    bool   scanning = true;
+    *corrupt        = false;
+
+    while (scanning && (cursor < fileSize))
+    {
+        scanning = AdvancePastSentRecord(recordStore, file, &cursor, fileSize, corrupt);
+    }
+
+    return cursor;
+}
+
+static bool AdvancePastSentRecord(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t* cursor, size_t fileSize, bool* corrupt)
+{
+    uint16_t length   = 0;
+    bool     advanced = false;
+
+    if (ReadAndValidateRecord(recordStore, file, *cursor, &length))
+    {
+        if (IsRecordSent(recordStore, file, *cursor, length))
+        {
+            SkipRecord(recordStore, cursor, length);
+            advanced = true;
+        }
+    }
+    else
+    {
+        *cursor  = fileSize;
+        *corrupt = true;
+    }
+
+    return advanced;
+}
+
+static inline bool ReadSentFlag(struct SolidSyslogFile* file, size_t sentFlagOffset, uint8_t* flag)
+{
+    SolidSyslogFile_SeekTo(file, sentFlagOffset);
+    return SolidSyslogFile_Read(file, flag, SENT_FLAG_SIZE);
+}
+
+static inline bool IsRecordSent(const struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t recordStart, uint16_t length)
+{
+    uint8_t flag = SENT_FLAG_SENT;
+    ReadSentFlag(file, SentFlagFileOffset(recordStore, recordStart, length), &flag);
+    return flag == SENT_FLAG_SENT;
+}
+
+static inline void SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length)
+{
+    *cursor += RecordStore_RecordSize(recordStore, length);
+}

--- a/Core/Source/RecordStore.c
+++ b/Core/Source/RecordStore.c
@@ -15,6 +15,12 @@ enum
     SENT_FLAG_SENT     = 0x00
 };
 
+/* Each record in the buffer is laid out as
+ *   [ magic | length | message | integrity | sentFlag ]
+ * Field-address helpers chain outward from the record's base so the
+ * field offsets are stated in one place each. The same chaining shapes
+ * the file-offset helpers below. */
+
 static inline uint8_t* MagicAddress(struct RecordStore* recordStore)
 {
     return recordStore->buffer;
@@ -22,17 +28,22 @@ static inline uint8_t* MagicAddress(struct RecordStore* recordStore)
 
 static inline uint8_t* LengthAddress(struct RecordStore* recordStore)
 {
-    return recordStore->buffer + MAGIC_SIZE;
+    return MagicAddress(recordStore) + MAGIC_SIZE;
 }
 
 static inline uint8_t* MessageAddress(struct RecordStore* recordStore)
 {
-    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE;
+    return LengthAddress(recordStore) + RECORD_LENGTH_SIZE;
 }
 
 static inline uint8_t* IntegrityChecksumAddress(struct RecordStore* recordStore, size_t dataSize)
 {
-    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize;
+    return MessageAddress(recordStore) + dataSize;
+}
+
+static inline uint8_t* SentFlagAddress(struct RecordStore* recordStore, size_t dataSize)
+{
+    return IntegrityChecksumAddress(recordStore, dataSize) + recordStore->securityPolicy->integritySize;
 }
 
 static inline uint8_t* IntegrityRegionAddress(struct RecordStore* recordStore)
@@ -45,19 +56,14 @@ static inline uint16_t IntegrityRegionSize(size_t dataSize)
     return (uint16_t) (MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize);
 }
 
-static inline uint8_t* SentFlagAddress(struct RecordStore* recordStore, size_t dataSize)
+static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength)
 {
-    return recordStore->buffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize + recordStore->securityPolicy->integritySize;
+    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
 }
 
 static inline size_t SentFlagFileOffset(const struct RecordStore* recordStore, size_t recordStart, uint16_t dataLength)
 {
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + recordStore->securityPolicy->integritySize;
-}
-
-static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength)
-{
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
+    return IntegrityChecksumFileOffset(recordStart, dataLength) + recordStore->securityPolicy->integritySize;
 }
 
 void RecordStore_Init(struct RecordStore* recordStore, struct SolidSyslogSecurityPolicy* securityPolicy)
@@ -120,7 +126,6 @@ bool RecordStore_Read(struct RecordStore* recordStore, struct SolidSyslogFile* f
     return read;
 }
 
-static inline bool ReadFromFile(struct SolidSyslogFile* file, void* buf, size_t count);
 static inline bool ReadRecordHeader(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset);
 static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* length);
 static inline bool ReadRecordBody(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t length);
@@ -133,15 +138,10 @@ static bool ReadAndValidateRecord(struct RecordStore* recordStore, struct SolidS
            ReadIntegrityChecksum(recordStore, file, offset, *length) && VerifyIntegrity(recordStore, *length);
 }
 
-static inline bool ReadFromFile(struct SolidSyslogFile* file, void* buf, size_t count)
-{
-    return SolidSyslogFile_Read(file, buf, count);
-}
-
 static inline bool ReadRecordHeader(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset)
 {
     SolidSyslogFile_SeekTo(file, offset);
-    return ReadFromFile(file, IntegrityRegionAddress(recordStore), MAGIC_SIZE + RECORD_LENGTH_SIZE);
+    return SolidSyslogFile_Read(file, IntegrityRegionAddress(recordStore), MAGIC_SIZE + RECORD_LENGTH_SIZE);
 }
 
 static inline bool IsMagicValid(struct RecordStore* recordStore)
@@ -179,13 +179,13 @@ static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* len
 static inline bool ReadRecordBody(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, uint16_t length)
 {
     SolidSyslogFile_SeekTo(file, offset + MAGIC_SIZE + RECORD_LENGTH_SIZE);
-    return ReadFromFile(file, MessageAddress(recordStore), length);
+    return SolidSyslogFile_Read(file, MessageAddress(recordStore), length);
 }
 
 static inline bool ReadIntegrityChecksum(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t recordStart, uint16_t dataLength)
 {
     SolidSyslogFile_SeekTo(file, IntegrityChecksumFileOffset(recordStart, dataLength));
-    return ReadFromFile(file, IntegrityChecksumAddress(recordStore, dataLength), recordStore->securityPolicy->integritySize);
+    return SolidSyslogFile_Read(file, IntegrityChecksumAddress(recordStore, dataLength), recordStore->securityPolicy->integritySize);
 }
 
 static inline bool VerifyIntegrity(struct RecordStore* recordStore, uint16_t length)

--- a/Core/Source/RecordStore.h
+++ b/Core/Source/RecordStore.h
@@ -1,0 +1,40 @@
+#ifndef SOLIDSYSLOG_RECORDSTORE_H
+#define SOLIDSYSLOG_RECORDSTORE_H
+
+#include "SolidSyslog.h"
+#include "SolidSyslogSecurityPolicyDefinition.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct SolidSyslogFile;
+
+enum
+{
+    RECORD_BUFFER_SIZE = 2 + 2 + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE + 1
+};
+
+struct RecordStore
+{
+    struct SolidSyslogSecurityPolicy* securityPolicy;
+    bool                              hasReadRecord;
+    size_t                            lastSentFlagFileOffset;
+    uint8_t                           buffer[RECORD_BUFFER_SIZE];
+};
+
+void RecordStore_Init(struct RecordStore* recordStore, struct SolidSyslogSecurityPolicy* securityPolicy);
+
+size_t RecordStore_RecordSize(const struct RecordStore* recordStore, uint16_t dataLength);
+
+bool RecordStore_Append(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t position, const void* data, size_t dataSize);
+
+bool RecordStore_Read(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t offset, void* dst, size_t maxSize, size_t* bytesRead);
+
+bool RecordStore_MarkLastReadAsSent(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t* nextCursor);
+
+void RecordStore_ForgetLastRead(struct RecordStore* recordStore);
+
+size_t RecordStore_FindFirstUnsent(struct RecordStore* recordStore, struct SolidSyslogFile* file, size_t fileSize, bool* corrupt);
+
+#endif /* SOLIDSYSLOG_RECORDSTORE_H */

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -7,11 +7,13 @@
 #include "SolidSyslogStoreDefinition.h"
 
 /* vtable — forward-declared because InitialiseVtable references them before their definitions */
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
-static void MarkSent(struct SolidSyslogStore* self);
-static bool HasUnsent(struct SolidSyslogStore* self);
-static bool IsHalted(struct SolidSyslogStore* self);
+static bool   Write(struct SolidSyslogStore* self, const void* data, size_t size);
+static bool   ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
+static void   MarkSent(struct SolidSyslogStore* self);
+static bool   HasUnsent(struct SolidSyslogStore* self);
+static bool   IsHalted(struct SolidSyslogStore* self);
+static size_t GetTotalBytes(struct SolidSyslogStore* self);
+static size_t GetUsedBytes(struct SolidSyslogStore* self);
 
 /* ------------------------------------------------------------------
  * Instance
@@ -92,6 +94,8 @@ static inline void InitialiseVtable(struct SolidSyslogFileStore* fileStore)
     fileStore->base.MarkSent       = MarkSent;
     fileStore->base.HasUnsent      = HasUnsent;
     fileStore->base.IsHalted       = IsHalted;
+    fileStore->base.GetTotalBytes  = GetTotalBytes;
+    fileStore->base.GetUsedBytes   = GetUsedBytes;
 }
 
 static void ResumeFromExistingFile(struct SolidSyslogFileStore* fileStore)
@@ -174,6 +178,16 @@ static bool HasUnsent(struct SolidSyslogStore* self)
 static bool IsHalted(struct SolidSyslogStore* self)
 {
     return BlockSequence_IsHalted(&AsFileStore(self)->blockSequence);
+}
+
+static size_t GetTotalBytes(struct SolidSyslogStore* self)
+{
+    return BlockSequence_TotalBytes(&AsFileStore(self)->blockSequence);
+}
+
+static size_t GetUsedBytes(struct SolidSyslogStore* self)
+{
+    return BlockSequence_UsedBytes(&AsFileStore(self)->blockSequence);
 }
 
 /* ------------------------------------------------------------------

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -2,6 +2,7 @@
 #include "BlockSequence.h"
 #include "RecordStore.h"
 #include "SolidSyslog.h"
+#include "SolidSyslogMacros.h"
 #include "SolidSyslogNullSecurityPolicy.h"
 #include "SolidSyslogStoreDefinition.h"
 
@@ -23,45 +24,55 @@ struct SolidSyslogFileStore
     struct BlockSequence    blockSequence;
 };
 
-static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
-static struct SolidSyslogFileStore       instance;
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogFileStore) <= sizeof(SolidSyslogFileStoreStorage),
+                          "SOLIDSYSLOG_FILESTORE_STORAGE_SIZE is too small for struct SolidSyslogFileStore");
 
+static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
+
+static inline struct SolidSyslogFileStore*      AsFileStore(struct SolidSyslogStore* store);
 static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
-static inline void                              InitialiseVtable(void);
-static void                                     ResumeFromExistingFile(void);
+static inline void                              InitialiseVtable(struct SolidSyslogFileStore* fileStore);
+static void                                     ResumeFromExistingFile(struct SolidSyslogFileStore* fileStore);
 
 /* ------------------------------------------------------------------
  * Create
  * ----------------------------------------------------------------*/
 
-struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config)
+struct SolidSyslogStore* SolidSyslogFileStore_Create(SolidSyslogFileStoreStorage* storage, const struct SolidSyslogFileStoreConfig* config)
 {
-    instance = DEFAULT_INSTANCE;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast) -- C header; integrator-supplied storage blob recast to impl
+    struct SolidSyslogFileStore* fileStore = (struct SolidSyslogFileStore*) storage;
+    *fileStore                             = DEFAULT_INSTANCE;
 
     struct SolidSyslogSecurityPolicy* securityPolicy = ResolveSecurityPolicy(config->securityPolicy);
-    RecordStore_Init(&instance.recordStore, securityPolicy);
+    RecordStore_Init(&fileStore->recordStore, securityPolicy);
 
+    size_t                     minFileSize = RecordStore_RecordSize(&fileStore->recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
     struct BlockSequenceConfig blockConfig = {
         .readFile      = config->readFile,
         .writeFile     = config->writeFile,
         .pathPrefix    = config->pathPrefix,
-        .maxFileSize   = (config->maxFileSize < RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE))
-                             ? RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE)
-                             : config->maxFileSize,
+        .maxFileSize   = (config->maxFileSize < minFileSize) ? minFileSize : config->maxFileSize,
         .maxFiles      = config->maxFiles,
         .discardPolicy = config->discardPolicy,
         .onStoreFull   = config->onStoreFull,
     };
-    BlockSequence_Init(&instance.blockSequence, &blockConfig);
+    BlockSequence_Init(&fileStore->blockSequence, &blockConfig);
 
-    InitialiseVtable();
+    InitialiseVtable(fileStore);
 
-    if (BlockSequence_Open(&instance.blockSequence))
+    if (BlockSequence_Open(&fileStore->blockSequence))
     {
-        ResumeFromExistingFile();
+        ResumeFromExistingFile(fileStore);
     }
 
-    return &instance.base;
+    return &fileStore->base;
+}
+
+static inline struct SolidSyslogFileStore* AsFileStore(struct SolidSyslogStore* store)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast) -- C; base is the first member of struct SolidSyslogFileStore
+    return (struct SolidSyslogFileStore*) store;
 }
 
 static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
@@ -74,26 +85,26 @@ static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct Sol
     return configured;
 }
 
-static inline void InitialiseVtable(void)
+static inline void InitialiseVtable(struct SolidSyslogFileStore* fileStore)
 {
-    instance.base.Write          = Write;
-    instance.base.ReadNextUnsent = ReadNextUnsent;
-    instance.base.MarkSent       = MarkSent;
-    instance.base.HasUnsent      = HasUnsent;
-    instance.base.IsHalted       = IsHalted;
+    fileStore->base.Write          = Write;
+    fileStore->base.ReadNextUnsent = ReadNextUnsent;
+    fileStore->base.MarkSent       = MarkSent;
+    fileStore->base.HasUnsent      = HasUnsent;
+    fileStore->base.IsHalted       = IsHalted;
 }
 
-static void ResumeFromExistingFile(void)
+static void ResumeFromExistingFile(struct SolidSyslogFileStore* fileStore)
 {
     bool   corrupt = false;
-    size_t cursor  = RecordStore_FindFirstUnsent(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence),
-                                                 BlockSequence_WritePosition(&instance.blockSequence), &corrupt);
+    size_t cursor  = RecordStore_FindFirstUnsent(&fileStore->recordStore, BlockSequence_ReadFile(&fileStore->blockSequence),
+                                                 BlockSequence_WritePosition(&fileStore->blockSequence), &corrupt);
 
-    BlockSequence_SetReadCursor(&instance.blockSequence, cursor);
+    BlockSequence_SetReadCursor(&fileStore->blockSequence, cursor);
 
     if (corrupt)
     {
-        BlockSequence_MarkWriteFileCorrupt(&instance.blockSequence);
+        BlockSequence_MarkWriteFileCorrupt(&fileStore->blockSequence);
     }
 }
 
@@ -101,48 +112,49 @@ static void ResumeFromExistingFile(void)
  * Destroy
  * ----------------------------------------------------------------*/
 
-void SolidSyslogFileStore_Destroy(void)
+void SolidSyslogFileStore_Destroy(struct SolidSyslogStore* store)
 {
-    BlockSequence_Close(&instance.blockSequence);
-    instance = DEFAULT_INSTANCE;
+    struct SolidSyslogFileStore* fileStore = AsFileStore(store);
+    BlockSequence_Close(&fileStore->blockSequence);
+    *fileStore = DEFAULT_INSTANCE;
 }
 
 /* ------------------------------------------------------------------
  * Write
  * ----------------------------------------------------------------*/
 
-static bool StoreRecord(const void* data, size_t size);
+static bool StoreRecord(struct SolidSyslogFileStore* fileStore, const void* data, size_t size);
 
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
 {
-    (void) self;
-    bool written = false;
+    struct SolidSyslogFileStore* fileStore = AsFileStore(self);
+    bool                         written   = false;
 
-    if (SolidSyslogFile_IsOpen(BlockSequence_WriteFile(&instance.blockSequence)))
+    if (SolidSyslogFile_IsOpen(BlockSequence_WriteFile(&fileStore->blockSequence)))
     {
-        written = StoreRecord(data, size);
+        written = StoreRecord(fileStore, data, size);
     }
 
     return written;
 }
 
-static bool StoreRecord(const void* data, size_t size)
+static bool StoreRecord(struct SolidSyslogFileStore* fileStore, const void* data, size_t size)
 {
-    size_t recordSize      = RecordStore_RecordSize(&instance.recordStore, (uint16_t) size);
+    size_t recordSize      = RecordStore_RecordSize(&fileStore->recordStore, (uint16_t) size);
     bool   readFileChanged = false;
     bool   written         = false;
 
-    if (BlockSequence_PrepareForWrite(&instance.blockSequence, recordSize, &readFileChanged))
+    if (BlockSequence_PrepareForWrite(&fileStore->blockSequence, recordSize, &readFileChanged))
     {
         if (readFileChanged)
         {
-            RecordStore_ForgetLastRead(&instance.recordStore);
+            RecordStore_ForgetLastRead(&fileStore->recordStore);
         }
 
-        if (RecordStore_Append(&instance.recordStore, BlockSequence_WriteFile(&instance.blockSequence), BlockSequence_WritePosition(&instance.blockSequence),
-                               data, size))
+        if (RecordStore_Append(&fileStore->recordStore, BlockSequence_WriteFile(&fileStore->blockSequence),
+                               BlockSequence_WritePosition(&fileStore->blockSequence), data, size))
         {
-            BlockSequence_NoteRecordWritten(&instance.blockSequence, recordSize);
+            BlockSequence_NoteRecordWritten(&fileStore->blockSequence, recordSize);
             written = true;
         }
     }
@@ -156,47 +168,45 @@ static bool StoreRecord(const void* data, size_t size)
 
 static bool HasUnsent(struct SolidSyslogStore* self)
 {
-    (void) self;
-    return BlockSequence_HasUnsent(&instance.blockSequence);
+    return BlockSequence_HasUnsent(&AsFileStore(self)->blockSequence);
 }
 
 static bool IsHalted(struct SolidSyslogStore* self)
 {
-    (void) self;
-    return BlockSequence_IsHalted(&instance.blockSequence);
+    return BlockSequence_IsHalted(&AsFileStore(self)->blockSequence);
 }
 
 /* ------------------------------------------------------------------
  * ReadNextUnsent
  * ----------------------------------------------------------------*/
 
-static bool ReadCurrent(void* data, size_t maxSize, size_t* bytesRead);
+static bool ReadCurrent(struct SolidSyslogFileStore* fileStore, void* data, size_t maxSize, size_t* bytesRead);
 
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
-    (void) self;
-    bool read  = false;
-    *bytesRead = 0;
+    struct SolidSyslogFileStore* fileStore = AsFileStore(self);
+    bool                         read      = false;
+    *bytesRead                             = 0;
 
-    if (BlockSequence_HasUnsent(&instance.blockSequence))
+    if (BlockSequence_HasUnsent(&fileStore->blockSequence))
     {
-        read = ReadCurrent(data, maxSize, bytesRead);
+        read = ReadCurrent(fileStore, data, maxSize, bytesRead);
 
-        while (!read && BlockSequence_ReadingOlderFile(&instance.blockSequence))
+        while (!read && BlockSequence_ReadingOlderFile(&fileStore->blockSequence))
         {
-            BlockSequence_AdvanceToNextReadFile(&instance.blockSequence);
-            RecordStore_ForgetLastRead(&instance.recordStore);
-            read = ReadCurrent(data, maxSize, bytesRead);
+            BlockSequence_AdvanceToNextReadFile(&fileStore->blockSequence);
+            RecordStore_ForgetLastRead(&fileStore->recordStore);
+            read = ReadCurrent(fileStore, data, maxSize, bytesRead);
         }
     }
 
     return read;
 }
 
-static bool ReadCurrent(void* data, size_t maxSize, size_t* bytesRead)
+static bool ReadCurrent(struct SolidSyslogFileStore* fileStore, void* data, size_t maxSize, size_t* bytesRead)
 {
-    return RecordStore_Read(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence), BlockSequence_ReadCursor(&instance.blockSequence), data,
-                            maxSize, bytesRead);
+    return RecordStore_Read(&fileStore->recordStore, BlockSequence_ReadFile(&fileStore->blockSequence), BlockSequence_ReadCursor(&fileStore->blockSequence),
+                            data, maxSize, bytesRead);
 }
 
 /* ------------------------------------------------------------------
@@ -205,12 +215,11 @@ static bool ReadCurrent(void* data, size_t maxSize, size_t* bytesRead)
 
 static void MarkSent(struct SolidSyslogStore* self)
 {
-    (void) self;
+    struct SolidSyslogFileStore* fileStore  = AsFileStore(self);
+    size_t                       nextCursor = 0;
 
-    size_t nextCursor = 0;
-
-    if (RecordStore_MarkLastReadAsSent(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence), &nextCursor))
+    if (RecordStore_MarkLastReadAsSent(&fileStore->recordStore, BlockSequence_ReadFile(&fileStore->blockSequence), &nextCursor))
     {
-        BlockSequence_SetReadCursor(&instance.blockSequence, nextCursor);
+        BlockSequence_SetReadCursor(&fileStore->blockSequence, nextCursor);
     }
 }

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -1,4 +1,5 @@
 #include "SolidSyslogFileStore.h"
+#include "RecordStore.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogFile.h"
 #include "SolidSyslogFormatter.h"
@@ -6,23 +7,13 @@
 #include "SolidSyslogStoreDefinition.h"
 
 #include <stdint.h>
-#include <string.h>
 
 enum
 {
-    MAGIC_SIZE         = 2,
-    MAGIC_BYTE_0       = 0xA5,
-    MAGIC_BYTE_1       = 0x5A,
-    RECORD_LENGTH_SIZE = 2,
-    SENT_FLAG_SIZE     = 1,
-    RECORD_OVERHEAD    = MAGIC_SIZE + RECORD_LENGTH_SIZE + SENT_FLAG_SIZE,
-    SENT_FLAG_UNSENT   = 0xFF,
-    SENT_FLAG_SENT     = 0x00,
-    MIN_MAX_FILES      = 2,
-    MAX_MAX_FILES      = 99,
-    SEQUENCE_MODULUS   = 100,
-    MIN_MAX_FILE_SIZE  = SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD,
-    MAX_PATH_SIZE      = 128
+    MIN_MAX_FILES    = 2,
+    MAX_MAX_FILES    = 99,
+    SEQUENCE_MODULUS = 100,
+    MAX_PATH_SIZE    = 128
 };
 
 /* vtable — forward-declared because InitialiseVtable references them before their definitions */
@@ -33,93 +24,35 @@ static bool HasUnsent(struct SolidSyslogStore* self);
 static bool IsHalted(struct SolidSyslogStore* self);
 
 /* ------------------------------------------------------------------
- * Record buffer — single static buffer for integrity computation
- * ----------------------------------------------------------------*/
-
-enum
-{
-    RECORD_BUFFER_SIZE = MAGIC_SIZE + RECORD_LENGTH_SIZE + SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_MAX_INTEGRITY_SIZE + SENT_FLAG_SIZE
-};
-
-static uint8_t recordBuffer[RECORD_BUFFER_SIZE];
-
-static inline uint8_t* MagicAddress(void)
-{
-    return recordBuffer;
-}
-
-static inline uint8_t* LengthAddress(void)
-{
-    return recordBuffer + MAGIC_SIZE;
-}
-
-static inline uint8_t* MessageAddress(void)
-{
-    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE;
-}
-
-static inline uint8_t* IntegrityChecksumAddress(size_t dataSize)
-{
-    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize;
-}
-
-static inline uint8_t* IntegrityRegionAddress(void)
-{
-    return MagicAddress();
-}
-
-static inline uint16_t IntegrityRegionSize(size_t dataSize)
-{
-    return (uint16_t) (MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize);
-}
-
-/* ------------------------------------------------------------------
  * Instance
  * ----------------------------------------------------------------*/
 
 struct SolidSyslogFileStore
 {
-    struct SolidSyslogStore           base;
-    struct SolidSyslogFile*           readFile;
-    struct SolidSyslogFile*           writeFile;
-    struct SolidSyslogSecurityPolicy* securityPolicy;
-    const char*                       pathPrefix;
-    size_t                            maxFileSize;
-    size_t                            maxFiles;
-    enum SolidSyslogDiscardPolicy     discardPolicy;
-    SolidSyslogStoreFullCallback      onStoreFull;
-    bool                              halted;
-    uint8_t                           oldestSequence;
-    uint8_t                           readSequence;
-    uint8_t                           writeSequence;
-    size_t                            readCursor;
-    size_t                            writePosition;
-    size_t                            lastSentFlagFileOffset;
-    bool                              hasReadRecord;
-    bool                              writeFileCorrupt;
+    struct SolidSyslogStore       base;
+    struct RecordStore            recordStore;
+    struct SolidSyslogFile*       readFile;
+    struct SolidSyslogFile*       writeFile;
+    const char*                   pathPrefix;
+    size_t                        maxFileSize;
+    size_t                        maxFiles;
+    enum SolidSyslogDiscardPolicy discardPolicy;
+    SolidSyslogStoreFullCallback  onStoreFull;
+    bool                          halted;
+    uint8_t                       oldestSequence;
+    uint8_t                       readSequence;
+    uint8_t                       writeSequence;
+    size_t                        readCursor;
+    size_t                        writePosition;
+    bool                          writeFileCorrupt;
 };
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
 static struct SolidSyslogFileStore       instance;
 
-static inline uint8_t* SentFlagAddress(size_t dataSize)
-{
-    return recordBuffer + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize + instance.securityPolicy->integritySize;
-}
-
 /* ------------------------------------------------------------------
- * Shared helpers — used by both Create (resume scan) and ReadNextUnsent
+ * Shared helpers
  * ----------------------------------------------------------------*/
-
-static inline bool ReadFromFile(void* buf, size_t count)
-{
-    return SolidSyslogFile_Read(instance.readFile, buf, count);
-}
-
-static inline bool WriteToFile(const void* buf, size_t count)
-{
-    return SolidSyslogFile_Write(instance.writeFile, buf, count);
-}
 
 static inline bool OpenWriteFile(const char* path)
 {
@@ -139,60 +72,6 @@ static inline bool IsWriteFileOpen(void)
 static inline bool IsReadFileOpen(void)
 {
     return (instance.readFile != NULL) && SolidSyslogFile_IsOpen(instance.readFile);
-}
-
-static inline size_t RecordSize(uint16_t dataLength)
-{
-    return (size_t) MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize + SENT_FLAG_SIZE;
-}
-
-static inline size_t SentFlagFileOffset(size_t recordStart, uint16_t dataLength)
-{
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength + instance.securityPolicy->integritySize;
-}
-
-static inline bool ReadRecordHeader(size_t offset)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, offset);
-    return ReadFromFile(IntegrityRegionAddress(), MAGIC_SIZE + RECORD_LENGTH_SIZE);
-}
-
-static inline bool IsMagicValid(void)
-{
-    return (MagicAddress()[0] == MAGIC_BYTE_0) && (MagicAddress()[1] == MAGIC_BYTE_1);
-}
-
-static inline uint16_t RecordLength(void)
-{
-    uint16_t length = 0;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
-    memcpy(&length, LengthAddress(), RECORD_LENGTH_SIZE);
-    return length;
-}
-
-static inline bool IsValidLength(uint16_t length)
-{
-    return length <= SOLIDSYSLOG_MAX_MESSAGE_SIZE;
-}
-
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- offset is a file position, length is a data size; distinct semantics
-static bool ReadRecordBody(size_t offset, uint16_t length)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, offset + MAGIC_SIZE + RECORD_LENGTH_SIZE);
-    return ReadFromFile(MessageAddress(), length);
-}
-
-static bool ReadSentFlag(size_t recordStart, uint16_t dataLength, uint8_t* flag)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, SentFlagFileOffset(recordStart, dataLength));
-    return ReadFromFile(flag, SENT_FLAG_SIZE);
-}
-
-static inline bool IsRecordSent(size_t recordStart, uint16_t length)
-{
-    uint8_t flag = SENT_FLAG_SENT;
-    ReadSentFlag(recordStart, length, &flag);
-    return flag == SENT_FLAG_SENT;
 }
 
 static const char FILE_EXTENSION[] = ".log";
@@ -242,10 +121,6 @@ static inline void   InitialiseVtable(void);
 static void          ScanForExistingFiles(void);
 static void          ResumeFromExistingFile(void);
 static inline void   MeasureFileSize(void);
-static size_t        ScanForFirstUnsent(size_t fileSize, bool* corrupt);
-static bool          AdvancePastSentRecord(size_t* cursor, size_t fileSize, bool* corrupt);
-static inline void   SkipRecord(size_t* cursor, uint16_t length);
-static inline void   SkipToEndOfValidData(size_t* cursor, size_t fileSize);
 
 /* Write helpers — forward-declared because they appear below Write */
 static bool        StoreRecord(const void* data, size_t size);
@@ -257,23 +132,10 @@ static void        DiscardOldestFile(void);
 static void        DeleteOldestFile(void);
 static void        SwitchReadFile(uint8_t newSequence);
 static bool        MakeSpaceForRecord(size_t dataSize);
-static inline void AssembleRecord(const void* data, size_t size);
-static bool        FlushRecord(size_t dataSize);
+static bool        FlushRecord(const void* data, size_t dataSize);
 
 /* ReadNextUnsent helpers */
-static void          AdvanceToNextReadFile(void);
-static bool          ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead);
-static bool          ValidateHeader(uint16_t* length);
-static bool          VerifyIntegrity(uint16_t length);
-static inline bool   ReadIntegrityChecksum(size_t recordStart, uint16_t dataLength);
-static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength);
-static inline void   CopyRecordData(uint16_t length, void* data, size_t maxSize, size_t* bytesRead);
-static inline size_t BoundedSize(uint16_t length, size_t maxSize);
-static inline void   RememberCurrentRecord(uint16_t length);
-
-/* MarkSent helpers */
-static inline bool WriteSentFlag(void);
-static inline void AdvanceReadCursor(void);
+static void AdvanceToNextReadFile(void);
 
 /* ------------------------------------------------------------------
  * Create
@@ -281,11 +143,10 @@ static inline void AdvanceReadCursor(void);
 
 struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config)
 {
-    instance                = DEFAULT_INSTANCE;
-    instance.readFile       = config->readFile;
-    instance.writeFile      = config->writeFile;
-    instance.securityPolicy = config->securityPolicy;
-    instance.pathPrefix     = config->pathPrefix;
+    instance            = DEFAULT_INSTANCE;
+    instance.readFile   = config->readFile;
+    instance.writeFile  = config->writeFile;
+    instance.pathPrefix = config->pathPrefix;
     ValidateConfig(config);
     InitialiseVtable();
 
@@ -307,20 +168,24 @@ struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFil
 
 static inline size_t MinFileSize(void)
 {
-    return SOLIDSYSLOG_MAX_MESSAGE_SIZE + RECORD_OVERHEAD + instance.securityPolicy->integritySize;
+    return RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 }
 
 static inline void ValidateConfig(const struct SolidSyslogFileStoreConfig* config)
 {
-    if (instance.securityPolicy == NULL)
+    struct SolidSyslogSecurityPolicy* securityPolicy = config->securityPolicy;
+
+    if (securityPolicy == NULL)
     {
-        instance.securityPolicy = SolidSyslogNullSecurityPolicy_Create();
+        securityPolicy = SolidSyslogNullSecurityPolicy_Create();
     }
 
-    if (instance.securityPolicy->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE)
+    if (securityPolicy->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE)
     {
-        instance.securityPolicy = SolidSyslogNullSecurityPolicy_Create();
+        securityPolicy = SolidSyslogNullSecurityPolicy_Create();
     }
+
+    RecordStore_Init(&instance.recordStore, securityPolicy);
 
     instance.maxFiles      = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
     instance.maxFileSize   = ClampToRange(config->maxFileSize, MinFileSize(), (size_t) -1);
@@ -388,7 +253,7 @@ static void ResumeFromExistingFile(void)
     MeasureFileSize();
 
     bool corrupt        = false;
-    instance.readCursor = ScanForFirstUnsent(instance.writePosition, &corrupt);
+    instance.readCursor = RecordStore_FindFirstUnsent(&instance.recordStore, instance.readFile, instance.writePosition, &corrupt);
 
     instance.writeFileCorrupt = corrupt;
 }
@@ -396,53 +261,6 @@ static void ResumeFromExistingFile(void)
 static inline void MeasureFileSize(void)
 {
     instance.writePosition = SolidSyslogFile_Size(instance.writeFile);
-}
-
-static size_t ScanForFirstUnsent(size_t fileSize, bool* corrupt)
-{
-    size_t cursor   = 0;
-    bool   scanning = true;
-    *corrupt        = false;
-
-    while (scanning && (cursor < fileSize))
-    {
-        scanning = AdvancePastSentRecord(&cursor, fileSize, corrupt);
-    }
-
-    return cursor;
-}
-
-static bool AdvancePastSentRecord(size_t* cursor, size_t fileSize, bool* corrupt)
-{
-    uint16_t length   = 0;
-    bool     advanced = false;
-
-    if (ReadRecordHeader(*cursor) && ValidateHeader(&length) && ReadRecordBody(*cursor, length) && ReadIntegrityChecksum(*cursor, length) &&
-        VerifyIntegrity(length))
-    {
-        if (IsRecordSent(*cursor, length))
-        {
-            SkipRecord(cursor, length);
-            advanced = true;
-        }
-    }
-    else
-    {
-        SkipToEndOfValidData(cursor, fileSize);
-        *corrupt = true;
-    }
-
-    return advanced;
-}
-
-static inline void SkipRecord(size_t* cursor, uint16_t length)
-{
-    *cursor += RecordSize(length);
-}
-
-static inline void SkipToEndOfValidData(size_t* cursor, size_t fileSize)
-{
-    *cursor = fileSize;
 }
 
 /* ------------------------------------------------------------------
@@ -487,8 +305,7 @@ static bool StoreRecord(const void* data, size_t size)
 
     if (MakeSpaceForRecord(size))
     {
-        AssembleRecord(data, size);
-        written = FlushRecord(size);
+        written = FlushRecord(data, size);
     }
 
     return written;
@@ -513,7 +330,7 @@ static bool MakeSpaceForRecord(size_t dataSize)
 
 static inline bool FileIsFull(size_t dataSize)
 {
-    return instance.writeFileCorrupt || (instance.writePosition + RecordSize((uint16_t) dataSize)) > instance.maxFileSize;
+    return instance.writeFileCorrupt || (instance.writePosition + RecordStore_RecordSize(&instance.recordStore, (uint16_t) dataSize)) > instance.maxFileSize;
 }
 
 static inline bool StoreIsFull(void)
@@ -561,9 +378,9 @@ static void DeleteOldestFile(void)
 static void SwitchReadFile(uint8_t newSequence)
 {
     SolidSyslogFile_Close(instance.readFile);
-    instance.readSequence  = newSequence;
-    instance.readCursor    = 0;
-    instance.hasReadRecord = false;
+    instance.readSequence = newSequence;
+    instance.readCursor   = 0;
+    RecordStore_ForgetLastRead(&instance.recordStore);
     SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
     const char*                 name = FormatFilename(nameStorage, instance.readSequence);
     OpenReadFile(name);
@@ -586,41 +403,13 @@ static void DiscardOldestFile(void)
     }
 }
 
-static inline void SeekToWritePosition(void)
+static bool FlushRecord(const void* data, size_t dataSize)
 {
-    SolidSyslogFile_SeekTo(instance.writeFile, instance.writePosition);
-}
-
-static inline void AssembleRecord(const void* data, size_t size)
-{
-    MagicAddress()[0] = MAGIC_BYTE_0;
-    MagicAddress()[1] = MAGIC_BYTE_1;
-
-    uint16_t length = (uint16_t) size;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
-    memcpy(LengthAddress(), &length, RECORD_LENGTH_SIZE);
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
-    memcpy(MessageAddress(), data, size);
-
-    instance.securityPolicy->ComputeIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(size), IntegrityChecksumAddress(size));
-
-    *SentFlagAddress(size) = SENT_FLAG_UNSENT;
-}
-
-static inline void AdvanceWritePosition(size_t dataSize)
-{
-    instance.writePosition += RecordSize((uint16_t) dataSize);
-}
-
-static bool FlushRecord(size_t dataSize)
-{
-    SeekToWritePosition();
-
-    bool written = WriteToFile(recordBuffer, RecordSize((uint16_t) dataSize));
+    bool written = RecordStore_Append(&instance.recordStore, instance.writeFile, instance.writePosition, data, dataSize);
 
     if (written)
     {
-        AdvanceWritePosition(dataSize);
+        instance.writePosition += RecordStore_RecordSize(&instance.recordStore, (uint16_t) dataSize);
     }
 
     return written;
@@ -654,12 +443,12 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
 
     if (HasUnsentRecords())
     {
-        read = ReadCurrentRecord(data, maxSize, bytesRead);
+        read = RecordStore_Read(&instance.recordStore, instance.readFile, instance.readCursor, data, maxSize, bytesRead);
 
         while (!read && ReadingOlderFile())
         {
             AdvanceToNextReadFile();
-            read = ReadCurrentRecord(data, maxSize, bytesRead);
+            read = RecordStore_Read(&instance.recordStore, instance.readFile, instance.readCursor, data, maxSize, bytesRead);
         }
     }
 
@@ -671,70 +460,6 @@ static void AdvanceToNextReadFile(void)
     SwitchReadFile(NextSequence(instance.readSequence));
 }
 
-static bool ReadCurrentRecord(void* data, size_t maxSize, size_t* bytesRead)
-{
-    uint16_t length = 0;
-    bool     read   = false;
-
-    if (ReadRecordHeader(instance.readCursor) && ValidateHeader(&length) && ReadRecordBody(instance.readCursor, length) &&
-        ReadIntegrityChecksum(instance.readCursor, length) && VerifyIntegrity(length))
-    {
-        CopyRecordData(length, data, maxSize, bytesRead);
-        RememberCurrentRecord(length);
-        read = *bytesRead > 0;
-    }
-
-    return read;
-}
-
-static bool ValidateHeader(uint16_t* length)
-{
-    bool valid = IsMagicValid();
-
-    if (valid)
-    {
-        *length = RecordLength();
-        valid   = IsValidLength(*length);
-    }
-
-    return valid;
-}
-
-static bool VerifyIntegrity(uint16_t length)
-{
-    return instance.securityPolicy->VerifyIntegrity(IntegrityRegionAddress(), IntegrityRegionSize(length), IntegrityChecksumAddress(length));
-}
-
-static inline bool ReadIntegrityChecksum(size_t recordStart, uint16_t dataLength)
-{
-    SolidSyslogFile_SeekTo(instance.readFile, IntegrityChecksumFileOffset(recordStart, dataLength));
-    return ReadFromFile(IntegrityChecksumAddress(dataLength), instance.securityPolicy->integritySize);
-}
-
-static inline size_t IntegrityChecksumFileOffset(size_t recordStart, uint16_t dataLength)
-{
-    return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
-}
-
-static inline void CopyRecordData(uint16_t length, void* data, size_t maxSize, size_t* bytesRead)
-{
-    size_t copySize = BoundedSize(length, maxSize);
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
-    memcpy(data, MessageAddress(), copySize);
-    *bytesRead = copySize;
-}
-
-static inline size_t BoundedSize(uint16_t length, size_t maxSize)
-{
-    return (length < maxSize) ? length : maxSize;
-}
-
-static inline void RememberCurrentRecord(uint16_t length)
-{
-    instance.lastSentFlagFileOffset = SentFlagFileOffset(instance.readCursor, length);
-    instance.hasReadRecord          = true;
-}
-
 /* ------------------------------------------------------------------
  * MarkSent
  * ----------------------------------------------------------------*/
@@ -743,22 +468,10 @@ static void MarkSent(struct SolidSyslogStore* self)
 {
     (void) self;
 
-    if (instance.hasReadRecord && WriteSentFlag())
+    size_t nextCursor = 0;
+
+    if (RecordStore_MarkLastReadAsSent(&instance.recordStore, instance.readFile, &nextCursor))
     {
-        AdvanceReadCursor();
+        instance.readCursor = nextCursor;
     }
-}
-
-static inline bool WriteSentFlag(void)
-{
-    uint8_t flag = SENT_FLAG_SENT;
-
-    SolidSyslogFile_SeekTo(instance.readFile, instance.lastSentFlagFileOffset);
-    return SolidSyslogFile_Write(instance.readFile, &flag, SENT_FLAG_SIZE);
-}
-
-static inline void AdvanceReadCursor(void)
-{
-    instance.readCursor    = instance.lastSentFlagFileOffset + SENT_FLAG_SIZE;
-    instance.hasReadRecord = false;
 }

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -217,7 +217,7 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
     {
         read = ReadCurrent(fileStore, data, maxSize, bytesRead);
 
-        while (!read && BlockSequence_ReadingOlderFile(&fileStore->blockSequence))
+        while (!read && BlockSequence_IsReadingOlderFile(&fileStore->blockSequence))
         {
             BlockSequence_AdvanceToNextReadFile(&fileStore->blockSequence);
             RecordStore_ForgetLastRead(&fileStore->recordStore);

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -33,8 +33,9 @@ static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
 
 static inline struct SolidSyslogFileStore*      AsFileStore(struct SolidSyslogStore* store);
 static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
-static inline void                              InitialiseVtable(struct SolidSyslogFileStore* fileStore);
-static void                                     ResumeFromExistingFile(struct SolidSyslogFileStore* fileStore);
+static inline struct BlockSequenceConfig BuildBlockSequenceConfig(const struct SolidSyslogFileStoreConfig* config, const struct RecordStore* recordStore);
+static inline void                       InitialiseVtable(struct SolidSyslogFileStore* fileStore);
+static void                              ResumeFromExistingFile(struct SolidSyslogFileStore* fileStore);
 
 /* ------------------------------------------------------------------
  * Create
@@ -46,20 +47,9 @@ struct SolidSyslogStore* SolidSyslogFileStore_Create(SolidSyslogFileStoreStorage
     struct SolidSyslogFileStore* fileStore = (struct SolidSyslogFileStore*) storage;
     *fileStore                             = DEFAULT_INSTANCE;
 
-    struct SolidSyslogSecurityPolicy* securityPolicy = ResolveSecurityPolicy(config->securityPolicy);
-    RecordStore_Init(&fileStore->recordStore, securityPolicy);
+    RecordStore_Init(&fileStore->recordStore, ResolveSecurityPolicy(config->securityPolicy));
 
-    size_t                     minFileSize = RecordStore_RecordSize(&fileStore->recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
-    struct BlockSequenceConfig blockConfig = {
-        .readFile         = config->readFile,
-        .writeFile        = config->writeFile,
-        .pathPrefix       = config->pathPrefix,
-        .maxFileSize      = (config->maxFileSize < minFileSize) ? minFileSize : config->maxFileSize,
-        .maxFiles         = config->maxFiles,
-        .discardPolicy    = config->discardPolicy,
-        .onStoreFull      = config->onStoreFull,
-        .storeFullContext = config->storeFullContext,
-    };
+    struct BlockSequenceConfig blockConfig = BuildBlockSequenceConfig(config, &fileStore->recordStore);
     BlockSequence_Init(&fileStore->blockSequence, &blockConfig);
 
     InitialiseVtable(fileStore);
@@ -88,6 +78,24 @@ static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct Sol
     }
 
     return resolved;
+}
+
+static inline struct BlockSequenceConfig BuildBlockSequenceConfig(const struct SolidSyslogFileStoreConfig* config, const struct RecordStore* recordStore)
+{
+    size_t minFileSize = RecordStore_RecordSize(recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+    size_t maxFileSize = (config->maxFileSize < minFileSize) ? minFileSize : config->maxFileSize;
+
+    struct BlockSequenceConfig blockConfig = {
+        .readFile         = config->readFile,
+        .writeFile        = config->writeFile,
+        .pathPrefix       = config->pathPrefix,
+        .maxFileSize      = maxFileSize,
+        .maxFiles         = config->maxFiles,
+        .discardPolicy    = config->discardPolicy,
+        .onStoreFull      = config->onStoreFull,
+        .storeFullContext = config->storeFullContext,
+    };
+    return blockConfig;
 }
 
 static inline void InitialiseVtable(struct SolidSyslogFileStore* fileStore)

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -80,12 +80,14 @@ static inline struct SolidSyslogFileStore* AsFileStore(struct SolidSyslogStore* 
 
 static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
 {
-    if ((configured == NULL) || (configured->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE))
+    struct SolidSyslogSecurityPolicy* resolved = configured;
+
+    if ((resolved == NULL) || (resolved->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE))
     {
-        return SolidSyslogNullSecurityPolicy_Create();
+        resolved = SolidSyslogNullSecurityPolicy_Create();
     }
 
-    return configured;
+    return resolved;
 }
 
 static inline void InitialiseVtable(struct SolidSyslogFileStore* fileStore)

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -1,20 +1,9 @@
 #include "SolidSyslogFileStore.h"
+#include "BlockSequence.h"
 #include "RecordStore.h"
 #include "SolidSyslog.h"
-#include "SolidSyslogFile.h"
-#include "SolidSyslogFormatter.h"
 #include "SolidSyslogNullSecurityPolicy.h"
 #include "SolidSyslogStoreDefinition.h"
-
-#include <stdint.h>
-
-enum
-{
-    MIN_MAX_FILES    = 2,
-    MAX_MAX_FILES    = 99,
-    SEQUENCE_MODULUS = 100,
-    MAX_PATH_SIZE    = 128
-};
 
 /* vtable — forward-declared because InitialiseVtable references them before their definitions */
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
@@ -29,113 +18,17 @@ static bool IsHalted(struct SolidSyslogStore* self);
 
 struct SolidSyslogFileStore
 {
-    struct SolidSyslogStore       base;
-    struct RecordStore            recordStore;
-    struct SolidSyslogFile*       readFile;
-    struct SolidSyslogFile*       writeFile;
-    const char*                   pathPrefix;
-    size_t                        maxFileSize;
-    size_t                        maxFiles;
-    enum SolidSyslogDiscardPolicy discardPolicy;
-    SolidSyslogStoreFullCallback  onStoreFull;
-    bool                          halted;
-    uint8_t                       oldestSequence;
-    uint8_t                       readSequence;
-    uint8_t                       writeSequence;
-    size_t                        readCursor;
-    size_t                        writePosition;
-    bool                          writeFileCorrupt;
+    struct SolidSyslogStore base;
+    struct RecordStore      recordStore;
+    struct BlockSequence    blockSequence;
 };
 
 static const struct SolidSyslogFileStore DEFAULT_INSTANCE = {0};
 static struct SolidSyslogFileStore       instance;
 
-/* ------------------------------------------------------------------
- * Shared helpers
- * ----------------------------------------------------------------*/
-
-static inline bool OpenWriteFile(const char* path)
-{
-    return SolidSyslogFile_Open(instance.writeFile, path);
-}
-
-static inline bool OpenReadFile(const char* path)
-{
-    return SolidSyslogFile_Open(instance.readFile, path);
-}
-
-static inline bool IsWriteFileOpen(void)
-{
-    return (instance.writeFile != NULL) && SolidSyslogFile_IsOpen(instance.writeFile);
-}
-
-static inline bool IsReadFileOpen(void)
-{
-    return (instance.readFile != NULL) && SolidSyslogFile_IsOpen(instance.readFile);
-}
-
-static const char FILE_EXTENSION[] = ".log";
-
-enum
-{
-    SEQUENCE_DIGITS   = 2,
-    FILENAME_SUFFIX   = SEQUENCE_DIGITS + sizeof(FILE_EXTENSION) - 1,
-    MAX_PREFIX_LENGTH = MAX_PATH_SIZE - FILENAME_SUFFIX - 1
-};
-
-static inline const char* FormatFilename(SolidSyslogFormatterStorage* storage, uint8_t sequence)
-{
-    struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, MAX_PATH_SIZE);
-
-    SolidSyslogFormatter_BoundedString(f, instance.pathPrefix, MAX_PREFIX_LENGTH);
-    SolidSyslogFormatter_TwoDigit(f, sequence);
-    SolidSyslogFormatter_BoundedString(f, FILE_EXTENSION, sizeof(FILE_EXTENSION) - 1);
-
-    return SolidSyslogFormatter_AsFormattedBuffer(f);
-}
-
-static inline uint8_t NextSequence(uint8_t current)
-{
-    return (uint8_t) ((current + 1) % SEQUENCE_MODULUS);
-}
-
-static inline size_t FileCount(void)
-{
-    return (size_t) ((instance.writeSequence - instance.oldestSequence + SEQUENCE_MODULUS) % SEQUENCE_MODULUS) + 1;
-}
-
-static inline bool ReadingOlderFile(void)
-{
-    return instance.readSequence != instance.writeSequence;
-}
-
-static inline bool HasUnsentRecords(void)
-{
-    return ReadingOlderFile() || (instance.readCursor < instance.writePosition);
-}
-
-/* Create helpers — forward-declared because they appear below Create for top-down reading */
-static inline void   ValidateConfig(const struct SolidSyslogFileStoreConfig* config);
-static inline size_t ClampToRange(size_t value, size_t min, size_t max);
-static inline void   InitialiseVtable(void);
-static void          ScanForExistingFiles(void);
-static void          ResumeFromExistingFile(void);
-static inline void   MeasureFileSize(void);
-
-/* Write helpers — forward-declared because they appear below Write */
-static bool        StoreRecord(const void* data, size_t size);
-static inline bool FileIsFull(size_t dataSize);
-static inline bool StoreIsFull(void);
-static inline void NotifyStoreFull(void);
-static void        RotateToNextFile(void);
-static void        DiscardOldestFile(void);
-static void        DeleteOldestFile(void);
-static void        SwitchReadFile(uint8_t newSequence);
-static bool        MakeSpaceForRecord(size_t dataSize);
-static bool        FlushRecord(const void* data, size_t dataSize);
-
-/* ReadNextUnsent helpers */
-static void AdvanceToNextReadFile(void);
+static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
+static inline void                              InitialiseVtable(void);
+static void                                     ResumeFromExistingFile(void);
 
 /* ------------------------------------------------------------------
  * Create
@@ -143,72 +36,42 @@ static void AdvanceToNextReadFile(void);
 
 struct SolidSyslogStore* SolidSyslogFileStore_Create(const struct SolidSyslogFileStoreConfig* config)
 {
-    instance            = DEFAULT_INSTANCE;
-    instance.readFile   = config->readFile;
-    instance.writeFile  = config->writeFile;
-    instance.pathPrefix = config->pathPrefix;
-    ValidateConfig(config);
+    instance = DEFAULT_INSTANCE;
+
+    struct SolidSyslogSecurityPolicy* securityPolicy = ResolveSecurityPolicy(config->securityPolicy);
+    RecordStore_Init(&instance.recordStore, securityPolicy);
+
+    struct BlockSequenceConfig blockConfig = {
+        .readFile      = config->readFile,
+        .writeFile     = config->writeFile,
+        .pathPrefix    = config->pathPrefix,
+        .maxFileSize   = (config->maxFileSize < RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE))
+                             ? RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE)
+                             : config->maxFileSize,
+        .maxFiles      = config->maxFiles,
+        .discardPolicy = config->discardPolicy,
+        .onStoreFull   = config->onStoreFull,
+    };
+    BlockSequence_Init(&instance.blockSequence, &blockConfig);
+
     InitialiseVtable();
 
-    ScanForExistingFiles();
-
-    SolidSyslogFormatterStorage writeNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char*                 writeName = FormatFilename(writeNameStorage, instance.writeSequence);
-
-    if (OpenWriteFile(writeName))
+    if (BlockSequence_Open(&instance.blockSequence))
     {
-        SolidSyslogFormatterStorage readNameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-        const char*                 readName = FormatFilename(readNameStorage, instance.readSequence);
-        OpenReadFile(readName);
         ResumeFromExistingFile();
     }
 
     return &instance.base;
 }
 
-static inline size_t MinFileSize(void)
+static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
 {
-    return RecordStore_RecordSize(&instance.recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
-}
-
-static inline void ValidateConfig(const struct SolidSyslogFileStoreConfig* config)
-{
-    struct SolidSyslogSecurityPolicy* securityPolicy = config->securityPolicy;
-
-    if (securityPolicy == NULL)
+    if ((configured == NULL) || (configured->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE))
     {
-        securityPolicy = SolidSyslogNullSecurityPolicy_Create();
+        return SolidSyslogNullSecurityPolicy_Create();
     }
 
-    if (securityPolicy->integritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE)
-    {
-        securityPolicy = SolidSyslogNullSecurityPolicy_Create();
-    }
-
-    RecordStore_Init(&instance.recordStore, securityPolicy);
-
-    instance.maxFiles      = ClampToRange(config->maxFiles, MIN_MAX_FILES, MAX_MAX_FILES);
-    instance.maxFileSize   = ClampToRange(config->maxFileSize, MinFileSize(), (size_t) -1);
-    instance.discardPolicy = config->discardPolicy;
-    instance.onStoreFull   = config->onStoreFull;
-}
-
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value, min, max have distinct semantics
-static inline size_t ClampToRange(size_t value, size_t min, size_t max)
-{
-    size_t result = value;
-
-    if (result < min)
-    {
-        result = min;
-    }
-
-    if (result > max)
-    {
-        result = max;
-    }
-
-    return result;
+    return configured;
 }
 
 static inline void InitialiseVtable(void)
@@ -220,47 +83,18 @@ static inline void InitialiseVtable(void)
     instance.base.IsHalted       = IsHalted;
 }
 
-static void ScanForExistingFiles(void)
-{
-    enum
-    {
-        MAX_SEQUENCE = 100
-    };
-
-    bool foundFirst = false;
-
-    for (int seq = 0; seq < MAX_SEQUENCE; seq++)
-    {
-        SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-        const char*                 name = FormatFilename(nameStorage, (uint8_t) seq);
-
-        if (SolidSyslogFile_Exists(instance.writeFile, name))
-        {
-            if (!foundFirst)
-            {
-                instance.oldestSequence = (uint8_t) seq;
-                instance.readSequence   = (uint8_t) seq;
-                foundFirst              = true;
-            }
-
-            instance.writeSequence = (uint8_t) seq;
-        }
-    }
-}
-
 static void ResumeFromExistingFile(void)
 {
-    MeasureFileSize();
+    bool   corrupt = false;
+    size_t cursor  = RecordStore_FindFirstUnsent(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence),
+                                                 BlockSequence_WritePosition(&instance.blockSequence), &corrupt);
 
-    bool corrupt        = false;
-    instance.readCursor = RecordStore_FindFirstUnsent(&instance.recordStore, instance.readFile, instance.writePosition, &corrupt);
+    BlockSequence_SetReadCursor(&instance.blockSequence, cursor);
 
-    instance.writeFileCorrupt = corrupt;
-}
-
-static inline void MeasureFileSize(void)
-{
-    instance.writePosition = SolidSyslogFile_Size(instance.writeFile);
+    if (corrupt)
+    {
+        BlockSequence_MarkWriteFileCorrupt(&instance.blockSequence);
+    }
 }
 
 /* ------------------------------------------------------------------
@@ -269,16 +103,7 @@ static inline void MeasureFileSize(void)
 
 void SolidSyslogFileStore_Destroy(void)
 {
-    if (IsWriteFileOpen())
-    {
-        SolidSyslogFile_Close(instance.writeFile);
-    }
-
-    if (IsReadFileOpen())
-    {
-        SolidSyslogFile_Close(instance.readFile);
-    }
-
+    BlockSequence_Close(&instance.blockSequence);
     instance = DEFAULT_INSTANCE;
 }
 
@@ -286,12 +111,14 @@ void SolidSyslogFileStore_Destroy(void)
  * Write
  * ----------------------------------------------------------------*/
 
+static bool StoreRecord(const void* data, size_t size);
+
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
 {
     (void) self;
     bool written = false;
 
-    if (IsWriteFileOpen())
+    if (SolidSyslogFile_IsOpen(BlockSequence_WriteFile(&instance.blockSequence)))
     {
         written = StoreRecord(data, size);
     }
@@ -301,139 +128,49 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
 
 static bool StoreRecord(const void* data, size_t size)
 {
-    bool written = false;
+    size_t recordSize      = RecordStore_RecordSize(&instance.recordStore, (uint16_t) size);
+    bool   readFileChanged = false;
+    bool   written         = false;
 
-    if (MakeSpaceForRecord(size))
+    if (BlockSequence_PrepareForWrite(&instance.blockSequence, recordSize, &readFileChanged))
     {
-        written = FlushRecord(data, size);
-    }
-
-    return written;
-}
-
-static bool MakeSpaceForRecord(size_t dataSize)
-{
-    bool spaceAvailable = true;
-
-    if (FileIsFull(dataSize) && StoreIsFull())
-    {
-        NotifyStoreFull();
-        spaceAvailable = false;
-    }
-    else if (FileIsFull(dataSize))
-    {
-        RotateToNextFile();
-    }
-
-    return spaceAvailable;
-}
-
-static inline bool FileIsFull(size_t dataSize)
-{
-    return instance.writeFileCorrupt || (instance.writePosition + RecordStore_RecordSize(&instance.recordStore, (uint16_t) dataSize)) > instance.maxFileSize;
-}
-
-static inline bool StoreIsFull(void)
-{
-    return (FileCount() >= instance.maxFiles) && (instance.discardPolicy != SOLIDSYSLOG_DISCARD_OLDEST);
-}
-
-static inline void NotifyStoreFull(void)
-{
-    if (instance.discardPolicy == SOLIDSYSLOG_HALT)
-    {
-        instance.halted = true;
-
-        if (instance.onStoreFull != NULL)
+        if (readFileChanged)
         {
-            instance.onStoreFull();
+            RecordStore_ForgetLastRead(&instance.recordStore);
         }
-    }
-}
 
-static void RotateToNextFile(void)
-{
-    SolidSyslogFile_Close(instance.writeFile);
-    instance.writeSequence    = NextSequence(instance.writeSequence);
-    instance.writePosition    = 0;
-    instance.writeFileCorrupt = false;
-    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char*                 name = FormatFilename(nameStorage, instance.writeSequence);
-    OpenWriteFile(name);
-
-    if (FileCount() > instance.maxFiles)
-    {
-        DiscardOldestFile();
-    }
-}
-
-static void DeleteOldestFile(void)
-{
-    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char*                 name = FormatFilename(nameStorage, instance.oldestSequence);
-    SolidSyslogFile_Delete(instance.writeFile, name);
-    instance.oldestSequence = NextSequence(instance.oldestSequence);
-}
-
-static void SwitchReadFile(uint8_t newSequence)
-{
-    SolidSyslogFile_Close(instance.readFile);
-    instance.readSequence = newSequence;
-    instance.readCursor   = 0;
-    RecordStore_ForgetLastRead(&instance.recordStore);
-    SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char*                 name = FormatFilename(nameStorage, instance.readSequence);
-    OpenReadFile(name);
-}
-
-static void ResetReadToOldestFile(void)
-{
-    SwitchReadFile(instance.oldestSequence);
-}
-
-static void DiscardOldestFile(void)
-{
-    bool readingOldestFile = (instance.readSequence == instance.oldestSequence);
-
-    DeleteOldestFile();
-
-    if (readingOldestFile)
-    {
-        ResetReadToOldestFile();
-    }
-}
-
-static bool FlushRecord(const void* data, size_t dataSize)
-{
-    bool written = RecordStore_Append(&instance.recordStore, instance.writeFile, instance.writePosition, data, dataSize);
-
-    if (written)
-    {
-        instance.writePosition += RecordStore_RecordSize(&instance.recordStore, (uint16_t) dataSize);
+        if (RecordStore_Append(&instance.recordStore, BlockSequence_WriteFile(&instance.blockSequence), BlockSequence_WritePosition(&instance.blockSequence),
+                               data, size))
+        {
+            BlockSequence_NoteRecordWritten(&instance.blockSequence, recordSize);
+            written = true;
+        }
     }
 
     return written;
 }
 
 /* ------------------------------------------------------------------
- * HasUnsent
+ * HasUnsent / IsHalted
  * ----------------------------------------------------------------*/
 
 static bool HasUnsent(struct SolidSyslogStore* self)
 {
     (void) self;
-    return HasUnsentRecords();
+    return BlockSequence_HasUnsent(&instance.blockSequence);
 }
 
 static bool IsHalted(struct SolidSyslogStore* self)
 {
     (void) self;
-    return instance.halted;
+    return BlockSequence_IsHalted(&instance.blockSequence);
 }
 
 /* ------------------------------------------------------------------
  * ReadNextUnsent
  * ----------------------------------------------------------------*/
+
+static bool ReadCurrent(void* data, size_t maxSize, size_t* bytesRead);
 
 static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
@@ -441,23 +178,25 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
     bool read  = false;
     *bytesRead = 0;
 
-    if (HasUnsentRecords())
+    if (BlockSequence_HasUnsent(&instance.blockSequence))
     {
-        read = RecordStore_Read(&instance.recordStore, instance.readFile, instance.readCursor, data, maxSize, bytesRead);
+        read = ReadCurrent(data, maxSize, bytesRead);
 
-        while (!read && ReadingOlderFile())
+        while (!read && BlockSequence_ReadingOlderFile(&instance.blockSequence))
         {
-            AdvanceToNextReadFile();
-            read = RecordStore_Read(&instance.recordStore, instance.readFile, instance.readCursor, data, maxSize, bytesRead);
+            BlockSequence_AdvanceToNextReadFile(&instance.blockSequence);
+            RecordStore_ForgetLastRead(&instance.recordStore);
+            read = ReadCurrent(data, maxSize, bytesRead);
         }
     }
 
     return read;
 }
 
-static void AdvanceToNextReadFile(void)
+static bool ReadCurrent(void* data, size_t maxSize, size_t* bytesRead)
 {
-    SwitchReadFile(NextSequence(instance.readSequence));
+    return RecordStore_Read(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence), BlockSequence_ReadCursor(&instance.blockSequence), data,
+                            maxSize, bytesRead);
 }
 
 /* ------------------------------------------------------------------
@@ -470,8 +209,8 @@ static void MarkSent(struct SolidSyslogStore* self)
 
     size_t nextCursor = 0;
 
-    if (RecordStore_MarkLastReadAsSent(&instance.recordStore, instance.readFile, &nextCursor))
+    if (RecordStore_MarkLastReadAsSent(&instance.recordStore, BlockSequence_ReadFile(&instance.blockSequence), &nextCursor))
     {
-        instance.readCursor = nextCursor;
+        BlockSequence_SetReadCursor(&instance.blockSequence, nextCursor);
     }
 }

--- a/Core/Source/SolidSyslogFileStore.c
+++ b/Core/Source/SolidSyslogFileStore.c
@@ -51,13 +51,14 @@ struct SolidSyslogStore* SolidSyslogFileStore_Create(SolidSyslogFileStoreStorage
 
     size_t                     minFileSize = RecordStore_RecordSize(&fileStore->recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
     struct BlockSequenceConfig blockConfig = {
-        .readFile      = config->readFile,
-        .writeFile     = config->writeFile,
-        .pathPrefix    = config->pathPrefix,
-        .maxFileSize   = (config->maxFileSize < minFileSize) ? minFileSize : config->maxFileSize,
-        .maxFiles      = config->maxFiles,
-        .discardPolicy = config->discardPolicy,
-        .onStoreFull   = config->onStoreFull,
+        .readFile         = config->readFile,
+        .writeFile        = config->writeFile,
+        .pathPrefix       = config->pathPrefix,
+        .maxFileSize      = (config->maxFileSize < minFileSize) ? minFileSize : config->maxFileSize,
+        .maxFiles         = config->maxFiles,
+        .discardPolicy    = config->discardPolicy,
+        .onStoreFull      = config->onStoreFull,
+        .storeFullContext = config->storeFullContext,
     };
     BlockSequence_Init(&fileStore->blockSequence, &blockConfig);
 

--- a/Core/Source/SolidSyslogNullStore.c
+++ b/Core/Source/SolidSyslogNullStore.c
@@ -1,11 +1,13 @@
 #include "SolidSyslogNullStore.h"
 #include "SolidSyslogStoreDefinition.h"
 
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
-static void MarkSent(struct SolidSyslogStore* self);
-static bool HasUnsent(struct SolidSyslogStore* self);
-static bool IsHalted(struct SolidSyslogStore* self);
+static bool   Write(struct SolidSyslogStore* self, const void* data, size_t size);
+static bool   ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
+static void   MarkSent(struct SolidSyslogStore* self);
+static bool   HasUnsent(struct SolidSyslogStore* self);
+static bool   IsHalted(struct SolidSyslogStore* self);
+static size_t GetTotalBytes(struct SolidSyslogStore* self);
+static size_t GetUsedBytes(struct SolidSyslogStore* self);
 
 struct SolidSyslogNullStore
 {
@@ -21,6 +23,8 @@ struct SolidSyslogStore* SolidSyslogNullStore_Create(void)
     instance.base.MarkSent       = MarkSent;
     instance.base.HasUnsent      = HasUnsent;
     instance.base.IsHalted       = IsHalted;
+    instance.base.GetTotalBytes  = GetTotalBytes;
+    instance.base.GetUsedBytes   = GetUsedBytes;
     return &instance.base;
 }
 
@@ -31,6 +35,8 @@ void SolidSyslogNullStore_Destroy(void)
     instance.base.MarkSent       = NULL;
     instance.base.HasUnsent      = NULL;
     instance.base.IsHalted       = NULL;
+    instance.base.GetTotalBytes  = NULL;
+    instance.base.GetUsedBytes   = NULL;
 }
 
 static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
@@ -65,4 +71,16 @@ static bool IsHalted(struct SolidSyslogStore* self)
 {
     (void) self;
     return false;
+}
+
+static size_t GetTotalBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
+}
+
+static size_t GetUsedBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
 }

--- a/Core/Source/SolidSyslogStore.c
+++ b/Core/Source/SolidSyslogStore.c
@@ -24,3 +24,13 @@ bool SolidSyslogStore_IsHalted(struct SolidSyslogStore* store)
 {
     return store->IsHalted(store);
 }
+
+size_t SolidSyslogStore_GetTotalBytes(struct SolidSyslogStore* store)
+{
+    return store->GetTotalBytes(store);
+}
+
+size_t SolidSyslogStore_GetUsedBytes(struct SolidSyslogStore* store)
+{
+    return store->GetUsedBytes(store);
+}

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -140,7 +140,9 @@ static struct SolidSyslogStore* CreateStore(const struct ExampleOptions* options
         storeConfig.discardPolicy                            = MapDiscardPolicy(options->discardPolicy);
         storeConfig.securityPolicy                           = SolidSyslogCrc16Policy_Create();
         storeConfig.onStoreFull                              = OnStoreFull;
-        return SolidSyslogFileStore_Create(&storeConfig);
+
+        static SolidSyslogFileStoreStorage storeStorage;
+        return SolidSyslogFileStore_Create(&storeStorage, &storeConfig);
     }
 
     return SolidSyslogNullStore_Create();
@@ -157,13 +159,13 @@ static void DestroySender(void)
     SolidSyslogGetAddrInfoResolver_Destroy();
 }
 
-static void DestroyStore(const struct ExampleOptions* options)
+static void DestroyStore(const struct ExampleOptions* options, struct SolidSyslogStore* store)
 {
     bool useFile = (strcmp(options->store, "file") == 0);
 
     if (useFile)
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         SolidSyslogCrc16Policy_Destroy();
         SolidSyslogPosixFile_Destroy(storeWriteFile);
         SolidSyslogPosixFile_Destroy(storeReadFile);
@@ -246,7 +248,7 @@ int main(int argc, char* argv[])
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
     SolidSyslogStdAtomicOps_Destroy();
-    DestroyStore(&options);
+    DestroyStore(&options, store);
     SolidSyslogPosixMessageQueueBuffer_Destroy();
     DestroySender();
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -160,7 +160,7 @@ static void DestroySender(void)
     SolidSyslogGetAddrInfoResolver_Destroy();
 }
 
-static void DestroyStore(const struct ExampleOptions* options, struct SolidSyslogStore* store)
+static void DestroyStore(struct SolidSyslogStore* store, const struct ExampleOptions* options)
 {
     bool useFile = (strcmp(options->store, "file") == 0);
 
@@ -249,7 +249,7 @@ int main(int argc, char* argv[])
     SolidSyslogMetaSd_Destroy();
     SolidSyslogAtomicCounter_Destroy();
     SolidSyslogStdAtomicOps_Destroy();
-    DestroyStore(&options, store);
+    DestroyStore(store, &options);
     SolidSyslogPosixMessageQueueBuffer_Destroy();
     DestroySender();
 

--- a/Example/Threaded/main.c
+++ b/Example/Threaded/main.c
@@ -112,8 +112,9 @@ static enum SolidSyslogDiscardPolicy MapDiscardPolicy(const char* policy)
 
 static volatile bool haltExit;
 
-static void OnStoreFull(void)
+static void OnStoreFull(void* context)
 {
+    (void) context;
     if (haltExit)
     {
         _exit(2);

--- a/Tests/SolidSyslogFileStorePosixTest.cpp
+++ b/Tests/SolidSyslogFileStorePosixTest.cpp
@@ -9,6 +9,8 @@
 
 static const char* const TEST_PATH_PREFIX = "/tmp/test_posix_store";
 
+static SolidSyslogFileStoreStorage storeStorage = {};
+
 static void CleanStoreFiles()
 {
     glob_t      results = {};
@@ -51,7 +53,7 @@ TEST_GROUP(SolidSyslogFileStorePosix)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         SolidSyslogPosixFile_Destroy(writeFile);
         SolidSyslogPosixFile_Destroy(readFile);
         CleanStoreFiles();
@@ -68,7 +70,7 @@ TEST_GROUP(SolidSyslogFileStorePosix)
         config.maxFiles      = maxFiles;
         config.discardPolicy = SOLIDSYSLOG_DISCARD_OLDEST;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void WriteMaxMsg()

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1599,3 +1599,138 @@ TEST(SolidSyslogFileStoreCorruptionRecovery, CorruptWriteFileRotatesOnNextWrite)
     CHECK_TRUE(SolidSyslogStore_Write(store, newMsg, sizeof(newMsg)));
     CHECK_TRUE(SolidSyslogFile_Exists(writeFile, "/tmp/test_store01.log"));
 }
+
+/* ------------------------------------------------------------------
+ * Capacity getters
+ * ----------------------------------------------------------------*/
+
+// clang-format off
+TEST_GROUP(SolidSyslogFileStoreCapacity)
+{
+    struct FileFakeStorage storage = {};
+    struct SolidSyslogFile* file = nullptr;
+    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+    struct SolidSyslogStore* store = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        file = FileFake_Create(&storage);
+    }
+
+    void teardown() override
+    {
+        if (store != nullptr) { SolidSyslogFileStore_Destroy(store); }
+        FileFake_Destroy();
+    }
+};
+
+// clang-format on
+
+/* Given maxFiles × maxFileSize configured,
+ * When GetTotalBytes is queried,
+ * Then it returns the product. */
+TEST(SolidSyslogFileStoreCapacity, GetTotalBytesReturnsMaxFilesTimesMaxFileSize)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    LONGS_EQUAL(TEST_MAX_FILES * TEST_MAX_FILE_SIZE, SolidSyslogStore_GetTotalBytes(store));
+}
+
+TEST(SolidSyslogFileStoreCapacity, GetTotalBytesScalesWithConfig)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.maxFiles                          = 3;
+    config.maxFileSize                       = 10000;
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    LONGS_EQUAL(3 * 10000, SolidSyslogStore_GetTotalBytes(store));
+}
+
+/* Given an empty store,
+ * When GetUsedBytes is queried,
+ * Then it returns 0. */
+TEST(SolidSyslogFileStoreCapacity, GetUsedBytesIsZeroOnEmptyStore)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    LONGS_EQUAL(0, SolidSyslogStore_GetUsedBytes(store));
+}
+
+/* Given an empty store,
+ * When records totalling X bytes are written,
+ * Then GetUsedBytes returns X (including record overhead). */
+TEST(SolidSyslogFileStoreCapacity, GetUsedBytesTracksOneWrite)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
+    /* TEST_DATA_LEN data + TEST_RECORD_OVERHEAD (no integrity) */
+    LONGS_EQUAL(TEST_DATA_LEN + TEST_RECORD_OVERHEAD, SolidSyslogStore_GetUsedBytes(store));
+}
+
+TEST(SolidSyslogFileStoreCapacity, GetUsedBytesCountsClosedBlocksAtFullSize)
+{
+    /* Tight maxFileSize so a single max-msg record fills a block; second write
+     * rotates. Closed block contributes maxFileSize regardless of slack. */
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.maxFileSize                       = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
+    config.maxFiles                          = 3;
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(maxMsg, 'A', sizeof(maxMsg));
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0 fills */
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* rotates to block 1 */
+
+    size_t recordSize = sizeof(maxMsg) + TEST_RECORD_OVERHEAD;
+    LONGS_EQUAL(config.maxFileSize + recordSize, SolidSyslogStore_GetUsedBytes(store));
+}
+
+/* Given a full store with SOLIDSYSLOG_DISCARD_OLDEST,
+ * When the oldest block is discarded,
+ * Then GetUsedBytes drops by one block size. */
+TEST(SolidSyslogFileStoreCapacity, GetUsedBytesDropsOnDiscardOldest)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    config.maxFileSize                       = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
+    config.maxFiles                          = 2;
+    config.discardPolicy                     = SOLIDSYSLOG_DISCARD_OLDEST;
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(maxMsg, 'A', sizeof(maxMsg));
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0 full */
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 1 full, at maxFiles */
+
+    LONGS_EQUAL(2 * config.maxFileSize, SolidSyslogStore_GetUsedBytes(store));
+
+    SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN); /* rotates to block 2, discards block 0 */
+
+    /* 1 closed block (block 1) + active block holds one small record. */
+    LONGS_EQUAL(config.maxFileSize + TEST_DATA_LEN + TEST_RECORD_OVERHEAD, SolidSyslogStore_GetUsedBytes(store));
+}
+
+/* Given a store at capacity with SOLIDSYSLOG_HALT,
+ * When a Write fails for size,
+ * Then GetUsedBytes returns total even when the active block has slack. */
+TEST(SolidSyslogFileStoreCapacity, GetUsedBytesIsStickyAtTotalAfterSizeFailure)
+{
+    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+    /* maxFileSize larger than one max-msg record so the active block has slack. */
+    config.maxFileSize   = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD + 100;
+    config.maxFiles      = 2;
+    config.discardPolicy = SOLIDSYSLOG_HALT;
+    store                = SolidSyslogFileStore_Create(&storeStorage, &config);
+
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(maxMsg, 'A', sizeof(maxMsg));
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0: 100 bytes slack */
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 1: 100 bytes slack, at maxFiles */
+
+    /* The next write needs to rotate but can't (HALT, at maxFiles) — fails for size. */
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+
+    /* Sticky: GetUsedBytes returns total (2 * maxFileSize) even though the
+     * actual bytes stored leave 200 bytes of slack across the two blocks. */
+    LONGS_EQUAL(SolidSyslogStore_GetTotalBytes(store), SolidSyslogStore_GetUsedBytes(store));
+}

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -694,14 +694,17 @@ TEST_GROUP(SolidSyslogFileStoreRotation)
     }
 
     void CreateWithMaxFileSize(size_t maxFileSize, enum SolidSyslogDiscardPolicy policy = SOLIDSYSLOG_DISCARD_OLDEST,
-                               size_t maxFiles = 2)
+                               size_t maxFiles = 2,
+                               SolidSyslogStoreFullCallback onStoreFull = nullptr, void* storeFullContext = nullptr)
     {
         struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-        config.readFile      = readFile;
-        config.writeFile     = writeFile;
-        config.maxFileSize   = maxFileSize;
-        config.maxFiles      = maxFiles;
-        config.discardPolicy = policy;
+        config.readFile          = readFile;
+        config.writeFile         = writeFile;
+        config.maxFileSize       = maxFileSize;
+        config.maxFiles          = maxFiles;
+        config.discardPolicy     = policy;
+        config.onStoreFull       = onStoreFull;
+        config.storeFullContext  = storeFullContext;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
@@ -880,15 +883,7 @@ static void StoreFullCallback(void* context)
 TEST(SolidSyslogFileStoreRotation, HaltInvokesCallbackWhenStoreFull)
 {
     storeFullCallbackInvoked = false;
-
-    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-    config.readFile                          = readFile;
-    config.writeFile                         = writeFile;
-    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_HALT;
-    config.onStoreFull                       = StoreFullCallback;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_HALT, 2, StoreFullCallback);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -899,14 +894,7 @@ TEST(SolidSyslogFileStoreRotation, HaltInvokesCallbackWhenStoreFull)
 
 TEST(SolidSyslogFileStoreRotation, HaltWithNullCallbackDoesNotCrash)
 {
-    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-    config.readFile                          = readFile;
-    config.writeFile                         = writeFile;
-    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_HALT;
-    config.onStoreFull                       = nullptr;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_HALT);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -916,14 +904,7 @@ TEST(SolidSyslogFileStoreRotation, HaltWithNullCallbackDoesNotCrash)
 
 TEST(SolidSyslogFileStoreRotation, HaltSetsIsHaltedTrue)
 {
-    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-    config.readFile                          = readFile;
-    config.writeFile                         = writeFile;
-    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_HALT;
-    config.onStoreFull                       = nullptr;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_HALT);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -936,15 +917,7 @@ TEST(SolidSyslogFileStoreRotation, HaltSetsIsHaltedTrue)
 TEST(SolidSyslogFileStoreRotation, DiscardNewestDoesNotInvokeCallback)
 {
     storeFullCallbackInvoked = false;
-
-    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-    config.readFile                          = readFile;
-    config.writeFile                         = writeFile;
-    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_DISCARD_NEWEST;
-    config.onStoreFull                       = StoreFullCallback;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_DISCARD_NEWEST, 2, StoreFullCallback);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -968,15 +941,7 @@ TEST(SolidSyslogFileStoreRotation, OnStoreFullReceivesConfiguredContext)
     int sentinel             = 0;
     storeFullCallbackContext = nullptr;
 
-    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
-    config.readFile                          = readFile;
-    config.writeFile                         = writeFile;
-    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_HALT;
-    config.onStoreFull                       = StoreFullCallbackCapturingContext;
-    config.storeFullContext                  = &sentinel;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_HALT, 2, StoreFullCallbackCapturingContext, &sentinel);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — at maxFiles */

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -1641,21 +1641,46 @@ TEST(SolidSyslogFileStoreCorruptionRecovery, CorruptWriteFileRotatesOnNextWrite)
 // clang-format off
 TEST_GROUP(SolidSyslogFileStoreCapacity)
 {
+    static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
+
     struct FileFakeStorage storage = {};
     struct SolidSyslogFile* file = nullptr;
     // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStore* store = nullptr;
+    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         file = FileFake_Create(&storage);
+        memset(maxMsg, 'A', sizeof(maxMsg));
     }
 
     void teardown() override
     {
         if (store != nullptr) { SolidSyslogFileStore_Destroy(store); }
         FileFake_Destroy();
+    }
+
+    void CreateDefault()
+    {
+        struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
+    }
+
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- maxFileSize is a byte size, maxFiles is a count; distinct semantics
+    void CreateWithCapacity(size_t maxFileSize, size_t maxFiles,
+                            enum SolidSyslogDiscardPolicy policy = SOLIDSYSLOG_DISCARD_OLDEST)
+    {
+        struct SolidSyslogFileStoreConfig config = MakeConfig(file);
+        config.maxFileSize   = maxFileSize;
+        config.maxFiles      = maxFiles;
+        config.discardPolicy = policy;
+        store                = SolidSyslogFileStore_Create(&storeStorage, &config);
+    }
+
+    void WriteMaxMsg()
+    {
+        SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg));
     }
 };
 
@@ -1666,17 +1691,13 @@ TEST_GROUP(SolidSyslogFileStoreCapacity)
  * Then it returns the product. */
 TEST(SolidSyslogFileStoreCapacity, GetTotalBytesReturnsMaxFilesTimesMaxFileSize)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateDefault();
     LONGS_EQUAL(TEST_MAX_FILES * TEST_MAX_FILE_SIZE, SolidSyslogStore_GetTotalBytes(store));
 }
 
 TEST(SolidSyslogFileStoreCapacity, GetTotalBytesScalesWithConfig)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    config.maxFiles                          = 3;
-    config.maxFileSize                       = 10000;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithCapacity(10000, 3);
     LONGS_EQUAL(3 * 10000, SolidSyslogStore_GetTotalBytes(store));
 }
 
@@ -1685,8 +1706,7 @@ TEST(SolidSyslogFileStoreCapacity, GetTotalBytesScalesWithConfig)
  * Then it returns 0. */
 TEST(SolidSyslogFileStoreCapacity, GetUsedBytesIsZeroOnEmptyStore)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateDefault();
     LONGS_EQUAL(0, SolidSyslogStore_GetUsedBytes(store));
 }
 
@@ -1695,10 +1715,8 @@ TEST(SolidSyslogFileStoreCapacity, GetUsedBytesIsZeroOnEmptyStore)
  * Then GetUsedBytes returns X (including record overhead). */
 TEST(SolidSyslogFileStoreCapacity, GetUsedBytesTracksOneWrite)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateDefault();
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
-    /* TEST_DATA_LEN data + TEST_RECORD_OVERHEAD (no integrity) */
     LONGS_EQUAL(TEST_DATA_LEN + TEST_RECORD_OVERHEAD, SolidSyslogStore_GetUsedBytes(store));
 }
 
@@ -1706,18 +1724,11 @@ TEST(SolidSyslogFileStoreCapacity, GetUsedBytesCountsClosedBlocksAtFullSize)
 {
     /* Tight maxFileSize so a single max-msg record fills a block; second write
      * rotates. Closed block contributes maxFileSize regardless of slack. */
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    config.maxFileSize                       = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
-    config.maxFiles                          = 3;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithCapacity(ONE_MAX_MSG_RECORD, 3);
+    WriteMaxMsg(); /* block 0 fills */
+    WriteMaxMsg(); /* rotates to block 1 */
 
-    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
-    memset(maxMsg, 'A', sizeof(maxMsg));
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0 fills */
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* rotates to block 1 */
-
-    size_t recordSize = sizeof(maxMsg) + TEST_RECORD_OVERHEAD;
-    LONGS_EQUAL(config.maxFileSize + recordSize, SolidSyslogStore_GetUsedBytes(store));
+    LONGS_EQUAL(ONE_MAX_MSG_RECORD + ONE_MAX_MSG_RECORD, SolidSyslogStore_GetUsedBytes(store));
 }
 
 /* Given a full store with SOLIDSYSLOG_DISCARD_OLDEST,
@@ -1725,23 +1736,16 @@ TEST(SolidSyslogFileStoreCapacity, GetUsedBytesCountsClosedBlocksAtFullSize)
  * Then GetUsedBytes drops by one block size. */
 TEST(SolidSyslogFileStoreCapacity, GetUsedBytesDropsOnDiscardOldest)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    config.maxFileSize                       = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
-    config.maxFiles                          = 2;
-    config.discardPolicy                     = SOLIDSYSLOG_DISCARD_OLDEST;
-    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+    CreateWithCapacity(ONE_MAX_MSG_RECORD, 2);
+    WriteMaxMsg(); /* block 0 full */
+    WriteMaxMsg(); /* block 1 full, at maxFiles */
 
-    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
-    memset(maxMsg, 'A', sizeof(maxMsg));
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0 full */
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 1 full, at maxFiles */
-
-    LONGS_EQUAL(2 * config.maxFileSize, SolidSyslogStore_GetUsedBytes(store));
+    LONGS_EQUAL(2 * ONE_MAX_MSG_RECORD, SolidSyslogStore_GetUsedBytes(store));
 
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN); /* rotates to block 2, discards block 0 */
 
     /* 1 closed block (block 1) + active block holds one small record. */
-    LONGS_EQUAL(config.maxFileSize + TEST_DATA_LEN + TEST_RECORD_OVERHEAD, SolidSyslogStore_GetUsedBytes(store));
+    LONGS_EQUAL(ONE_MAX_MSG_RECORD + TEST_DATA_LEN + TEST_RECORD_OVERHEAD, SolidSyslogStore_GetUsedBytes(store));
 }
 
 /* Given a store at capacity with SOLIDSYSLOG_HALT,
@@ -1749,22 +1753,15 @@ TEST(SolidSyslogFileStoreCapacity, GetUsedBytesDropsOnDiscardOldest)
  * Then GetUsedBytes returns total even when the active block has slack. */
 TEST(SolidSyslogFileStoreCapacity, GetUsedBytesIsStickyAtTotalAfterSizeFailure)
 {
-    struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     /* maxFileSize larger than one max-msg record so the active block has slack. */
-    config.maxFileSize   = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD + 100;
-    config.maxFiles      = 2;
-    config.discardPolicy = SOLIDSYSLOG_HALT;
-    store                = SolidSyslogFileStore_Create(&storeStorage, &config);
-
-    char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
-    memset(maxMsg, 'A', sizeof(maxMsg));
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 0: 100 bytes slack */
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* block 1: 100 bytes slack, at maxFiles */
+    static const size_t SLACK = 100;
+    CreateWithCapacity(ONE_MAX_MSG_RECORD + SLACK, 2, SOLIDSYSLOG_HALT);
+    WriteMaxMsg(); /* block 0: SLACK bytes slack */
+    WriteMaxMsg(); /* block 1: SLACK bytes slack, at maxFiles */
 
     /* The next write needs to rotate but can't (HALT, at maxFiles) — fails for size. */
     CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
 
-    /* Sticky: GetUsedBytes returns total (2 * maxFileSize) even though the
-     * actual bytes stored leave 200 bytes of slack across the two blocks. */
+    /* Sticky: GetUsedBytes returns total even though the active blocks have slack. */
     LONGS_EQUAL(SolidSyslogStore_GetTotalBytes(store), SolidSyslogStore_GetUsedBytes(store));
 }

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -31,6 +31,10 @@ static const struct SolidSyslogFileStoreConfig DEFAULT_CONFIG = {
     nullptr, nullptr, TEST_PATH_PREFIX, TEST_MAX_FILE_SIZE, TEST_MAX_FILES, SOLIDSYSLOG_DISCARD_OLDEST, nullptr, nullptr,
 };
 
+/* Single backing slab reused across tests — tests run serially and Destroy
+ * resets the store, so one storage instance is sufficient. */
+static SolidSyslogFileStoreStorage storeStorage = {};
+
 static struct SolidSyslogFileStoreConfig MakeConfig(struct SolidSyslogFile* file)
 {
     struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
@@ -56,12 +60,12 @@ TEST_GROUP(SolidSyslogFileStore)
         file = FileFake_Create(&storage);
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 };
@@ -278,7 +282,7 @@ TEST_GROUP(SolidSyslogFileStoreResume)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 
@@ -287,13 +291,13 @@ TEST_GROUP(SolidSyslogFileStoreResume)
     {
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         // cppcheck-suppress unreadVariable -- used by WriteMessages/DrainMessages; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
         WriteMessages(total);
         DrainMessages(markedSent);
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
 
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void WriteMessages(int count) const
@@ -409,18 +413,18 @@ TEST_GROUP(SolidSyslogFileStoreDestroy)
 TEST(SolidSyslogFileStoreDestroy, DestroyClosesFile)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    SolidSyslogFileStore_Create(&config);
+    struct SolidSyslogStore*          store  = SolidSyslogFileStore_Create(&storeStorage, &config);
     CHECK_TRUE(SolidSyslogFile_IsOpen(file));
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
     CHECK_FALSE(SolidSyslogFile_IsOpen(file));
 }
 
 TEST(SolidSyslogFileStoreDestroy, DoubleDestroyDoesNotCrash)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    SolidSyslogFileStore_Create(&config);
-    SolidSyslogFileStore_Destroy();
-    SolidSyslogFileStore_Destroy();
+    struct SolidSyslogStore*          store  = SolidSyslogFileStore_Create(&storeStorage, &config);
+    SolidSyslogFileStore_Destroy(store);
+    SolidSyslogFileStore_Destroy(store);
 }
 
 /* ------------------------------------------------------------------
@@ -442,7 +446,7 @@ TEST_GROUP(SolidSyslogFileStoreConfig)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 
@@ -451,7 +455,7 @@ TEST_GROUP(SolidSyslogFileStoreConfig)
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         config.maxFiles = maxFiles;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void CreateWithMaxFileSize(size_t maxFileSize)
@@ -459,7 +463,7 @@ TEST_GROUP(SolidSyslogFileStoreConfig)
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         config.maxFileSize = maxFileSize;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void CreateWithPathPrefix(const char* prefix)
@@ -467,7 +471,7 @@ TEST_GROUP(SolidSyslogFileStoreConfig)
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         config.pathPrefix = prefix;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void VerifyWriteAndReadBack() const
@@ -546,7 +550,7 @@ TEST(SolidSyslogFileStoreConfig, NullSecurityPolicyDefaultsToNoOp)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     config.securityPolicy                    = nullptr;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     VerifyWriteAndReadBack();
 }
 
@@ -559,7 +563,7 @@ TEST(SolidSyslogFileStoreConfig, OversizedSecurityPolicyLeavesNoIntegrityGap)
     };
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     config.securityPolicy                    = &oversizedPolicy;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     const char   body[]  = "HELLO WORLD";
     const size_t bodyLen = sizeof(body) - 1;
@@ -591,7 +595,7 @@ TEST_GROUP(SolidSyslogFileStoreErrors)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 };
@@ -602,7 +606,7 @@ TEST(SolidSyslogFileStoreErrors, OpenFailureStillReturnsNonNull)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     FileFake_FailNextOpen();
-    store = SolidSyslogFileStore_Create(&config);
+    store = SolidSyslogFileStore_Create(&storeStorage, &config);
     CHECK_TRUE(store != nullptr);
 }
 
@@ -610,14 +614,14 @@ TEST(SolidSyslogFileStoreErrors, WriteReturnsFalseWhenNotOpen)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     FileFake_FailNextOpen();
-    store = SolidSyslogFileStore_Create(&config);
+    store = SolidSyslogFileStore_Create(&storeStorage, &config);
     CHECK_FALSE(SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN));
 }
 
 TEST(SolidSyslogFileStoreErrors, WriteReturnsFalseOnWriteFailure)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     FileFake_FailNextWrite();
     CHECK_FALSE(SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN));
 }
@@ -625,7 +629,7 @@ TEST(SolidSyslogFileStoreErrors, WriteReturnsFalseOnWriteFailure)
 TEST(SolidSyslogFileStoreErrors, ReadReturnsFalseOnReadFailure)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
     FileFake_FailNextRead();
 
@@ -639,14 +643,14 @@ TEST(SolidSyslogFileStoreErrors, HasUnsentReturnsFalseWhenNotOpen)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     FileFake_FailNextOpen();
-    store = SolidSyslogFileStore_Create(&config);
+    store = SolidSyslogFileStore_Create(&storeStorage, &config);
     CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
 }
 
 TEST(SolidSyslogFileStoreErrors, MarkSentDoesNotAdvanceWhenWriteFails)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
 
     char   buf[TEST_BUF_SIZE];
@@ -685,7 +689,7 @@ TEST_GROUP(SolidSyslogFileStoreRotation)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 
@@ -699,7 +703,7 @@ TEST_GROUP(SolidSyslogFileStoreRotation)
         config.maxFiles      = maxFiles;
         config.discardPolicy = policy;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void WriteMaxMsg()
@@ -883,7 +887,7 @@ TEST(SolidSyslogFileStoreRotation, HaltInvokesCallbackWhenStoreFull)
     config.maxFiles                          = 2;
     config.discardPolicy                     = SOLIDSYSLOG_HALT;
     config.onStoreFull                       = StoreFullCallback;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -901,7 +905,7 @@ TEST(SolidSyslogFileStoreRotation, HaltWithNullCallbackDoesNotCrash)
     config.maxFiles                          = 2;
     config.discardPolicy                     = SOLIDSYSLOG_HALT;
     config.onStoreFull                       = nullptr;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -918,7 +922,7 @@ TEST(SolidSyslogFileStoreRotation, HaltSetsIsHaltedTrue)
     config.maxFiles                          = 2;
     config.discardPolicy                     = SOLIDSYSLOG_HALT;
     config.onStoreFull                       = nullptr;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -939,7 +943,7 @@ TEST(SolidSyslogFileStoreRotation, DiscardNewestDoesNotInvokeCallback)
     config.maxFiles                          = 2;
     config.discardPolicy                     = SOLIDSYSLOG_DISCARD_NEWEST;
     config.onStoreFull                       = StoreFullCallback;
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
@@ -953,7 +957,7 @@ TEST(SolidSyslogFileStoreRotation, ResumeHasUnsentWhenMultipleFilesExist)
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     CHECK_TRUE(SolidSyslogStore_HasUnsent(store));
@@ -968,7 +972,7 @@ TEST(SolidSyslogFileStoreRotation, ResumeDrainsAcrossFilesInOrder)
     SolidSyslogStore_Write(store, firstMsg, sizeof(firstMsg)); /* file 00 */
 
     WriteMaxMsg(); /* file 01 — 'A' */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
 
@@ -991,7 +995,7 @@ TEST(SolidSyslogFileStoreRotation, ResumeContinuesWritingToCorrectFile)
 {
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* file 00 */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* should rotate to file 01, not overwrite 00 */
@@ -1005,7 +1009,7 @@ TEST(SolidSyslogFileStoreRotation, ResumeWithMultipleFilesCanWriteNewMessage)
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
 
@@ -1025,7 +1029,7 @@ TEST(SolidSyslogFileStoreRotation, ResumeWriteAppendsToPartiallyFilledWriteFile)
     WriteMaxMsg(); /* file 00, record 1 */
     WriteMaxMsg(); /* file 00, record 2 — file 00 full */
     WriteMaxMsg(); /* file 01, record 1 — file 01 partially filled */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CreateWithMaxFileSize(TWO_MAX_MSG_RECORDS);
 
@@ -1070,7 +1074,7 @@ TEST(SolidSyslogFileStoreRotation, DestroyClosesBothHandles)
     CreateWithMaxFileSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 — read on 00, write on 01 */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CHECK_FALSE(SolidSyslogFile_IsOpen(readFile));
     CHECK_FALSE(SolidSyslogFile_IsOpen(writeFile));
@@ -1266,12 +1270,12 @@ TEST_GROUP(SolidSyslogFileStoreIntegrity)
         config.writeFile      = file;
         config.securityPolicy = &spyPolicy;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 };
@@ -1354,7 +1358,7 @@ TEST_GROUP(SolidSyslogFileStoreCorruption)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 
@@ -1369,7 +1373,7 @@ TEST_GROUP(SolidSyslogFileStoreCorruption)
     {
         struct SolidSyslogFileStoreConfig config = MakeConfig(file);
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 };
 
@@ -1412,10 +1416,10 @@ TEST(SolidSyslogFileStoreCorruption, ValidRecordBeforeCorruptionIsReadable)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     config.securityPolicy                    = SolidSyslogCrc16Policy_Create();
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     SolidSyslogStore_Write(store, "first", 5);
     SolidSyslogStore_Write(store, "second", 6);
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     /* Corrupt the second record's body */
     enum
@@ -1435,7 +1439,7 @@ TEST(SolidSyslogFileStoreCorruption, ValidRecordBeforeCorruptionIsReadable)
     SolidSyslogFile_Close(file);
 
     /* Re-open: first record is valid, second is corrupt */
-    store                     = SolidSyslogFileStore_Create(&config);
+    store                     = SolidSyslogFileStore_Create(&storeStorage, &config);
     char   buf[TEST_BUF_SIZE] = {};
     size_t bytesRead          = 0;
 
@@ -1448,9 +1452,9 @@ TEST(SolidSyslogFileStoreCorruption, IntegrityFailureReadReturnsFalse)
 {
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
     config.securityPolicy                    = SolidSyslogCrc16Policy_Create();
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
     SolidSyslogStore_Write(store, TEST_DATA, TEST_DATA_LEN);
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     /* Corrupt one byte of the body in the stored record */
     SolidSyslogFile_Open(file, "/tmp/test_store00.log");
@@ -1459,7 +1463,7 @@ TEST(SolidSyslogFileStoreCorruption, IntegrityFailureReadReturnsFalse)
     SolidSyslogFile_Write(file, &corrupt, 1);
     SolidSyslogFile_Close(file);
 
-    store = SolidSyslogFileStore_Create(&config);
+    store = SolidSyslogFileStore_Create(&storeStorage, &config);
     char   buf[TEST_BUF_SIZE];
     size_t bytesRead = 0;
     CHECK_FALSE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
@@ -1470,13 +1474,13 @@ TEST(SolidSyslogFileStoreCorruption, InvalidLengthReadReturnsFalse)
     /* Write many records to make the file large enough that a bogus length
      * doesn't hit EOF — the length check must reject it explicitly */
     struct SolidSyslogFileStoreConfig config = MakeConfig(file);
-    store                                    = SolidSyslogFileStore_Create(&config);
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
 
     char largeMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     memset(largeMsg, 'X', sizeof(largeMsg));
     SolidSyslogStore_Write(store, largeMsg, sizeof(largeMsg));
     SolidSyslogStore_Write(store, largeMsg, sizeof(largeMsg));
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     /* Overwrite the length field of the first record (bytes 2-3) */
     SolidSyslogFile_Open(file, "/tmp/test_store00.log");
@@ -1485,7 +1489,7 @@ TEST(SolidSyslogFileStoreCorruption, InvalidLengthReadReturnsFalse)
     SolidSyslogFile_Write(file, &badLength, 2);
     SolidSyslogFile_Close(file);
 
-    store = SolidSyslogFileStore_Create(&config);
+    store = SolidSyslogFileStore_Create(&storeStorage, &config);
     char   buf[TEST_BUF_SIZE];
     size_t bytesRead = 0;
     CHECK_FALSE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
@@ -1519,7 +1523,7 @@ TEST_GROUP(SolidSyslogFileStoreCorruptionRecovery)
 
     void teardown() override
     {
-        SolidSyslogFileStore_Destroy();
+        SolidSyslogFileStore_Destroy(store);
         FileFake_Destroy();
     }
 
@@ -1533,7 +1537,7 @@ TEST_GROUP(SolidSyslogFileStoreCorruptionRecovery)
         config.maxFiles        = maxFiles;
         config.securityPolicy  = policy;
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        store = SolidSyslogFileStore_Create(&config);
+        store = SolidSyslogFileStore_Create(&storeStorage, &config);
     }
 
     void WriteMaxMsg()
@@ -1562,7 +1566,7 @@ TEST(SolidSyslogFileStoreCorruptionRecovery, ReadSkipsCorruptOlderFileToNextFile
     SolidSyslogStore_Write(store, firstMsg, sizeof(firstMsg)); /* file 00 */
 
     WriteMaxMsg(); /* file 01 */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CorruptFirstRecordBody("/tmp/test_store00.log");
 
@@ -1583,7 +1587,7 @@ TEST(SolidSyslogFileStoreCorruptionRecovery, CorruptWriteFileRotatesOnNextWrite)
 
     CreateWithMaxFileSize(TWO_MAX_MSG_RECORDS);
     WriteMaxMsg(); /* file 00 — partially filled */
-    SolidSyslogFileStore_Destroy();
+    SolidSyslogFileStore_Destroy(store);
 
     CorruptFirstRecordBody("/tmp/test_store00.log");
 

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -28,7 +28,7 @@ enum
 };
 
 static const struct SolidSyslogFileStoreConfig DEFAULT_CONFIG = {
-    nullptr, nullptr, TEST_PATH_PREFIX, TEST_MAX_FILE_SIZE, TEST_MAX_FILES, SOLIDSYSLOG_DISCARD_OLDEST, nullptr, nullptr,
+    nullptr, nullptr, TEST_PATH_PREFIX, TEST_MAX_FILE_SIZE, TEST_MAX_FILES, SOLIDSYSLOG_DISCARD_OLDEST, nullptr, nullptr, nullptr,
 };
 
 /* Single backing slab reused across tests — tests run serially and Destroy
@@ -871,8 +871,9 @@ TEST(SolidSyslogFileStoreRotation, DiscardNewestReturnsFalseWhenAtMaxFiles)
 
 static bool storeFullCallbackInvoked;
 
-static void StoreFullCallback()
+static void StoreFullCallback(void* context)
 {
+    (void) context;
     storeFullCallbackInvoked = true;
 }
 
@@ -950,6 +951,39 @@ TEST(SolidSyslogFileStoreRotation, DiscardNewestDoesNotInvokeCallback)
 
     CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
     CHECK_FALSE(storeFullCallbackInvoked);
+}
+
+static void* storeFullCallbackContext;
+
+static void StoreFullCallbackCapturingContext(void* context)
+{
+    storeFullCallbackContext = context;
+}
+
+/* Given the integrator wires storeFullContext at config time,
+ * When onStoreFull fires,
+ * Then the callback receives the configured context pointer unchanged. */
+TEST(SolidSyslogFileStoreRotation, OnStoreFullReceivesConfiguredContext)
+{
+    int sentinel             = 0;
+    storeFullCallbackContext = nullptr;
+
+    struct SolidSyslogFileStoreConfig config = DEFAULT_CONFIG;
+    config.readFile                          = readFile;
+    config.writeFile                         = writeFile;
+    config.maxFileSize                       = ONE_MAX_MSG_RECORD;
+    config.maxFiles                          = 2;
+    config.discardPolicy                     = SOLIDSYSLOG_HALT;
+    config.onStoreFull                       = StoreFullCallbackCapturingContext;
+    config.storeFullContext                  = &sentinel;
+    store                                    = SolidSyslogFileStore_Create(&storeStorage, &config);
+
+    WriteMaxMsg(); /* file 00 */
+    WriteMaxMsg(); /* file 01 — at maxFiles */
+
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* triggers halt callback */
+
+    POINTERS_EQUAL(&sentinel, storeFullCallbackContext);
 }
 
 TEST(SolidSyslogFileStoreRotation, ResumeHasUnsentWhenMultipleFilesExist)

--- a/Tests/SolidSyslogNullStoreTest.cpp
+++ b/Tests/SolidSyslogNullStoreTest.cpp
@@ -41,3 +41,13 @@ TEST(SolidSyslogNullStore, MarkSentDoesNotCrash)
 {
     SolidSyslogStore_MarkSent(store);
 }
+
+TEST(SolidSyslogNullStore, GetTotalBytesReturnsZero)
+{
+    LONGS_EQUAL(0, SolidSyslogStore_GetTotalBytes(store));
+}
+
+TEST(SolidSyslogNullStore, GetUsedBytesReturnsZero)
+{
+    LONGS_EQUAL(0, SolidSyslogStore_GetUsedBytes(store));
+}


### PR DESCRIPTION
## Summary

- Splits the 764-line `Core/Source/SolidSyslogFileStore.c` into two internal layers under `Core/Source/`: **RecordStore** (record format, integrity, scan-for-unsent, current-record cursor) and **BlockSequence** (rotation, sequence numbering, gap detection, capacity tracking, discard policy, halt callback). FileStore.c is now a thin wiring layer that orchestrates the two.
- Public surface migrates to integrator-injected storage (`SolidSyslogFileStoreStorage` + `SOLIDSYSLOG_FILESTORE_STORAGE_SIZE`) — no `malloc` anywhere — plus a context-pointer `SolidSyslogStoreFullCallback(void* context)` with paired `storeFullContext` field, per the new `Callback Conventions` in `CLAUDE.md`.
- New capacity getters on the Store vtable (`SolidSyslogStore_GetTotalBytes`, `_GetUsedBytes`) plus a sticky-100% bit on size failure under HALT and DISCARD_NEWEST. NullStore returns 0/0.

## How it slices

Each of the slices below is a separate commit in this branch — easier to review one at a time than as the squash merge.

| Slice | Commit | Scope |
|---|---|---|
| 1 | `3cb66a4` | Extract `RecordStore` as internal sub-component (no header surface change). |
| 2 | `4412ef5` | Extract `BlockSequence` as internal sub-component. FileStore shrinks from 425 → 216 lines. |
| 3 | `14f713a` | Storage injection (`Create(storage, config)` / `Destroy(store)`); kills the singleton. |
| 4 | `a10bd67` | Capacity getters on the Store vtable + sticky 100% bit. TDD-driven, 9 unit tests. |
| 5 | `af7c41f` | Migrate `SolidSyslogStoreFullCallback` to take `void* context`. |
| R1–R7 | `b04d7fd` … `3fc8960` | Refactor pass: single-return points, helper-chaining DRY in RecordStore, SLA in `Create`, `Is` prefix on bool getter, `DestroyStore` arg order, test helper extraction. |
| 6 | `4ea2d27` | Refresh `CLAUDE.md` audience rows for `SolidSyslogStore.h` / `SolidSyslogFileStore.h`. |

## Acceptance criteria coverage

Per the framing decision discussed during slicing, the four query-shaped ACs land as BDD given/when/then-styled unit tests rather than Gherkin scenarios — the existing `Bdd/features/store_capacity.feature` already covers the observable rotation/halt/discard behaviour end-to-end via message-delivery counts, and adding capacity-probe scaffolding to the threaded example would be heavier than the value warrants.

- [x] **GetTotalBytes returns configured capacity** — `Tests/SolidSyslogFileStoreTest.cpp:GetTotalBytesReturnsMaxFilesTimesMaxFileSize` + `GetTotalBytesScalesWithConfig`
- [x] **GetUsedBytes tracks writes** — `GetUsedBytesIsZeroOnEmptyStore` + `GetUsedBytesTracksOneWrite` + `GetUsedBytesCountsClosedBlocksAtFullSize`
- [x] **GetUsedBytes drops on discard** — `GetUsedBytesDropsOnDiscardOldest`
- [x] **Sticky 100% on size failure** — `GetUsedBytesIsStickyAtTotalAfterSizeFailure`
- [x] **`onStoreFull` receives context** — `OnStoreFullReceivesConfiguredContext`
- [x] **No regression** — all pre-existing FileStore unit + BDD scenarios remain green

## Test plan

- [ ] CI gates pass (build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel)
- [ ] Local: 957 tests pass under debug + sanitize (ASan + UBSan)
- [ ] Local: coverage 100% line/function whole-library (1645 lines / 365 functions)
- [ ] Local: tidy / cppcheck / clang-format clean
- [ ] Spot-check Threaded example builds and `--store file` end-to-end works after the storage-injection switch

## Out of scope

- Flash work (S18.02–S18.04) — the BlockDevice layer comes next.
- Threshold callback (S05.09 #111) — depends on this story; can now wire on top of `_GetTotalBytes` / `_GetUsedBytes` and the migrated callback shape.
- Dispose-on-empty block lifecycle (S18.03) — also unblocks the sticky-bit clear path, which intentionally has no caller in this PR (no current operation frees a block under HALT/NEWEST).

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capacity reporting functions to query total and used bytes in storage.
  * Introduced explicit discard policies for handling full store conditions.

* **API Changes**
  * File store creation now requires explicit storage parameter.
  * File store destruction now accepts store reference.
  * Store-full callback now includes context parameter for flexible callback handling.

* **Improvements**
  * Enhanced internal record serialization and storage rotation management.
  * Improved file scanning and unsent record tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->