### PR TITLE
fix(filestore): edge-trigger onStoreFull under HALT (S05.10)

### DIFF
--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -195,7 +195,7 @@ static inline bool StoreIsFull(const struct BlockSequence* blockSequence)
 
 static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
 {
-    if (blockSequence->discardPolicy == SOLIDSYSLOG_HALT)
+    if ((blockSequence->discardPolicy == SOLIDSYSLOG_HALT) && !blockSequence->halted)
     {
         blockSequence->halted = true;
 

--- a/Tests/SolidSyslogFileStoreTest.cpp
+++ b/Tests/SolidSyslogFileStoreTest.cpp
@@ -926,6 +926,30 @@ TEST(SolidSyslogFileStoreRotation, DiscardNewestDoesNotInvokeCallback)
     CHECK_FALSE(storeFullCallbackInvoked);
 }
 
+static int storeFullCallbackCount;
+
+static void CountStoreFullInvocations(void* context)
+{
+    (void) context;
+    storeFullCallbackCount++;
+}
+
+TEST(SolidSyslogFileStoreRotation, HaltOnStoreFullFiresOncePerRisingEdge)
+{
+    storeFullCallbackCount = 0;
+    CreateWithMaxFileSize(ONE_MAX_MSG_RECORD, SOLIDSYSLOG_HALT, 2, CountStoreFullInvocations);
+
+    WriteMaxMsg(); /* file 00 */
+    WriteMaxMsg(); /* file 01 — now at maxFiles=2 */
+
+    /* Three consecutive failed Writes — callback must fire on the first only. */
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+
+    LONGS_EQUAL(1, storeFullCallbackCount);
+}
+
 static void* storeFullCallbackContext;
 
 static void StoreFullCallbackCapturingContext(void* context)


### PR DESCRIPTION
## Summary

- One-line fix in `NotifyStoreFull` — the HALT branch now guards on `!halted`, so the callback fires exactly once per rising edge instead of re-firing on every subsequent failed `Write`.
- Reuses the existing `halted` bit as the latch — no new state, no public API change.
- New unit test asserts three consecutive failed Writes invoke `onStoreFull` exactly once.

## Test plan

- [x] `./build/debug/Tests/SolidSyslogTests` (968 tests, 100% pass)
- [x] `cmake --build --preset sanitize` ASan/UBSan
- [x] `cmake --build --preset coverage` — 100% line + function (`1667/1667` lines, `367/367` functions)
- [x] `cmake --build --preset tidy` — clean
- [x] `cmake --build --preset cppcheck` — clean
- [x] `cmake --build --preset clang-debug` — clean
- [ ] CI: build-windows-msvc, integration-linux-openssl, bdd-linux-syslog-ng, bdd-windows-otel, summary

Closes #241. With this story closed, E05 has no remaining child stories — the epic itself can be closed once the PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)