### PR TITLE
feat: dispose-on-empty block lifecycle (S18.03)

### DIFF
--- a/Bdd/features/block_lifecycle.feature
+++ b/Bdd/features/block_lifecycle.feature
@@ -1,11 +1,12 @@
 @tcp @buffered
 Feature: Block lifecycle
-  The block store rotates blocks across files of fixed size. Block files are
-  disposed (deleted) only when capacity pressure forces rotation past the
-  oldest block; idle drains do not delete blocks. This baseline pins today's
-  semantics — S18.03 will introduce dispose-on-empty for non-active blocks.
+  The block store rotates blocks across files of fixed size. Once every record
+  in a non-active block is sent and acknowledged, that block is disposed
+  immediately — flash drivers prefer "erase-then-write" so producers can drain
+  retired blocks during idle moments rather than clustering erases at capacity
+  boundaries. The active write block is never disposed by this path.
 
-  Scenario: Block files are not disposed when capacity is not exhausted
+  Scenario: Active write block is not disposed when its only records are sent
     Given syslog-ng is running
     And the block store is enabled with max-blocks 4 and max-block-size 5000 and discard-policy oldest
     And the threaded example is running with transport tcp and no structured data
@@ -13,3 +14,11 @@ Feature: Block lifecycle
     When the client sends 2 messages
     Then syslog-ng receives 2 messages
     And no recorded block file has been disposed
+
+  Scenario: Older block is disposed once all its records are drained
+    Given syslog-ng is running
+    And the block store is enabled with max-blocks 4 and max-block-size 520 and discard-policy oldest
+    And the threaded example is running with transport tcp and no structured data
+    When the client sends 5 messages
+    Then syslog-ng receives 5 messages
+    And block file 00 has been disposed

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -559,6 +559,14 @@ def step_no_block_disposed(context):
     assert not missing, f"Block files disposed unexpectedly: {missing}"
 
 
+@then("block file {index} has been disposed")
+def step_block_file_disposed(context, index):
+    path = f"{STORE_PATH_PREFIX}{index}.log"
+    assert not os.path.exists(path), (
+        f"Expected block file {path} to have been disposed but it is still on disk"
+    )
+
+
 @when("the client sends a message")
 def step_client_sends_message(context):
     send_command(context.interactive_process, "send")

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -237,11 +237,12 @@ static void ResetReadToOldest(struct BlockSequence* blockSequence);
 
 static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence);
 static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence);
+static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex);
 
 static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged)
 {
     uint8_t nextSequence = NextSequence(blockSequence->writeSequence);
-    bool    acquired     = SolidSyslogBlockDevice_Acquire(blockSequence->blockDevice, nextSequence);
+    bool    acquired     = AcquireEmptyBlock(blockSequence->blockDevice, nextSequence);
 
     *readBlockChanged = false;
 
@@ -256,6 +257,20 @@ static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlo
     }
 
     return acquired;
+}
+
+/* Dispose-then-Acquire enforces the BlockDevice contract that an Acquired block
+ * starts empty. Stale content can be left by a crash mid-Append on a previous
+ * run, or by a Dispose that succeeded after our state had already advanced
+ * past it. Flash drivers depend on this — Acquire = erase, and writing into
+ * a non-erased block corrupts data on most flash families. */
+static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex)
+{
+    if (SolidSyslogBlockDevice_Exists(device, blockIndex))
+    {
+        SolidSyslogBlockDevice_Dispose(device, blockIndex);
+    }
+    return SolidSyslogBlockDevice_Acquire(device, blockIndex);
 }
 
 static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -254,6 +254,13 @@ static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlo
         {
             *readBlockChanged = DiscardOldestBlock(blockSequence);
         }
+
+        /* Sealing the prior write block can re-arm dispose-on-empty: drain that
+         * fully MarkSent the block before rotation could not fire here because
+         * IsReadBlockActiveWrite was true at MarkSent time. Re-evaluate now. */
+        bool disposedAfterRotate = false;
+        BlockSequence_DisposeReadBlockIfDrained(blockSequence, &disposedAfterRotate);
+        *readBlockChanged = *readBlockChanged || disposedAfterRotate;
     }
 
     return acquired;

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -186,7 +186,7 @@ static inline int CircularPrev(int index)
 static inline bool BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize);
 static inline bool StoreIsFull(const struct BlockSequence* blockSequence);
 static inline void NotifyStoreFull(struct BlockSequence* blockSequence);
-static bool        RotateToNextBlock(struct BlockSequence* blockSequence);
+static bool        RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged);
 
 bool BlockSequence_PrepareForWrite(struct BlockSequence* blockSequence, size_t recordSize, bool* readBlockChanged)
 {
@@ -203,7 +203,7 @@ bool BlockSequence_PrepareForWrite(struct BlockSequence* blockSequence, size_t r
     }
     else if (blockFull)
     {
-        *readBlockChanged = RotateToNextBlock(blockSequence);
+        spaceAvailable = RotateToNextBlock(blockSequence, readBlockChanged);
     }
 
     return spaceAvailable;
@@ -235,21 +235,39 @@ static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
 static bool DiscardOldestBlock(struct BlockSequence* blockSequence);
 static void ResetReadToOldest(struct BlockSequence* blockSequence);
 
-static bool RotateToNextBlock(struct BlockSequence* blockSequence)
+static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence);
+static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence);
+
+static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged)
 {
-    blockSequence->writeSequence     = NextSequence(blockSequence->writeSequence);
-    blockSequence->writePosition     = 0;
-    blockSequence->writeBlockCorrupt = false;
-    SolidSyslogBlockDevice_Acquire(blockSequence->blockDevice, blockSequence->writeSequence);
+    uint8_t nextSequence = NextSequence(blockSequence->writeSequence);
+    bool    acquired     = SolidSyslogBlockDevice_Acquire(blockSequence->blockDevice, nextSequence);
 
-    bool readBlockChanged = false;
+    *readBlockChanged = false;
 
-    if (BlockCount(blockSequence) > blockSequence->maxBlocks)
+    if (acquired)
     {
-        readBlockChanged = DiscardOldestBlock(blockSequence);
+        AdvanceWriteToNewBlock(blockSequence, nextSequence);
+
+        if (ExceedsMaxBlocks(blockSequence))
+        {
+            *readBlockChanged = DiscardOldestBlock(blockSequence);
+        }
     }
 
-    return readBlockChanged;
+    return acquired;
+}
+
+static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence)
+{
+    blockSequence->writeSequence     = nextSequence;
+    blockSequence->writePosition     = 0;
+    blockSequence->writeBlockCorrupt = false;
+}
+
+static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence)
+{
+    return BlockCount(blockSequence) > blockSequence->maxBlocks;
 }
 
 static bool DiscardOldestBlock(struct BlockSequence* blockSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -270,14 +270,27 @@ static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlo
  * starts empty. Stale content can be left by a crash mid-Append on a previous
  * run, or by a Dispose that succeeded after our state had already advanced
  * past it. Flash drivers depend on this — Acquire = erase, and writing into
- * a non-erased block corrupts data on most flash families. */
+ * a non-erased block corrupts data on most flash families.
+ *
+ * If Dispose fails we surface the failure rather than letting Acquire mask it:
+ * a "verify-and-use" flash driver (S18.04 design notes) would Acquire-fail on
+ * the still-stale block anyway, and skipping the wasted Acquire keeps callers'
+ * retry path (slice 3) symmetric with the dispose-failure path. */
 static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex)
 {
+    bool ready = true;
+
     if (SolidSyslogBlockDevice_Exists(device, blockIndex))
     {
-        SolidSyslogBlockDevice_Dispose(device, blockIndex);
+        ready = SolidSyslogBlockDevice_Dispose(device, blockIndex);
     }
-    return SolidSyslogBlockDevice_Acquire(device, blockIndex);
+
+    if (ready)
+    {
+        ready = SolidSyslogBlockDevice_Acquire(device, blockIndex);
+    }
+
+    return ready;
 }
 
 static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -272,17 +272,21 @@ static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence)
 
 static bool DiscardOldestBlock(struct BlockSequence* blockSequence)
 {
-    bool readingOldestBlock = (blockSequence->readSequence == blockSequence->oldestSequence);
+    bool readBlockChanged = false;
 
-    SolidSyslogBlockDevice_Dispose(blockSequence->blockDevice, blockSequence->oldestSequence);
-    blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
-
-    if (readingOldestBlock)
+    if (SolidSyslogBlockDevice_Dispose(blockSequence->blockDevice, blockSequence->oldestSequence))
     {
-        ResetReadToOldest(blockSequence);
+        bool readingOldestBlock       = (blockSequence->readSequence == blockSequence->oldestSequence);
+        blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
+
+        if (readingOldestBlock)
+        {
+            ResetReadToOldest(blockSequence);
+            readBlockChanged = true;
+        }
     }
 
-    return readingOldestBlock;
+    return readBlockChanged;
 }
 
 static void ResetReadToOldest(struct BlockSequence* blockSequence)

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -340,6 +340,48 @@ void BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cur
     blockSequence->readCursor = cursor;
 }
 
+static inline bool IsReadBlockActiveWrite(const struct BlockSequence* blockSequence);
+static inline bool IsReadBlockOldest(const struct BlockSequence* blockSequence);
+static inline bool IsReadBlockFullyDrained(const struct BlockSequence* blockSequence);
+static inline void AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence);
+
+void BlockSequence_DisposeReadBlockIfDrained(struct BlockSequence* blockSequence, bool* readBlockChanged)
+{
+    *readBlockChanged = false;
+
+    if (!IsReadBlockActiveWrite(blockSequence) && IsReadBlockOldest(blockSequence) && IsReadBlockFullyDrained(blockSequence))
+    {
+        if (SolidSyslogBlockDevice_Dispose(blockSequence->blockDevice, blockSequence->readSequence))
+        {
+            AdvancePastDrainedReadBlock(blockSequence);
+            *readBlockChanged = true;
+        }
+    }
+}
+
+static inline bool IsReadBlockActiveWrite(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readSequence == blockSequence->writeSequence;
+}
+
+static inline bool IsReadBlockOldest(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readSequence == blockSequence->oldestSequence;
+}
+
+static inline bool IsReadBlockFullyDrained(const struct BlockSequence* blockSequence)
+{
+    return blockSequence->readCursor >= SolidSyslogBlockDevice_Size(blockSequence->blockDevice, blockSequence->readSequence);
+}
+
+static inline void AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence)
+{
+    blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
+    blockSequence->readSequence   = blockSequence->oldestSequence;
+    blockSequence->readCursor     = 0;
+    NotifyThresholdCrossed(blockSequence);
+}
+
 void BlockSequence_AdvanceToNextReadBlock(struct BlockSequence* blockSequence)
 {
     blockSequence->readSequence = NextSequence(blockSequence->readSequence);

--- a/Core/Source/BlockSequence.h
+++ b/Core/Source/BlockSequence.h
@@ -58,6 +58,7 @@ size_t BlockSequence_ReadCursor(const struct BlockSequence* blockSequence);
 void   BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cursor);
 void   BlockSequence_AdvanceToNextReadBlock(struct BlockSequence* blockSequence);
 bool   BlockSequence_ReadIsBehindWrite(const struct BlockSequence* blockSequence);
+void   BlockSequence_DisposeReadBlockIfDrained(struct BlockSequence* blockSequence, bool* readBlockChanged);
 
 bool   BlockSequence_HasUnsent(const struct BlockSequence* blockSequence);
 bool   BlockSequence_IsHalted(const struct BlockSequence* blockSequence);

--- a/Core/Source/SolidSyslogBlockStore.c
+++ b/Core/Source/SolidSyslogBlockStore.c
@@ -246,5 +246,13 @@ static void MarkSent(struct SolidSyslogStore* self)
     if (RecordStore_MarkLastReadAsSent(&blockStore->recordStore, BlockSequence_BlockDevice(&blockStore->blockSequence), &nextCursor))
     {
         BlockSequence_SetReadCursor(&blockStore->blockSequence, nextCursor);
+
+        bool readBlockChanged = false;
+        BlockSequence_DisposeReadBlockIfDrained(&blockStore->blockSequence, &readBlockChanged);
+
+        if (readBlockChanged)
+        {
+            RecordStore_ForgetLastRead(&blockStore->recordStore);
+        }
     }
 }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,95 @@
 # Dev Log
 
+## 2026-05-04 — S18.03 Dispose-on-empty block lifecycle
+
+### Decisions
+
+- **Dispose trigger lives in MarkSent AND post-rotation.** Slice 1
+  hooked `BlockSequence_DisposeReadBlockIfDrained` into MarkSent only.
+  The unit tests passed (rotate-then-drain pattern: MarkSent fires
+  while writeSequence has already moved on). Then the new BDD scenario
+  failed: the threaded service-thread drain pattern is _interleaved_
+  (each Service iteration: receive 1 from buffer → write 1 to store →
+  read 1 from store → MarkSent). With this pattern, MarkSent fires
+  while the write block is still active — IsReadBlockActiveWrite is
+  true so dispose is suppressed. Then the next iteration's Write
+  triggers rotation, but no MarkSent follows for the just-sealed block.
+  The trigger needed a second call site after rotation seals the prior
+  write block. Now in `RotateToNextBlock`, post-AdvanceWriteToNewBlock.
+  Slice 1's MarkSent call still earns its keep for the rotate-then-drain
+  pattern (where the block is already non-active at MarkSent time).
+- **Dispose-on-empty guard: oldestSequence == readSequence.** The trigger
+  declines to dispose when readSequence has advanced past oldestSequence
+  (e.g. via AdvanceToNextReadBlock skipping a fully-sent block). Disposing
+  an interior block would punch a gap in the sequence run that
+  `ScanForExistingBlocks` can't represent (it assumes a single contiguous
+  run). The pre-existing capacity-pressure DiscardOldestBlock path still
+  reaps those interior holdovers eventually.
+- **Acquire empty-check in RotateToNextBlock, not Open's cold start.**
+  Story acceptance asked for "BlockSequence asserts the block is empty
+  before Acquire". Open's cold-start branch only fires when
+  `ScanForExistingBlocks` returned nothing — by construction Exists(0)
+  is false at that point, so an empty-check would always be a no-op.
+  Adding it would be defensive code for an impossible scenario per
+  CLAUDE.md. So `AcquireEmptyBlock` wraps `RotateToNextBlock`'s Acquire
+  only.
+- **Success-only state advancement: separate failure-injection paths
+  for Acquire and Dispose.** `RotateToNextBlock` now plumbs Acquire's
+  result through `PrepareForWrite`'s `spaceAvailable` return — a
+  transient device failure surfaces to the caller as `Write → false`
+  with `writeSequence`/`writePosition` unchanged, ready to retry.
+  `DiscardOldestBlock` wraps state mutation in `if (Dispose(...))` —
+  on failure `oldestSequence` stays put and the next discard cycle
+  re-attempts the same block. Without this, a failed Dispose would
+  orphan a still-on-disk block forever (oldest pointer skipped past).
+- **FileFake_FailNextDelete added (test infrastructure).** Mirrors the
+  existing FailNext{Open,Write,Read} shape so the dispose-failure path
+  could be exercised at the integration boundary, not just at the
+  BlockSequence unit level. The unit-level fake (ScanFake in
+  BlockSequenceTest) gained call-log + size-tracking knobs to model
+  call ordering and "block has data" semantics that previously the
+  no-op stubs couldn't represent. The pin test
+  `RotationSkipsDisposeWhenTargetBlockEmpty` regressed when the new
+  post-rotation dispose check shipped — fake's FakeSize returned 0,
+  so dispose-on-empty thought block 0 was always drained. Fix: track
+  sizes in the fake and seed `sizes[0]` after Open in the rotation
+  test setup.
+- **block_lifecycle.feature reframed.** The pre-S18.03 baseline
+  scenario said "block files are not disposed when capacity is not
+  exhausted" — now overturned. Reworded to pin the active-write-block
+  guard, plus added "Older block is disposed once all its records are
+  drained" as the positive case. The failure-injection scenarios from
+  the story acceptance (Acquire/Dispose failure) live at unit level —
+  exercising them at BDD level would need a fault-injection harness
+  in the threaded example which is scope creep.
+
+### Deferred
+
+- **AdvanceToNextReadBlock as a third dispose trigger.** When the read
+  cursor walks off the end of a block via this path (record corruption
+  or end-of-data hit), the block is technically "drained" but the
+  trigger doesn't fire — IsReadBlockOldest tests against the new
+  readSequence which has already moved on. Capacity-pressure
+  DiscardOldestBlock still reaps it. Worth revisiting once the example
+  flash driver lands and we see if the latency matters.
+- **Block-device-side empty-check verification.** Today the contract
+  is "BlockSequence Disposes-then-Acquires when the target block
+  exists". A more defensive contract would have the BlockDevice itself
+  assert empty in Acquire (returning false on stale content). Pushed
+  to S18.04 since the contract shape depends on what flash drivers
+  actually want.
+
+### Open questions
+
+- **Should `DisposeReadBlockIfDrained` propagate Dispose-success to
+  the caller?** Today it returns `readBlockChanged` only when Dispose
+  succeeded AND the read pointer advanced — but a failed Dispose is
+  silently swallowed (oldest stays put per the slice-4 contract,
+  no-op). An integrator-supplied error reporter could surface the
+  Dispose failure once that path lands. Not a blocker for S18.03;
+  noted alongside the "persistent media error" path mentioned in
+  RecordStore's IsRecordSent comment.
+
 ## 2026-05-03 — S18.02 BlockDevice abstraction + file-backed driver
 
 ### Decisions

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -1,4 +1,5 @@
 #include <set>
+#include <vector>
 
 #include "CppUTest/TestHarness.h"
 
@@ -11,10 +12,26 @@ extern "C"
 
 namespace
 {
+enum class CallType
+{
+    Acquire,
+    Dispose,
+    Exists
+};
+
+struct DeviceCall
+{
+    // cppcheck-suppress unusedStructMember -- read by DisposePrecedesAcquire / loop assertions; cppcheck does not model std::vector element access
+    CallType type;
+    // cppcheck-suppress unusedStructMember -- read by DisposePrecedesAcquire; cppcheck does not model std::vector element access
+    size_t blockIndex;
+};
+
 struct ScanFake
 {
     struct SolidSyslogBlockDevice base;
     std::set<size_t>*             existing;
+    std::vector<DeviceCall>*      calls; /* optional — tests that don't care leave nullptr */
 };
 
 inline ScanFake& ToFake(struct SolidSyslogBlockDevice* self)
@@ -23,22 +40,34 @@ inline ScanFake& ToFake(struct SolidSyslogBlockDevice* self)
     return *reinterpret_cast<ScanFake*>(self);
 }
 
+inline void RecordCall(ScanFake& fake, CallType type, size_t blockIndex)
+{
+    if (fake.calls != nullptr)
+    {
+        fake.calls->push_back({type, blockIndex});
+    }
+}
+
 bool FakeExists(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
-    return ToFake(self).existing->count(blockIndex) > 0;
+    ScanFake& fake = ToFake(self);
+    RecordCall(fake, CallType::Exists, blockIndex);
+    return fake.existing->count(blockIndex) > 0;
 }
 
 bool FakeAcquire(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
-    (void) self;
-    (void) blockIndex;
+    ScanFake& fake = ToFake(self);
+    RecordCall(fake, CallType::Acquire, blockIndex);
+    fake.existing->insert(blockIndex);
     return true;
 }
 
 bool FakeDispose(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
-    (void) self;
-    (void) blockIndex;
+    ScanFake& fake = ToFake(self);
+    RecordCall(fake, CallType::Dispose, blockIndex);
+    fake.existing->erase(blockIndex);
     return true;
 }
 
@@ -153,4 +182,93 @@ TEST(BlockSequenceScan, ResumesWrappedSingleBlockAtBoundary)
     CHECK_TRUE(BlockSequence_Open(&sequence));
     LONGS_EQUAL(99, BlockSequence_ReadSequence(&sequence));
     LONGS_EQUAL(0, BlockSequence_WriteSequence(&sequence));
+}
+
+namespace
+{
+enum
+{
+    ROTATION_BLOCK_SIZE = 100
+};
+} // namespace
+
+// clang-format off
+TEST_GROUP(BlockSequenceRotation)
+{
+    ScanFake fakeDevice = {};
+    std::set<size_t> existing;
+    std::vector<DeviceCall> calls;
+    struct BlockSequence sequence = {};
+
+    void setup() override
+    {
+        fakeDevice.base.Acquire = FakeAcquire;
+        fakeDevice.base.Dispose = FakeDispose;
+        fakeDevice.base.Exists  = FakeExists;
+        fakeDevice.base.Read    = FakeRead;
+        fakeDevice.base.Append  = FakeAppend;
+        fakeDevice.base.WriteAt = FakeWriteAt;
+        fakeDevice.base.Size    = FakeSize;
+        fakeDevice.existing     = &existing;
+        // cppcheck-suppress unreadVariable -- read indirectly via Fake* functions; cppcheck does not model the function-pointer indirection
+        fakeDevice.calls        = &calls;
+
+        struct BlockSequenceConfig config = {};
+        config.blockDevice                = &fakeDevice.base;
+        config.maxBlockSize               = ROTATION_BLOCK_SIZE;
+        config.maxBlocks                  = 99;
+        config.discardPolicy              = SOLIDSYSLOG_DISCARD_OLDEST;
+        BlockSequence_Init(&sequence, &config);
+
+        BlockSequence_Open(&sequence); /* cold start: Acquire(0) */
+        calls.clear();
+    }
+
+    [[nodiscard]] bool DisposePrecedesAcquire(size_t blockIndex) const
+    {
+        ssize_t disposeAt = -1;
+        ssize_t acquireAt = -1;
+        for (size_t i = 0; i < calls.size(); i++)
+        {
+            if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Dispose))
+            {
+                disposeAt = (ssize_t) i;
+            }
+            if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Acquire))
+            {
+                acquireAt = (ssize_t) i;
+            }
+        }
+        return (disposeAt >= 0) && (acquireAt >= 0) && (disposeAt < acquireAt);
+    }
+
+    void ForceRotation()
+    {
+        bool readBlockChanged = false;
+        BlockSequence_PrepareForWrite(&sequence, ROTATION_BLOCK_SIZE + 1, &readBlockChanged);
+    }
+};
+
+// clang-format on
+
+TEST(BlockSequenceRotation, RotationDisposesStaleBlockBeforeAcquiring)
+{
+    existing.insert(1); /* simulate stale content left from a previous run */
+
+    ForceRotation();
+
+    CHECK_TRUE(DisposePrecedesAcquire(1));
+}
+
+TEST(BlockSequenceRotation, RotationSkipsDisposeWhenTargetBlockEmpty)
+{
+    /* Baseline: target block isn't on disk; no Dispose call should be emitted.
+     * Pins the cost optimisation that distinguishes flash drivers' "verify-and-use"
+     * fast path from "erase-and-use". */
+    ForceRotation();
+
+    for (const auto& call : calls)
+    {
+        CHECK_FALSE(call.type == CallType::Dispose);
+    }
 }

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -34,6 +34,7 @@ struct ScanFake
     std::set<size_t>*             existing;
     std::vector<DeviceCall>*      calls; /* optional — tests that don't care leave nullptr */
     std::map<size_t, size_t>*     sizes; /* optional — tests that need realistic Size readings populate */
+    bool                          failNextDispose;
 };
 
 inline ScanFake& ToFake(struct SolidSyslogBlockDevice* self)
@@ -73,6 +74,13 @@ bool FakeDispose(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
     ScanFake& fake = ToFake(self);
     RecordCall(fake, CallType::Dispose, blockIndex);
+
+    if (fake.failNextDispose)
+    {
+        fake.failNextDispose = false;
+        return false;
+    }
+
     fake.existing->erase(blockIndex);
     if (fake.sizes != nullptr)
     {
@@ -261,11 +269,11 @@ TEST_GROUP(BlockSequenceRotation)
         {
             if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Dispose))
             {
-                disposeAt = (std::ptrdiff_t) i;
+                disposeAt = static_cast<std::ptrdiff_t>(i);
             }
             if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Acquire))
             {
-                acquireAt = (std::ptrdiff_t) i;
+                acquireAt = static_cast<std::ptrdiff_t>(i);
             }
         }
         return (disposeAt >= 0) && (acquireAt >= 0) && (disposeAt < acquireAt);
@@ -299,5 +307,26 @@ TEST(BlockSequenceRotation, RotationSkipsDisposeWhenTargetBlockEmpty)
     for (const auto& call : calls)
     {
         CHECK_FALSE(call.type == CallType::Dispose);
+    }
+}
+
+TEST(BlockSequenceRotation, RotationFailsWhenStaleBlockDisposeFails)
+{
+    /* If the stale block can't be Disposed, we must NOT proceed to Acquire —
+     * a flash "verify-and-use" driver would reject the stale block anyway,
+     * and surfacing the failure here matches the slice-3 retry contract. */
+    existing.insert(1);
+    fakeDevice.failNextDispose = true;
+
+    bool readBlockChanged = false;
+    bool acquired         = BlockSequence_PrepareForWrite(&sequence, ROTATION_BLOCK_SIZE + 1, &readBlockChanged);
+
+    CHECK_FALSE(acquired);
+    for (const auto& call : calls)
+    {
+        if ((call.type == CallType::Acquire) && (call.blockIndex == 1))
+        {
+            FAIL("Acquire(1) was called even though Dispose(1) failed");
+        }
     }
 }

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -255,17 +255,17 @@ TEST_GROUP(BlockSequenceRotation)
 
     [[nodiscard]] bool DisposePrecedesAcquire(size_t blockIndex) const
     {
-        ssize_t disposeAt = -1;
-        ssize_t acquireAt = -1;
+        std::ptrdiff_t disposeAt = -1;
+        std::ptrdiff_t acquireAt = -1;
         for (size_t i = 0; i < calls.size(); i++)
         {
             if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Dispose))
             {
-                disposeAt = (ssize_t) i;
+                disposeAt = (std::ptrdiff_t) i;
             }
             if ((calls[i].blockIndex == blockIndex) && (calls[i].type == CallType::Acquire))
             {
-                acquireAt = (ssize_t) i;
+                acquireAt = (std::ptrdiff_t) i;
             }
         }
         return (disposeAt >= 0) && (acquireAt >= 0) && (disposeAt < acquireAt);

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include <set>
 #include <vector>
 
@@ -32,6 +33,7 @@ struct ScanFake
     struct SolidSyslogBlockDevice base;
     std::set<size_t>*             existing;
     std::vector<DeviceCall>*      calls; /* optional — tests that don't care leave nullptr */
+    std::map<size_t, size_t>*     sizes; /* optional — tests that need realistic Size readings populate */
 };
 
 inline ScanFake& ToFake(struct SolidSyslogBlockDevice* self)
@@ -60,6 +62,10 @@ bool FakeAcquire(struct SolidSyslogBlockDevice* self, size_t blockIndex)
     ScanFake& fake = ToFake(self);
     RecordCall(fake, CallType::Acquire, blockIndex);
     fake.existing->insert(blockIndex);
+    if (fake.sizes != nullptr)
+    {
+        (*fake.sizes)[blockIndex] = 0;
+    }
     return true;
 }
 
@@ -68,6 +74,10 @@ bool FakeDispose(struct SolidSyslogBlockDevice* self, size_t blockIndex)
     ScanFake& fake = ToFake(self);
     RecordCall(fake, CallType::Dispose, blockIndex);
     fake.existing->erase(blockIndex);
+    if (fake.sizes != nullptr)
+    {
+        fake.sizes->erase(blockIndex);
+    }
     return true;
 }
 
@@ -104,9 +114,19 @@ bool FakeWriteAt(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t 
 
 size_t FakeSize(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
-    (void) self;
-    (void) blockIndex;
-    return 0;
+    const ScanFake& fake = ToFake(self);
+    size_t          size = 0;
+
+    if (fake.sizes != nullptr)
+    {
+        auto it = fake.sizes->find(blockIndex);
+        if (it != fake.sizes->end())
+        {
+            size = it->second;
+        }
+    }
+
+    return size;
 }
 } // namespace
 
@@ -195,9 +215,12 @@ enum
 // clang-format off
 TEST_GROUP(BlockSequenceRotation)
 {
+    static const size_t SIMULATED_RECORD_SIZE = 50;
+
     ScanFake fakeDevice = {};
     std::set<size_t> existing;
     std::vector<DeviceCall> calls;
+    std::map<size_t, size_t> sizes;
     struct BlockSequence sequence = {};
 
     void setup() override
@@ -210,8 +233,9 @@ TEST_GROUP(BlockSequenceRotation)
         fakeDevice.base.WriteAt = FakeWriteAt;
         fakeDevice.base.Size    = FakeSize;
         fakeDevice.existing     = &existing;
-        // cppcheck-suppress unreadVariable -- read indirectly via Fake* functions; cppcheck does not model the function-pointer indirection
         fakeDevice.calls        = &calls;
+        // cppcheck-suppress unreadVariable -- read indirectly via FakeSize; cppcheck does not model the function-pointer indirection
+        fakeDevice.sizes        = &sizes;
 
         struct BlockSequenceConfig config = {};
         config.blockDevice                = &fakeDevice.base;
@@ -221,6 +245,11 @@ TEST_GROUP(BlockSequenceRotation)
         BlockSequence_Init(&sequence, &config);
 
         BlockSequence_Open(&sequence); /* cold start: Acquire(0) */
+        /* Simulate one record's worth of data in block 0 — production rotation
+         * never seals an empty block, and the dispose-on-empty trigger uses
+         * device.Size to decide drained-ness. */
+        BlockSequence_NoteRecordWritten(&sequence, SIMULATED_RECORD_SIZE);
+        sizes[BlockSequence_WriteSequence(&sequence)] = SIMULATED_RECORD_SIZE;
         calls.clear();
     }
 

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -63,7 +63,7 @@ struct FileFake
     bool                   failNextDelete;
 };
 
-SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct FileFake) == sizeof(struct FileFakeStorage), "FileFakeStorage size does not match struct FileFake");
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct FileFake) <= sizeof(struct FileFakeStorage), "FileFakeStorage is too small for struct FileFake");
 
 /* shared in-memory filesystem */
 static struct FileEntry filesystem[FILEFAKE_MAX_FILES];

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -60,6 +60,7 @@ struct FileFake
     bool                   failNextOpen;
     bool                   failNextWrite;
     bool                   failNextRead;
+    bool                   failNextDelete;
 };
 
 SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct FileFake) == sizeof(struct FileFakeStorage), "FileFakeStorage size does not match struct FileFake");
@@ -163,6 +164,16 @@ void FileFake_FailNextRead(struct SolidSyslogFile* file)
         return;
     }
     AsFake(file)->failNextRead = true;
+}
+
+void FileFake_FailNextDelete(struct SolidSyslogFile* file)
+{
+    if (file == NULL)
+    {
+        TestAssert_Fail("FileFake_FailNextDelete called with null file");
+        return;
+    }
+    AsFake(file)->failNextDelete = true;
 }
 
 /* ------------------------------------------------------------------
@@ -456,7 +467,13 @@ static bool FileFake_Exists(struct SolidSyslogFile* self, const char* path)
 
 static bool FileFake_Delete(struct SolidSyslogFile* self, const char* path)
 {
-    (void) self;
+    struct FileFake* fake = AsFake(self);
+
+    if (ShouldFailOnThisCall(&fake->failNextDelete))
+    {
+        return false;
+    }
+
     struct FileEntry* entry = FindEntry(path);
     bool              found = FoundEntry(entry);
 

--- a/Tests/FileFake.h
+++ b/Tests/FileFake.h
@@ -9,7 +9,9 @@ EXTERN_C_BEGIN
 
     enum
     {
-        FILEFAKE_STORAGE_SLOTS = 13
+        /* Sized to fit struct FileFake on both ILP32 and LP64 hosts.
+         * Bump if a new field grows the implementation past current capacity. */
+        FILEFAKE_STORAGE_SLOTS = 14
     };
 
     struct FileFakeStorage

--- a/Tests/FileFake.h
+++ b/Tests/FileFake.h
@@ -22,6 +22,7 @@ EXTERN_C_BEGIN
     void                    FileFake_FailNextOpen(struct SolidSyslogFile * file);
     void                    FileFake_FailNextWrite(struct SolidSyslogFile * file);
     void                    FileFake_FailNextRead(struct SolidSyslogFile * file);
+    void                    FileFake_FailNextDelete(struct SolidSyslogFile * file);
     const void*             FileFake_FileContent(void);
     size_t                  FileFake_FileSize(void);
 

--- a/Tests/FileFakeTest.cpp
+++ b/Tests/FileFakeTest.cpp
@@ -159,6 +159,24 @@ TEST(FileFake, FailNextReadOnlyAffectsOneCall)
     CHECK_TRUE(SolidSyslogFile_Read(api, buf, 5));
 }
 
+TEST(FileFake, FailNextDeleteMakesDeleteReturnFalse)
+{
+    SolidSyslogFile_Open(api, "test.dat");
+    SolidSyslogFile_Close(api);
+    FileFake_FailNextDelete(api);
+    CHECK_FALSE(SolidSyslogFile_Delete(api, "test.dat"));
+    CHECK_TRUE(SolidSyslogFile_Exists(api, "test.dat"));
+}
+
+TEST(FileFake, FailNextDeleteOnlyAffectsOneCall)
+{
+    SolidSyslogFile_Open(api, "test.dat");
+    SolidSyslogFile_Close(api);
+    FileFake_FailNextDelete(api);
+    CHECK_FALSE(SolidSyslogFile_Delete(api, "test.dat"));
+    CHECK_TRUE(SolidSyslogFile_Delete(api, "test.dat"));
+}
+
 TEST(FileFake, FileContentReturnsInternalBuffer)
 {
     SolidSyslogFile_Open(api, "test.dat");

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1272,6 +1272,19 @@ TEST(SolidSyslogBlockStoreRotation, MarkSentDisposesOlderBlockWhenDrained)
     CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
 }
 
+TEST(SolidSyslogBlockStoreRotation, MarkSentDoesNotDisposeActiveWriteBlock)
+{
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 — also the active write block */
+
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    size_t bytesRead = 0;
+    SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
+    SolidSyslogStore_MarkSent(store);
+
+    CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
+}
+
 /* ------------------------------------------------------------------
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1323,7 +1323,7 @@ TEST(SolidSyslogBlockStoreRotation, RotationRetriesAfterTransientAcquireFailure)
     WriteMaxMsg(); /* file 00 */
 
     FileFake_FailNextOpen(file);
-    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* fails — Acquire on file 01 rejected */
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg))); /* fails — Acquire on file 01 rejected */
 
     CHECK_TRUE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg))); /* retry succeeds */
     CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store01.log"));
@@ -1334,14 +1334,15 @@ TEST(SolidSyslogBlockStoreRotation, DiscardRetriesAfterTransientDisposeFailure)
     /* Without this guarantee the oldest pointer would advance past a still-on-disk
      * block, leaving it orphaned forever. Force a Dispose failure on the discard
      * during file-02 rotation, then trigger another rotation: the next discard
-     * cycle must re-attempt block 00 — not skip past it to block 01. */
+     * cycle must re-attempt block 00 — not skip past it to block 01. Both Writes
+     * succeed (rotation acquires the new block; only the discard silently fails). */
     CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
     WriteMaxMsg(); /* file 00 */
     WriteMaxMsg(); /* file 01 */
 
     FileFake_FailNextDelete(file);
-    WriteMaxMsg(); /* file 02 — discard of 00 fails; oldest must stay at 0 */
-    WriteMaxMsg(); /* file 03 — next discard cycle re-attempts and removes 00 */
+    CHECK_TRUE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg))); /* file 02 — discard of 00 fails; oldest must stay at 0 */
+    CHECK_TRUE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg))); /* file 03 — next discard cycle re-attempts and removes 00 */
 
     CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
 }

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1307,6 +1307,23 @@ TEST(SolidSyslogBlockStoreRotation, RotationRetriesAfterTransientAcquireFailure)
     CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store01.log"));
 }
 
+TEST(SolidSyslogBlockStoreRotation, DiscardRetriesAfterTransientDisposeFailure)
+{
+    /* Without this guarantee the oldest pointer would advance past a still-on-disk
+     * block, leaving it orphaned forever. Force a Dispose failure on the discard
+     * during file-02 rotation, then trigger another rotation: the next discard
+     * cycle must re-attempt block 00 — not skip past it to block 01. */
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 */
+    WriteMaxMsg(); /* file 01 */
+
+    FileFake_FailNextDelete(file);
+    WriteMaxMsg(); /* file 02 — discard of 00 fails; oldest must stay at 0 */
+    WriteMaxMsg(); /* file 03 — next discard cycle re-attempts and removes 00 */
+
+    CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
+}
+
 /* ------------------------------------------------------------------
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1285,6 +1285,28 @@ TEST(SolidSyslogBlockStoreRotation, MarkSentDoesNotDisposeActiveWriteBlock)
     CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
 }
 
+TEST(SolidSyslogBlockStoreRotation, RotationDisposesPriorBlockWhenAlreadyDrained)
+{
+    /* Interleaved drain pattern: MarkSent fires for the only record in block 00
+     * while it is still the active write block, so dispose-on-empty cannot fire
+     * yet. The trigger must re-evaluate after the next Write rotates writeSequence
+     * to 01 — otherwise the just-filled-and-drained block lingers until capacity
+     * pressure forces discard. This pattern is what the threaded service thread
+     * does in practice. */
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+
+    WriteMaxMsg();
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    size_t bytesRead = 0;
+    SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
+    SolidSyslogStore_MarkSent(store);
+    CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
+
+    WriteMaxMsg(); /* triggers rotation; block 00 becomes non-active */
+
+    CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
+}
+
 TEST(SolidSyslogBlockStoreRotation, WriteReturnsFalseWhenRotationAcquireFails)
 {
     CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1258,6 +1258,20 @@ TEST(SolidSyslogBlockStoreRotation, MultipleRecordsPerFileDrainAcrossRotation)
     CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
 }
 
+TEST(SolidSyslogBlockStoreRotation, MarkSentDisposesOlderBlockWhenDrained)
+{
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 */
+    WriteMaxMsg(); /* rotates to file 01 */
+
+    char   buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    size_t bytesRead = 0;
+    SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead);
+    SolidSyslogStore_MarkSent(store);
+
+    CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
+}
+
 /* ------------------------------------------------------------------
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -1285,6 +1285,28 @@ TEST(SolidSyslogBlockStoreRotation, MarkSentDoesNotDisposeActiveWriteBlock)
     CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
 }
 
+TEST(SolidSyslogBlockStoreRotation, WriteReturnsFalseWhenRotationAcquireFails)
+{
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 — fills block */
+
+    FileFake_FailNextOpen(file); /* next Acquire on rotation will fail */
+    CHECK_FALSE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)));
+    CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store01.log"));
+}
+
+TEST(SolidSyslogBlockStoreRotation, RotationRetriesAfterTransientAcquireFailure)
+{
+    CreateWithMaxBlockSize(ONE_MAX_MSG_RECORD);
+    WriteMaxMsg(); /* file 00 */
+
+    FileFake_FailNextOpen(file);
+    SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg)); /* fails — Acquire on file 01 rejected */
+
+    CHECK_TRUE(SolidSyslogStore_Write(store, maxMsg, sizeof(maxMsg))); /* retry succeeds */
+    CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store01.log"));
+}
+
 /* ------------------------------------------------------------------
  * Integrity (SecurityPolicy integration)
  * ----------------------------------------------------------------*/


### PR DESCRIPTION
## Summary
- `BlockSequence_DisposeReadBlockIfDrained` frees a sealed read block as soon as `MarkSent` (or rotation) leaves its cursor at end-of-data and it is no longer the active write block. Flash drivers prefer "erase-then-write" so producers can drain retired blocks during idle moments rather than clustering erases at capacity boundaries.
- `RotateToNextBlock` and `DiscardOldestBlock` now publish state only after `Acquire` / `Dispose` succeed. A transient device failure surfaces as `Write → false` with the ring coherent for retry; a failed `Dispose` leaves `oldestSequence` put so the next discard cycle re-attempts the same block instead of orphaning data on disk.
- `AcquireEmptyBlock` wraps rotation's Acquire — if the target block already exists (crash mid-Append on a previous run, stale Dispose state from before this change), the device disposes-then-acquires so the block contract holds.

Closes #236

## Test plan
- [x] Unit tests: 1015 / 1015 under gcc, sanitize, clang
- [x] Coverage: 100% (1825 / 1825 lines)
- [x] clang-format / clang-tidy / cppcheck clean
- [x] BDD `block_lifecycle.feature` — both scenarios green (active-write-block guard pin + new dispose-on-empty positive case)
- [ ] CI to confirm Windows MSVC + remaining BDD suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-active, fully-drained blocks are disposed immediately after their records are sent; the active write block is not disposed via this path. Rotation and dispose error paths were hardened.

* **Tests**
  * Expanded unit and BDD tests covering disposal, rotation, and delete-failure scenarios; added failure-injection for delete operations.

* **Documentation**
  * DEVLOG updated to reflect revised block lifecycle and disposal decision points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->