### PR TITLE
feat: S04.05 portable ring buffer with mutex injection

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,8 @@ Checks: >
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-avoid-c-arrays,
   -modernize-avoid-c-arrays,
-  -modernize-deprecated-headers
+  -modernize-deprecated-headers,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
 
 # Treat all clang-tidy warnings as errors.
 WarningsAsErrors: '*'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |
-| `SolidSyslogCircularBuffer.h` | System setup code using an in-memory ring buffer (bare-metal / RTOS / Windows) | `SolidSyslogCircularBufferStorage`, `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)`, `SolidSyslogCircularBuffer_Create(storage, maxMessages, mutex)`, `_Destroy(buffer)` (length-prefixed records, drop-newest on overflow, no-split wrap) |
+| `SolidSyslogCircularBuffer.h` | System setup code using an in-memory ring buffer (bare-metal / RTOS / Windows) | `SolidSyslogCircularBufferStorage`, `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)` (friendly: N max-sized messages), `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(ringBytes)` (raw byte capacity), `SolidSyslogCircularBuffer_Create(storage, sizeof(storage), mutex)`, `_Destroy(buffer)` (uint16-length-prefixed records, drop-newest on overflow, no-split wrap, mutex-injected synchronization) |
 | `SolidSyslogMutex.h` | Any code holding a mutex handle | `SolidSyslogMutex_Lock`, `_Unlock` |
 | `SolidSyslogMutexDefinition.h` | Mutex implementors (extension point) | `SolidSyslogMutex` vtable struct (`Lock`, `Unlock`) |
 | `SolidSyslogNullMutex.h` | System setup code (single-task, no synchronization) | `SolidSyslogNullMutex_Create`, `_Destroy` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,12 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogBufferDefinition.h` | Buffer implementors (extension point) | `SolidSyslogBuffer` vtable struct |
 | `SolidSyslogNullBuffer.h` | System setup code (single-task, no buffering) | `SolidSyslogNullBuffer_Create`, `_Destroy` |
 | `SolidSyslogPosixMessageQueueBuffer.h` | System setup code using POSIX message queue buffer | `SolidSyslogPosixMessageQueueBuffer_Create`, `_Destroy` |
+| `SolidSyslogCircularBuffer.h` | System setup code using an in-memory ring buffer (bare-metal / RTOS / Windows) | `SolidSyslogCircularBufferStorage`, `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)`, `SolidSyslogCircularBuffer_Create(storage, maxMessages, mutex)`, `_Destroy(buffer)` (length-prefixed records, drop-newest on overflow, no-split wrap) |
+| `SolidSyslogMutex.h` | Any code holding a mutex handle | `SolidSyslogMutex_Lock`, `_Unlock` |
+| `SolidSyslogMutexDefinition.h` | Mutex implementors (extension point) | `SolidSyslogMutex` vtable struct (`Lock`, `Unlock`) |
+| `SolidSyslogNullMutex.h` | System setup code (single-task, no synchronization) | `SolidSyslogNullMutex_Create`, `_Destroy` |
+| `SolidSyslogPosixMutex.h` | System setup code on POSIX targets needing thread-safe buffering | `SolidSyslogPosixMutexStorage`, `SOLIDSYSLOG_POSIXMUTEX_SIZE`, `SolidSyslogPosixMutex_Create(storage)`, `_Destroy(mutex)` (wraps `pthread_mutex_t`) |
+| `SolidSyslogWindowsMutex.h` | System setup code on Windows targets needing thread-safe buffering | `SolidSyslogWindowsMutexStorage`, `SOLIDSYSLOG_WINDOWSMUTEX_SIZE`, `SolidSyslogWindowsMutex_Create(storage)`, `_Destroy(mutex)` (wraps `CRITICAL_SECTION`) |
 | `SolidSyslogStore.h` | Library internals consuming a store (Service algorithm) and integrator code querying capacity | `SolidSyslogStore_Write`, `_ReadNextUnsent`, `_MarkSent`, `_HasUnsent`, `_IsHalted`, `_GetTotalBytes`, `_GetUsedBytes` |
 | `SolidSyslogStoreDefinition.h` | Store implementors (extension point) | `SolidSyslogStore` vtable struct (`Write`, `ReadNextUnsent`, `MarkSent`, `HasUnsent`, `IsHalted`, `GetTotalBytes`, `GetUsedBytes`) |
 | `SolidSyslogNullStore.h` | System setup code (no store-and-forward) | `SolidSyslogNullStore_Create`, `_Destroy` |

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -22,12 +22,12 @@ EXTERN_C_BEGIN
     };
 
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
-#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)                                                                                              \
-    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD                                                                                                                  \
-     + (((maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES) + sizeof(SolidSyslogCircularBufferStorage) - 1)         \
-        / sizeof(SolidSyslogCircularBufferStorage)))
+#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)                                                                                               \
+    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD +                                                                                                                 \
+     (((size_t) (maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES) + sizeof(SolidSyslogCircularBufferStorage) - 1) / \
+      sizeof(SolidSyslogCircularBufferStorage)))
 
-    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages, struct SolidSyslogMutex * mutex);
+    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages, struct SolidSyslogMutex* mutex);
     void                      SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer * buffer);
 
 EXTERN_C_END

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -11,12 +11,13 @@
 EXTERN_C_BEGIN
 
     struct SolidSyslogBuffer;
+    struct SolidSyslogMutex;
 
     typedef size_t SolidSyslogCircularBufferStorage;
 
     enum
     {
-        SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD     = 6,
+        SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD     = 7,
         SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES = sizeof(uint16_t)
     };
 
@@ -26,7 +27,7 @@ EXTERN_C_BEGIN
      + (((maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES) + sizeof(SolidSyslogCircularBufferStorage) - 1)         \
         / sizeof(SolidSyslogCircularBufferStorage)))
 
-    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages);
+    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages, struct SolidSyslogMutex * mutex);
     void                      SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer * buffer);
 
 EXTERN_C_END

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "SolidSyslog.h"
+#include "SolidSyslog.h"  // IWYU pragma: keep -- macro body references SOLIDSYSLOG_MAX_MESSAGE_SIZE
 
 EXTERN_C_BEGIN
 

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "SolidSyslog.h"
+
 EXTERN_C_BEGIN
 
     struct SolidSyslogBuffer;

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "SolidSyslog.h"
+#include "SolidSyslog.h"  // IWYU pragma: keep -- macro expands to SOLIDSYSLOG_MAX_MESSAGE_SIZE at user call sites
 
 EXTERN_C_BEGIN
 

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -20,9 +20,8 @@ EXTERN_C_BEGIN
     };
 
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
-#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(ringBytes)                                                                                              \
-    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD +                                                                                                                    \
-     (((ringBytes) + sizeof(SolidSyslogCircularBufferStorage) - 1) / sizeof(SolidSyslogCircularBufferStorage)))
+#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(ringBytes) \
+    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD + (((ringBytes) + sizeof(SolidSyslogCircularBufferStorage) - 1) / sizeof(SolidSyslogCircularBufferStorage)))
 
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
 #define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages) \

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -3,12 +3,31 @@
 
 #include "ExternC.h"
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include "SolidSyslog.h"
+
 EXTERN_C_BEGIN
 
     struct SolidSyslogBuffer;
 
-    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void);
-    void                      SolidSyslogCircularBuffer_Destroy(void);
+    typedef size_t SolidSyslogCircularBufferStorage;
+
+    enum
+    {
+        SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD     = 6,
+        SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES = sizeof(uint16_t)
+    };
+
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
+#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)                                                                                              \
+    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD                                                                                                                  \
+     + (((maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES) + sizeof(SolidSyslogCircularBufferStorage) - 1)         \
+        / sizeof(SolidSyslogCircularBufferStorage)))
+
+    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages);
+    void                      SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer * buffer);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -1,0 +1,15 @@
+#ifndef SOLIDSYSLOGCIRCULARBUFFER_H
+#define SOLIDSYSLOGCIRCULARBUFFER_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogBuffer;
+
+    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void);
+    void                      SolidSyslogCircularBuffer_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGCIRCULARBUFFER_H */

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -20,12 +20,15 @@ EXTERN_C_BEGIN
     };
 
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
-#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages)                                                                                               \
-    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD +                                                                                                                 \
-     (((size_t) (maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES) + sizeof(SolidSyslogCircularBufferStorage) - 1) / \
-      sizeof(SolidSyslogCircularBufferStorage)))
+#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(ringBytes)                                                                                              \
+    (SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD +                                                                                                                    \
+     (((ringBytes) + sizeof(SolidSyslogCircularBufferStorage) - 1) / sizeof(SolidSyslogCircularBufferStorage)))
 
-    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t maxMessages, struct SolidSyslogMutex* mutex);
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
+#define SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(maxMessages) \
+    SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES((size_t) (maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES))
+
+    struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage * storage, size_t storageBytes, struct SolidSyslogMutex* mutex);
     void                      SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer * buffer);
 
 EXTERN_C_END

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "SolidSyslog.h"  // IWYU pragma: keep -- macro body references SOLIDSYSLOG_MAX_MESSAGE_SIZE
+#include "SolidSyslog.h" // IWYU pragma: keep -- macro body references SOLIDSYSLOG_MAX_MESSAGE_SIZE
 
 EXTERN_C_BEGIN
 

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -6,8 +6,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "SolidSyslog.h"  // IWYU pragma: keep -- macro expands to SOLIDSYSLOG_MAX_MESSAGE_SIZE at user call sites
-
 EXTERN_C_BEGIN
 
     struct SolidSyslogBuffer;

--- a/Core/Interface/SolidSyslogMutex.h
+++ b/Core/Interface/SolidSyslogMutex.h
@@ -1,0 +1,15 @@
+#ifndef SOLIDSYSLOGMUTEX_H
+#define SOLIDSYSLOGMUTEX_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex;
+
+    void SolidSyslogMutex_Lock(struct SolidSyslogMutex * mutex);
+    void SolidSyslogMutex_Unlock(struct SolidSyslogMutex * mutex);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGMUTEX_H */

--- a/Core/Interface/SolidSyslogMutexDefinition.h
+++ b/Core/Interface/SolidSyslogMutexDefinition.h
@@ -1,0 +1,16 @@
+#ifndef SOLIDSYSLOGMUTEXDEFINITION_H
+#define SOLIDSYSLOGMUTEXDEFINITION_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex
+    {
+        void (*Lock)(struct SolidSyslogMutex* self);
+        void (*Unlock)(struct SolidSyslogMutex* self);
+    };
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGMUTEXDEFINITION_H */

--- a/Core/Interface/SolidSyslogNullMutex.h
+++ b/Core/Interface/SolidSyslogNullMutex.h
@@ -1,0 +1,15 @@
+#ifndef SOLIDSYSLOGNULLMUTEX_H
+#define SOLIDSYSLOGNULLMUTEX_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex;
+
+    struct SolidSyslogMutex* SolidSyslogNullMutex_Create(void);
+    void                     SolidSyslogNullMutex_Destroy(void);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGNULLMUTEX_H */

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SOURCES
     SolidSyslogMetaSd.c
     SolidSyslogNullBuffer.c
     SolidSyslogCircularBuffer.c
+    SolidSyslogMutex.c
+    SolidSyslogNullMutex.c
     SolidSyslogSender.c
     SolidSyslogStore.c
     SolidSyslogNullStore.c

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     SolidSyslogFormatter.c
     SolidSyslogMetaSd.c
     SolidSyslogNullBuffer.c
+    SolidSyslogCircularBuffer.c
     SolidSyslogSender.c
     SolidSyslogStore.c
     SolidSyslogNullStore.c

--- a/Core/Source/RecordStore.c
+++ b/Core/Source/RecordStore.c
@@ -93,9 +93,7 @@ static inline void AssembleRecord(struct RecordStore* recordStore, const void* d
     MagicAddress(recordStore)[1] = MAGIC_BYTE_1;
 
     uint16_t length = (uint16_t) size;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
     memcpy(LengthAddress(recordStore), &length, RECORD_LENGTH_SIZE);
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
     memcpy(MessageAddress(recordStore), data, size);
 
     recordStore->securityPolicy->ComputeIntegrity(IntegrityRegionAddress(recordStore), IntegrityRegionSize(size), IntegrityChecksumAddress(recordStore, size));
@@ -156,7 +154,6 @@ static inline bool IsMagicValid(struct RecordStore* recordStore)
 static inline uint16_t RecordLength(struct RecordStore* recordStore)
 {
     uint16_t length = 0;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
     memcpy(&length, LengthAddress(recordStore), RECORD_LENGTH_SIZE);
     return length;
 }
@@ -207,7 +204,6 @@ static inline size_t BoundedSize(uint16_t length, size_t maxSize)
 static inline void CopyRecordData(struct RecordStore* recordStore, uint16_t length, void* dst, size_t maxSize, size_t* bytesRead)
 {
     size_t copySize = BoundedSize(length, maxSize);
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded size
     memcpy(dst, MessageAddress(recordStore), copySize);
     *bytesRead = copySize;
 }

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -25,8 +25,7 @@ struct SolidSyslogCircularBuffer
     uint8_t                  storage[];
 };
 
-SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogCircularBuffer)
-                              == SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD * sizeof(SolidSyslogCircularBufferStorage),
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogCircularBuffer) == SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD * sizeof(SolidSyslogCircularBufferStorage),
                           "SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD does not match struct layout");
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
@@ -103,7 +102,7 @@ static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 
 static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
 {
-    uint16_t header;
+    uint16_t header = 0;
     memcpy(&header, &circular->storage[circular->head], HEADER_BYTES);
     size_t recordSize = header;
     memcpy(data, &circular->storage[circular->head + HEADER_BYTES], recordSize);

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -7,6 +7,7 @@
 
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogMacros.h"
+#include "SolidSyslogMutex.h"
 
 enum
 {
@@ -16,6 +17,7 @@ enum
 struct SolidSyslogCircularBuffer
 {
     struct SolidSyslogBuffer base;
+    struct SolidSyslogMutex* mutex;
     size_t                   capacity;
     size_t                   head;
     size_t                   tail;
@@ -41,11 +43,12 @@ static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
 static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
 
-struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t maxMessages)
+struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t maxMessages, struct SolidSyslogMutex* mutex)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) storage;
     circular->base.Read                        = Read;
     circular->base.Write                       = Write;
+    circular->mutex                            = mutex;
     circular->capacity                         = maxMessages * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + HEADER_BYTES);
     ResetToStart(circular);
     return &circular->base;
@@ -56,6 +59,7 @@ void SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer* buffer)
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) buffer;
     circular->base.Read                        = NULL;
     circular->base.Write                       = NULL;
+    circular->mutex                            = NULL;
     circular->capacity                         = 0;
     circular->head                             = 0;
     circular->tail                             = 0;
@@ -66,6 +70,7 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
     (void) maxSize;
+    SolidSyslogMutex_Lock(circular->mutex);
     *bytesRead     = 0;
     bool hadRecord = !IsEmpty(circular);
     if (hadRecord)
@@ -76,6 +81,7 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
         }
         LoadRecord(circular, data, bytesRead);
     }
+    SolidSyslogMutex_Unlock(circular->mutex);
     return hadRecord;
 }
 
@@ -108,6 +114,7 @@ static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* 
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
+    SolidSyslogMutex_Lock(circular->mutex);
     if (IsEmpty(circular))
     {
         ResetToStart(circular);
@@ -123,6 +130,7 @@ static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
         }
         StoreRecord(circular, data, size);
     }
+    SolidSyslogMutex_Unlock(circular->mutex);
 }
 
 static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -1,0 +1,64 @@
+#include "SolidSyslogCircularBuffer.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "SolidSyslogBufferDefinition.h"
+
+enum
+{
+    STORAGE_BYTES = 512
+};
+
+static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
+static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
+
+struct SolidSyslogCircularBuffer
+{
+    struct SolidSyslogBuffer base;
+    uint8_t                  storage[STORAGE_BYTES];
+    bool                     hasRecord;
+    size_t                   recordSize;
+};
+
+static struct SolidSyslogCircularBuffer instance;
+
+struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void)
+{
+    instance.base.Read  = Read;
+    instance.base.Write = Write;
+    instance.hasRecord  = false;
+    instance.recordSize = 0;
+    return &instance.base;
+}
+
+void SolidSyslogCircularBuffer_Destroy(void)
+{
+    instance.base.Read  = NULL;
+    instance.base.Write = NULL;
+    instance.hasRecord  = false;
+}
+
+static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+{
+    struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
+    (void) maxSize;
+    *bytesRead          = circular->recordSize;
+    bool hadRecord      = circular->hasRecord;
+    circular->hasRecord = false;
+    if (hadRecord)
+    {
+        memcpy(data, circular->storage, circular->recordSize);
+    }
+    return hadRecord;
+}
+
+static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
+{
+    struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
+    memcpy(circular->storage, data, size);
+    circular->hasRecord  = true;
+    circular->recordSize = size;
+}

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -19,8 +19,8 @@ struct SolidSyslogCircularBuffer
 {
     struct SolidSyslogBuffer base;
     uint8_t                  storage[STORAGE_BYTES];
-    bool                     hasRecord;
-    size_t                   recordSize;
+    size_t                   head;
+    size_t                   tail;
 };
 
 static struct SolidSyslogCircularBuffer instance;
@@ -29,8 +29,8 @@ struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void)
 {
     instance.base.Read  = Read;
     instance.base.Write = Write;
-    instance.hasRecord  = false;
-    instance.recordSize = 0;
+    instance.head       = 0;
+    instance.tail       = 0;
     return &instance.base;
 }
 
@@ -38,19 +38,24 @@ void SolidSyslogCircularBuffer_Destroy(void)
 {
     instance.base.Read  = NULL;
     instance.base.Write = NULL;
-    instance.hasRecord  = false;
+    instance.head       = 0;
+    instance.tail       = 0;
 }
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
     (void) maxSize;
-    *bytesRead          = circular->recordSize;
-    bool hadRecord      = circular->hasRecord;
-    circular->hasRecord = false;
+    bool hadRecord = circular->head != circular->tail;
+    *bytesRead     = 0;
     if (hadRecord)
     {
-        memcpy(data, circular->storage, circular->recordSize);
+        uint16_t header;
+        memcpy(&header, &circular->storage[circular->head], sizeof(header));
+        size_t recordSize = header;
+        memcpy(data, &circular->storage[circular->head + sizeof(header)], recordSize);
+        circular->head += sizeof(header) + recordSize;
+        *bytesRead = recordSize;
     }
     return hadRecord;
 }
@@ -58,7 +63,8 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
-    memcpy(circular->storage, data, size);
-    circular->hasRecord  = true;
-    circular->recordSize = size;
+    uint16_t                          header   = (uint16_t) size;
+    memcpy(&circular->storage[circular->tail], &header, sizeof(header));
+    memcpy(&circular->storage[circular->tail + sizeof(header)], data, size);
+    circular->tail += sizeof(header) + size;
 }

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "SolidSyslog.h"
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogMutex.h"

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -9,11 +9,9 @@
 
 enum
 {
-    STORAGE_BYTES = 512
+    STORAGE_BYTES = 512,
+    HEADER_BYTES  = sizeof(uint16_t)
 };
-
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
 struct SolidSyslogCircularBuffer
 {
@@ -21,7 +19,22 @@ struct SolidSyslogCircularBuffer
     uint8_t                  storage[STORAGE_BYTES];
     size_t                   head;
     size_t                   tail;
+    size_t                   wrapPoint;
 };
+
+static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
+static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
+
+static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular);
+static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular);
+static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
+static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular);
+static inline void WrapTail(struct SolidSyslogCircularBuffer* circular);
+static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
+static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
+static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
 
 static struct SolidSyslogCircularBuffer instance;
 
@@ -29,8 +42,7 @@ struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void)
 {
     instance.base.Read  = Read;
     instance.base.Write = Write;
-    instance.head       = 0;
-    instance.tail       = 0;
+    ResetToStart(&instance);
     return &instance.base;
 }
 
@@ -38,33 +50,105 @@ void SolidSyslogCircularBuffer_Destroy(void)
 {
     instance.base.Read  = NULL;
     instance.base.Write = NULL;
-    instance.head       = 0;
-    instance.tail       = 0;
+    ResetToStart(&instance);
 }
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
     (void) maxSize;
-    bool hadRecord = circular->head != circular->tail;
     *bytesRead     = 0;
+    bool hadRecord = !IsEmpty(circular);
     if (hadRecord)
     {
-        uint16_t header;
-        memcpy(&header, &circular->storage[circular->head], sizeof(header));
-        size_t recordSize = header;
-        memcpy(data, &circular->storage[circular->head + sizeof(header)], recordSize);
-        circular->head += sizeof(header) + recordSize;
-        *bytesRead = recordSize;
+        if (HeadAtWrapPoint(circular))
+        {
+            ConsumeWrapMarker(circular);
+        }
+        LoadRecord(circular, data, bytesRead);
     }
     return hadRecord;
+}
+
+static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular)
+{
+    return circular->head == circular->tail;
+}
+
+static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular)
+{
+    return circular->head >= circular->wrapPoint;
+}
+
+static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
+{
+    circular->head      = 0;
+    circular->wrapPoint = STORAGE_BYTES;
+}
+
+static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
+{
+    uint16_t header;
+    memcpy(&header, &circular->storage[circular->head], HEADER_BYTES);
+    size_t recordSize = header;
+    memcpy(data, &circular->storage[circular->head + HEADER_BYTES], recordSize);
+    circular->head += HEADER_BYTES + recordSize;
+    *bytesRead = recordSize;
 }
 
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
-    uint16_t                          header   = (uint16_t) size;
-    memcpy(&circular->storage[circular->tail], &header, sizeof(header));
-    memcpy(&circular->storage[circular->tail + sizeof(header)], data, size);
-    circular->tail += sizeof(header) + size;
+    if (IsEmpty(circular))
+    {
+        ResetToStart(circular);
+    }
+    size_t recordBytes = HEADER_BYTES + size;
+    bool   fitsAtTail  = RecordFitsAtTail(circular, recordBytes);
+    bool   shouldWrite = fitsAtTail || RecordFitsAfterWrap(circular, recordBytes);
+    if (shouldWrite)
+    {
+        if (!fitsAtTail)
+        {
+            WrapTail(circular);
+        }
+        StoreRecord(circular, data, size);
+    }
+}
+
+static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)
+{
+    return circular->head > circular->tail;
+}
+
+static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
+{
+    size_t limit = IsWrapped(circular) ? circular->head : (size_t) STORAGE_BYTES;
+    return circular->tail + recordBytes <= limit;
+}
+
+static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
+{
+    return (!IsWrapped(circular)) && recordBytes <= circular->head;
+}
+
+static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular)
+{
+    circular->head      = 0;
+    circular->tail      = 0;
+    circular->wrapPoint = STORAGE_BYTES;
+}
+
+static inline void WrapTail(struct SolidSyslogCircularBuffer* circular)
+{
+    circular->wrapPoint = circular->tail;
+    circular->tail      = 0;
+}
+
+static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size)
+{
+    uint16_t header = (uint16_t) size;
+    memcpy(&circular->storage[circular->tail], &header, HEADER_BYTES);
+    memcpy(&circular->storage[circular->tail + HEADER_BYTES], data, size);
+    circular->tail += HEADER_BYTES + size;
 }

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -6,21 +6,26 @@
 #include <string.h>
 
 #include "SolidSyslogBufferDefinition.h"
+#include "SolidSyslogMacros.h"
 
 enum
 {
-    STORAGE_BYTES = 512,
-    HEADER_BYTES  = sizeof(uint16_t)
+    HEADER_BYTES = SOLIDSYSLOG_CIRCULARBUFFER_HEADER_BYTES
 };
 
 struct SolidSyslogCircularBuffer
 {
     struct SolidSyslogBuffer base;
-    uint8_t                  storage[STORAGE_BYTES];
+    size_t                   capacity;
     size_t                   head;
     size_t                   tail;
     size_t                   wrapPoint;
+    uint8_t                  storage[];
 };
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogCircularBuffer)
+                              == SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD * sizeof(SolidSyslogCircularBufferStorage),
+                          "SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD does not match struct layout");
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
@@ -36,21 +41,25 @@ static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
 static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
 
-static struct SolidSyslogCircularBuffer instance;
-
-struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(void)
+struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t maxMessages)
 {
-    instance.base.Read  = Read;
-    instance.base.Write = Write;
-    ResetToStart(&instance);
-    return &instance.base;
+    struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) storage;
+    circular->base.Read                        = Read;
+    circular->base.Write                       = Write;
+    circular->capacity                         = maxMessages * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + HEADER_BYTES);
+    ResetToStart(circular);
+    return &circular->base;
 }
 
-void SolidSyslogCircularBuffer_Destroy(void)
+void SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer* buffer)
 {
-    instance.base.Read  = NULL;
-    instance.base.Write = NULL;
-    ResetToStart(&instance);
+    struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) buffer;
+    circular->base.Read                        = NULL;
+    circular->base.Write                       = NULL;
+    circular->capacity                         = 0;
+    circular->head                             = 0;
+    circular->tail                             = 0;
+    circular->wrapPoint                        = 0;
 }
 
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
@@ -83,7 +92,7 @@ static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circu
 static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 {
     circular->head      = 0;
-    circular->wrapPoint = STORAGE_BYTES;
+    circular->wrapPoint = circular->capacity;
 }
 
 static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
@@ -123,7 +132,7 @@ static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)
 
 static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
 {
-    size_t limit = IsWrapped(circular) ? circular->head : (size_t) STORAGE_BYTES;
+    size_t limit = IsWrapped(circular) ? circular->head : circular->capacity;
     return circular->tail + recordBytes <= limit;
 }
 
@@ -136,7 +145,7 @@ static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular)
 {
     circular->head      = 0;
     circular->tail      = 0;
-    circular->wrapPoint = STORAGE_BYTES;
+    circular->wrapPoint = circular->capacity;
 }
 
 static inline void WrapTail(struct SolidSyslogCircularBuffer* circular)

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "SolidSyslog.h"
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogMutex.h"
@@ -43,13 +42,13 @@ static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
 static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
 
-struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t maxMessages, struct SolidSyslogMutex* mutex)
+struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t storageBytes, struct SolidSyslogMutex* mutex)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) storage;
     circular->base.Read                        = Read;
     circular->base.Write                       = Write;
     circular->mutex                            = mutex;
-    circular->capacity                         = maxMessages * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + HEADER_BYTES);
+    circular->capacity                         = storageBytes - sizeof(struct SolidSyslogCircularBuffer);
     ResetToStart(circular);
     return &circular->base;
 }

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "SolidSyslog.h"
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogMutex.h"
@@ -31,16 +32,17 @@ SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogCircularBuffer) == SOLIDSYSLO
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
-static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular);
-static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular);
-static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
-static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
-static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
-static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular);
-static inline void WrapTail(struct SolidSyslogCircularBuffer* circular);
-static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
-static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
-static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
+static inline bool   IsEmpty(const struct SolidSyslogCircularBuffer* circular);
+static inline bool   IsWrapped(const struct SolidSyslogCircularBuffer* circular);
+static inline bool   HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
+static inline bool   RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline bool   RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline void   ResetToStart(struct SolidSyslogCircularBuffer* circular);
+static inline void   WrapTail(struct SolidSyslogCircularBuffer* circular);
+static inline void   ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
+static inline void   StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
+static inline void   LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
+static inline size_t PeekRecordSize(const struct SolidSyslogCircularBuffer* circular);
 
 struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(SolidSyslogCircularBufferStorage* storage, size_t storageBytes, struct SolidSyslogMutex* mutex)
 {
@@ -68,20 +70,26 @@ void SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer* buffer)
 static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
-    (void) maxSize;
     SolidSyslogMutex_Lock(circular->mutex);
     *bytesRead     = 0;
-    bool hadRecord = !IsEmpty(circular);
-    if (hadRecord)
+    bool delivered = !IsEmpty(circular);
+    if (delivered)
     {
         if (HeadAtWrapPoint(circular))
         {
             ConsumeWrapMarker(circular);
         }
-        LoadRecord(circular, data, bytesRead);
+        if (PeekRecordSize(circular) <= maxSize)
+        {
+            LoadRecord(circular, data, bytesRead);
+        }
+        else
+        {
+            delivered = false;
+        }
     }
     SolidSyslogMutex_Unlock(circular->mutex);
-    return hadRecord;
+    return delivered;
 }
 
 static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular)
@@ -100,11 +108,16 @@ static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
     circular->wrapPoint = circular->capacity;
 }
 
-static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
+static inline size_t PeekRecordSize(const struct SolidSyslogCircularBuffer* circular)
 {
     uint16_t header = 0;
     memcpy(&header, &circular->storage[circular->head], HEADER_BYTES);
-    size_t recordSize = header;
+    return header;
+}
+
+static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
+{
+    size_t recordSize = PeekRecordSize(circular);
     memcpy(data, &circular->storage[circular->head + HEADER_BYTES], recordSize);
     circular->head += HEADER_BYTES + recordSize;
     *bytesRead = recordSize;
@@ -113,23 +126,26 @@ static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* 
 static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
-    SolidSyslogMutex_Lock(circular->mutex);
-    if (IsEmpty(circular))
+    if (size <= SOLIDSYSLOG_MAX_MESSAGE_SIZE)
     {
-        ResetToStart(circular);
-    }
-    size_t recordBytes = HEADER_BYTES + size;
-    bool   fitsAtTail  = RecordFitsAtTail(circular, recordBytes);
-    bool   shouldWrite = fitsAtTail || RecordFitsAfterWrap(circular, recordBytes);
-    if (shouldWrite)
-    {
-        if (!fitsAtTail)
+        SolidSyslogMutex_Lock(circular->mutex);
+        if (IsEmpty(circular))
         {
-            WrapTail(circular);
+            ResetToStart(circular);
         }
-        StoreRecord(circular, data, size);
+        size_t recordBytes = HEADER_BYTES + size;
+        bool   fitsAtTail  = RecordFitsAtTail(circular, recordBytes);
+        bool   shouldWrite = fitsAtTail || RecordFitsAfterWrap(circular, recordBytes);
+        if (shouldWrite)
+        {
+            if (!fitsAtTail)
+            {
+                WrapTail(circular);
+            }
+            StoreRecord(circular, data, size);
+        }
+        SolidSyslogMutex_Unlock(circular->mutex);
     }
-    SolidSyslogMutex_Unlock(circular->mutex);
 }
 
 static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)
@@ -139,13 +155,16 @@ static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)
 
 static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
 {
-    size_t limit = IsWrapped(circular) ? circular->head : circular->capacity;
-    return circular->tail + recordBytes <= limit;
+    if (IsWrapped(circular))
+    {
+        return circular->tail + recordBytes < circular->head;
+    }
+    return circular->tail + recordBytes <= circular->capacity;
 }
 
 static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
 {
-    return (!IsWrapped(circular)) && recordBytes <= circular->head;
+    return (!IsWrapped(circular)) && recordBytes < circular->head;
 }
 
 static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular)

--- a/Core/Source/SolidSyslogMutex.c
+++ b/Core/Source/SolidSyslogMutex.c
@@ -1,0 +1,13 @@
+#include "SolidSyslogMutex.h"
+
+#include "SolidSyslogMutexDefinition.h"
+
+void SolidSyslogMutex_Lock(struct SolidSyslogMutex* mutex)
+{
+    mutex->Lock(mutex);
+}
+
+void SolidSyslogMutex_Unlock(struct SolidSyslogMutex* mutex)
+{
+    mutex->Unlock(mutex);
+}

--- a/Core/Source/SolidSyslogNullMutex.c
+++ b/Core/Source/SolidSyslogNullMutex.c
@@ -1,0 +1,33 @@
+#include "SolidSyslogNullMutex.h"
+
+#include <stddef.h>
+
+#include "SolidSyslogMutexDefinition.h"
+
+static void Lock(struct SolidSyslogMutex* self);
+static void Unlock(struct SolidSyslogMutex* self);
+
+static struct SolidSyslogMutex instance;
+
+struct SolidSyslogMutex* SolidSyslogNullMutex_Create(void)
+{
+    instance.Lock   = Lock;
+    instance.Unlock = Unlock;
+    return &instance;
+}
+
+void SolidSyslogNullMutex_Destroy(void)
+{
+    instance.Lock   = NULL;
+    instance.Unlock = NULL;
+}
+
+static void Lock(struct SolidSyslogMutex* self)
+{
+    (void) self;
+}
+
+static void Unlock(struct SolidSyslogMutex* self)
+{
+    (void) self;
+}

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2540,3 +2540,82 @@ the reality was 84 files with findings on the first run, dropping to
   addressed later with a CMake cache variable for `MAX_MESSAGE_SIZE`
   (already on the project memory backlog) or by relaxing the macro to
   take an explicit byte count alongside the message count.
+
+## 2026-05-04 — S04.05 review-driven fixes
+
+CodeRabbit review on PR #263 surfaced four substantive findings beyond the
+IWYU/format hygiene noise. All addressed via strict TDD (Red test → Green fix)
+in commit `ebddeb4`:
+
+### Decisions
+
+- **`Read` discards `maxSize`** (Critical). `Read` now refuses if
+  `recordSize > maxSize`: returns `false`, leaves the record queued, sets
+  `bytesRead = 0`. Mirrors `mq_receive` `EMSGSIZE` semantics (fail loud, not
+  silent truncation). New TEST_GROUP `SolidSyslogCircularBufferSmallRing`
+  with a 32-byte ring keeps the boundary tests readable.
+
+- **`Write` truncates `size` to `uint16_t`** (Critical). `Write` now drops
+  payloads larger than `SOLIDSYSLOG_MAX_MESSAGE_SIZE` outright, before any
+  framing. `MAX_MESSAGE_SIZE = 2048` is far below `UINT16_MAX = 65535`, so
+  this single bound subsumes the 16-bit truncation concern and aligns with
+  the rest of the library's invariant.
+
+- **`<=` on the fit-helpers collapsed full onto empty** (Critical).
+  `RecordFitsAtTail` (wrapped branch) and `RecordFitsAfterWrap` now use `<`
+  instead of `<=`. The non-wrapped branch in `RecordFitsAtTail` keeps `<=`
+  because perfect-fit at end of storage (`tail + recordBytes == capacity`)
+  does not collapse onto `head == tail` while there is unread data. Two
+  distinct tests probe both helper paths.
+
+- **`pthread_mutex_init` return ignored** (Major). Deferred to E12 (error
+  handling). Default in-process mutex init is reliable in practice; the
+  project does not yet have an error-reporting infrastructure to surface
+  failures to callers, so adding the check inconsistently with the rest of
+  the library would be premature. Tracked in
+  [robustness backlog](memory). Same applies to
+  `InitializeCriticalSection`, which is `void` on Vista+ anyway.
+
+### Refactor
+
+- **`_Create` now takes `storageBytes` instead of `maxMessages`** (commit
+  `0b89e69`). Added `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(ringBytes)`
+  alongside the friendly `_STORAGE_SIZE(maxMessages)`. Lets the small-ring
+  TEST_GROUP construct a 32-byte ring directly, decoupled from
+  `MAX_MESSAGE_SIZE`. Per-record byte counts in tests are now tractable
+  (10/12/19 byte payloads instead of 1000-byte ones).
+
+### IWYU pragma keep on `SolidSyslog.h`
+
+- IWYU's verdict on `SolidSyslogCircularBuffer.h` differs per TU: the .c
+  (which does not expand `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE`) sees
+  `SolidSyslog.h` as unused and asks to remove it; the test (which does
+  expand the macro) sees the macro body's reference to
+  `SOLIDSYSLOG_MAX_MESSAGE_SIZE` and asks to add it. The two TUs cannot
+  agree — one or the other always complains. `// IWYU pragma: keep` on the
+  include is the canonical remediation for this exact case (commit
+  `c74f142` after format pass). Verified locally with
+  `cmake --build --preset iwyu --target iwyu` exiting `0`.
+
+- This is the only IWYU pragma added in this PR. The two existing pragmas
+  (`Tests/Support/OpenSslFake.h` keeping `<stdbool.h>`, `Tests/TestUtils.h`
+  keeping `CppUTest/TestHarness.h`) cover *load-bearing* includes that IWYU
+  cannot see through; this new one covers a *macro-deferred reference*.
+
+### Cleanup
+
+- **Disabled `clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling`
+  globally** (commit `fdf75f9`). Rule recommends C11 Annex K (`memcpy_s`
+  etc.) which glibc does not ship; every `memcpy`/`memset`/`strncpy` site
+  in the codebase had a `NOLINTNEXTLINE` suppression — 21 in total. When
+  every hit is suppressed, the rule is pure noise. ASan/UBSan and
+  bounded-by-construction call sites are the real defence.
+
+### Deferred — to revisit after S04.05 lands
+
+- `.clang-tidy` also disables `-readability-magic-numbers` and
+  `-cppcoreguidelines-avoid-magic-numbers`. David's reviewer-side
+  preference is "no magic numbers." Worth a separate discussion to decide
+  whether to re-enable those rules and accept the resulting cleanup sweep.
+  Tracked in
+  [project_clang_tidy_magic_numbers.md](memory).

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2459,3 +2459,84 @@ the reality was 84 files with findings on the first run, dropping to
   headers; IWYU's strict purist rule is much narrower than human
   intuition. Lesson for future "small CI gate" stories: estimate by
   running the tool, not by reading the code.
+
+
+## 2026-05-04 — S04.05 Circular buffer with mutex injection
+
+### Decisions
+
+- **Drop-newest under back-pressure.** Originally the story body called
+  for drop-oldest plus a lost-message marker. Closing comment on S04.06
+  (#55) made that obsolete: gap detection on the receive side via
+  `origin sequenceId` covers loss visibility. Drop-newest is also what
+  `PosixMessageQueueBuffer` already does silently (`O_NONBLOCK` +
+  ignored `mq_send` return), so the two non-null buffer implementations
+  now share semantics. If a need for drop-oldest or halt at this layer
+  ever shows up, `SolidSyslogDiscardPolicy` from `BlockStore` is the
+  natural place to extend.
+
+- **No-split records on wrap.** When a record wouldn't fit between
+  `tail` and the storage end, the impl marks the unused tail with a
+  `wrapPoint` and writes the new record at index 0 — but only if the
+  pre-wrap unread region wouldn't be overwritten. Otherwise the write
+  is dropped. This keeps records contiguous, simplifies reasoning, and
+  bounded the wasted tail space at one record-worth. The trade-off
+  (a few bytes of waste at each wrap) is fine; if it ever matters we
+  can switch to modular indices without changing the public API.
+
+- **Drained-buffer reset.** When `head == tail` at a non-zero offset,
+  Write recycles to `head = tail = 0` before deciding whether to write.
+  This avoids dropping records that are smaller than `capacity` but
+  larger than the remaining tail space. Caught during ZOMBIES probing
+  before the test ever shipped — there was a state-space hole in the
+  initial overflow logic.
+
+- **`maxMessages` as the user-facing capacity unit.** The
+  `SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE` macro takes "max messages
+  at max size" rather than raw bytes. Friendlier than asking
+  integrators to multiply by `MAX_MESSAGE_SIZE + sizeof(uint16_t)`
+  themselves; matches the embedded "size for the worst case" mindset.
+
+- **Mutex vtable shape mirrors `SolidSyslogAtomicOps`** (`Lock(self)` /
+  `Unlock(self)` rather than the new `void* context` callback
+  convention) since a mutex naturally has state. `SolidSyslogNullMutex`
+  is the no-op default for single-task use; `SolidSyslogPosixMutex`
+  wraps `pthread_mutex_t`; `SolidSyslogWindowsMutex` wraps
+  `CRITICAL_SECTION`. Both platforms in scope so S13.18's BDD wiring
+  has both ready.
+
+- **Disable `clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling`
+  globally.** The rule recommends C11 Annex K (`memcpy_s` etc.) which
+  glibc doesn't ship. Every `memcpy`/`memset`/`strncpy` site in the
+  codebase already had a `NOLINTNEXTLINE` suppression — 21 in total.
+  When *every* hit is suppressed, the rule is doing zero discrimination.
+  Sanitizers and bounded-by-construction call sites are the real
+  defence. Added the rule to the negation list in `.clang-tidy` and
+  swept the 21 inline suppressions out.
+
+### Deferred
+
+- **Magic-numbers clang-tidy suppressions.** `.clang-tidy` also
+  disables `-readability-magic-numbers` and
+  `-cppcoreguidelines-avoid-magic-numbers`. The "no magic numbers"
+  preference David has been asking for in code reviews is the
+  opposite — re-enabling these rules might enforce that automatically.
+  Worth a separate discussion + cleanup PR after S04.05 lands.
+
+- **Atomics-based lock-free SPSC ring.** The original story body
+  mentioned "or atomics where available". A lock-free ring is a
+  substantially different design (writer doesn't wait, reader doesn't
+  wait, ABA hazards, etc.) and isn't needed by current targets.
+  Revisit under a future RTOS / lock-free epic if a real need emerges.
+
+- **Wiring the ring buffer through the BDD harness on Windows.** That
+  is S13.18 (#244), now unblocked.
+
+### Open questions
+
+- **Buffer sizing in the embedded use-case.** With `maxMessages = 1`
+  and `MAX_MESSAGE_SIZE = 2048`, the smallest buffer is ~2 KB plus
+  overhead. For very small targets that's significant. Could be
+  addressed later with a CMake cache variable for `MAX_MESSAGE_SIZE`
+  (already on the project memory backlog) or by relaxing the macro to
+  take an explicit byte count alongside the message count.

--- a/Platform/Posix/CMakeLists.txt
+++ b/Platform/Posix/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     Source/SolidSyslogPosixClock.c
     Source/SolidSyslogPosixHostname.c
     Source/SolidSyslogPosixMessageQueueBuffer.c
+    Source/SolidSyslogPosixMutex.c
     Source/SolidSyslogPosixProcessId.c
     Source/SolidSyslogPosixSysUpTime.c
     Source/SolidSyslogAddress.c

--- a/Platform/Posix/Interface/SolidSyslogPosixMutex.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixMutex.h
@@ -1,0 +1,28 @@
+#ifndef SOLIDSYSLOGPOSIXMUTEX_H
+#define SOLIDSYSLOGPOSIXMUTEX_H
+
+#include "ExternC.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex;
+
+    enum
+    {
+        SOLIDSYSLOG_POSIXMUTEX_SIZE = sizeof(intptr_t) * 10
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_POSIXMUTEX_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogPosixMutexStorage;
+
+    struct SolidSyslogMutex* SolidSyslogPosixMutex_Create(SolidSyslogPosixMutexStorage * storage);
+    void                     SolidSyslogPosixMutex_Destroy(struct SolidSyslogMutex * mutex);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGPOSIXMUTEX_H */

--- a/Platform/Posix/Interface/SolidSyslogPosixMutex.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixMutex.h
@@ -3,7 +3,6 @@
 
 #include "ExternC.h"
 
-#include <stddef.h>
 #include <stdint.h>
 
 EXTERN_C_BEGIN

--- a/Platform/Posix/Source/SolidSyslogPosixMutex.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMutex.c
@@ -1,0 +1,48 @@
+#include "SolidSyslogPosixMutex.h"
+
+#include <pthread.h>
+#include <stddef.h>
+
+#include "SolidSyslogMacros.h"
+#include "SolidSyslogMutexDefinition.h"
+
+struct SolidSyslogPosixMutex
+{
+    struct SolidSyslogMutex base;
+    pthread_mutex_t         mutex;
+};
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogPosixMutex) <= SOLIDSYSLOG_POSIXMUTEX_SIZE,
+                          "SOLIDSYSLOG_POSIXMUTEX_SIZE is too small for SolidSyslogPosixMutex layout");
+
+static void Lock(struct SolidSyslogMutex* self);
+static void Unlock(struct SolidSyslogMutex* self);
+
+struct SolidSyslogMutex* SolidSyslogPosixMutex_Create(SolidSyslogPosixMutexStorage* storage)
+{
+    struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) storage;
+    posix->base.Lock                    = Lock;
+    posix->base.Unlock                  = Unlock;
+    pthread_mutex_init(&posix->mutex, NULL);
+    return &posix->base;
+}
+
+void SolidSyslogPosixMutex_Destroy(struct SolidSyslogMutex* mutex)
+{
+    struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) mutex;
+    pthread_mutex_destroy(&posix->mutex);
+    posix->base.Lock   = NULL;
+    posix->base.Unlock = NULL;
+}
+
+static void Lock(struct SolidSyslogMutex* self)
+{
+    struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) self;
+    pthread_mutex_lock(&posix->mutex);
+}
+
+static void Unlock(struct SolidSyslogMutex* self)
+{
+    struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) self;
+    pthread_mutex_unlock(&posix->mutex);
+}

--- a/Platform/Windows/CMakeLists.txt
+++ b/Platform/Windows/CMakeLists.txt
@@ -9,6 +9,7 @@ if(HAVE_WINDOWS_PLATFORM)
         Source/SolidSyslogWindowsClock.c
         Source/SolidSyslogWindowsFile.c
         Source/SolidSyslogWindowsHostname.c
+        Source/SolidSyslogWindowsMutex.c
         Source/SolidSyslogWindowsProcessId.c
         Source/SolidSyslogWindowsSysUpTime.c
     )

--- a/Platform/Windows/Interface/SolidSyslogWindowsMutex.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsMutex.h
@@ -1,0 +1,28 @@
+#ifndef SOLIDSYSLOGWINDOWSMUTEX_H
+#define SOLIDSYSLOGWINDOWSMUTEX_H
+
+#include "ExternC.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex;
+
+    enum
+    {
+        SOLIDSYSLOG_WINDOWSMUTEX_SIZE = sizeof(intptr_t) * 10
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_WINDOWSMUTEX_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogWindowsMutexStorage;
+
+    struct SolidSyslogMutex* SolidSyslogWindowsMutex_Create(SolidSyslogWindowsMutexStorage * storage);
+    void                     SolidSyslogWindowsMutex_Destroy(struct SolidSyslogMutex * mutex);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGWINDOWSMUTEX_H */

--- a/Platform/Windows/Interface/SolidSyslogWindowsMutex.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsMutex.h
@@ -3,7 +3,6 @@
 
 #include "ExternC.h"
 
-#include <stddef.h>
 #include <stdint.h>
 
 EXTERN_C_BEGIN

--- a/Platform/Windows/Source/SolidSyslogWindowsMutex.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsMutex.c
@@ -1,0 +1,48 @@
+#include "SolidSyslogWindowsMutex.h"
+
+#include <stddef.h>
+#include <windows.h>
+
+#include "SolidSyslogMacros.h"
+#include "SolidSyslogMutexDefinition.h"
+
+struct SolidSyslogWindowsMutex
+{
+    struct SolidSyslogMutex base;
+    CRITICAL_SECTION        section;
+};
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct SolidSyslogWindowsMutex) <= SOLIDSYSLOG_WINDOWSMUTEX_SIZE,
+                          "SOLIDSYSLOG_WINDOWSMUTEX_SIZE is too small for SolidSyslogWindowsMutex layout");
+
+static void Lock(struct SolidSyslogMutex* self);
+static void Unlock(struct SolidSyslogMutex* self);
+
+struct SolidSyslogMutex* SolidSyslogWindowsMutex_Create(SolidSyslogWindowsMutexStorage* storage)
+{
+    struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) storage;
+    windows->base.Lock                      = Lock;
+    windows->base.Unlock                    = Unlock;
+    InitializeCriticalSection(&windows->section);
+    return &windows->base;
+}
+
+void SolidSyslogWindowsMutex_Destroy(struct SolidSyslogMutex* mutex)
+{
+    struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) mutex;
+    DeleteCriticalSection(&windows->section);
+    windows->base.Lock   = NULL;
+    windows->base.Unlock = NULL;
+}
+
+static void Lock(struct SolidSyslogMutex* self)
+{
+    struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) self;
+    EnterCriticalSection(&windows->section);
+}
+
+static void Unlock(struct SolidSyslogMutex* self)
+{
+    struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) self;
+    LeaveCriticalSection(&windows->section);
+}

--- a/Tests/BufferFake.c
+++ b/Tests/BufferFake.c
@@ -45,7 +45,6 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
     if (success)
     {
         size_t copySize = MinSize(fake->storedSize, maxSize);
-        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
         memcpy(data, fake->stored, copySize);
         *bytesRead    = copySize;
         fake->pending = false;
@@ -59,7 +58,6 @@ static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
     struct BufferFake* fake = (struct BufferFake*) self;
 
     size_t copySize = MinSize(size, sizeof(fake->stored));
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
     memcpy(fake->stored, data, copySize);
     fake->storedSize = copySize;
     fake->pending    = true;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCES
     SolidSyslogOriginSdTest.cpp
     SolidSyslogNullBufferTest.cpp
     SolidSyslogCircularBufferTest.cpp
+    SolidSyslogNullMutexTest.cpp
     SolidSyslogNullStoreTest.cpp
     SolidSyslogNullSecurityPolicyTest.cpp
     SolidSyslogCrc16Test.cpp
@@ -23,6 +24,7 @@ set(TEST_SOURCES
     SolidSyslogUdpPayloadTest.cpp
     BufferFakeTest.cpp
     BufferFake.c
+    MutexFake.c
     StoreFakeTest.cpp
     StoreFake.c
     SenderFakeTest.cpp

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -74,6 +74,7 @@ if(SOLIDSYSLOG_POSIX)
     list(APPEND TEST_SOURCES
         SolidSyslogPosixClockTest.cpp
         SolidSyslogPosixMessageQueueBufferTest.cpp
+        SolidSyslogPosixMutexTest.cpp
         SolidSyslogPosixSysUpTimeTest.cpp
         ClockFakeTest.cpp
         SolidSyslogUdpSenderTest.cpp
@@ -103,6 +104,7 @@ if(HAVE_WINDOWS_PLATFORM)
         SolidSyslogWindowsClockTest.cpp
         SolidSyslogWindowsFileTest.cpp
         SolidSyslogWindowsHostnameTest.cpp
+        SolidSyslogWindowsMutexTest.cpp
         SolidSyslogWindowsProcessIdTest.cpp
         SolidSyslogWindowsSysUpTimeTest.cpp
     )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES
     SolidSyslogTimeQualitySdTest.cpp
     SolidSyslogOriginSdTest.cpp
     SolidSyslogNullBufferTest.cpp
+    SolidSyslogCircularBufferTest.cpp
     SolidSyslogNullStoreTest.cpp
     SolidSyslogNullSecurityPolicyTest.cpp
     SolidSyslogCrc16Test.cpp

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -113,7 +113,6 @@ static const struct SolidSyslogFile POISONED_VTABLE = {
 struct SolidSyslogFile* FileFake_Create(struct FileFakeStorage* storage)
 {
     struct FileFake* fake = (struct FileFake*) storage;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memset with bounded size; memset_s is not portable
     memset(fake, 0, sizeof(*fake));
     fake->base  = LIVE_VTABLE;
     lastCreated = fake;
@@ -124,13 +123,11 @@ void FileFake_Destroy(void)
 {
     if (lastCreated != NULL)
     {
-        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memset with bounded size; memset_s is not portable
         memset(lastCreated, 0, sizeof(*lastCreated));
         lastCreated->base = POISONED_VTABLE;
         lastCreated       = NULL;
     }
 
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memset with bounded size; memset_s is not portable
     memset(filesystem, 0, sizeof(filesystem));
 }
 
@@ -375,7 +372,6 @@ static inline bool HasBytesToRead(const struct FileFake* fake, size_t count)
 
 static inline void CopyFromFile(struct FileFake* fake, void* buf, size_t count)
 {
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded count; memcpy_s is not portable
     memcpy(buf, fake->active->content + fake->position, count);
     AdvancePosition(fake, count);
 }
@@ -416,7 +412,6 @@ static inline bool HasSpaceToWrite(const struct FileFake* fake, size_t count)
 
 static inline void CopyToFile(struct FileFake* fake, const void* buf, size_t count)
 {
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded count; memcpy_s is not portable
     memcpy(fake->active->content + fake->position, buf, count);
     AdvancePosition(fake, count);
     ExtendFileSize(fake);
@@ -489,7 +484,6 @@ static bool FileFake_Delete(struct SolidSyslogFile* self, const char* path)
 
 static inline void ClearEntry(struct FileEntry* entry)
 {
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memset with bounded size; memset_s is not portable
     memset(entry->content, 0, sizeof(entry->content));
     entry->fileSize = 0;
     entry->path[0]  = '\0';

--- a/Tests/MutexFake.c
+++ b/Tests/MutexFake.c
@@ -1,0 +1,61 @@
+#include "MutexFake.h"
+
+#include <stddef.h>
+
+#include "SolidSyslogMutexDefinition.h"
+
+enum
+{
+    SEQUENCE_CAPACITY = 32
+};
+
+static struct SolidSyslogMutex instance;
+static char                    sequence[SEQUENCE_CAPACITY];
+static size_t                  sequenceLength;
+
+static void Lock(struct SolidSyslogMutex* self);
+static void Unlock(struct SolidSyslogMutex* self);
+
+static inline void Append(char marker)
+{
+    if (sequenceLength + 1 < SEQUENCE_CAPACITY)
+    {
+        sequence[sequenceLength]     = marker;
+        sequence[sequenceLength + 1] = '\0';
+        sequenceLength += 1;
+    }
+}
+
+struct SolidSyslogMutex* MutexFake_Create(void)
+{
+    instance.Lock   = Lock;
+    instance.Unlock = Unlock;
+    sequence[0]     = '\0';
+    sequenceLength  = 0;
+    return &instance;
+}
+
+void MutexFake_Destroy(void)
+{
+    instance.Lock   = NULL;
+    instance.Unlock = NULL;
+    sequence[0]     = '\0';
+    sequenceLength  = 0;
+}
+
+const char* MutexFake_Sequence(void)
+{
+    return sequence;
+}
+
+static void Lock(struct SolidSyslogMutex* self)
+{
+    (void) self;
+    Append('L');
+}
+
+static void Unlock(struct SolidSyslogMutex* self)
+{
+    (void) self;
+    Append('U');
+}

--- a/Tests/MutexFake.h
+++ b/Tests/MutexFake.h
@@ -1,0 +1,14 @@
+#ifndef MUTEXFAKE_H
+#define MUTEXFAKE_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogMutex* MutexFake_Create(void);
+    void                     MutexFake_Destroy(void);
+    const char*              MutexFake_Sequence(void);
+
+EXTERN_C_END
+
+#endif /* MUTEXFAKE_H */

--- a/Tests/SenderFake.c
+++ b/Tests/SenderFake.c
@@ -22,7 +22,6 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
 {
     struct SenderFake* fake     = (struct SenderFake*) self;
     size_t             copySize = MinSize(size, sizeof(fake->lastBuffer) - 1);
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
     memcpy(fake->lastBuffer, buffer, copySize);
     fake->lastBuffer[copySize] = '\0';
     fake->lastSize             = size;

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -33,6 +33,11 @@ TEST_GROUP(SolidSyslogCircularBuffer)
         SolidSyslogCircularBuffer_Destroy(buffer);
         SolidSyslogNullMutex_Destroy();
     }
+
+    bool Read()
+    {
+        return SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    }
 };
 
 // clang-format on
@@ -108,6 +113,7 @@ TEST(SolidSyslogCircularBuffer, WrapsAroundEndOfStorage)
         CYCLES       = 400,
         PAYLOAD_SIZE = 10
     };
+
     char payload[PAYLOAD_SIZE];
     memset(payload, 'X', PAYLOAD_SIZE);
 
@@ -170,6 +176,11 @@ TEST_GROUP(SolidSyslogCircularBufferMutex)
     {
         SolidSyslogCircularBuffer_Destroy(buffer);
         MutexFake_Destroy();
+    }
+
+    bool Read()
+    {
+        return SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
     }
 };
 

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -1,9 +1,11 @@
 #include <cstring>
 
 #include "CppUTest/TestHarness.h"
+#include "MutexFake.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogCircularBuffer.h"
+#include "SolidSyslogNullMutex.h"
 
 enum
 {
@@ -22,13 +24,14 @@ TEST_GROUP(SolidSyslogCircularBuffer)
     void setup() override
     {
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES);
+        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES, SolidSyslogNullMutex_Create());
         readSize = 0;
     }
 
     void teardown() override
     {
         SolidSyslogCircularBuffer_Destroy(buffer);
+        SolidSyslogNullMutex_Destroy();
     }
 };
 
@@ -145,4 +148,41 @@ TEST(SolidSyslogCircularBuffer, WriteAfterDrainAcceptsRecordTooLargeForRemaining
     CHECK_TRUE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
     LONGS_EQUAL(sizeof(big), readSize);
     MEMCMP_EQUAL(big, readData, sizeof(big));
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogCircularBufferMutex)
+{
+    SolidSyslogCircularBufferStorage storage[SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(TEST_MAX_MESSAGES)];
+    struct SolidSyslogBuffer* buffer = nullptr;
+    char                      readData[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    size_t                    readSize;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES, MutexFake_Create());
+        readSize = 0;
+    }
+
+    void teardown() override
+    {
+        SolidSyslogCircularBuffer_Destroy(buffer);
+        MutexFake_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogCircularBufferMutex, WriteCallsLockThenUnlockOnce)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+    STRCMP_EQUAL("LU", MutexFake_Sequence());
+}
+
+TEST(SolidSyslogCircularBufferMutex, ReadCallsLockThenUnlockOnce)
+{
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    STRCMP_EQUAL("LU", MutexFake_Sequence());
 }

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -60,3 +60,26 @@ TEST(SolidSyslogCircularBuffer, SecondReadAfterSingleWriteReturnsFalse)
     SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
     CHECK_FALSE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
 }
+
+TEST(SolidSyslogCircularBuffer, TwoWritesReadInOrder)
+{
+    SolidSyslogBuffer_Write(buffer, "first", 5);
+    SolidSyslogBuffer_Write(buffer, "second", 6);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("first", readData, 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("second", readData, 6);
+}
+
+TEST(SolidSyslogCircularBuffer, ThreeWritesReadInOrder)
+{
+    SolidSyslogBuffer_Write(buffer, "alpha", 5);
+    SolidSyslogBuffer_Write(buffer, "bravo", 5);
+    SolidSyslogBuffer_Write(buffer, "charlie", 7);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("alpha", readData, 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("bravo", readData, 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("charlie", readData, 7);
+}

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -24,7 +24,7 @@ TEST_GROUP(SolidSyslogCircularBuffer)
     void setup() override
     {
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES, SolidSyslogNullMutex_Create());
+        buffer   = SolidSyslogCircularBuffer_Create(storage, sizeof(storage), SolidSyslogNullMutex_Create());
         readSize = 0;
     }
 
@@ -168,7 +168,7 @@ TEST_GROUP(SolidSyslogCircularBufferMutex)
     void setup() override
     {
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES, MutexFake_Create());
+        buffer   = SolidSyslogCircularBuffer_Create(storage, sizeof(storage), MutexFake_Create());
         readSize = 0;
     }
 

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -1,27 +1,34 @@
 #include <cstring>
 
 #include "CppUTest/TestHarness.h"
+#include "SolidSyslog.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogCircularBuffer.h"
+
+enum
+{
+    TEST_MAX_MESSAGES = 1
+};
 
 // clang-format off
 TEST_GROUP(SolidSyslogCircularBuffer)
 {
+    SolidSyslogCircularBufferStorage storage[SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE(TEST_MAX_MESSAGES)];
     struct SolidSyslogBuffer* buffer = nullptr;
-    char                      readData[512];
+    char                      readData[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     size_t                    readSize;
 
     void setup() override
     {
         // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-        buffer   = SolidSyslogCircularBuffer_Create();
+        buffer   = SolidSyslogCircularBuffer_Create(storage, TEST_MAX_MESSAGES);
         readSize = 0;
     }
 
     void teardown() override
     {
-        SolidSyslogCircularBuffer_Destroy();
+        SolidSyslogCircularBuffer_Destroy(buffer);
     }
 };
 
@@ -29,6 +36,11 @@ TEST_GROUP(SolidSyslogCircularBuffer)
 
 TEST(SolidSyslogCircularBuffer, CreateDestroyDoesNotCrash)
 {
+}
+
+TEST(SolidSyslogCircularBuffer, HandleEqualsStorageAddress)
+{
+    POINTERS_EQUAL(&storage, buffer);
 }
 
 TEST(SolidSyslogCircularBuffer, ReadFromEmptyReturnsFalse)
@@ -90,7 +102,7 @@ TEST(SolidSyslogCircularBuffer, WrapsAroundEndOfStorage)
 {
     enum
     {
-        CYCLES       = 200,
+        CYCLES       = 400,
         PAYLOAD_SIZE = 10
     };
     char payload[PAYLOAD_SIZE];
@@ -107,31 +119,30 @@ TEST(SolidSyslogCircularBuffer, WrapsAroundEndOfStorage)
 
 TEST(SolidSyslogCircularBuffer, OverflowingWriteIsDropped)
 {
-    char filler[400];
-    memset(filler, 'A', 400);
-    char overflow[200];
-    memset(overflow, 'B', 200);
+    char filler[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(filler, 'A', sizeof(filler));
+    char overflow[100];
+    memset(overflow, 'B', sizeof(overflow));
 
-    SolidSyslogBuffer_Write(buffer, filler, 400);
-    SolidSyslogBuffer_Write(buffer, overflow, 200);
+    SolidSyslogBuffer_Write(buffer, filler, sizeof(filler));
+    SolidSyslogBuffer_Write(buffer, overflow, sizeof(overflow));
 
     SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
-    MEMCMP_EQUAL(filler, readData, 400);
+    LONGS_EQUAL(sizeof(filler), readSize);
+    MEMCMP_EQUAL(filler, readData, sizeof(filler));
     CHECK_FALSE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
 }
 
 TEST(SolidSyslogCircularBuffer, WriteAfterDrainAcceptsRecordTooLargeForRemainingTailSpace)
 {
-    char first[200];
-    memset(first, 'A', 200);
-    SolidSyslogBuffer_Write(buffer, first, 200);
+    SolidSyslogBuffer_Write(buffer, "x", 1);
     SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
 
-    char second[400];
-    memset(second, 'B', 400);
-    SolidSyslogBuffer_Write(buffer, second, 400);
+    char big[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
+    memset(big, 'B', sizeof(big));
+    SolidSyslogBuffer_Write(buffer, big, sizeof(big));
 
     CHECK_TRUE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
-    LONGS_EQUAL(400, readSize);
-    MEMCMP_EQUAL(second, readData, 400);
+    LONGS_EQUAL(sizeof(big), readSize);
+    MEMCMP_EQUAL(big, readData, sizeof(big));
 }

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -156,6 +156,17 @@ TEST(SolidSyslogCircularBuffer, WriteAfterDrainAcceptsRecordTooLargeForRemaining
     MEMCMP_EQUAL(big, readData, sizeof(big));
 }
 
+TEST(SolidSyslogCircularBuffer, WriteExceedingMaxMessageSizeIsDropped)
+{
+    char tooBig[SOLIDSYSLOG_MAX_MESSAGE_SIZE + 1];
+    memset(tooBig, 'X', sizeof(tooBig));
+    SolidSyslogBuffer_Write(buffer, tooBig, sizeof(tooBig));
+
+    char   bigDest[SOLIDSYSLOG_MAX_MESSAGE_SIZE + 1];
+    size_t got = 0;
+    CHECK_FALSE(SolidSyslogBuffer_Read(buffer, bigDest, sizeof(bigDest), &got));
+}
+
 // clang-format off
 TEST_GROUP(SolidSyslogCircularBufferMutex)
 {
@@ -196,4 +207,100 @@ TEST(SolidSyslogCircularBufferMutex, ReadCallsLockThenUnlockOnce)
 {
     SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
     STRCMP_EQUAL("LU", MutexFake_Sequence());
+}
+
+enum
+{
+    SMALL_RING_BYTES = 32
+};
+
+// clang-format off
+TEST_GROUP(SolidSyslogCircularBufferSmallRing)
+{
+    SolidSyslogCircularBufferStorage storage[SOLIDSYSLOG_CIRCULARBUFFER_STORAGE_SIZE_BYTES(SMALL_RING_BYTES)];
+    struct SolidSyslogBuffer*        buffer = nullptr;
+    char                             readData[SMALL_RING_BYTES];
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    size_t                           readSize;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        buffer   = SolidSyslogCircularBuffer_Create(storage, sizeof(storage), SolidSyslogNullMutex_Create());
+        readSize = 0;
+    }
+
+    void teardown() override
+    {
+        SolidSyslogCircularBuffer_Destroy(buffer);
+        SolidSyslogNullMutex_Destroy();
+    }
+
+    bool Read()
+    {
+        return SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    }
+};
+
+// clang-format on
+
+// 32-byte ring, 2-byte header per record.
+// recA(12)→ tail=14, recB(12)→ tail=28, read recA → head=14.
+// recC(12) recordBytes=14: doesn't fit at tail (28+14=42>32);
+// canWrap: recordBytes(14) vs head(14). With `<=` bug: wraps, tail=14=head → IsEmpty.
+// With `<` fix: drops; recB still readable.
+TEST(SolidSyslogCircularBufferSmallRing, WrapWriteFillingExactlyToHeadDoesNotCollapseToEmpty)
+{
+    char rec[12];
+    memset(rec, 'A', sizeof(rec));
+    SolidSyslogBuffer_Write(buffer, rec, sizeof(rec));
+    SolidSyslogBuffer_Write(buffer, rec, sizeof(rec));
+    Read();
+    SolidSyslogBuffer_Write(buffer, rec, sizeof(rec));
+
+    CHECK_TRUE(Read());
+    LONGS_EQUAL(sizeof(rec), readSize);
+}
+
+// 32-byte ring. Establish wrapped state (head=24, tail=3 after a, b, c, d), then
+// write e of size 19 → recordBytes=21 = head-tail. With `<=` bug, fitsAtTail in
+// wrapped state lets tail advance to head exactly → IsEmpty collapse.
+TEST(SolidSyslogCircularBufferSmallRing, WriteInWrappedStateFillingExactlyToHeadDoesNotCollapseToEmpty)
+{
+    char a[10];
+    char b[10];
+    char c[4];
+    char d[1];
+    char e[19];
+    memset(a, 'a', sizeof(a));
+    memset(b, 'b', sizeof(b));
+    memset(c, 'c', sizeof(c));
+    memset(d, 'd', sizeof(d));
+    memset(e, 'e', sizeof(e));
+
+    SolidSyslogBuffer_Write(buffer, a, sizeof(a));
+    SolidSyslogBuffer_Write(buffer, b, sizeof(b));
+    Read();
+    SolidSyslogBuffer_Write(buffer, c, sizeof(c));
+    Read();
+    SolidSyslogBuffer_Write(buffer, d, sizeof(d));
+    SolidSyslogBuffer_Write(buffer, e, sizeof(e));
+
+    CHECK_TRUE(Read());
+    LONGS_EQUAL(sizeof(c), readSize);
+    MEMCMP_EQUAL(c, readData, sizeof(c));
+}
+
+TEST(SolidSyslogCircularBufferSmallRing, ReadIntoSmallerBufferReturnsFalseAndLeavesRecordQueued)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+
+    char   dest[5];
+    size_t got = 0;
+    CHECK_FALSE(SolidSyslogBuffer_Read(buffer, dest, 4, &got));
+    LONGS_EQUAL(0, got);
+
+    CHECK_TRUE(Read());
+    LONGS_EQUAL(5, readSize);
+    MEMCMP_EQUAL("hello", readData, 5);
 }

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogCircularBuffer.h"
@@ -82,4 +84,54 @@ TEST(SolidSyslogCircularBuffer, ThreeWritesReadInOrder)
     MEMCMP_EQUAL("bravo", readData, 5);
     SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
     MEMCMP_EQUAL("charlie", readData, 7);
+}
+
+TEST(SolidSyslogCircularBuffer, WrapsAroundEndOfStorage)
+{
+    enum
+    {
+        CYCLES       = 200,
+        PAYLOAD_SIZE = 10
+    };
+    char payload[PAYLOAD_SIZE];
+    memset(payload, 'X', PAYLOAD_SIZE);
+
+    for (int i = 0; i < CYCLES; i++)
+    {
+        SolidSyslogBuffer_Write(buffer, payload, PAYLOAD_SIZE);
+        SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+        LONGS_EQUAL(PAYLOAD_SIZE, readSize);
+        MEMCMP_EQUAL(payload, readData, PAYLOAD_SIZE);
+    }
+}
+
+TEST(SolidSyslogCircularBuffer, OverflowingWriteIsDropped)
+{
+    char filler[400];
+    memset(filler, 'A', 400);
+    char overflow[200];
+    memset(overflow, 'B', 200);
+
+    SolidSyslogBuffer_Write(buffer, filler, 400);
+    SolidSyslogBuffer_Write(buffer, overflow, 200);
+
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL(filler, readData, 400);
+    CHECK_FALSE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
+}
+
+TEST(SolidSyslogCircularBuffer, WriteAfterDrainAcceptsRecordTooLargeForRemainingTailSpace)
+{
+    char first[200];
+    memset(first, 'A', 200);
+    SolidSyslogBuffer_Write(buffer, first, 200);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+
+    char second[400];
+    memset(second, 'B', 400);
+    SolidSyslogBuffer_Write(buffer, second, 400);
+
+    CHECK_TRUE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
+    LONGS_EQUAL(400, readSize);
+    MEMCMP_EQUAL(second, readData, 400);
 }

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -304,3 +304,32 @@ TEST(SolidSyslogCircularBufferSmallRing, ReadIntoSmallerBufferReturnsFalseAndLea
     LONGS_EQUAL(5, readSize);
     MEMCMP_EQUAL("hello", readData, 5);
 }
+
+// Exercises the ConsumeWrapMarker branch of Read: write A, B, drain A, write
+// C, D (D forces a wrap), then drain in order. The fourth read must cross
+// the wrap point — head reaches wrapPoint and jumps to 0 to read D.
+TEST(SolidSyslogCircularBufferSmallRing, WrappedBufferReadsAllRecordsInOrder)
+{
+    char a[10];
+    char b[10];
+    char c[4];
+    char d[1];
+    memset(a, 'a', sizeof(a));
+    memset(b, 'b', sizeof(b));
+    memset(c, 'c', sizeof(c));
+    memset(d, 'd', sizeof(d));
+
+    SolidSyslogBuffer_Write(buffer, a, sizeof(a));
+    SolidSyslogBuffer_Write(buffer, b, sizeof(b));
+    Read();
+    SolidSyslogBuffer_Write(buffer, c, sizeof(c));
+    SolidSyslogBuffer_Write(buffer, d, sizeof(d));
+
+    CHECK_TRUE(Read());
+    MEMCMP_EQUAL(b, readData, sizeof(b));
+    CHECK_TRUE(Read());
+    MEMCMP_EQUAL(c, readData, sizeof(c));
+    CHECK_TRUE(Read());
+    MEMCMP_EQUAL(d, readData, sizeof(d));
+    CHECK_FALSE(Read());
+}

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -1,0 +1,62 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogBuffer.h"
+#include "SolidSyslogCircularBuffer.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogCircularBuffer)
+{
+    struct SolidSyslogBuffer* buffer = nullptr;
+    char                      readData[512];
+    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
+    size_t                    readSize;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        buffer   = SolidSyslogCircularBuffer_Create();
+        readSize = 0;
+    }
+
+    void teardown() override
+    {
+        SolidSyslogCircularBuffer_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogCircularBuffer, CreateDestroyDoesNotCrash)
+{
+}
+
+TEST(SolidSyslogCircularBuffer, ReadFromEmptyReturnsFalse)
+{
+    CHECK_FALSE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
+}
+
+TEST(SolidSyslogCircularBuffer, WriteThenReadReturnsTrue)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+    CHECK_TRUE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
+}
+
+TEST(SolidSyslogCircularBuffer, ReadReturnsWrittenSize)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    LONGS_EQUAL(5, readSize);
+}
+
+TEST(SolidSyslogCircularBuffer, ReadReturnsWrittenData)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    MEMCMP_EQUAL("hello", readData, 5);
+}
+
+TEST(SolidSyslogCircularBuffer, SecondReadAfterSingleWriteReturnsFalse)
+{
+    SolidSyslogBuffer_Write(buffer, "hello", 5);
+    SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize);
+    CHECK_FALSE(SolidSyslogBuffer_Read(buffer, readData, sizeof(readData), &readSize));
+}

--- a/Tests/SolidSyslogNullMutexTest.cpp
+++ b/Tests/SolidSyslogNullMutexTest.cpp
@@ -1,0 +1,32 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogMutex.h"
+#include "SolidSyslogNullMutex.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogNullMutex)
+{
+    struct SolidSyslogMutex* mutex = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        mutex = SolidSyslogNullMutex_Create();
+    }
+
+    void teardown() override
+    {
+        SolidSyslogNullMutex_Destroy();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogNullMutex, CreateDestroyDoesNotCrash)
+{
+}
+
+TEST(SolidSyslogNullMutex, LockUnlockDoesNotCrash)
+{
+    SolidSyslogMutex_Lock(mutex);
+    SolidSyslogMutex_Unlock(mutex);
+}

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -1,0 +1,38 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogMutex.h"
+#include "SolidSyslogPosixMutex.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogPosixMutex)
+{
+    SolidSyslogPosixMutexStorage storage{};
+    struct SolidSyslogMutex*     mutex = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        mutex = SolidSyslogPosixMutex_Create(&storage);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogPosixMutex_Destroy(mutex);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogPosixMutex, CreateDestroyDoesNotCrash)
+{
+}
+
+TEST(SolidSyslogPosixMutex, HandleEqualsStorageAddress)
+{
+    POINTERS_EQUAL(&storage, mutex);
+}
+
+TEST(SolidSyslogPosixMutex, LockUnlockDoesNotCrash)
+{
+    SolidSyslogMutex_Lock(mutex);
+    SolidSyslogMutex_Unlock(mutex);
+}

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -1,0 +1,38 @@
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogMutex.h"
+#include "SolidSyslogWindowsMutex.h"
+
+// clang-format off
+TEST_GROUP(SolidSyslogWindowsMutex)
+{
+    SolidSyslogWindowsMutexStorage storage{};
+    struct SolidSyslogMutex*       mutex = nullptr;
+
+    void setup() override
+    {
+        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
+        mutex = SolidSyslogWindowsMutex_Create(&storage);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogWindowsMutex_Destroy(mutex);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogWindowsMutex, CreateDestroyDoesNotCrash)
+{
+}
+
+TEST(SolidSyslogWindowsMutex, HandleEqualsStorageAddress)
+{
+    POINTERS_EQUAL(&storage, mutex);
+}
+
+TEST(SolidSyslogWindowsMutex, LockUnlockDoesNotCrash)
+{
+    SolidSyslogMutex_Lock(mutex);
+    SolidSyslogMutex_Unlock(mutex);
+}

--- a/Tests/StoreFake.c
+++ b/Tests/StoreFake.c
@@ -69,7 +69,6 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
     if (!fake->unsent)
     {
         size_t copySize = MinSize(size, sizeof(fake->stored));
-        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
         memcpy(fake->stored, data, copySize);
         fake->storedSize = copySize;
         fake->unsent     = true;
@@ -93,7 +92,6 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
     if (success)
     {
         size_t copySize = MinSize(fake->storedSize, maxSize);
-        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
         memcpy(data, fake->stored, copySize);
         *bytesRead = copySize;
     }

--- a/Tests/Support/ClockFake.c
+++ b/Tests/Support/ClockFake.c
@@ -63,7 +63,6 @@ struct tm* gmtime_r(const time_t* timep, struct tm* result)
         return NULL;
     }
 
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with known fixed size
     memcpy(result, breakdown, sizeof(struct tm));
     return result;
 }

--- a/Tests/Support/SafeStringStandard.c
+++ b/Tests/Support/SafeStringStandard.c
@@ -8,7 +8,6 @@ void SafeString_Copy(char* dest, size_t destSize, const char* src)
     {
         return;
     }
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- wrapping strncpy is the whole point of this abstraction
     strncpy(dest, src, destSize - 1);
     dest[destSize - 1] = '\0';
 }

--- a/Tests/Support/SocketFake.c
+++ b/Tests/Support/SocketFake.c
@@ -497,7 +497,6 @@ ssize_t sendto(int sockfd, const void* buf, size_t len, int flags, const struct 
     sendtoCallCount++;
     lastSendtoFd    = sockfd;
     size_t copySize = len < sizeof(lastBufCopy) - 1 ? len : sizeof(lastBufCopy) - 1;
-    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize; memcpy_s is not portable
     memcpy(lastBufCopy, buf, copySize);
     lastBufCopy[copySize] = '\0';
     lastLen               = len;
@@ -553,7 +552,6 @@ ssize_t send(int sockfd, const void* buf, size_t len, int flags)
     if (sendCallCount < SOCKETFAKE_MAX_SEND_CALLS)
     {
         size_t copySize = len < sizeof(sendBufCopy[0]) - 1 ? len : sizeof(sendBufCopy[0]) - 1;
-        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) -- memcpy with bounded copySize
         memcpy(sendBufCopy[sendCallCount], buf, copySize);
         sendBufCopy[sendCallCount][copySize] = '\0';
         sendLenCopy[sendCallCount]           = len;


### PR DESCRIPTION
## Purpose

Closes #54.

Adds a portable in-memory ring buffer satisfying the `SolidSyslogBuffer` interface, suitable for bare-metal / RTOS targets without POSIX message queues, and as the buffer of choice for Windows. Synchronization is by injected mutex vtable; `pthread_mutex_t` and `CRITICAL_SECTION` adapters are both delivered so this is end-to-end usable on Linux and Windows. Unblocks S13.18 (#244).

## Change Description

**Ring buffer (`Core/`)** — `SolidSyslogCircularBuffer` with caller-supplied storage (Formatter-style variable-size pattern). Records framed by a `uint16_t` length header. No-split wrap: when a record won't fit between `tail` and the storage end, `wrapPoint` records the abandoned tail and the new record goes at index 0. **Drop-newest** under back-pressure — silently, matching `PosixMessageQueueBuffer`. Drained buffer auto-resets to start so a record larger than the remaining tail-space can still be accepted when nothing is unread.

**Mutex abstraction (`Core/`)** — `SolidSyslogMutex` vtable (`Lock` / `Unlock`), thin shim functions, and `SolidSyslogNullMutex` no-op default. `CircularBuffer` wraps both `Read` and `Write` with `Lock` / `Unlock`.

**Platform mutex impls** — `SolidSyslogPosixMutex` (wraps `pthread_mutex_t`) and `SolidSyslogWindowsMutex` (wraps `CRITICAL_SECTION`). Both use the caller-supplied `intptr_t`-slot storage pattern with a `STATIC_ASSERT` check on struct size.

**Cleanup** — `clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling` is now disabled in `.clang-tidy`. The rule recommends C11 Annex K (`memcpy_s` etc.) which glibc doesn't ship; every memcpy/memset/strncpy site already had a NOLINT suppression. 21 inline suppressions removed across `Core/`, `Tests/`, `Tests/Support/`. ASan/UBSan + bounded-by-construction call sites are the actual defence.

Decisions and trade-offs are written up in DEVLOG.md (drop-newest, no-split wrap, drained-buffer reset, `maxMessages` as the user-facing capacity unit, vtable shape, atomics path deferred).

## Test Evidence

Strict TDD throughout — ZOMBIES order. 11 behaviour tests in Phase A (Z, O, M, B, I), 1 storage-contract test in Phase B (`HandleEqualsStorageAddress`), 3 mutex-call-pattern tests in Phase C (`MutexFake` records the `Lock`/`Unlock` sequence), plus 2 `NullMutex` smoke tests, 3 `PosixMutex` smoke tests, 3 `WindowsMutex` smoke tests.

- `build-linux-gcc` (debug preset) — 1035 ran, 4 ignored, 0 failures
- `sanitize-linux-gcc` — 1035 ran, no ASan/UBSan reports
- `build-linux-clang` (clang-debug preset) — 1035 ran, 0 failures
- `coverage-linux-gcc` — 99.5% line, 99.5% function (gate is 90%)
- `analyze-tidy` — clean (one int→size_t widening fixed, one uninitialized variable initialized)
- `analyze-cppcheck` — clean (added `Read()` helpers in TEST_GROUPs so cppcheck sees `readData` / `readSize` use)
- `analyze-format` — clean

Windows mutex (`SolidSyslogWindowsMutex.c` and `Tests/SolidSyslogWindowsMutexTest.cpp`) was not built locally — Linux container has no MSVC. Mirrors `SolidSyslogWindowsAtomicOps` line-for-line; trusting `build-windows-msvc` CI.

## Areas Affected

- **New public headers**: `SolidSyslogCircularBuffer.h`, `SolidSyslogMutex.h`, `SolidSyslogMutexDefinition.h`, `SolidSyslogNullMutex.h`, `SolidSyslogPosixMutex.h`, `SolidSyslogWindowsMutex.h`
- **Audience table** in CLAUDE.md updated with rows for each
- **`.clang-tidy`** has one new entry in the negation list
- **No existing public APIs changed.** `SolidSyslog_Create` and the `SolidSyslogBuffer` interface are unchanged; `CircularBuffer` is purely additive.
- **Out of scope** — wiring this buffer through any example or BDD harness (S13.18, #244); configurable discard policy at this layer; magic-numbers clang-tidy rules (separate discussion captured in memory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Circular buffer implementation for syslog logging with configurable message capacity
  * Thread-safe mutex support with platform-specific implementations (POSIX, Windows, null/no-op)
  * Mutex abstraction interface for flexible synchronization

* **Documentation**
  * Added public API documentation for circular buffer and mutex interfaces

* **Chores**
  * Enhanced code analysis tooling configuration
  * Removed redundant lint suppressions from codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->