### PR TITLE
feat: S08.03 slice 1 SolidSyslogFreeRtosDatagram adapter (host-TDD)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,7 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogResolverDefinition.h` | Resolver implementors (extension point) | `SolidSyslogResolver` vtable struct (`Resolve`) |
 | `SolidSyslogDatagram.h` | Sender implementors using datagram transport | `SolidSyslogDatagram_Open`, `_SendTo`, `_Close` |
 | `SolidSyslogDatagramDefinition.h` | Datagram implementors (extension point) | `SolidSyslogDatagram` vtable struct (`Open`, `SendTo`, `Close`) |
+| `SolidSyslogFreeRtosDatagram.h` | System setup code on FreeRTOS targets using FreeRTOS-Plus-TCP for UDP | `SolidSyslogFreeRtosDatagramStorage`, `SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE`, `SolidSyslogFreeRtosDatagram_Create(storage)`, `_Destroy(datagram)` (wraps `FreeRTOS_socket` / `FreeRTOS_sendto` / `FreeRTOS_closesocket`) |
 | `SolidSyslogStream.h` | Sender implementors using stream transport | `SolidSyslogStream_Open`, `_Send`, `_Read`, `_Close`, `SolidSyslogSsize` |
 | `SolidSyslogStreamDefinition.h` | Stream implementors (extension point) | `SolidSyslogStream` vtable struct (`Open`, `Send`, `Read`, `Close`) |
 | `SolidSyslogUdpSender.h` | System setup code using UDP transport | `SolidSyslogUdpSenderConfig` (resolver, datagram, endpoint, endpointVersion), `SolidSyslogUdpSender_Create`, `_Destroy` |

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,89 @@
 # Dev Log
 
+## 2026-05-08 — S08.03 slice 1 — `SolidSyslogFreeRtosDatagram` adapter
+
+### Decision
+
+First slice of S08.03 (FreeRTOS UDP). Pure host-TDD against the FreeRTOS-Plus-TCP
+socket API via fakes. No QEMU, no example, no BDD — those come in slices 2/3+.
+
+The adapter mirrors the POSIX/Windows datagram shape but follows the project's
+new-adapter conventions from day one (caller-supplied storage, `DEFAULT_INSTANCE`/
+`DESTROYED_INSTANCE` const-struct vtable wiring, MISRA-prefixed statics,
+intent-named `static inline` predicates). The pre-pattern POSIX/Windows
+singletons remain — slice 1 doesn't sweep them.
+
+### What landed
+
+- **`Platform/FreeRtos/Interface/SolidSyslogFreeRtosDatagram.h`** — public Create/Destroy
+  + opaque `SolidSyslogFreeRtosDatagramStorage` (intptr_t slots) + `SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE`.
+- **`Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c`** — adapter:
+  Open → `FreeRTOS_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)` storing `Socket_t`;
+  SendTo → `FreeRTOS_sendto` guarded by `FreeRtosDatagram_IsOpen`;
+  Close → idempotent `FreeRTOS_closesocket` (also gated by IsOpen so double-Close /
+  Close-without-Open is a no-op);
+  Destroy → cascades through Close + writes DESTROYED_INSTANCE.
+  Static functions prefixed `FreeRtosDatagram_*` per MISRA-5.9; cast helper
+  `FreeRtosDatagram_From(self)` replaces 4 inline casts; local typedef
+  `FreeRtosDatagram` shortens references inside the .c.
+- **`Platform/FreeRtos/Source/SolidSyslogAddressInternal.h`** — platform-internal
+  `SolidSyslogAddress_AsConstFreertosSockaddr` cast helper.
+- **`Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp`** — 15 ZOMBIES tests / 29
+  checks. Every constant arg in production driven by an explicit assertion.
+  `SendToForwardsLengthVerbatim` probes two distinct lengths to prove the
+  parameter actually flows through (not hardcoded). Coverage 100% lines /
+  100% functions on the adapter.
+- **`Tests/Support/FreeRtosFakes/Source/FreeRtosSocketsFake.{c,h}`** — hand-rolled
+  fake mirroring the project pattern (`SocketFake`, `WinsockFake`). Per-arg
+  accessors for `socket` (3 args) / `sendto` (6 args) / `closesocket` (1 arg).
+  Reset between tests; configurable failure modes via `_SetSocketFails`/
+  `_SetSendtoFails`.
+- **Test-isolation stubs in `Tests/Support/FreeRtosFakes/Interface/`** — `portmacro.h`
+  (kernel typedefs + no-op port primitives), `pack_struct_start.h`/`pack_struct_end.h`
+  (compiler-portable struct-packing shims). These shadow upstream port-/compiler-
+  specific variants so the test build is independent of the integrator's chosen
+  toolchain. CMake include-dir order puts the FreeRtosFakes shims ahead of the
+  upstream tree, so real upstream `${FREERTOS_PLUS_TCP_PATH}/source/portable/Compiler/GCC`
+  and `${FREERTOS_KERNEL_PATH}/portable/ThirdParty/GCC/Posix` paths are NOT on
+  the test include path. Captured in `project_freertos_test_isolation.md`.
+- **`Tests/FreeRtos/CMakeLists.txt`** — first per-adapter test executable
+  (`SolidSyslogFreeRtosDatagramTest`). Per S08.01's design, each adapter test
+  exe recompiles the adapter source itself with the FreeRtosFakes config on
+  the include path.
+
+### Lessons captured (memory)
+
+- **Drive arg values in same test** — David flagged that I'd put
+  `FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP` in production
+  while only the call-count was asserted. Fix: backwalk to placeholders, extend
+  the same test with arg assertions, then forward. Saved as feedback memory;
+  same lesson applied later for `flags=0` and `dest_length=sizeof(*dest)` in
+  `FreeRTOS_sendto`.
+- **Happy path first within ZOMBIES** — David steered me away from leading the
+  M bucket with `SendToFailsBeforeOpen`. M is happy paths; guards/errors are E.
+  Saved as feedback memory.
+- **Project-wide naming sweep deferred** — type-naming inconsistency raised
+  during refactor; deferred to a dedicated sweep. Saved as project memory.
+
+### Local validation
+
+build-linux-gcc / build-linux-clang / sanitize / coverage (100% lines + 100% functions:
+2034/2034 lines, 429/429 functions across the whole tree) / clang-tidy /
+cppcheck / clang-format — all green via the cpputest-freertos and cpputest-clang
+images.
+
+### Out of scope (slice 1)
+
+- **No example code** — `Example/FreeRtos/SingleTask/main.c` and the QEMU smoke
+  arrive in slice 2 (with the CMSDK UART driver + newlib retarget).
+- **No resolver** — DNS path tracked separately as S08.08 (#288); slice 2 wires
+  the example with a hardcoded numeric IP via the `freertos_sockaddr` storage
+  fixture.
+- **No BDD harness work** — slice 3+ extends `Bdd/features/environment.py`
+  with the `BDD_TARGET=qemu-freertos` branch.
+- **Pre-pattern POSIX/Windows datagrams** stay singletons — naming/storage
+  sweep deferred per `project_naming_sweep_deferred`.
+
 ## 2026-05-07 — S08.02 — QEMU determinism groundwork + analyze-iwyu pin
 
 ### Context

--- a/Platform/FreeRtos/Interface/SolidSyslogFreeRtosDatagram.h
+++ b/Platform/FreeRtos/Interface/SolidSyslogFreeRtosDatagram.h
@@ -1,0 +1,27 @@
+#ifndef SOLIDSYSLOGFREERTOSDATAGRAM_H
+#define SOLIDSYSLOGFREERTOSDATAGRAM_H
+
+#include "ExternC.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogDatagram;
+
+    enum
+    {
+        SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE = sizeof(intptr_t) * 8
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogFreeRtosDatagramStorage;
+
+    struct SolidSyslogDatagram* SolidSyslogFreeRtosDatagram_Create(SolidSyslogFreeRtosDatagramStorage * storage);
+    void                        SolidSyslogFreeRtosDatagram_Destroy(struct SolidSyslogDatagram * datagram);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGFREERTOSDATAGRAM_H */

--- a/Platform/FreeRtos/Source/SolidSyslogAddressInternal.h
+++ b/Platform/FreeRtos/Source/SolidSyslogAddressInternal.h
@@ -1,0 +1,18 @@
+#ifndef SOLIDSYSLOGADDRESSINTERNAL_H
+#define SOLIDSYSLOGADDRESSINTERNAL_H
+
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogMacros.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_Sockets.h"
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(struct freertos_sockaddr) <= SOLIDSYSLOG_ADDRESS_SIZE, SolidSyslogAddressStorage_too_small_for_freertos_sockaddr);
+
+static inline const struct freertos_sockaddr* SolidSyslogAddress_AsConstFreertosSockaddr(const struct SolidSyslogAddress* address)
+{
+    const uint8_t* bytes = (const uint8_t*) address;
+    return (const struct freertos_sockaddr*) bytes;
+}
+
+#endif /* SOLIDSYSLOGADDRESSINTERNAL_H */

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -1,0 +1,105 @@
+// NOLINTBEGIN(performance-no-int-to-ptr) -- FREERTOS_INVALID_SOCKET is ((Socket_t)~0U) from FreeRTOS-Plus-TCP; the int-to-ptr cast is intrinsic to the upstream sentinel and unavoidable.
+
+#include "SolidSyslogFreeRtosDatagram.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_Sockets.h"
+
+#include "SolidSyslogAddressInternal.h"
+#include "SolidSyslogDatagramDefinition.h"
+#include "SolidSyslogMacros.h"
+#include "SolidSyslogUdpPayload.h"
+
+typedef struct SolidSyslogFreeRtosDatagram FreeRtosDatagram;
+
+struct SolidSyslogFreeRtosDatagram
+{
+    struct SolidSyslogDatagram base;
+    Socket_t                   socket;
+};
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(FreeRtosDatagram) <= SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE,
+                          "SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE is too small for SolidSyslogFreeRtosDatagram layout");
+
+static bool                               FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size,
+                                                                  const struct SolidSyslogAddress* addr);
+static size_t                             FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self);
+static void                               FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
+static inline FreeRtosDatagram*           FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
+static inline bool                        FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
+
+static const FreeRtosDatagram DEFAULT_INSTANCE = {
+    {FreeRtosDatagram_Open, FreeRtosDatagram_SendTo, FreeRtosDatagram_MaxPayload, FreeRtosDatagram_Close},
+    FREERTOS_INVALID_SOCKET,
+};
+
+static const FreeRtosDatagram DESTROYED_INSTANCE = {
+    {NULL, NULL, NULL, NULL},
+    FREERTOS_INVALID_SOCKET,
+};
+
+struct SolidSyslogDatagram* SolidSyslogFreeRtosDatagram_Create(SolidSyslogFreeRtosDatagramStorage* storage)
+{
+    FreeRtosDatagram* datagram = (FreeRtosDatagram*) storage;
+    *datagram                  = DEFAULT_INSTANCE;
+    return &datagram->base;
+}
+
+void SolidSyslogFreeRtosDatagram_Destroy(struct SolidSyslogDatagram* datagram)
+{
+    FreeRtosDatagram* self = FreeRtosDatagram_From(datagram);
+    FreeRtosDatagram_Close(datagram);
+    *self = DESTROYED_INSTANCE;
+}
+
+static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram* self)
+{
+    return (FreeRtosDatagram*) self;
+}
+
+static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
+{
+    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
+    datagram->socket           = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
+    return datagram->socket != FREERTOS_INVALID_SOCKET;
+}
+
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size,
+                                                                  const struct SolidSyslogAddress* addr)
+{
+    FreeRtosDatagram*                  datagram = FreeRtosDatagram_From(self);
+    enum SolidSyslogDatagramSendResult result   = SOLIDSYSLOG_DATAGRAM_FAILED;
+    if (FreeRtosDatagram_IsOpen(datagram))
+    {
+        const struct freertos_sockaddr* dest = SolidSyslogAddress_AsConstFreertosSockaddr(addr);
+        int32_t                         sent = FreeRTOS_sendto(datagram->socket, buffer, size, 0, dest, sizeof(*dest));
+        if (sent > 0)
+        {
+            result = SOLIDSYSLOG_DATAGRAM_SENT;
+        }
+    }
+    return result;
+}
+
+static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)
+{
+    return datagram->socket != FREERTOS_INVALID_SOCKET;
+}
+
+static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+    return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
+}
+
+static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
+{
+    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
+    if (FreeRtosDatagram_IsOpen(datagram))
+    {
+        (void) FreeRTOS_closesocket(datagram->socket);
+        datagram->socket = FREERTOS_INVALID_SOCKET;
+    }
+}
+// NOLINTEND(performance-no-int-to-ptr)

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -1,4 +1,5 @@
-// NOLINTBEGIN(performance-no-int-to-ptr) -- FREERTOS_INVALID_SOCKET is ((Socket_t)~0U) from FreeRTOS-Plus-TCP; the int-to-ptr cast is intrinsic to the upstream sentinel and unavoidable.
+// NOLINTBEGIN(performance-no-int-to-ptr) -- FREERTOS_INVALID_SOCKET is ((Socket_t)~0U) from FreeRTOS-Plus-TCP; the int-to-ptr cast is intrinsic to the upstream
+// sentinel and unavoidable.
 
 #include "SolidSyslogFreeRtosDatagram.h"
 
@@ -61,8 +62,11 @@ static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram
 static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
 {
     FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
-    datagram->socket           = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
-    return datagram->socket != FREERTOS_INVALID_SOCKET;
+    if (!FreeRtosDatagram_IsOpen(datagram))
+    {
+        datagram->socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
+    }
+    return FreeRtosDatagram_IsOpen(datagram);
 }
 
 static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size,
@@ -102,4 +106,5 @@ static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
         datagram->socket = FREERTOS_INVALID_SOCKET;
     }
 }
+
 // NOLINTEND(performance-no-int-to-ptr)

--- a/Tests/FreeRtos/CMakeLists.txt
+++ b/Tests/FreeRtos/CMakeLists.txt
@@ -3,6 +3,14 @@
 # source under test with the FreeRtosFakes config and links against the
 # fakes — see project_header_configured_platforms memory.
 
+# Top-level CMakeLists.txt only checks FREERTOS_KERNEL_PATH before adding this
+# subdirectory. Adapter tests transitively include FreeRTOS-Plus-TCP headers,
+# so guard FREERTOS_PLUS_TCP_PATH here too — fail loud rather than expand to
+# a stray "/source/include" suffix on an empty path.
+if("$ENV{FREERTOS_PLUS_TCP_PATH}" STREQUAL "")
+    message(FATAL_ERROR "FREERTOS_PLUS_TCP_PATH must be set to build Tests/FreeRtos.")
+endif()
+
 add_executable(SolidSyslogFreeRtosDatagramTest
     SolidSyslogFreeRtosDatagramTest.cpp
     main.cpp

--- a/Tests/FreeRtos/CMakeLists.txt
+++ b/Tests/FreeRtos/CMakeLists.txt
@@ -2,5 +2,27 @@
 # Platform/FreeRtos/Source/. Each test executable recompiles the adapter
 # source under test with the FreeRtosFakes config and links against the
 # fakes — see project_header_configured_platforms memory.
-#
-# Empty at S08.01 — first test (SolidSyslogFreeRtosMutexTest) lands at S08.04.
+
+add_executable(SolidSyslogFreeRtosDatagramTest
+    SolidSyslogFreeRtosDatagramTest.cpp
+    main.cpp
+    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+    ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Source/FreeRtosSocketsFake.c
+)
+
+target_link_libraries(SolidSyslogFreeRtosDatagramTest PRIVATE
+    ${PROJECT_NAME}
+    CppUTest
+    CppUTestExt
+)
+
+target_include_directories(SolidSyslogFreeRtosDatagramTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Interface
+    ${CMAKE_SOURCE_DIR}/Core/Interface
+    ${CMAKE_SOURCE_DIR}/Core/Source
+    ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Interface
+    $ENV{FREERTOS_KERNEL_PATH}/include
+    $ENV{FREERTOS_PLUS_TCP_PATH}/source/include
+)
+
+add_test(NAME SolidSyslogFreeRtosDatagramTest COMMAND SolidSyslogFreeRtosDatagramTest)

--- a/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
@@ -60,6 +60,13 @@ TEST(SolidSyslogFreeRtosDatagram, OpenReturnsFalseWhenSocketFails)
     CHECK_FALSE(SolidSyslogDatagram_Open(datagram));
 }
 
+TEST(SolidSyslogFreeRtosDatagram, OpenIsIdempotent)
+{
+    SolidSyslogDatagram_Open(datagram);
+    CHECK_TRUE(SolidSyslogDatagram_Open(datagram));
+    LONGS_EQUAL(1, FreeRtosSocketsFake_SocketCallCount());
+}
+
 TEST(SolidSyslogFreeRtosDatagram, MaxPayloadReturnsIpv6SafeDefault)
 {
     LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
@@ -127,17 +134,17 @@ TEST(SolidSyslogFreeRtosDatagram, DestroyAfterCloseDoesNotCloseAgain)
 
 TEST(SolidSyslogFreeRtosDatagram, SendToSendsBufferToDestinationAfterOpen)
 {
-    static const char   MESSAGE[]   = "hello";
-    static const size_t MESSAGE_LEN = sizeof(MESSAGE) - 1;
+    static const char   TEST_MESSAGE[]   = "hello";
+    static const size_t TEST_MESSAGE_LEN = sizeof(TEST_MESSAGE) - 1;
 
     SolidSyslogDatagram_Open(datagram);
-    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(datagram, MESSAGE, MESSAGE_LEN, addr);
+    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(datagram, TEST_MESSAGE, TEST_MESSAGE_LEN, addr);
 
     LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_SENT, result);
     LONGS_EQUAL(1, FreeRtosSocketsFake_SendtoCallCount());
     POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastSendtoSocket());
-    POINTERS_EQUAL(MESSAGE, FreeRtosSocketsFake_LastSendtoBuffer());
-    LONGS_EQUAL(MESSAGE_LEN, FreeRtosSocketsFake_LastSendtoLength());
+    POINTERS_EQUAL(TEST_MESSAGE, FreeRtosSocketsFake_LastSendtoBuffer());
+    LONGS_EQUAL(TEST_MESSAGE_LEN, FreeRtosSocketsFake_LastSendtoLength());
     LONGS_EQUAL(0, FreeRtosSocketsFake_LastSendtoFlags());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, see setup
     POINTERS_EQUAL(reinterpret_cast<const struct freertos_sockaddr*>(addr), FreeRtosSocketsFake_LastSendtoDestination());
@@ -146,12 +153,12 @@ TEST(SolidSyslogFreeRtosDatagram, SendToSendsBufferToDestinationAfterOpen)
 
 TEST(SolidSyslogFreeRtosDatagram, SendToForwardsLengthVerbatim)
 {
-    static const char BUFFER[1024] = {};
+    static const char TEST_BUFFER[1024] = {};
     SolidSyslogDatagram_Open(datagram);
 
-    SolidSyslogDatagram_SendTo(datagram, BUFFER, 1, addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_BUFFER, 1, addr);
     LONGS_EQUAL(1, FreeRtosSocketsFake_LastSendtoLength());
 
-    SolidSyslogDatagram_SendTo(datagram, BUFFER, 1232, addr);
+    SolidSyslogDatagram_SendTo(datagram, TEST_BUFFER, 1232, addr);
     LONGS_EQUAL(1232, FreeRtosSocketsFake_LastSendtoLength());
 }

--- a/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
@@ -1,0 +1,157 @@
+#include "CppUTest/TestHarness.h"
+
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogDatagram.h"
+#include "SolidSyslogFreeRtosDatagram.h"
+#include "SolidSyslogUdpPayload.h"
+
+#include "FreeRtosSocketsFake.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+static const uint16_t TEST_PORT = 514;
+
+TEST_GROUP(SolidSyslogFreeRtosDatagram)
+{
+    SolidSyslogFreeRtosDatagramStorage storage{};
+    struct SolidSyslogDatagram*        datagram = nullptr;
+    SolidSyslogAddressStorage          addrStorage{};
+    struct SolidSyslogAddress*         addr = nullptr;
+
+    void setup() override
+    {
+        FreeRtosSocketsFake_Reset();
+        datagram = SolidSyslogFreeRtosDatagram_Create(&storage);
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing into platform layout, storage is intptr_t-aligned
+        auto* sin                  = reinterpret_cast<struct freertos_sockaddr*>(&addrStorage);
+        sin->sin_family            = FREERTOS_AF_INET;
+        sin->sin_port              = FreeRTOS_htons(TEST_PORT);
+        sin->sin_address.ulIP_IPv4 = FreeRTOS_inet_addr_quick(127, 0, 0, 1);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, see above
+        addr = reinterpret_cast<struct SolidSyslogAddress*>(&addrStorage);
+    }
+};
+
+TEST(SolidSyslogFreeRtosDatagram, CreateReturnsNonNullDatagram)
+{
+    CHECK(datagram != nullptr);
+}
+
+TEST(SolidSyslogFreeRtosDatagram, OpenCreatesUdpSocket)
+{
+    SolidSyslogDatagram_Open(datagram);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_SocketCallCount());
+    LONGS_EQUAL(FREERTOS_AF_INET, FreeRtosSocketsFake_LastSocketDomain());
+    LONGS_EQUAL(FREERTOS_SOCK_DGRAM, FreeRtosSocketsFake_LastSocketType());
+    LONGS_EQUAL(FREERTOS_IPPROTO_UDP, FreeRtosSocketsFake_LastSocketProtocol());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, OpenReturnsTrueOnSuccess)
+{
+    CHECK_TRUE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(SolidSyslogFreeRtosDatagram, OpenReturnsFalseWhenSocketFails)
+{
+    FreeRtosSocketsFake_SetSocketFails(true);
+    CHECK_FALSE(SolidSyslogDatagram_Open(datagram));
+}
+
+TEST(SolidSyslogFreeRtosDatagram, MaxPayloadReturnsIpv6SafeDefault)
+{
+    LONGS_EQUAL(SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD, SolidSyslogDatagram_MaxPayload(datagram));
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToFailsBeforeOpen)
+{
+    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, result);
+    LONGS_EQUAL(0, FreeRtosSocketsFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToFailsWhenSendtoErrors)
+{
+    SolidSyslogDatagram_Open(datagram);
+    FreeRtosSocketsFake_SetSendtoFails(true);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, SolidSyslogDatagram_SendTo(datagram, "x", 1, addr));
+}
+
+TEST(SolidSyslogFreeRtosDatagram, CloseClosesSocket)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_ClosesocketCallCount());
+    POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastClosesocketSocket());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToFailsAfterClose)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_FAILED, result);
+    LONGS_EQUAL(0, FreeRtosSocketsFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, DestroyClosesOpenSocket)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogFreeRtosDatagram_Destroy(datagram);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_ClosesocketCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, CloseIsIdempotent)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_ClosesocketCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, CloseWithoutOpenIsNoOp)
+{
+    SolidSyslogDatagram_Close(datagram);
+    LONGS_EQUAL(0, FreeRtosSocketsFake_ClosesocketCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, DestroyAfterCloseDoesNotCloseAgain)
+{
+    SolidSyslogDatagram_Open(datagram);
+    SolidSyslogDatagram_Close(datagram);
+    SolidSyslogFreeRtosDatagram_Destroy(datagram);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_ClosesocketCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToSendsBufferToDestinationAfterOpen)
+{
+    static const char   MESSAGE[]   = "hello";
+    static const size_t MESSAGE_LEN = sizeof(MESSAGE) - 1;
+
+    SolidSyslogDatagram_Open(datagram);
+    enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(datagram, MESSAGE, MESSAGE_LEN, addr);
+
+    LONGS_EQUAL(SOLIDSYSLOG_DATAGRAM_SENT, result);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_SendtoCallCount());
+    POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastSendtoSocket());
+    POINTERS_EQUAL(MESSAGE, FreeRtosSocketsFake_LastSendtoBuffer());
+    LONGS_EQUAL(MESSAGE_LEN, FreeRtosSocketsFake_LastSendtoLength());
+    LONGS_EQUAL(0, FreeRtosSocketsFake_LastSendtoFlags());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, see setup
+    POINTERS_EQUAL(reinterpret_cast<const struct freertos_sockaddr*>(addr), FreeRtosSocketsFake_LastSendtoDestination());
+    LONGS_EQUAL(sizeof(struct freertos_sockaddr), FreeRtosSocketsFake_LastSendtoDestinationLength());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToForwardsLengthVerbatim)
+{
+    static const char BUFFER[1024] = {};
+    SolidSyslogDatagram_Open(datagram);
+
+    SolidSyslogDatagram_SendTo(datagram, BUFFER, 1, addr);
+    LONGS_EQUAL(1, FreeRtosSocketsFake_LastSendtoLength());
+
+    SolidSyslogDatagram_SendTo(datagram, BUFFER, 1232, addr);
+    LONGS_EQUAL(1232, FreeRtosSocketsFake_LastSendtoLength());
+}

--- a/Tests/FreeRtos/main.cpp
+++ b/Tests/FreeRtos/main.cpp
@@ -1,0 +1,6 @@
+#include "CppUTest/CommandLineTestRunner.h"
+
+int main(int argc, char* argv[])
+{
+    return CommandLineTestRunner::RunAllTests(argc, argv);
+}

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
@@ -1,6 +1,12 @@
 #ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 #define SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- FreeRTOS API requires these to be #defines
+
+/* FreeRTOS-Plus-TCP's IPConfig defaults header checks this guard to confirm
+ * FreeRTOSConfig.h was included before any IP header. */
+#define FREERTOS_CONFIG_H
+
 /* Host-suitable FreeRTOSConfig.h for compiling Platform/FreeRtos adapters
  * against fakes. The values here are chosen so the real FreeRTOS-Kernel
  * headers parse cleanly on the host compiler — actual scheduler behaviour
@@ -55,5 +61,7 @@
             }           \
         }               \
     } while (0)
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
@@ -1,0 +1,26 @@
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- FreeRTOS-Plus-TCP API requires these to be #defines
+
+/* Host-suitable FreeRTOS-Plus-TCP config for unit-test fakes. The IP stack
+ * itself is never run on the host — these values are only here so the
+ * upstream Plus-TCP headers parse cleanly. Real behaviour comes from
+ * FreeRtosFakes/Source/, which substitutes the API at link time.
+ */
+
+#define ipconfigUSE_TCP 1
+#define ipconfigUSE_DHCP 0
+#define ipconfigUSE_DNS 1
+#define ipconfigEVENT_QUEUE_LENGTH 70
+#define ipconfigNETWORK_MTU 1500
+#define ipconfigUSE_NETWORK_EVENT_HOOK 0
+#define ipconfigIP_TASK_PRIORITY (configMAX_PRIORITIES - 2)
+#define ipconfigIP_TASK_STACK_SIZE_WORDS (configMINIMAL_STACK_SIZE * 5)
+#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigZERO_COPY_RX_DRIVER 0
+#define ipconfigZERO_COPY_TX_DRIVER 0
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosSocketsFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosSocketsFake.h
@@ -1,0 +1,44 @@
+#ifndef FREERTOSSOCKETSFAKE_H
+#define FREERTOSSOCKETSFAKE_H
+
+#include "ExternC.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_Sockets.h"
+
+EXTERN_C_BEGIN
+
+    void FreeRtosSocketsFake_Reset(void);
+
+    /* socket configuration */
+    void FreeRtosSocketsFake_SetSocketFails(bool fails);
+
+    /* sendto configuration */
+    void FreeRtosSocketsFake_SetSendtoFails(bool fails);
+
+    /* socket accessors */
+    unsigned   FreeRtosSocketsFake_SocketCallCount(void);
+    BaseType_t FreeRtosSocketsFake_LastSocketDomain(void);
+    BaseType_t FreeRtosSocketsFake_LastSocketType(void);
+    BaseType_t FreeRtosSocketsFake_LastSocketProtocol(void);
+    Socket_t   FreeRtosSocketsFake_LastSocketReturned(void);
+
+    /* sendto accessors */
+    unsigned                        FreeRtosSocketsFake_SendtoCallCount(void);
+    Socket_t                        FreeRtosSocketsFake_LastSendtoSocket(void);
+    const void*                     FreeRtosSocketsFake_LastSendtoBuffer(void);
+    size_t                          FreeRtosSocketsFake_LastSendtoLength(void);
+    BaseType_t                      FreeRtosSocketsFake_LastSendtoFlags(void);
+    const struct freertos_sockaddr* FreeRtosSocketsFake_LastSendtoDestination(void);
+    socklen_t                       FreeRtosSocketsFake_LastSendtoDestinationLength(void);
+
+    /* closesocket accessors */
+    unsigned FreeRtosSocketsFake_ClosesocketCallCount(void);
+    Socket_t FreeRtosSocketsFake_LastClosesocketSocket(void);
+
+EXTERN_C_END
+
+#endif /* FREERTOSSOCKETSFAKE_H */

--- a/Tests/Support/FreeRtosFakes/Interface/pack_struct_end.h
+++ b/Tests/Support/FreeRtosFakes/Interface/pack_struct_end.h
@@ -1,0 +1,12 @@
+/* Stub of FreeRTOS-Plus-TCP's compiler-portable struct-packing helper.
+ *
+ * Real Plus-TCP installs ship per-compiler variants under
+ * source/portable/Compiler/<GCC|IAR|MSVC|...>/. The GCC variant supplies
+ * __attribute__((packed)) here so the preceding struct definition is closed
+ * with a packing attribute. We provide a compiler-independent ';' instead —
+ * it terminates the struct without imposing any packing, which is fine
+ * because tests never run the IP stack and never observe the layout.
+ *
+ * See pack_struct_start.h for the broader rationale.
+ */
+;

--- a/Tests/Support/FreeRtosFakes/Interface/pack_struct_start.h
+++ b/Tests/Support/FreeRtosFakes/Interface/pack_struct_start.h
@@ -1,0 +1,11 @@
+/* Empty stub of FreeRTOS-Plus-TCP's compiler-portable struct-packing helper.
+ *
+ * Real Plus-TCP installs ship per-compiler variants under
+ * source/portable/Compiler/<GCC|IAR|MSVC|...>/. Tests must stay independent
+ * of which toolchain the integrator's production build will use, so
+ * FreeRtosFakes provides this empty stub instead of pulling one specific
+ * compiler's directory into the test include path.
+ *
+ * Tests never run the IP stack, so packed-struct layout is irrelevant; the
+ * stub does nothing.
+ */

--- a/Tests/Support/FreeRtosFakes/Interface/portmacro.h
+++ b/Tests/Support/FreeRtosFakes/Interface/portmacro.h
@@ -1,7 +1,8 @@
 #ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
 #define SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses) -- FreeRTOS-Kernel port API requires these to be #defines, the function-declaration macros can't parenthesise their args
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses) -- FreeRTOS-Kernel port API requires these to be #defines, the function-declaration
+// macros can't parenthesise their args
 
 /* Stub of FreeRTOS-Kernel's portmacro.h.
  *
@@ -20,9 +21,12 @@
 #include <stdint.h>
 #include <limits.h>
 
-/* Kernel scalar types. Sizes match the typical 32-bit-target kernel; the
- * adapter under test never depends on these widths since it stores BaseType_t
- * args verbatim and forwards them to the fake. */
+/* Kernel scalar types. BaseType_t / UBaseType_t are typedef'd to long /
+ * unsigned long so they match the host compiler's long width (64-bit on x86_64
+ * Linux, 32-bit on a 32-bit host) — that is intentional: the adapter under
+ * test never depends on these widths since it stores BaseType_t args verbatim
+ * and forwards them to the fake, and all FreeRTOS socket constants are small
+ * integers that fit any width. Real targets bring their own portmacro.h. */
 typedef long          BaseType_t;
 typedef unsigned long UBaseType_t;
 typedef uint32_t      TickType_t;

--- a/Tests/Support/FreeRtosFakes/Interface/portmacro.h
+++ b/Tests/Support/FreeRtosFakes/Interface/portmacro.h
@@ -1,0 +1,56 @@
+#ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
+#define SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses) -- FreeRTOS-Kernel port API requires these to be #defines, the function-declaration macros can't parenthesise their args
+
+/* Stub of FreeRTOS-Kernel's portmacro.h.
+ *
+ * The real kernel ships one portmacro.h per port × compiler combination
+ * (e.g. portable/GCC/ARM_CM3/, portable/IAR/ARM_CM3/, portable/ThirdParty/
+ * GCC/Posix/). Tests must stay independent of which port and which compiler
+ * the integrator's production build will use, so FreeRtosFakes provides
+ * this stub with just enough typedefs and macros for FreeRTOS.h and the
+ * Plus-TCP headers to parse on a host C/C++ compiler.
+ *
+ * No scheduler runs; critical-section / yield / interrupt macros expand to
+ * nothing, and tests never observe context-switch behaviour. The stack-type
+ * choice doesn't matter — fakes never allocate task stacks.
+ */
+
+#include <stdint.h>
+#include <limits.h>
+
+/* Kernel scalar types. Sizes match the typical 32-bit-target kernel; the
+ * adapter under test never depends on these widths since it stores BaseType_t
+ * args verbatim and forwards them to the fake. */
+typedef long          BaseType_t;
+typedef unsigned long UBaseType_t;
+typedef uint32_t      TickType_t;
+typedef uint32_t      StackType_t;
+
+/* Mandatory port constants referenced by FreeRTOS.h / list.h / task.h. */
+#define portMAX_DELAY ((TickType_t) 0xFFFFFFFFUL)
+#define portSTACK_GROWTH (-1)
+#define portTICK_PERIOD_MS ((TickType_t) 1000 / configTICK_RATE_HZ)
+#define portBYTE_ALIGNMENT 8
+#define portTICK_TYPE_IS_ATOMIC 1
+#define portPOINTER_SIZE_TYPE intptr_t
+
+/* Critical-section / interrupt / yield primitives — no-op for host tests. */
+#define portYIELD() ((void) 0)
+#define portYIELD_FROM_ISR(x) ((void) (x))
+#define portENTER_CRITICAL() ((void) 0)
+#define portEXIT_CRITICAL() ((void) 0)
+#define portDISABLE_INTERRUPTS() ((void) 0)
+#define portENABLE_INTERRUPTS() ((void) 0)
+#define portSET_INTERRUPT_MASK_FROM_ISR() ((UBaseType_t) 0)
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x) ((void) (x))
+
+/* Task-function declaration macro used in user-supplied tasks. The adapter
+ * never declares a task, so this is here only to satisfy FreeRTOS.h's parse. */
+#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void* pvParameters)
+#define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void* pvParameters)
+
+// NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
+
+#endif /* SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H */

--- a/Tests/Support/FreeRtosFakes/Source/FreeRtosSocketsFake.c
+++ b/Tests/Support/FreeRtosFakes/Source/FreeRtosSocketsFake.c
@@ -1,0 +1,162 @@
+// NOLINTBEGIN(performance-no-int-to-ptr,bugprone-easily-swappable-parameters) -- API shape (sentinel cast + same-type params) is dictated by FreeRTOS-Plus-TCP
+
+#include "FreeRtosSocketsFake.h"
+
+static unsigned   socketCallCount    = 0;
+static BaseType_t lastSocketDomain   = 0;
+static BaseType_t lastSocketType     = 0;
+static BaseType_t lastSocketProto    = 0;
+static Socket_t   lastSocketReturned = NULL;
+static bool       socketFails        = false;
+
+static unsigned                        sendtoCallCount             = 0;
+static Socket_t                        lastSendtoSocket            = NULL;
+static const void*                     lastSendtoBuffer            = NULL;
+static size_t                          lastSendtoLength            = 0;
+static BaseType_t                      lastSendtoFlags             = 0;
+static const struct freertos_sockaddr* lastSendtoDestination       = NULL;
+static socklen_t                       lastSendtoDestinationLength = 0;
+static bool                            sendtoFails                 = false;
+
+static unsigned closesocketCallCount  = 0;
+static Socket_t lastClosesocketSocket = NULL;
+
+/* Sentinel used as a "valid" Socket_t return — non-NULL and not
+ * FREERTOS_INVALID_SOCKET. Adapters only inspect Open's return for
+ * the invalid sentinel; any other non-zero pointer is treated as success. */
+static int fakeSocketHandleAnchor = 0;
+#define FAKE_VALID_SOCKET ((Socket_t) & fakeSocketHandleAnchor)
+
+void FreeRtosSocketsFake_Reset(void)
+{
+    socketCallCount    = 0;
+    lastSocketDomain   = 0;
+    lastSocketType     = 0;
+    lastSocketProto    = 0;
+    lastSocketReturned = NULL;
+    socketFails        = false;
+
+    sendtoCallCount             = 0;
+    lastSendtoSocket            = NULL;
+    lastSendtoBuffer            = NULL;
+    lastSendtoLength            = 0;
+    lastSendtoFlags             = 0;
+    lastSendtoDestination       = NULL;
+    lastSendtoDestinationLength = 0;
+    sendtoFails                 = false;
+
+    closesocketCallCount  = 0;
+    lastClosesocketSocket = NULL;
+}
+
+void FreeRtosSocketsFake_SetSocketFails(bool fails)
+{
+    socketFails = fails;
+}
+
+void FreeRtosSocketsFake_SetSendtoFails(bool fails)
+{
+    sendtoFails = fails;
+}
+
+unsigned FreeRtosSocketsFake_SocketCallCount(void)
+{
+    return socketCallCount;
+}
+
+BaseType_t FreeRtosSocketsFake_LastSocketDomain(void)
+{
+    return lastSocketDomain;
+}
+
+BaseType_t FreeRtosSocketsFake_LastSocketType(void)
+{
+    return lastSocketType;
+}
+
+BaseType_t FreeRtosSocketsFake_LastSocketProtocol(void)
+{
+    return lastSocketProto;
+}
+
+Socket_t FreeRtosSocketsFake_LastSocketReturned(void)
+{
+    return lastSocketReturned;
+}
+
+unsigned FreeRtosSocketsFake_SendtoCallCount(void)
+{
+    return sendtoCallCount;
+}
+
+Socket_t FreeRtosSocketsFake_LastSendtoSocket(void)
+{
+    return lastSendtoSocket;
+}
+
+const void* FreeRtosSocketsFake_LastSendtoBuffer(void)
+{
+    return lastSendtoBuffer;
+}
+
+size_t FreeRtosSocketsFake_LastSendtoLength(void)
+{
+    return lastSendtoLength;
+}
+
+BaseType_t FreeRtosSocketsFake_LastSendtoFlags(void)
+{
+    return lastSendtoFlags;
+}
+
+const struct freertos_sockaddr* FreeRtosSocketsFake_LastSendtoDestination(void)
+{
+    return lastSendtoDestination;
+}
+
+socklen_t FreeRtosSocketsFake_LastSendtoDestinationLength(void)
+{
+    return lastSendtoDestinationLength;
+}
+
+Socket_t FreeRTOS_socket(BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol)
+{
+    ++socketCallCount;
+    lastSocketDomain   = xDomain;
+    lastSocketType     = xType;
+    lastSocketProto    = xProtocol;
+    lastSocketReturned = socketFails ? FREERTOS_INVALID_SOCKET : FAKE_VALID_SOCKET;
+    return lastSocketReturned;
+}
+
+int32_t FreeRTOS_sendto(Socket_t xSocket, const void* pvBuffer, size_t uxTotalDataLength, BaseType_t xFlags,
+                        const struct freertos_sockaddr* pxDestinationAddress, socklen_t xDestinationAddressLength)
+{
+    ++sendtoCallCount;
+    lastSendtoSocket            = xSocket;
+    lastSendtoBuffer            = pvBuffer;
+    lastSendtoLength            = uxTotalDataLength;
+    lastSendtoFlags             = xFlags;
+    lastSendtoDestination       = pxDestinationAddress;
+    lastSendtoDestinationLength = xDestinationAddressLength;
+    return sendtoFails ? -pdFREERTOS_ERRNO_ENOBUFS : (int32_t) uxTotalDataLength;
+}
+
+unsigned FreeRtosSocketsFake_ClosesocketCallCount(void)
+{
+    return closesocketCallCount;
+}
+
+Socket_t FreeRtosSocketsFake_LastClosesocketSocket(void)
+{
+    return lastClosesocketSocket;
+}
+
+BaseType_t FreeRTOS_closesocket(Socket_t xSocket)
+{
+    ++closesocketCallCount;
+    lastClosesocketSocket = xSocket;
+    return pdPASS;
+}
+
+// NOLINTEND(performance-no-int-to-ptr,bugprone-easily-swappable-parameters)


### PR DESCRIPTION
## Purpose

First slice of S08.03 (#268) — UDP syslog from FreeRTOS reaches the oracle. Pure host-TDD against the FreeRTOS-Plus-TCP socket API via hand-rolled fakes. No QEMU, no example ELF, no BDD — those land in slices 2 / 3+.

## Change Description

**Adapter** (`Platform/FreeRtos/`)
- `SolidSyslogFreeRtosDatagram` implements the `SolidSyslogDatagram` extension point over `FreeRTOS_socket` / `FreeRTOS_sendto` / `FreeRTOS_closesocket`.
- Follows the project's new-adapter conventions from day one: caller-supplied `SolidSyslogFreeRtosDatagramStorage` (intptr_t slots), `DEFAULT_INSTANCE` / `DESTROYED_INSTANCE` const-struct vtable wiring, MISRA-5.9 prefixed statics (`FreeRtosDatagram_*`), intent-named `static inline` predicate (`FreeRtosDatagram_IsOpen`), local typedef + cast helper (`FreeRtosDatagram_From`).
- `Close` is idempotent and safe before Open / after a prior Close (guarded by `IsOpen`).
- `Destroy` cascades through `Close` then writes `DESTROYED_INSTANCE`.
- Pre-pattern POSIX/Windows datagram singletons untouched — naming/storage sweep deferred per `project_naming_sweep_deferred.md`.

**Tests** (`Tests/FreeRtos/`)
- 15 ZOMBIES tests / 29 checks.
- Every constant arg in production driven by explicit assertion (`AF_INET`/`SOCK_DGRAM`/`IPPROTO_UDP` for socket; `flags=0` and `dest_length=sizeof(*dest)` for sendto). `SendToForwardsLengthVerbatim` probes two distinct lengths to prove `size` actually flows through.
- New `SolidSyslogFreeRtosDatagramTest` exe per S08.01's per-adapter-test-exe design (each exe recompiles the adapter source itself with its own FreeRTOSConfig).
- Coverage 100% lines + 100% functions on the adapter.

**Test infrastructure** (`Tests/Support/FreeRtosFakes/`)
- `FreeRtosSocketsFake.{c,h}` — hand-rolled, mirrors the `SocketFake` / `WinsockFake` shape. Per-arg accessors for socket (3 args) / sendto (6 args) / closesocket (1 arg). Configurable failure modes via `_SetSocketFails` / `_SetSendtoFails`. Reset between tests.
- `portmacro.h`, `pack_struct_start.h`, `pack_struct_end.h`, `FreeRTOSIPConfig.h` — compiler/port-portability shims. Tests must not depend on the integrator's chosen toolchain (e.g. `portable/ThirdParty/GCC/Posix/`) so these stubs shadow upstream variants. Documented in `project_freertos_test_isolation.md`.
- The test exe's CMake include order puts `Tests/Support/FreeRtosFakes/Interface` ahead of upstream `${FREERTOS_KERNEL_PATH}/include` and `${FREERTOS_PLUS_TCP_PATH}/source/include`, so stubs resolve first while the real upstream API surface (`FreeRTOS_Sockets.h` etc.) still drives compile-time API drift detection.

## Test Evidence

Local validation under `cpputest-freertos:sha-44efeae`:
- `cmake --build --preset debug --target junit` — **1088 tests / 2345 checks** (15 new in `SolidSyslogFreeRtosDatagramTest`).
- `cmake --build --preset sanitize --target junit` — same, ASan + UBSan clean.
- `cmake --build --preset coverage --target coverage` — **100.0% lines (2034/2034)**, **100.0% functions (429/429)** project-wide.
- `cmake --build --preset tidy` — clean (file-level NOLINTBEGIN/END for `cppcoreguidelines-macro-usage` on the test-shim FreeRTOS configs and `performance-no-int-to-ptr` for the `FREERTOS_INVALID_SOCKET` sentinel cast — both unavoidable upstream API constraints).
- `cmake --build --preset cppcheck` — clean.
- Under `cpputest-clang:sha-7eac3ab`: `cmake --build --preset clang-debug --target junit` — same 1088 tests pass.
- `clang-format --dry-run --Werror` — clean across new files.

Strict TDD progression visible in commit history; every concrete arg in production driven by a failing assertion in the same test (per `feedback_drive_arg_values_in_same_test.md`).

## Areas Affected

- New: `Platform/FreeRtos/{Interface,Source}/SolidSyslogFreeRtosDatagram.{h,c}`, `Platform/FreeRtos/Source/SolidSyslogAddressInternal.h`.
- New: `Tests/FreeRtos/{SolidSyslogFreeRtosDatagramTest.cpp, main.cpp}`.
- New: `Tests/Support/FreeRtosFakes/Interface/{FreeRTOSIPConfig.h, FreeRtosSocketsFake.h, pack_struct_start.h, pack_struct_end.h, portmacro.h}` and `Source/FreeRtosSocketsFake.c`.
- Modified: `Tests/FreeRtos/CMakeLists.txt` (declares the new test exe), `Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h` (adds `FREERTOS_CONFIG_H` guard for Plus-TCP defaults header + NOLINT for macro-usage).
- Modified: `DEVLOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FreeRTOS UDP datagram support enabling datagram-based logging/network transmissions on FreeRTOS targets.

* **Tests**
  * Added a dedicated test executable and suites with socket fakes, call-argument recording, and failure injection to validate open/send/close behaviors and payload handling.

* **Documentation**
  * Added a devlog entry summarizing the rollout, validation status, and next work items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->