### PR TITLE
feat: S08.03 slice 3a FreeRTOS static address resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,7 @@ live under `Core/Interface/`; platform-specific helpers (the `SolidSyslogPosix*`
 | `SolidSyslogTransport.h` | Any code selecting a transport or needing default port constants | `SolidSyslogTransport` enum (`UDP`, `TCP`), `SOLIDSYSLOG_UDP_DEFAULT_PORT`, `SOLIDSYSLOG_TCP_DEFAULT_PORT` |
 | `SolidSyslogResolver.h` | Any code that needs to resolve a destination | `SolidSyslogResolver_Resolve(resolver, transport, host, port, *out)` |
 | `SolidSyslogResolverDefinition.h` | Resolver implementors (extension point) | `SolidSyslogResolver` vtable struct (`Resolve`) |
+| `SolidSyslogFreeRtosStaticResolver.h` | System setup code on FreeRTOS targets pinned to a hardcoded IPv4 destination (no DNS) | `SolidSyslogFreeRtosStaticResolverStorage`, `SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE`, `SolidSyslogFreeRtosStaticResolver_Create(storage, ipv4Octets)`, `_Destroy(resolver)` (ignores host and transport at Resolve time; port is taken from each call) |
 | `SolidSyslogDatagram.h` | Sender implementors using datagram transport | `SolidSyslogDatagram_Open`, `_SendTo`, `_Close` |
 | `SolidSyslogDatagramDefinition.h` | Datagram implementors (extension point) | `SolidSyslogDatagram` vtable struct (`Open`, `SendTo`, `Close`) |
 | `SolidSyslogFreeRtosDatagram.h` | System setup code on FreeRTOS targets using FreeRTOS-Plus-TCP for UDP | `SolidSyslogFreeRtosDatagramStorage`, `SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE`, `SolidSyslogFreeRtosDatagram_Create(storage)`, `_Destroy(datagram)` (wraps `FreeRTOS_socket` / `FreeRTOS_sendto` / `FreeRTOS_closesocket`) |

--- a/Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h
+++ b/Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h
@@ -1,0 +1,27 @@
+#ifndef SOLIDSYSLOGFREERTOSSTATICRESOLVER_H
+#define SOLIDSYSLOGFREERTOSSTATICRESOLVER_H
+
+#include "ExternC.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogResolver;
+
+    enum
+    {
+        SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE = sizeof(intptr_t) * 4
+    };
+
+    typedef struct
+    {
+        intptr_t slots[(SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE + sizeof(intptr_t) - 1) / sizeof(intptr_t)];
+    } SolidSyslogFreeRtosStaticResolverStorage;
+
+    struct SolidSyslogResolver* SolidSyslogFreeRtosStaticResolver_Create(SolidSyslogFreeRtosStaticResolverStorage * storage, const uint8_t ipv4Octets[4]);
+    void                        SolidSyslogFreeRtosStaticResolver_Destroy(struct SolidSyslogResolver * resolver);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGFREERTOSSTATICRESOLVER_H */

--- a/Platform/FreeRtos/Source/SolidSyslogAddressInternal.h
+++ b/Platform/FreeRtos/Source/SolidSyslogAddressInternal.h
@@ -15,4 +15,10 @@ static inline const struct freertos_sockaddr* SolidSyslogAddress_AsConstFreertos
     return (const struct freertos_sockaddr*) bytes;
 }
 
+static inline struct freertos_sockaddr* SolidSyslogAddress_AsFreertosSockaddr(struct SolidSyslogAddress* address)
+{
+    uint8_t* bytes = (uint8_t*) address;
+    return (struct freertos_sockaddr*) bytes;
+}
+
 #endif /* SOLIDSYSLOGADDRESSINTERNAL_H */

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
@@ -8,8 +8,6 @@
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogResolverDefinition.h"
 
-#include <string.h>
-
 typedef struct SolidSyslogFreeRtosStaticResolver FreeRtosStaticResolver;
 
 struct SolidSyslogFreeRtosStaticResolver
@@ -39,7 +37,10 @@ struct SolidSyslogResolver* SolidSyslogFreeRtosStaticResolver_Create(SolidSyslog
 {
     FreeRtosStaticResolver* self = (FreeRtosStaticResolver*) storage;
     *self                        = DEFAULT_INSTANCE;
-    memcpy(self->octets, ipv4Octets, sizeof(self->octets));
+    self->octets[0]              = ipv4Octets[0];
+    self->octets[1]              = ipv4Octets[1];
+    self->octets[2]              = ipv4Octets[2];
+    self->octets[3]              = ipv4Octets[3];
     return &self->base;
 }
 

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
@@ -1,0 +1,68 @@
+#include "SolidSyslogFreeRtosStaticResolver.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+#include "SolidSyslogAddressInternal.h"
+#include "SolidSyslogMacros.h"
+#include "SolidSyslogResolverDefinition.h"
+
+#include <string.h>
+
+typedef struct SolidSyslogFreeRtosStaticResolver FreeRtosStaticResolver;
+
+struct SolidSyslogFreeRtosStaticResolver
+{
+    struct SolidSyslogResolver base;
+    uint8_t                    octets[4];
+};
+
+SOLIDSYSLOG_STATIC_ASSERT(sizeof(FreeRtosStaticResolver) <= SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE,
+                          "SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE is too small for SolidSyslogFreeRtosStaticResolver layout");
+
+static bool FreeRtosStaticResolver_Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                           struct SolidSyslogAddress* result);
+static inline FreeRtosStaticResolver* FreeRtosStaticResolver_From(struct SolidSyslogResolver* self);
+
+static const FreeRtosStaticResolver DEFAULT_INSTANCE = {
+    {FreeRtosStaticResolver_Resolve},
+    {0, 0, 0, 0},
+};
+
+static const FreeRtosStaticResolver DESTROYED_INSTANCE = {
+    {NULL},
+    {0, 0, 0, 0},
+};
+
+struct SolidSyslogResolver* SolidSyslogFreeRtosStaticResolver_Create(SolidSyslogFreeRtosStaticResolverStorage* storage, const uint8_t ipv4Octets[4])
+{
+    FreeRtosStaticResolver* self = (FreeRtosStaticResolver*) storage;
+    *self                        = DEFAULT_INSTANCE;
+    memcpy(self->octets, ipv4Octets, sizeof(self->octets));
+    return &self->base;
+}
+
+void SolidSyslogFreeRtosStaticResolver_Destroy(struct SolidSyslogResolver* resolver)
+{
+    FreeRtosStaticResolver* self = FreeRtosStaticResolver_From(resolver);
+    *self                        = DESTROYED_INSTANCE;
+}
+
+static inline FreeRtosStaticResolver* FreeRtosStaticResolver_From(struct SolidSyslogResolver* self)
+{
+    return (FreeRtosStaticResolver*) self;
+}
+
+static bool FreeRtosStaticResolver_Resolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                                           struct SolidSyslogAddress* result)
+{
+    (void) transport;
+    (void) host;
+    FreeRtosStaticResolver*   me       = FreeRtosStaticResolver_From(self);
+    struct freertos_sockaddr* sockaddr = SolidSyslogAddress_AsFreertosSockaddr(result);
+    sockaddr->sin_family               = FREERTOS_AF_INET;
+    sockaddr->sin_port                 = (uint16_t) FreeRTOS_htons(port);
+    sockaddr->sin_address.ulIP_IPv4    = FreeRTOS_inet_addr_quick(me->octets[0], me->octets[1], me->octets[2], me->octets[3]);
+    return true;
+}

--- a/Tests/FreeRtos/CMakeLists.txt
+++ b/Tests/FreeRtos/CMakeLists.txt
@@ -34,6 +34,29 @@ else()
     )
 
     add_test(NAME SolidSyslogFreeRtosDatagramTest COMMAND SolidSyslogFreeRtosDatagramTest)
+
+    add_executable(SolidSyslogFreeRtosStaticResolverTest
+        SolidSyslogFreeRtosStaticResolverTest.cpp
+        main.cpp
+        ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
+    )
+
+    target_link_libraries(SolidSyslogFreeRtosStaticResolverTest PRIVATE
+        ${PROJECT_NAME}
+        CppUTest
+        CppUTestExt
+    )
+
+    target_include_directories(SolidSyslogFreeRtosStaticResolverTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Interface
+        ${CMAKE_SOURCE_DIR}/Core/Interface
+        ${CMAKE_SOURCE_DIR}/Core/Source
+        ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Interface
+        $ENV{FREERTOS_KERNEL_PATH}/include
+        $ENV{FREERTOS_PLUS_TCP_PATH}/source/include
+    )
+
+    add_test(NAME SolidSyslogFreeRtosStaticResolverTest COMMAND SolidSyslogFreeRtosStaticResolverTest)
 endif()
 
 # CMSDK UART driver host tests — recompiles the driver source from the

--- a/Tests/FreeRtos/SolidSyslogFreeRtosStaticResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosStaticResolverTest.cpp
@@ -1,0 +1,121 @@
+#include "CppUTest/TestHarness.h"
+
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogFreeRtosStaticResolver.h"
+#include "SolidSyslogResolver.h"
+#include "SolidSyslogTransport.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+static const uint8_t  TEST_OCTETS[4]      = {10, 0, 2, 2};
+static const uint16_t TEST_PORT           = 514;
+static const uint16_t TEST_ALTERNATE_PORT = 9999;
+static const char*    IGNORED_HOST        = "ignored.example.com";
+
+// clang-format off
+TEST_GROUP(SolidSyslogFreeRtosStaticResolver)
+{
+    SolidSyslogFreeRtosStaticResolverStorage storage{};
+    struct SolidSyslogResolver*              resolver = nullptr;
+    SolidSyslogAddressStorage                addrStorage{};
+    struct SolidSyslogAddress*               addr = nullptr;
+
+    void setup() override
+    {
+        resolver = SolidSyslogFreeRtosStaticResolver_Create(&storage, TEST_OCTETS);
+        addr     = SolidSyslogAddress_FromStorage(&addrStorage);
+    }
+
+    bool Resolve(const char* host = IGNORED_HOST, uint16_t port = TEST_PORT, enum SolidSyslogTransport transport = SOLIDSYSLOG_TRANSPORT_UDP)
+    {
+        return SolidSyslogResolver_Resolve(resolver, transport, host, port, addr);
+    }
+
+    void RecreateResolverWith(const uint8_t octets[4])
+    {
+        resolver = SolidSyslogFreeRtosStaticResolver_Create(&storage, octets);
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- used through accessor syntax in tests
+    const struct freertos_sockaddr* Result() const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, storage is intptr_t-aligned
+        return reinterpret_cast<const struct freertos_sockaddr*>(&addrStorage);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogFreeRtosStaticResolver, CreateReturnsNonNullResolver)
+{
+    CHECK(resolver != nullptr);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveReturnsTrue)
+{
+    CHECK_TRUE(Resolve());
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveSetsSinFamilyToFreeRtosAfInet)
+{
+    Resolve();
+    LONGS_EQUAL(FREERTOS_AF_INET, Result()->sin_family);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveWritesIpv4FromCreateOctets)
+{
+    Resolve();
+    LONGS_EQUAL(FreeRTOS_inet_addr_quick(10, 0, 2, 2), Result()->sin_address.ulIP_IPv4);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveWritesPortFromArgInNetworkOrder)
+{
+    Resolve(IGNORED_HOST, TEST_ALTERNATE_PORT);
+    LONGS_EQUAL(FreeRTOS_htons(TEST_ALTERNATE_PORT), Result()->sin_port);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveProducesSameIpv4ForAnyHostString)
+{
+    Resolve("first.host");
+    uint32_t firstIpv4 = Result()->sin_address.ulIP_IPv4;
+
+    addrStorage = {};
+    Resolve("totally.different.second.host");
+
+    LONGS_EQUAL(firstIpv4, Result()->sin_address.ulIP_IPv4);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveProducesSameIpv4ForUdpAndTcpTransport)
+{
+    Resolve(IGNORED_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_UDP);
+    uint32_t udpIpv4 = Result()->sin_address.ulIP_IPv4;
+
+    addrStorage = {};
+    Resolve(IGNORED_HOST, TEST_PORT, SOLIDSYSLOG_TRANSPORT_TCP);
+
+    LONGS_EQUAL(udpIpv4, Result()->sin_address.ulIP_IPv4);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveWritesAllZeroOctets)
+{
+    static const uint8_t ZERO_OCTETS[4] = {0, 0, 0, 0};
+    RecreateResolverWith(ZERO_OCTETS);
+    Resolve();
+    LONGS_EQUAL(FreeRTOS_inet_addr_quick(0, 0, 0, 0), Result()->sin_address.ulIP_IPv4);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, ResolveWritesAllOnesOctets)
+{
+    static const uint8_t MAX_OCTETS[4] = {255, 255, 255, 255};
+    RecreateResolverWith(MAX_OCTETS);
+    Resolve();
+    LONGS_EQUAL(FreeRTOS_inet_addr_quick(255, 255, 255, 255), Result()->sin_address.ulIP_IPv4);
+}
+
+TEST(SolidSyslogFreeRtosStaticResolver, DestroyIsIdempotent)
+{
+    SolidSyslogFreeRtosStaticResolver_Destroy(resolver);
+    SolidSyslogFreeRtosStaticResolver_Destroy(resolver);
+}


### PR DESCRIPTION
## Purpose

Slice 3a of S08.03 (#268). Adds a hardcoded-IPv4 resolver implementation under `Platform/FreeRtos/` so slice 3b's UDP smoke can target a numeric destination without needing DNS or `getaddrinfo`. Slice 3b is the first and currently only consumer; if/when the FreeRTOS port grows a DNS resolver, this stays as the explicit "no DNS" choice.

Closes #292.

## Change Description

- New public header `Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h` and implementation `Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c`. Mirrors the shape of slice 1's `SolidSyslogFreeRtosDatagram`: caller-supplied storage (`intptr_t slots`, `SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE` enum), `DEFAULT_INSTANCE` / `DESTROYED_INSTANCE` constants, no `malloc`.
- API: `_Create(storage, ipv4Octets[4])` configures the destination at construction. Port arrives per-call via the `SolidSyslogResolver_Resolve(transport, host, port, result)` vtable signature — same as `SolidSyslogGetAddrInfoResolver`. Resolve ignores `transport` and `host`, returns true unconditionally (no failure mode without DNS).
- Octets are stored as raw `uint8_t[4]` and emitted via `FreeRTOS_inet_addr_quick(o[0], o[1], o[2], o[3])` at Resolve time. No string parsing → no banned-API surface.
- Adds the read-write `SolidSyslogAddress_AsFreertosSockaddr` accessor to `Platform/FreeRtos/Source/SolidSyslogAddressInternal.h` (mirrors the existing const variant; needed because the resolver writes into the address rather than just reads from it).
- Per-platform-only (Option A from design discussion): no Posix/Windows static-resolver variants, no cross-platform `Address_SetIpv4` extension. Adopters on other platforms either use the existing `GetAddrInfoResolver` or supply their own resolver pattern from upstream project code.

## Test Evidence

Host-TDD'd in `Tests/FreeRtos/SolidSyslogFreeRtosStaticResolverTest.cpp` against the existing `FreeRtosFakes`. Gated on `FREERTOS_PLUS_TCP_PATH` like the slice-1 datagram test. 10 tests, ZOMBIES coverage:

- `CreateReturnsNonNullResolver` — construction
- `ResolveReturnsTrue` — vtable wired
- `ResolveSetsSinFamilyToFreeRtosAfInet`
- `ResolveWritesIpv4FromCreateOctets`
- `ResolveWritesPortFromArgInNetworkOrder` (drives port via `TEST_ALTERNATE_PORT = 9999` to prevent hardcoded values passing)
- `ResolveProducesSameIpv4ForAnyHostString` — regression lock
- `ResolveProducesSameIpv4ForUdpAndTcpTransport` — regression lock
- `ResolveWritesAllZeroOctets` — boundary
- `ResolveWritesAllOnesOctets` — boundary
- `DestroyIsIdempotent` — destroy survives double-call

Each test was driven Red→Green (compile-fail or runtime-fail first, then production minimum to pass). The DEFAULT/DESTROYED_INSTANCE refactor was applied under green after all tests passed, matching slice 1's idiom.

Validated locally:
- `debug` preset: full `ctest` (5 test executables) — 100% pass.
- `sanitize` preset: ASan + UBSan, full `ctest` — 100% pass, no findings.
- `clang-format --dry-run --Werror` on all changed files — clean.
- `clang-debug` preset in the clang container: full `ctest` (excludes FreeRtos targets without `FREERTOS_PLUS_TCP_PATH`) — passes; no regressions in the rest of the codebase.

Skipped locally (changes are scoped to `Platform/FreeRtos/` and `Tests/FreeRtos/`, no Core/Posix/Windows/OpenSsl impact): `coverage`, `tidy`, `cppcheck`. The `iwyu` preset's container (`cpputest-clang`) does not have `FREERTOS_PLUS_TCP_PATH` either locally or in CI, so slice 3a's specific files are silently outside its scope; manual include audit verified each include in the new `.c` is necessary and used.

## Areas Affected

- `Platform/FreeRtos/Interface/` — one new header.
- `Platform/FreeRtos/Source/` — one new source, one modified header (`SolidSyslogAddressInternal.h` adds the non-const sockaddr accessor).
- `Tests/FreeRtos/` — new test executable + CMakeLists wiring (gated on `FREERTOS_PLUS_TCP_PATH`).
- `CLAUDE.md` — new row in the public-header table.

No changes to `Core/`, `Platform/Posix/`, `Platform/Windows/`, `Platform/OpenSsl/`, `Example/`, `Bdd/`, or CI workflows.
