### PR TITLE
feat: S08.03 slice 3b.1 FreeRTOS-Plus-TCP bring-up + UDP smoke

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -26,6 +26,278 @@ QEMU smoke check: HelloWorld still builds clean under the
 `freertos-cross` preset and prints its banner over `-serial stdio`. No
 new tests — the relocation is invisible at runtime.
 
+## 2026-05-09 — S08.03 slice 3b.1 — FreeRTOS-Plus-TCP bring-up + UDP smoke (#295)
+
+### Decision
+
+Stand FreeRTOS-Plus-TCP up on the QEMU `mps2-an385` (Cortex-M3) target and
+prove that a UDP datagram from the guest reaches a host listener via slirp.
+No SolidSyslog adapter is involved at this stage — the goal is to isolate
+"the IP stack initialises and packets escape the guest" from "the slice-1
+datagram adapter wiring works". Slice 3b.2 will swap the smoke task's body
+for a `SolidSyslogConfig` + `SolidSyslogUdpSender` wiring that drives the
+slice-1 `SolidSyslogFreeRtosDatagram` adapter through the slice-3a
+`SolidSyslogFreeRtosStaticResolver`. The directory and CMake wiring stay.
+
+### No host TDD for this slice — explicitly
+
+Functional smoke is the test. The only logic this slice authors is the
+single `eNetworkUp && !smokeTaskCreated` guard inside the network event
+hook — everything else is config, build wiring, or call-into-Plus-TCP-API.
+Growing `Tests/Support/FreeRtosFakes/` with `xTaskCreate` /
+`FreeRTOS_socket` / `FreeRTOS_sendto` / `FreeRTOS_closesocket` /
+`FreeRTOS_OutputARPRequest` shims to cover one boolean would have cost ~80
+lines of fake plumbing for one assertion, and the fakes have no second
+customer (slice 3b.2 calls into the slice-1-host-TDD'd
+`SolidSyslogFreeRtosDatagram` via `SolidSyslogUdpSender`, not the raw API).
+The persistent abstractions on the FreeRTOS path
+(`SolidSyslogFreeRtosDatagram`, `SolidSyslogFreeRtosStaticResolver`) are
+already host-TDD'd. The smoke task in this slice is throwaway scaffolding
+that 3b.2 deletes. TDD discipline reasserts at slice 3b.2 if any new logic
+appears beyond glue.
+
+### NVIC priority gap in upstream NetworkInterface.c — real issue
+
+Upstream `Plus-TCP/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c`
+enables IRQ 13 (the SMSC9220/LAN9118) via `nwNVIC_ISER` but never writes
+the corresponding IPR byte. The Cortex-M3 NVIC reset-default is priority 0,
+which is numerically *more urgent* than `configMAX_SYSCALL_INTERRUPT_PRIORITY`
+(5 << 5). The ISR's first FreeRTOS API call from
+`vTaskNotifyGiveFromISR` would trip the
+`portASSERT_IF_INTERRUPT_PRIORITY_INVALID` check on a debug build (or
+silently corrupt internal kernel state on a release build). We set the
+IPR byte to 0xE0 (priority 7) ourselves in `main()` before
+`FreeRTOS_IPInit_Multi` triggers the interface init that flips ISER. This
+is upstream's bug, not ours; worth filing if not already known.
+
+### Slirp address decisions
+
+Static IPv4 wiring (`10.0.2.15` / `255.255.255.0` / gateway `10.0.2.2` /
+DNS `10.0.2.3`) chosen to match QEMU slirp's defaults so DHCP can stay
+disabled and the smoke can run without a DHCP server. The smoke task
+sends to `10.0.2.2:5514` — the slirp gateway IP — because slirp routes
+guest→gateway UDP traffic to the host's loopback. Confirmed by pcap
+(`-object filter-dump,id=f1,netdev=net0,...`): the host listener received
+`b'ping'` from `('127.0.0.1', <ephemeral>)`, with the corresponding guest
+emission visible as `IP proto=17 10.0.2.15 -> 10.0.2.2 len=46`.
+
+`-netdev user,id=net0 -net nic,netdev=net0,model=lan9118` is the canonical
+form that lights up the LAN9118 in QEMU's `mps2-an385` machine — the board
+exposes the SMSC9220 IP unconditionally, so no extra hostfwd or board
+options are required for the guest→host direction.
+
+### ARP-resolves-late dropped the first packet
+
+First QEMU smoke run: UART printed "network up", pcap showed only the ARP
+exchange (guest broadcast for 10.0.2.2, slirp reply with `52:55:0a:00:02:02`),
+no UDP. Plus-TCP's `FreeRTOS_sendto` on an unresolved destination triggers
+ARP and **drops the original payload** while resolution is in flight. Two
+fixes considered:
+
+1. Retry sendto N times with delays between attempts. Conflates "ARP not
+   warm yet" with "actually exercising the TX path" — and David flagged
+   it as the wrong fix.
+2. Pre-resolve via `FreeRTOS_OutputARPRequest`, short delay, single
+   sendto. Cleaner — exactly one user-visible datagram.
+
+Took option 2. Saved a project memory
+(`project_freertos_arp_first_packet.md`) so the same gotcha is surfaced
+when slice 3b.2 wires `SolidSyslogUdpSender` and again at the
+reconfiguration story (S04 equivalent for FreeRTOS) — any reconfig path
+on FreeRTOS will silently lose the first user log line under the same
+mechanism unless the sender path either pre-resolves on endpoint-version
+transitions, buffers-and-retries on `pdFAIL`, or primes ARP via
+`SolidSyslogEndpointVersionFunction`.
+
+### Heap and config sizing — one round of empirical iteration
+
+`configTOTAL_HEAP_SIZE` raised from HelloWorld's 32 KiB to 96 KiB
+(empirical — fits the IP task stack, the EMAC RX task stack, the timer
+task stack, ARP cache, 8 network-buffer descriptors, and the smoke task
+with margin). `configMAX_PRIORITIES` raised from 5 to 7 to satisfy
+`ipconfigIP_TASK_PRIORITY = configMAX_PRIORITIES - 2` and the EMAC RX
+task's `configMAX_PRIORITIES - 3`. `configUSE_TIMERS = 1` because the IP
+stack relies on FreeRTOS software timers for ARP age-out / DHCP retries
+(disabled in the IP config but the kernel-side timer task is still
+referenced by stack initialisation). `configUSE_RECURSIVE_MUTEXES = 1`
+because Plus-TCP uses `xSemaphoreCreateRecursiveMutex`.
+
+### What landed
+
+- **`Example/FreeRtos/SingleTask/CMakeLists.txt`** — Plus-TCP source list
+  (UDP-only — TCP files compile but are dead-code-eliminated by
+  `--gc-sections` since `ipconfigUSE_TCP=0`), `BufferAllocation_2.c`, the
+  MPS2_AN385 `NetworkInterface.c` + `smsc9220_eth_drv.c`, plus the
+  kernel sources HelloWorld already pulls in extended with `timers.c`
+  and `event_groups.c`. The strict-conversion / strict-shadow warnings
+  are silenced for this example only — the upstream sources don't meet
+  the host bar and we don't want to lower it everywhere.
+- **`Example/FreeRtos/SingleTask/Startup.c`** — Cortex-M3 startup with
+  the vector table extended through IRQ 31. IRQ 13 routes to
+  `EthernetISR` (declared `weak alias("Default_Handler")` so the strong
+  symbol from upstream `NetworkInterface.c` wins at link). Common's
+  `startup.c` is intentionally NOT included — having two `vector_table`
+  in the link would clash. The extra IRQ entries cost 64 bytes of FLASH
+  and aren't worth backporting to Common until a second consumer needs
+  them.
+- **`Example/FreeRtos/SingleTask/FreeRTOSConfig.h`** — kernel config
+  delta documented above.
+- **`Example/FreeRtos/SingleTask/FreeRTOSIPConfig.h`** — UDP-only IPv4-only
+  Plus-TCP config: `ipconfigUSE_TCP=0`, `ipconfigUSE_DHCP=0`,
+  `ipconfigUSE_DNS=0`, `ipconfigUSE_RA=0`, `ipconfigUSE_IPv6=0`,
+  `ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS=8`,
+  `ipconfigUSE_NETWORK_EVENT_HOOK=1`.
+- **`Example/FreeRtos/SingleTask/main.c`** — `pxMPS2_FillInterfaceDescriptor`
+  + `FreeRTOS_FillEndPoint` + `FreeRTOS_IPInit_Multi`. The
+  `vApplicationIPNetworkEventHook_Multi` spawns the one-shot smoke task
+  on first link-up; the smoke task pre-resolves ARP, sends `"ping"` to
+  `10.0.2.2:5514`, closes the socket, and self-deletes.
+  `xApplicationGetRandomNumber` and `ulApplicationGetNextSequenceNumber`
+  return tick-derived values — adequate for a smoke test, not adequate
+  for production (no entropy on QEMU mps2-an385). Slice 3b.2 keeps the
+  same shims; a real RNG arrives with the integration story.
+- **`Example/FreeRtos/CMakeLists.txt`** — `add_subdirectory(SingleTask)`.
+
+Common/ stays untouched.
+
+### Smoke validation
+
+Inside the devcontainer:
+
+```text
+$ qemu-system-arm -M mps2-an385 -m 16M -display none -serial stdio \
+    -netdev user,id=net0 -net nic,netdev=net0,model=lan9118 \
+    -object filter-dump,id=f1,netdev=net0,file=/tmp/qemu.pcap \
+    -kernel build/freertos-cross/Example/FreeRtos/SingleTask/SolidSyslogFreeRtosSingleTask.elf
+network up
+
+$ python3 -c "<bind 0.0.0.0:5514, recvfrom>"
+GOT b'ping' FROM ('127.0.0.1', 51998)
+
+$ <pcap parse>
+ARP len=42                                        # guest -> broadcast for 10.0.2.2
+ARP len=64                                        # slirp reply, MAC 52:55:0a:00:02:02
+IP proto=17 10.0.2.15 -> 10.0.2.2 len=46          # the UDP datagram
+```
+
+`nc -ul 5514` would have been the expected verifier per the issue but
+this devcontainer ships no `nc` / `ncat` / `socat`; a 7-line Python UDP
+listener was substituted (followup: add netcat to the
+cpputest-freertos-cross image). Pre-PR checks not run locally:
+`build-windows-msvc`, BDD, OpenSSL integration, `analyze-tidy` etc. — CI
+will run them.
+
+---
+
+## 2026-05-08 — S08.03 slice 3a — FreeRTOS static address resolver (#292/#293)
+
+### Decision
+
+Sliced the static resolver out of S08.03 slice 3 ahead of the FreeRTOS-Plus-TCP
+bring-up. Slice 3b's review surface was already large (Plus-TCP CMake wiring,
+LAN9118 driver + NVIC priority, slirp visibility, FreeRTOSIPConfig.h delta);
+the resolver is independently host-TDD'able with no FreeRTOS runtime
+dependencies, so it lands first to shrink slice 3b's PR footprint.
+
+### Resolver shape — per-platform only, no cross-platform abstraction
+
+Considered Option B (extend the public `SolidSyslogAddress` API with a
+`SetIpv4` fill function so a single Core resolver could populate any platform's
+sockaddr layout). Rejected in favour of Option A: a FreeRTOS-only resolver
+under `Platform/FreeRtos/`, no Posix/Windows variants, no `Address` extension.
+Reasoning: SolidSyslog adopters on FreeRTOS are predominantly integrating into
+existing projects that already have a resolver pattern they want to keep;
+shipping a cross-platform static resolver would push library scope where
+adopters don't need it. Posix/Windows already have working `GetAddrInfo`
+resolvers; Core stays minimal.
+
+### API
+
+```c
+struct SolidSyslogResolver* SolidSyslogFreeRtosStaticResolver_Create(
+    SolidSyslogFreeRtosStaticResolverStorage* storage,
+    const uint8_t                             ipv4Octets[4]);
+void SolidSyslogFreeRtosStaticResolver_Destroy(struct SolidSyslogResolver*);
+```
+
+Octets at Create — no string parsing, no banned-API surface, no allocator. Port
+arrives per-call via the existing `SolidSyslogResolver_Resolve(transport, host,
+port, result)` vtable (same shape as `SolidSyslogGetAddrInfoResolver`). Resolve
+ignores `transport` and `host` and returns true unconditionally — no failure
+mode without DNS. Storage-injection mirrors slice 1's `SolidSyslogFreeRtosDatagram`
+exactly: `intptr_t slots[…]`, `_SIZE` enum, `DEFAULT_INSTANCE`/`DESTROYED_INSTANCE`
+constants. Destroy clears the vtable to NULL — defensive against post-destroy
+use-after-free.
+
+Slice 3b's main.c will configure with `{10, 0, 2, 2}` to target QEMU slirp's
+host gateway. DNS resolver for FreeRTOS deferred to S08.08 (#288).
+
+### Test sequence — strict TDD, ZOMBIES coverage
+
+10 tests, each driven Red→Green→Refactor:
+
+1. `CreateReturnsNonNullResolver`
+2. `ResolveReturnsTrue` — drives vtable wiring (Red 2 was a clean SIGSEGV from
+   NULL vtable dispatch through `SolidSyslogResolver_Resolve`)
+3. `ResolveSetsSinFamilyToFreeRtosAfInet` — drives the non-const
+   `SolidSyslogAddress_AsFreertosSockaddr` accessor (slice 1 only had the const
+   variant; we needed write access)
+4. `ResolveWritesIpv4FromCreateOctets` — drives octet storage at Create + write
+   via `FreeRTOS_inet_addr_quick`
+5. `ResolveWritesPortFromArgInNetworkOrder` — uses `TEST_ALTERNATE_PORT = 9999`
+   to prevent a hardcoded `htons(514)` passing the test trivially (per
+   `feedback_drive_arg_values_in_same_test.md`)
+6. `ResolveProducesSameIpv4ForAnyHostString` — regression lock
+7. `ResolveProducesSameIpv4ForUdpAndTcpTransport` — regression lock
+8. `ResolveWritesAllZeroOctets` — boundary
+9. `ResolveWritesAllOnesOctets` — boundary
+10. `DestroyIsIdempotent`
+
+Refactor pass under green introduced `DEFAULT_INSTANCE`/`DESTROYED_INSTANCE`
+per project convention; David later flagged a `memcpy(self->octets,
+ipv4Octets, sizeof(self->octets))` for 4 fixed bytes — replaced with four
+explicit assignments. memcpy in production stays scoped to genuine variable-length
+record copies (`SolidSyslogCircularBuffer`, `RecordStore`).
+
+### What landed
+
+- **`Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h`** —
+  public header, opaque storage typedef, `_SIZE` enum.
+- **`Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c`** —
+  implementation: vtable wiring in Create, defensive null-vtable in Destroy,
+  Resolve writes `sin_family`, `sin_port` (via `FreeRTOS_htons`), and
+  `sin_address.ulIP_IPv4` (via `FreeRTOS_inet_addr_quick`).
+- **`Platform/FreeRtos/Source/SolidSyslogAddressInternal.h`** — added
+  `_AsFreertosSockaddr` (non-const) helper.
+- **`Tests/FreeRtos/SolidSyslogFreeRtosStaticResolverTest.cpp`** — 10 tests
+  via `FreeRtosFakes`, gated on `FREERTOS_PLUS_TCP_PATH` like the slice-1
+  datagram test.
+- **`Tests/FreeRtos/CMakeLists.txt`** — new test executable + include dirs.
+- **`CLAUDE.md`** — public-header table row.
+
+### Branch hygiene lesson
+
+I created the slice-3a branch from the local
+`feat/s08-03-slice2-cmsdk-uart` tip rather than from `origin/main`, so the
+branch carried 5 stale pre-squash slice-2 WIP commits that conflicted with
+slice 2's squash-merged form on main. Caught at PR-time when CI couldn't
+build; resolved by `git rebase --onto origin/main 17a2332` to drop the stale
+commits, then `git push --force-with-lease`. Going forward: always
+`git checkout main && git pull --ff-only` before `git checkout -b <new-slice>`.
+
+### Validation
+
+`debug` preset full ctest (5 executables) green; `sanitize` preset (ASan +
+UBSan) clean; `clang-format --dry-run --Werror` clean on changed files;
+`clang-debug` preset green for unchanged code in the clang container.
+Coverage / tidy / cppcheck / IWYU skipped locally — all changes scoped to
+`Platform/FreeRtos/` and `Tests/FreeRtos/`, those presets check unchanged
+code (per David's correction during the session). CI's iwyu container has
+no `FREERTOS_PLUS_TCP_PATH` either, so slice 3a's source is silently outside
+its scope; manual include audit was the substitute.
+
+---
+
 ## 2026-05-08 — S08.03 slice 2 — CMSDK UART + newlib retargeting (#290)
 
 ### Decision

--- a/Example/FreeRtos/CMakeLists.txt
+++ b/Example/FreeRtos/CMakeLists.txt
@@ -9,3 +9,4 @@
 set(SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Common)
 
 add_subdirectory(HelloWorld)
+add_subdirectory(SingleTask)

--- a/Example/FreeRtos/SingleTask/CMakeLists.txt
+++ b/Example/FreeRtos/SingleTask/CMakeLists.txt
@@ -1,0 +1,137 @@
+# FreeRTOS-Plus-TCP single-task UDP smoke ELF for QEMU mps2-an385 (Cortex-M3).
+#
+# Compiled cross-only — gated by the top-level CMakeLists.txt on
+# CMAKE_CROSSCOMPILING + CMAKE_SYSTEM_PROCESSOR == "arm".
+#
+# Slice 3b.1 of S08.03 stands the IP stack up and emits a single UDP
+# datagram on link-up. Slice 3b.2 swaps main.c's body for SolidSyslog wiring;
+# the directory + CMakeLists stay.
+
+set(FREERTOS_KERNEL_PATH "$ENV{FREERTOS_KERNEL_PATH}")
+if(NOT FREERTOS_KERNEL_PATH)
+    message(FATAL_ERROR
+        "FREERTOS_KERNEL_PATH not set. Use the cpputest-freertos-cross "
+        "container, which sets this to /opt/freertos/kernel.")
+endif()
+
+set(FREERTOS_PLUS_TCP_PATH "$ENV{FREERTOS_PLUS_TCP_PATH}")
+if(NOT FREERTOS_PLUS_TCP_PATH)
+    message(FATAL_ERROR
+        "FREERTOS_PLUS_TCP_PATH not set. Use the cpputest-freertos-cross "
+        "container, which sets this to /opt/freertos/plus-tcp.")
+endif()
+
+set(FREERTOS_PORT_DIR "${FREERTOS_KERNEL_PATH}/portable/GCC/ARM_CM3")
+
+set(PLUS_TCP_SRC_DIR "${FREERTOS_PLUS_TCP_PATH}/source")
+set(PLUS_TCP_PORT_GCC_DIR "${PLUS_TCP_SRC_DIR}/portable/Compiler/GCC")
+set(PLUS_TCP_BUF_DIR "${PLUS_TCP_SRC_DIR}/portable/BufferManagement")
+set(PLUS_TCP_NIF_DIR "${PLUS_TCP_SRC_DIR}/portable/NetworkInterface/MPS2_AN385")
+
+add_executable(SolidSyslogFreeRtosSingleTask
+    main.c
+    Startup.c
+    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/CmsdkUart.c
+    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/Syscalls.c
+    ${FREERTOS_KERNEL_PATH}/tasks.c
+    ${FREERTOS_KERNEL_PATH}/queue.c
+    ${FREERTOS_KERNEL_PATH}/list.c
+    ${FREERTOS_KERNEL_PATH}/timers.c
+    ${FREERTOS_KERNEL_PATH}/event_groups.c
+    ${FREERTOS_PORT_DIR}/port.c
+    ${FREERTOS_KERNEL_PATH}/portable/MemMang/heap_4.c
+    # Plus-TCP core (UDP-only — see FreeRTOSIPConfig.h).
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_ARP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_BitConfig.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DHCP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DHCPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DNS.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DNS_Cache.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DNS_Callback.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DNS_Networking.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_DNS_Parser.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_ICMP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IP_Timers.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IP_Utils.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv4_Sockets.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv4_Utils.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv6_Sockets.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_IPv6_Utils.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_ND.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_RA.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_Routing.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_Sockets.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_Stream_Buffer.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_IP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_IP_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_IP_IPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Reception.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_State_Handling.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_State_Handling_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_State_Handling_IPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Transmission.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Transmission_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Transmission_IPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Utils.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Utils_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_Utils_IPv6.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_TCP_WIN.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_Tiny_TCP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_UDP_IP.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_UDP_IPv4.c
+    ${PLUS_TCP_SRC_DIR}/FreeRTOS_UDP_IPv6.c
+    ${PLUS_TCP_BUF_DIR}/BufferAllocation_2.c
+    # MPS2_AN385 LAN9118 NetworkInterface + driver.
+    ${PLUS_TCP_NIF_DIR}/NetworkInterface.c
+    ${PLUS_TCP_NIF_DIR}/ether_lan9118/smsc9220_eth_drv.c
+)
+
+set_target_properties(SolidSyslogFreeRtosSingleTask PROPERTIES SUFFIX ".elf")
+
+target_compile_options(SolidSyslogFreeRtosSingleTask PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -ffunction-sections
+    -fdata-sections
+    -fno-common
+    # FreeRTOS-Kernel + Plus-TCP V11.1.0/V4.2.2 use non-prototype function
+    # declarations and type-narrowing constructs that trip our strict host
+    # warnings; relax for the upstream sources without lowering the bar
+    # everywhere. The Plus-TCP MPS2 driver also uses memcpy with possible
+    # null pointers (false positives under -Wnonnull) and unused parameters.
+    -Wno-unused-parameter
+    -Wno-unused-but-set-variable
+    -Wno-implicit-fallthrough
+    -Wno-array-bounds
+    -Wno-conversion
+    -Wno-sign-conversion
+    -Wno-shadow
+    -Wno-pedantic
+)
+
+target_include_directories(SolidSyslogFreeRtosSingleTask PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h, FreeRTOSIPConfig.h
+    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}       # CmsdkUart.h
+    ${FREERTOS_KERNEL_PATH}/include
+    ${FREERTOS_PORT_DIR}                              # portmacro.h
+    ${PLUS_TCP_SRC_DIR}/include
+    ${PLUS_TCP_PORT_GCC_DIR}                          # pack_struct_*.h
+    ${PLUS_TCP_NIF_DIR}                               # NetworkInterface.h consumed locally
+    ${PLUS_TCP_NIF_DIR}/ether_lan9118                 # SMM_MPS2.h, smsc9220_*.h
+)
+
+target_link_options(SolidSyslogFreeRtosSingleTask PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -T${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/mps2-an385.ld
+    --specs=nano.specs
+    --specs=nosys.specs
+    -Wl,--gc-sections
+    -Wl,-Map=$<TARGET_FILE:SolidSyslogFreeRtosSingleTask>.map
+)
+
+set_target_properties(SolidSyslogFreeRtosSingleTask PROPERTIES
+    LINK_DEPENDS ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/mps2-an385.ld)

--- a/Example/FreeRtos/SingleTask/CMakeLists.txt
+++ b/Example/FreeRtos/SingleTask/CMakeLists.txt
@@ -6,6 +6,13 @@
 # Slice 3b.1 of S08.03 stands the IP stack up and emits a single UDP
 # datagram on link-up. Slice 3b.2 swaps main.c's body for SolidSyslog wiring;
 # the directory + CMakeLists stay.
+#
+# Source layout: upstream FreeRTOS-Kernel + Plus-TCP sources are compiled
+# into a separate OBJECT library (`solid_syslog_freertos_upstream`) that
+# accepts the relaxed warning set those headers / sources require. Local
+# project code (main.c, Startup.c, Common/CmsdkUart.c, Common/Syscalls.c)
+# stays in the executable target under the strict project warning bar so
+# regressions in our own code can't slip through.
 
 set(FREERTOS_KERNEL_PATH "$ENV{FREERTOS_KERNEL_PATH}")
 if(NOT FREERTOS_KERNEL_PATH)
@@ -28,11 +35,13 @@ set(PLUS_TCP_PORT_GCC_DIR "${PLUS_TCP_SRC_DIR}/portable/Compiler/GCC")
 set(PLUS_TCP_BUF_DIR "${PLUS_TCP_SRC_DIR}/portable/BufferManagement")
 set(PLUS_TCP_NIF_DIR "${PLUS_TCP_SRC_DIR}/portable/NetworkInterface/MPS2_AN385")
 
-add_executable(SolidSyslogFreeRtosSingleTask
-    main.c
-    Startup.c
-    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/CmsdkUart.c
-    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/Syscalls.c
+# --- Upstream OBJECT library --------------------------------------------------
+#
+# Compiles all kernel + Plus-TCP + LAN9118 driver sources with the relaxed
+# warning set. Marked PRIVATE on this library; the executable consumes the
+# objects via $<TARGET_OBJECTS:...> so the relaxations don't leak.
+
+add_library(solid_syslog_freertos_upstream OBJECT
     ${FREERTOS_KERNEL_PATH}/tasks.c
     ${FREERTOS_KERNEL_PATH}/queue.c
     ${FREERTOS_KERNEL_PATH}/list.c
@@ -89,19 +98,16 @@ add_executable(SolidSyslogFreeRtosSingleTask
     ${PLUS_TCP_NIF_DIR}/ether_lan9118/smsc9220_eth_drv.c
 )
 
-set_target_properties(SolidSyslogFreeRtosSingleTask PROPERTIES SUFFIX ".elf")
-
-target_compile_options(SolidSyslogFreeRtosSingleTask PRIVATE
+target_compile_options(solid_syslog_freertos_upstream PRIVATE
     -mcpu=cortex-m3
     -mthumb
     -ffunction-sections
     -fdata-sections
     -fno-common
     # FreeRTOS-Kernel + Plus-TCP V11.1.0/V4.2.2 use non-prototype function
-    # declarations and type-narrowing constructs that trip our strict host
-    # warnings; relax for the upstream sources without lowering the bar
-    # everywhere. The Plus-TCP MPS2 driver also uses memcpy with possible
-    # null pointers (false positives under -Wnonnull) and unused parameters.
+    # declarations, type-narrowing constructs, sign-conversion patterns, and
+    # shadowed locals that trip our strict host warnings. Scoped to this
+    # OBJECT library so the relaxations never reach project code.
     -Wno-unused-parameter
     -Wno-unused-but-set-variable
     -Wno-implicit-fallthrough
@@ -112,6 +118,40 @@ target_compile_options(SolidSyslogFreeRtosSingleTask PRIVATE
     -Wno-pedantic
 )
 
+target_include_directories(solid_syslog_freertos_upstream PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h, FreeRTOSIPConfig.h
+    ${FREERTOS_KERNEL_PATH}/include
+    ${FREERTOS_PORT_DIR}                              # portmacro.h
+    ${PLUS_TCP_SRC_DIR}/include
+    ${PLUS_TCP_PORT_GCC_DIR}                          # pack_struct_*.h
+    ${PLUS_TCP_NIF_DIR}                               # NetworkInterface.h consumed locally
+    ${PLUS_TCP_NIF_DIR}/ether_lan9118                 # SMM_MPS2.h, smsc9220_*.h
+)
+
+# --- Executable ---------------------------------------------------------------
+#
+# Project code only. Inherits the full project warning set
+# (-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Werror)
+# from the top-level CMakeLists.txt — no -Wno-* relaxations here.
+
+add_executable(SolidSyslogFreeRtosSingleTask
+    main.c
+    Startup.c
+    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/CmsdkUart.c
+    ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}/Syscalls.c
+    $<TARGET_OBJECTS:solid_syslog_freertos_upstream>
+)
+
+set_target_properties(SolidSyslogFreeRtosSingleTask PROPERTIES SUFFIX ".elf")
+
+target_compile_options(SolidSyslogFreeRtosSingleTask PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -ffunction-sections
+    -fdata-sections
+    -fno-common
+)
+
 target_include_directories(SolidSyslogFreeRtosSingleTask PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h, FreeRTOSIPConfig.h
     ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}       # CmsdkUart.h
@@ -119,8 +159,6 @@ target_include_directories(SolidSyslogFreeRtosSingleTask PRIVATE
     ${FREERTOS_PORT_DIR}                              # portmacro.h
     ${PLUS_TCP_SRC_DIR}/include
     ${PLUS_TCP_PORT_GCC_DIR}                          # pack_struct_*.h
-    ${PLUS_TCP_NIF_DIR}                               # NetworkInterface.h consumed locally
-    ${PLUS_TCP_NIF_DIR}/ether_lan9118                 # SMM_MPS2.h, smsc9220_*.h
 )
 
 target_link_options(SolidSyslogFreeRtosSingleTask PRIVATE

--- a/Example/FreeRtos/SingleTask/FreeRTOSConfig.h
+++ b/Example/FreeRtos/SingleTask/FreeRTOSConfig.h
@@ -1,0 +1,73 @@
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/* FreeRTOS kernel configuration for Cortex-M3 on QEMU mps2-an385 with
+ * FreeRTOS-Plus-TCP. The IP stack runs in its own task at
+ * configMAX_PRIORITIES - 2, the NetworkInterface RX task at
+ * configMAX_PRIORITIES - 3, and timers + dynamic allocation are required
+ * by the stack. Heap is sized empirically to fit network buffer
+ * descriptors, ARP cache, IP stack stack, and the smoke task. */
+
+#define configUSE_PREEMPTION 1
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TICK_HOOK 0
+#define configCPU_CLOCK_HZ ((unsigned long) 25000000)
+#define configTICK_RATE_HZ ((TickType_t) 100)
+#define configMAX_PRIORITIES 7
+#define configMINIMAL_STACK_SIZE ((unsigned short) 128)
+#define configTOTAL_HEAP_SIZE ((size_t) (96 * 1024))
+#define configMAX_TASK_NAME_LEN 16
+#define configUSE_TRACE_FACILITY 0
+#define configUSE_16_BIT_TICKS 0
+#define configIDLE_SHOULD_YIELD 1
+#define configUSE_MUTEXES 1
+#define configUSE_RECURSIVE_MUTEXES 1
+#define configUSE_COUNTING_SEMAPHORES 1
+#define configUSE_TIMERS 1
+#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
+#define configTIMER_QUEUE_LENGTH 8
+#define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)
+#define configCHECK_FOR_STACK_OVERFLOW 2
+#define configUSE_MALLOC_FAILED_HOOK 1
+#define configSUPPORT_STATIC_ALLOCATION 0
+#define configSUPPORT_DYNAMIC_ALLOCATION 1
+
+#define configUSE_CO_ROUTINES 0
+#define configMAX_CO_ROUTINE_PRIORITIES 1
+
+#define INCLUDE_vTaskPrioritySet 1
+#define INCLUDE_uxTaskPriorityGet 1
+#define INCLUDE_vTaskDelete 1
+#define INCLUDE_vTaskCleanUpResources 0
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_vTaskDelayUntil 1
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_xTimerPendFunctionCall 1
+
+/* Cortex-M3 NVIC: top 3 priority bits implemented. */
+#define configPRIO_BITS 3
+#define configKERNEL_INTERRUPT_PRIORITY (7 << (8 - configPRIO_BITS))
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY (5 << (8 - configPRIO_BITS))
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 7
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 5
+
+/* Alias FreeRTOS port handlers to the standard CMSIS names so the vector
+ * table in Startup.c references SVC_Handler / PendSV_Handler / SysTick_Handler
+ * (and the FreeRTOS port supplies the bodies). */
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+#define xPortSysTickHandler SysTick_Handler
+
+#define configASSERT(x) \
+    do                  \
+    {                   \
+        if (!(x))       \
+        {               \
+            for (;;)    \
+            {           \
+            }           \
+        }               \
+    } while (0)
+
+#endif /* FREERTOS_CONFIG_H */

--- a/Example/FreeRtos/SingleTask/FreeRTOSIPConfig.h
+++ b/Example/FreeRtos/SingleTask/FreeRTOSIPConfig.h
@@ -1,0 +1,52 @@
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* FreeRTOS-Plus-TCP configuration for the QEMU mps2-an385 bring-up smoke
+ * test (slice 3b.1 of S08.03). UDP-only, IPv4 static address, no DHCP / DNS /
+ * LLMNR / NBNS / TCP / IPv6. The smoke task creates a UDP socket and sends a
+ * single datagram to the slirp gateway (10.0.2.2:5514). */
+
+#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+
+#define ipconfigUSE_IPv4 1
+#define ipconfigUSE_IPv6 0
+#define ipconfigUSE_RA 0
+#define ipconfigUSE_TCP 0
+#define ipconfigUSE_DHCP 0
+#define ipconfigUSE_DHCPv6 0
+#define ipconfigUSE_DHCP_HOOK 0
+#define ipconfigUSE_DNS 0
+#define ipconfigUSE_DNS_CACHE 0
+#define ipconfigUSE_LLMNR 0
+#define ipconfigUSE_NBNS 0
+#define ipconfigUSE_NETWORK_EVENT_HOOK 1
+
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM 0
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM 0
+
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND 1
+#define ipconfigINCLUDE_FULL_INET_ADDR 1
+#define ipconfigSUPPORT_OUTGOING_PINGS 0
+#define ipconfigSUPPORT_SELECT_FUNCTION 0
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES 1
+
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS 8
+#define ipconfigEVENT_QUEUE_LENGTH (ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5)
+#define ipconfigNETWORK_MTU 1500
+
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME (5000U)
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME (5000U)
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS (5000U / portTICK_PERIOD_MS)
+#define ipconfigUDP_TIME_TO_LIVE 128
+
+#define ipconfigARP_CACHE_ENTRIES 6
+#define ipconfigMAX_ARP_RETRANSMISSIONS 5
+#define ipconfigMAX_ARP_AGE 150
+
+#define ipconfigIP_TASK_PRIORITY (configMAX_PRIORITIES - 2)
+#define ipconfigIP_TASK_STACK_SIZE_WORDS (configMINIMAL_STACK_SIZE * 5U)
+
+#define ipconfigHAS_PRINTF 0
+#define ipconfigHAS_DEBUG_PRINTF 0
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/Example/FreeRtos/SingleTask/Startup.c
+++ b/Example/FreeRtos/SingleTask/Startup.c
@@ -1,0 +1,124 @@
+/* Cortex-M3 startup for the QEMU mps2-an385 machine — variant for the
+ * FreeRTOS-Plus-TCP single-task example.
+ *
+ * Differs from Example/FreeRtos/Common/startup.c by extending the vector
+ * table with the Cortex-M3 external IRQ entries (IRQ0..31). IRQ 13 is the
+ * SMSC9220 (LAN9118) Ethernet controller in QEMU's mps2-an385 model and is
+ * routed to EthernetISR (defined by the upstream Plus-TCP MPS2_AN385
+ * NetworkInterface.c). All other IRQ slots fall through to Default_Handler. */
+
+#include <stdint.h>
+
+extern uint32_t _estack;
+extern uint32_t _sidata;
+extern uint32_t _sdata;
+extern uint32_t _edata;
+extern uint32_t _sbss;
+extern uint32_t _ebss;
+
+extern int  main(void);
+extern void __libc_init_array(void);
+
+void Reset_Handler(void);
+void Default_Handler(void);
+
+void NMI_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void HardFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void MemManage_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void BusFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void UsageFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void DebugMon_Handler(void) __attribute__((weak, alias("Default_Handler")));
+
+void SVC_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+/* Provided by the Plus-TCP MPS2_AN385 NetworkInterface.c — drained by the
+ * EMAC RX task on each task notification. */
+void EthernetISR(void) __attribute__((weak, alias("Default_Handler")));
+
+void Reset_Handler(void)
+{
+    uint32_t* src = &_sidata;
+    uint32_t* dst = &_sdata;
+    while (dst < &_edata)
+    {
+        *dst++ = *src++;
+    }
+
+    dst = &_sbss;
+    while (dst < &_ebss)
+    {
+        *dst++ = 0;
+    }
+
+    __libc_init_array();
+
+    (void) main();
+
+    for (;;)
+    {
+    }
+}
+
+void Default_Handler(void)
+{
+    for (;;)
+    {
+        __asm volatile("bkpt #0");
+    }
+}
+
+/* Cortex-M3 vector table. System exceptions (entries 0..15) followed by 32
+ * external IRQs. Only IRQ 13 is wired to a real handler — every other slot
+ * traps via Default_Handler so a stray interrupt is debuggable rather than
+ * silently jumping into 0xFFFFFFFF. */
+__attribute__((section(".vectors"), used)) const uint32_t vector_table[] = {
+    (uint32_t) &_estack,           /* 0x00 — initial stack pointer */
+    (uint32_t) Reset_Handler,      /* 0x04 — reset                 */
+    (uint32_t) NMI_Handler,        /* 0x08                         */
+    (uint32_t) HardFault_Handler,  /* 0x0C                         */
+    (uint32_t) MemManage_Handler,  /* 0x10                         */
+    (uint32_t) BusFault_Handler,   /* 0x14                         */
+    (uint32_t) UsageFault_Handler, /* 0x18                         */
+    0U, 0U, 0U, 0U,                /* 0x1C-0x28 reserved           */
+    (uint32_t) SVC_Handler,        /* 0x2C — FreeRTOS              */
+    (uint32_t) DebugMon_Handler,   /* 0x30                         */
+    0U,                            /* 0x34 reserved                */
+    (uint32_t) PendSV_Handler,     /* 0x38 — FreeRTOS              */
+    (uint32_t) SysTick_Handler,    /* 0x3C — FreeRTOS              */
+
+    /* External interrupts — IRQ0..IRQ31. IRQ 13 = LAN9118 Ethernet. */
+    (uint32_t) Default_Handler, /* IRQ  0 — UART0 RX  */
+    (uint32_t) Default_Handler, /* IRQ  1 — UART0 TX  */
+    (uint32_t) Default_Handler, /* IRQ  2 — UART1 RX  */
+    (uint32_t) Default_Handler, /* IRQ  3 — UART1 TX  */
+    (uint32_t) Default_Handler, /* IRQ  4 — UART2 RX  */
+    (uint32_t) Default_Handler, /* IRQ  5 — UART2 TX  */
+    (uint32_t) Default_Handler, /* IRQ  6 — GPIO0     */
+    (uint32_t) Default_Handler, /* IRQ  7 — GPIO1     */
+    (uint32_t) Default_Handler, /* IRQ  8 — Timer0    */
+    (uint32_t) Default_Handler, /* IRQ  9 — Timer1    */
+    (uint32_t) Default_Handler, /* IRQ 10 — DualTimer */
+    (uint32_t) Default_Handler, /* IRQ 11 — SPI0/1    */
+    (uint32_t) Default_Handler, /* IRQ 12 — UART overflow */
+    (uint32_t) EthernetISR,     /* IRQ 13 — Ethernet (LAN9118) */
+    (uint32_t) Default_Handler, /* IRQ 14 — Touchscreen */
+    (uint32_t) Default_Handler, /* IRQ 15 — Audio I2S */
+    (uint32_t) Default_Handler, /* IRQ 16 */
+    (uint32_t) Default_Handler, /* IRQ 17 */
+    (uint32_t) Default_Handler, /* IRQ 18 */
+    (uint32_t) Default_Handler, /* IRQ 19 */
+    (uint32_t) Default_Handler, /* IRQ 20 */
+    (uint32_t) Default_Handler, /* IRQ 21 */
+    (uint32_t) Default_Handler, /* IRQ 22 */
+    (uint32_t) Default_Handler, /* IRQ 23 */
+    (uint32_t) Default_Handler, /* IRQ 24 */
+    (uint32_t) Default_Handler, /* IRQ 25 */
+    (uint32_t) Default_Handler, /* IRQ 26 */
+    (uint32_t) Default_Handler, /* IRQ 27 */
+    (uint32_t) Default_Handler, /* IRQ 28 */
+    (uint32_t) Default_Handler, /* IRQ 29 */
+    (uint32_t) Default_Handler, /* IRQ 30 */
+    (uint32_t) Default_Handler, /* IRQ 31 */
+};

--- a/Example/FreeRtos/SingleTask/main.c
+++ b/Example/FreeRtos/SingleTask/main.c
@@ -1,0 +1,201 @@
+/* FreeRTOS-Plus-TCP bring-up smoke test on QEMU mps2-an385 (Cortex-M3).
+ *
+ * Slice 3b.1 of S08.03: prove the IP stack initialises and a UDP datagram
+ * escapes the guest via slirp. Static IPv4 (10.0.2.15), default gateway
+ * (10.0.2.2 — the slirp gateway, routed to the host), no DHCP / DNS.
+ *
+ * On link-up the network event hook spawns a one-shot smoke task that
+ *   - prints "network up\n" over the CMSDK UART (QEMU -serial stdio)
+ *   - opens a UDP socket
+ *   - sends "ping" to {10.0.2.2, 5514}
+ *   - closes the socket and self-deletes.
+ *
+ * Slice 3b.2 replaces this scaffold with a SolidSyslogConfig + UdpSender
+ * wiring that drives the slice-1 SolidSyslogFreeRtosDatagram adapter via
+ * the slice-3a SolidSyslogFreeRtosStaticResolver. */
+
+#include "CmsdkUart.h"
+
+#include <FreeRTOS.h>
+#include <task.h>
+
+#include <FreeRTOS_ARP.h>
+#include <FreeRTOS_IP.h>
+#include <FreeRTOS_Routing.h>
+#include <FreeRTOS_Sockets.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define CMSDK_UART0_BASE_ADDRESS UINT32_C(0x40004000)
+
+/* IRQ number for the QEMU mps2-an385 LAN9118 Ethernet controller. The
+ * upstream Plus-TCP NetworkInterface.c enables ISER for this IRQ but does
+ * NOT write IPR — leaving the priority at the reset default of 0, which is
+ * numerically more urgent than configMAX_SYSCALL_INTERRUPT_PRIORITY and
+ * trips configASSERT the first time the ISR calls a FreeRTOS API. We set
+ * IPR explicitly here before FreeRTOS_IPInit_Multi triggers the interface
+ * init that flips ISER. */
+#define ETHERNET_IRQ_NUMBER 13U
+
+/* NVIC IPR (Interrupt Priority Register) base — one byte per IRQ. */
+#define NVIC_IPR_BASE_ADDRESS UINT32_C(0xE000E400)
+
+/* Lowest priority the NVIC will accept (8-bit register, top configPRIO_BITS
+ * implemented). 0xE0 = priority 7 with 3 priority bits — well below
+ * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+#define ETHERNET_IRQ_PRIORITY UINT8_C(0xE0)
+
+/* Static IPv4 wiring matching the QEMU slirp default. 10.0.2.15 is the
+ * standard slirp DHCP-allocated guest address; we hardcode it here so no
+ * DHCP server is required. */
+static const uint8_t SMOKE_IP_ADDRESS[ipIP_ADDRESS_LENGTH_BYTES] = {10U, 0U, 2U, 15U};
+static const uint8_t SMOKE_NETMASK[ipIP_ADDRESS_LENGTH_BYTES]    = {255U, 255U, 255U, 0U};
+static const uint8_t SMOKE_GATEWAY[ipIP_ADDRESS_LENGTH_BYTES]    = {10U, 0U, 2U, 2U};
+static const uint8_t SMOKE_DNS[ipIP_ADDRESS_LENGTH_BYTES]        = {10U, 0U, 2U, 3U};
+
+/* Locally-administered MAC (U/L bit set, multicast bit clear). */
+static const uint8_t SMOKE_MAC[ipMAC_ADDRESS_LENGTH_BYTES] = {0x02U, 0x00U, 0x00U, 0x00U, 0x00U, 0x01U};
+
+#define SMOKE_TARGET_PORT 5514U
+static const uint8_t SMOKE_PAYLOAD[] = {'p', 'i', 'n', 'g'};
+
+/* Static storage for the network interface and its single endpoint. The
+ * Plus-TCP API requires these to outlive the IP stack. */
+static NetworkInterface_t networkInterface;
+static NetworkEndPoint_t  networkEndPoint;
+
+/* Ensures the smoke task is created exactly once even if the network goes
+ * down and back up. */
+static BaseType_t smokeTaskCreated = pdFALSE;
+
+extern NetworkInterface_t* pxMPS2_FillInterfaceDescriptor(BaseType_t xEMACIndex, NetworkInterface_t* pxInterface);
+
+static uint32_t MmioRead32(uintptr_t address)
+{
+    // NOLINTNEXTLINE(performance-no-int-to-ptr) -- mapping the CMSDK UART MMIO address into a 32-bit volatile pointer.
+    return *(volatile uint32_t*) address;
+}
+
+static void MmioWrite32(uintptr_t address, uint32_t value)
+{
+    // NOLINTNEXTLINE(performance-no-int-to-ptr) -- mapping the CMSDK UART MMIO address into a 32-bit volatile pointer.
+    *(volatile uint32_t*) address = value;
+}
+
+static void RtosSleep(int milliseconds)
+{
+    vTaskDelay(pdMS_TO_TICKS((TickType_t) milliseconds));
+}
+
+static const CmsdkUartMemoryAccess MMIO_ACCESS = {MmioRead32, MmioWrite32, RtosSleep};
+
+static void SetEthernetIrqPriority(void)
+{
+    // NOLINTNEXTLINE(performance-no-int-to-ptr) -- writing the NVIC IPR byte for IRQ 13.
+    volatile uint8_t* ipr = (volatile uint8_t*) (NVIC_IPR_BASE_ADDRESS + ETHERNET_IRQ_NUMBER);
+    *ipr                  = ETHERNET_IRQ_PRIORITY;
+}
+
+static void SmokeTask(void* argument)
+{
+    (void) argument;
+
+    printf("network up\n");
+    fflush(stdout);
+
+    Socket_t socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
+    if (socket != FREERTOS_INVALID_SOCKET)
+    {
+        struct freertos_sockaddr destination;
+        memset(&destination, 0, sizeof(destination));
+        destination.sin_len               = (uint8_t) sizeof(destination);
+        destination.sin_family            = FREERTOS_AF_INET;
+        destination.sin_port              = FreeRTOS_htons(SMOKE_TARGET_PORT);
+        destination.sin_address.ulIP_IPv4 = FreeRTOS_inet_addr_quick(SMOKE_GATEWAY[0], SMOKE_GATEWAY[1], SMOKE_GATEWAY[2], SMOKE_GATEWAY[3]);
+
+        /* Pre-resolve ARP for the gateway. Without this the first sendto
+         * triggers ARP and the datagram is dropped while resolution is in
+         * flight; under slirp ARP completes in well under 200 ms. */
+        FreeRTOS_OutputARPRequest(destination.sin_address.ulIP_IPv4);
+        vTaskDelay(pdMS_TO_TICKS(200));
+
+        (void) FreeRTOS_sendto(socket, SMOKE_PAYLOAD, sizeof(SMOKE_PAYLOAD), 0, &destination, sizeof(destination));
+
+        (void) FreeRTOS_closesocket(socket);
+    }
+
+    vTaskDelete(NULL);
+}
+
+void vApplicationIPNetworkEventHook_Multi(eIPCallbackEvent_t eNetworkEvent, struct xNetworkEndPoint* pxEndPoint)
+{
+    (void) pxEndPoint;
+    if ((eNetworkEvent == eNetworkUp) && (smokeTaskCreated == pdFALSE))
+    {
+        if (xTaskCreate(SmokeTask, "smoke", configMINIMAL_STACK_SIZE * 4, NULL, tskIDLE_PRIORITY + 1, NULL) == pdPASS)
+        {
+            smokeTaskCreated = pdTRUE;
+        }
+    }
+}
+
+int main(void)
+{
+    CmsdkUart_Init(&MMIO_ACCESS, CMSDK_UART0_BASE_ADDRESS);
+
+    SetEthernetIrqPriority();
+
+    (void) pxMPS2_FillInterfaceDescriptor(0, &networkInterface);
+    FreeRTOS_FillEndPoint(&networkInterface, &networkEndPoint, SMOKE_IP_ADDRESS, SMOKE_NETMASK, SMOKE_GATEWAY, SMOKE_DNS, SMOKE_MAC);
+
+    if (FreeRTOS_IPInit_Multi() != pdPASS)
+    {
+        for (;;)
+        {
+        }
+    }
+
+    vTaskStartScheduler();
+
+    for (;;)
+    {
+    }
+    return 0;
+}
+
+void vApplicationMallocFailedHook(void)
+{
+    for (;;)
+    {
+    }
+}
+
+void vApplicationStackOverflowHook(TaskHandle_t task, char* taskName)
+{
+    (void) task;
+    (void) taskName;
+    for (;;)
+    {
+    }
+}
+
+/* Plus-TCP requires the application to provide a per-endpoint random seed
+ * source for ARP / IP-ID generation. The QEMU mps2-an385 has no RNG; for a
+ * deterministic smoke test we return the run-time tick mixed with the
+ * endpoint pointer. */
+BaseType_t xApplicationGetRandomNumber(uint32_t* pulValue)
+{
+    *pulValue = (uint32_t) xTaskGetTickCount() ^ 0xA5A5A5A5U;
+    return pdPASS;
+}
+
+uint32_t ulApplicationGetNextSequenceNumber(uint32_t ulSourceAddress, uint16_t usSourcePort, uint32_t ulDestinationAddress, uint16_t usDestinationPort)
+{
+    (void) ulSourceAddress;
+    (void) usSourcePort;
+    (void) ulDestinationAddress;
+    (void) usDestinationPort;
+    return (uint32_t) xTaskGetTickCount();
+}

--- a/Example/FreeRtos/SingleTask/main.c
+++ b/Example/FreeRtos/SingleTask/main.c
@@ -42,24 +42,25 @@
 /* NVIC IPR (Interrupt Priority Register) base — one byte per IRQ. */
 #define NVIC_IPR_BASE_ADDRESS UINT32_C(0xE000E400)
 
-/* Lowest priority the NVIC will accept (8-bit register, top configPRIO_BITS
- * implemented). 0xE0 = priority 7 with 3 priority bits — well below
- * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
-#define ETHERNET_IRQ_PRIORITY UINT8_C(0xE0)
+/* NVIC IPR is 8-bit per IRQ but only the top configPRIO_BITS are
+ * implemented; lower (zeroed) bits read back as 0. Derive from the
+ * FreeRTOSConfig macros so a kernel-config change can't silently leave
+ * IRQ 13 at a higher-than-syscall-safe priority. */
+#define ETHERNET_IRQ_PRIORITY ((uint8_t) (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8U - configPRIO_BITS)))
 
 /* Static IPv4 wiring matching the QEMU slirp default. 10.0.2.15 is the
  * standard slirp DHCP-allocated guest address; we hardcode it here so no
  * DHCP server is required. */
-static const uint8_t SMOKE_IP_ADDRESS[ipIP_ADDRESS_LENGTH_BYTES] = {10U, 0U, 2U, 15U};
-static const uint8_t SMOKE_NETMASK[ipIP_ADDRESS_LENGTH_BYTES]    = {255U, 255U, 255U, 0U};
-static const uint8_t SMOKE_GATEWAY[ipIP_ADDRESS_LENGTH_BYTES]    = {10U, 0U, 2U, 2U};
-static const uint8_t SMOKE_DNS[ipIP_ADDRESS_LENGTH_BYTES]        = {10U, 0U, 2U, 3U};
+static const uint8_t TEST_IP_ADDRESS[ipIP_ADDRESS_LENGTH_BYTES] = {10U, 0U, 2U, 15U};
+static const uint8_t TEST_NETMASK[ipIP_ADDRESS_LENGTH_BYTES]    = {255U, 255U, 255U, 0U};
+static const uint8_t TEST_GATEWAY[ipIP_ADDRESS_LENGTH_BYTES]    = {10U, 0U, 2U, 2U};
+static const uint8_t TEST_DNS[ipIP_ADDRESS_LENGTH_BYTES]        = {10U, 0U, 2U, 3U};
 
 /* Locally-administered MAC (U/L bit set, multicast bit clear). */
-static const uint8_t SMOKE_MAC[ipMAC_ADDRESS_LENGTH_BYTES] = {0x02U, 0x00U, 0x00U, 0x00U, 0x00U, 0x01U};
+static const uint8_t TEST_MAC[ipMAC_ADDRESS_LENGTH_BYTES] = {0x02U, 0x00U, 0x00U, 0x00U, 0x00U, 0x01U};
 
-#define SMOKE_TARGET_PORT 5514U
-static const uint8_t SMOKE_PAYLOAD[] = {'p', 'i', 'n', 'g'};
+#define TEST_TARGET_PORT 5514U
+static const uint8_t TEST_PAYLOAD[] = {'p', 'i', 'n', 'g'};
 
 /* Static storage for the network interface and its single endpoint. The
  * Plus-TCP API requires these to outlive the IP stack. */
@@ -112,8 +113,8 @@ static void SmokeTask(void* argument)
         memset(&destination, 0, sizeof(destination));
         destination.sin_len               = (uint8_t) sizeof(destination);
         destination.sin_family            = FREERTOS_AF_INET;
-        destination.sin_port              = FreeRTOS_htons(SMOKE_TARGET_PORT);
-        destination.sin_address.ulIP_IPv4 = FreeRTOS_inet_addr_quick(SMOKE_GATEWAY[0], SMOKE_GATEWAY[1], SMOKE_GATEWAY[2], SMOKE_GATEWAY[3]);
+        destination.sin_port              = FreeRTOS_htons(TEST_TARGET_PORT);
+        destination.sin_address.ulIP_IPv4 = FreeRTOS_inet_addr_quick(TEST_GATEWAY[0], TEST_GATEWAY[1], TEST_GATEWAY[2], TEST_GATEWAY[3]);
 
         /* Pre-resolve ARP for the gateway. Without this the first sendto
          * triggers ARP and the datagram is dropped while resolution is in
@@ -121,7 +122,7 @@ static void SmokeTask(void* argument)
         FreeRTOS_OutputARPRequest(destination.sin_address.ulIP_IPv4);
         vTaskDelay(pdMS_TO_TICKS(200));
 
-        (void) FreeRTOS_sendto(socket, SMOKE_PAYLOAD, sizeof(SMOKE_PAYLOAD), 0, &destination, sizeof(destination));
+        (void) FreeRTOS_sendto(socket, TEST_PAYLOAD, sizeof(TEST_PAYLOAD), 0, &destination, sizeof(destination));
 
         (void) FreeRTOS_closesocket(socket);
     }
@@ -148,7 +149,7 @@ int main(void)
     SetEthernetIrqPriority();
 
     (void) pxMPS2_FillInterfaceDescriptor(0, &networkInterface);
-    FreeRTOS_FillEndPoint(&networkInterface, &networkEndPoint, SMOKE_IP_ADDRESS, SMOKE_NETMASK, SMOKE_GATEWAY, SMOKE_DNS, SMOKE_MAC);
+    FreeRTOS_FillEndPoint(&networkInterface, &networkEndPoint, TEST_IP_ADDRESS, TEST_NETMASK, TEST_GATEWAY, TEST_DNS, TEST_MAC);
 
     if (FreeRTOS_IPInit_Multi() != pdPASS)
     {


### PR DESCRIPTION
## Purpose

Stand FreeRTOS-Plus-TCP up on the QEMU `mps2-an385` (Cortex-M3) target and prove that a UDP datagram from the guest reaches a host listener via slirp. No SolidSyslog adapter is involved at this stage — the goal is to isolate "the IP stack initialises and packets escape the guest" from "the slice-1 datagram adapter wiring works". Slice 3b.2 (next) replaces `main.c`'s body with a `SolidSyslogConfig` + `SolidSyslogUdpSender` wiring driving the slice-1 `SolidSyslogFreeRtosDatagram` adapter through the slice-3a `SolidSyslogFreeRtosStaticResolver`. Directory and CMake wiring stay across that swap.

Closes #295.

## Change Description

- **`Example/FreeRtos/SingleTask/CMakeLists.txt`** — Plus-TCP core source list (UDP-only — TCP files compile but `--gc-sections` discards them since `ipconfigUSE_TCP=0`), `BufferAllocation_2.c`, the MPS2_AN385 `NetworkInterface.c` + `smsc9220_eth_drv.c` driver, plus the kernel sources HelloWorld already pulls in extended with `timers.c` + `event_groups.c`. Strict-conversion / strict-shadow / strict-array-bounds warnings relaxed for this example only — upstream sources don't meet the host bar and we don't want to lower it everywhere.
- **`Example/FreeRtos/SingleTask/Startup.c`** — Cortex-M3 startup with the vector table extended through IRQ 31. IRQ 13 routes to `EthernetISR` (declared `weak alias("Default_Handler")` so the strong symbol from upstream `NetworkInterface.c` wins at link). Common's `startup.c` is intentionally NOT included — having two `vector_table` in the link would clash, and Common stays untouched per scope.
- **`Example/FreeRtos/SingleTask/FreeRTOSConfig.h`** — heap raised to 96 KiB (empirical), `configMAX_PRIORITIES` to 7 (so `ipconfigIP_TASK_PRIORITY = configMAX_PRIORITIES - 2` and the EMAC RX task at -3 fit), timers + recursive mutexes enabled because Plus-TCP requires both.
- **`Example/FreeRtos/SingleTask/FreeRTOSIPConfig.h`** — UDP-only IPv4-only: `ipconfigUSE_TCP=0`, `ipconfigUSE_DHCP=0`, `ipconfigUSE_DNS=0`, `ipconfigUSE_RA=0`, `ipconfigUSE_IPv6=0`, `ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS=8`, `ipconfigUSE_NETWORK_EVENT_HOOK=1`.
- **`Example/FreeRtos/SingleTask/main.c`** — `pxMPS2_FillInterfaceDescriptor` + `FreeRTOS_FillEndPoint(10.0.2.15 / 255.255.255.0 / 10.0.2.2)` + `FreeRTOS_IPInit_Multi`. The network event hook spawns a one-shot smoke task on first `eNetworkUp`; the smoke task pre-resolves ARP via `FreeRTOS_OutputARPRequest`, sleeps 200 ms, sends `"ping"` to `10.0.2.2:5514`, closes the socket, self-deletes. `xApplicationGetRandomNumber` and `ulApplicationGetNextSequenceNumber` use tick-derived values — adequate for a smoke test, replaced when a real RNG arrives.
- **`Example/FreeRtos/CMakeLists.txt`** — `add_subdirectory(SingleTask)`.

### Notable decisions

- **NVIC priority for IRQ 13 set explicitly.** Upstream `MPS2_AN385/NetworkInterface.c` enables ISER for IRQ 13 but never writes IPR, leaving priority at the Cortex-M3 reset default of 0 — numerically more urgent than `configMAX_SYSCALL_INTERRUPT_PRIORITY` and trips `configASSERT` on the first FreeRTOS API call from the ISR. We write IPR (0xE0 → priority 7) in `main()` before `FreeRTOS_IPInit_Multi` triggers the interface init that flips ISER. Worth filing upstream if not already known.
- **No host TDD for this slice — explicitly.** The only logic this slice authors is one boolean guard inside the network event hook. Growing `Tests/Support/FreeRtosFakes/` with `xTaskCreate` / `FreeRTOS_socket` / `FreeRTOS_sendto` / `FreeRTOS_OutputARPRequest` / `FreeRTOS_closesocket` shims to cover one assertion would have cost ~80 lines for one test, and the fakes have no second customer (slice 3b.2 calls into the host-TDD'd `SolidSyslogFreeRtosDatagram` via `SolidSyslogUdpSender`, not the raw API). The smoke task is throwaway scaffolding 3b.2 deletes. Documented in DEVLOG.
- **ARP-resolves-late drops the first packet.** First QEMU run printed "network up" but the pcap showed only ARP — the original `FreeRTOS_sendto` payload was dropped while ARP resolved. Fixed by `FreeRTOS_OutputARPRequest` + 200 ms delay before sendto. Saved a project memory so the same gotcha is surfaced for slice 3b.2 and the FreeRTOS reconfiguration story (S04 equivalent) — any reconfig path will silently lose the first user log line under the same mechanism unless the sender pre-resolves on endpoint-version transitions.

## Test Evidence

Smoke validated inside `cpputest-freertos-cross` devcontainer:

```text
$ qemu-system-arm -M mps2-an385 -m 16M -display none -serial stdio \
    -netdev user,id=net0 -net nic,netdev=net0,model=lan9118 \
    -object filter-dump,id=f1,netdev=net0,file=/tmp/qemu.pcap \
    -kernel build/freertos-cross/Example/FreeRtos/SingleTask/SolidSyslogFreeRtosSingleTask.elf
network up

$ python3 udp_listener.py    # bind 0.0.0.0:5514, recvfrom
GOT b'ping' FROM ('127.0.0.1', 51998)

$ pcap-parse /tmp/qemu.pcap
ARP len=42                                        # guest broadcast for 10.0.2.2
ARP len=64                                        # slirp reply (52:55:0a:00:02:02)
IP proto=17 10.0.2.15 -> 10.0.2.2 len=46          # the UDP datagram
```

`nc -ul 5514` would have been the expected verifier per the issue, but the cpputest-freertos-cross image ships no `nc` / `ncat` / `socat`; a 7-line Python UDP listener was substituted. (Followup: add netcat to the image.)

Pre-PR checks I could run locally:
- [x] `cmake --build --preset freertos-cross --target SolidSyslogFreeRtosSingleTask` — clean
- [x] `clang-format --dry-run --Werror` on changed files — clean
- [x] QEMU smoke (UART "network up" + python `recvfrom` + pcap)

Pre-PR checks I deferred to CI (this devcontainer is `freertos-target`, no host-side toolchains):
- [ ] build-linux-gcc / build-linux-clang / sanitize-linux-gcc / coverage-linux-gcc
- [ ] analyze-tidy / analyze-cppcheck / analyze-format / analyze-iwyu
- [ ] BDD, OpenSSL integration, Windows MSVC

## Areas Affected

- **`Example/FreeRtos/SingleTask/`** — new directory, all files new.
- **`Example/FreeRtos/CMakeLists.txt`** — one line: `add_subdirectory(SingleTask)`.
- **`DEVLOG.md`** — slice 3b.1 entry inserted above the queued slice 3a entry (preserved as-is).

Untouched: `Core/`, `Platform/Posix/`, `Platform/Windows/`, `Platform/FreeRtos/`, `Tests/`, `Bdd/`, `Example/Common/`, `Example/SingleTask/` (POSIX one), `Example/Threaded/`, `Example/FreeRtos/HelloWorld/`, `Example/FreeRtos/Common/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FreeRTOS example application with UDP networking capabilities.

* **Documentation**
  * Added development log documenting FreeRTOS-Plus-TCP UDP implementation, configuration, and validation approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->