### PR TITLE
feat: S08.03 slice 3b.1.5 FreeRtosDatagram ARP priming on cache miss (#298)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,117 @@
 # Dev Log
 
+## 2026-05-09 — S08.03 slice 3b.1.5 — FreeRtosDatagram ARP priming on cache miss (#298)
+
+`SolidSyslogFreeRtosDatagram::SendTo` now probes ARP transparently when the
+destination IP isn't in the cache. SendTo delegates to a `static inline`
+helper so the function reads at one level of abstraction:
+
+```c
+PrimeArpIfMissing(dest->sin_address.ulIP_IPv4);
+FreeRTOS_sendto(datagram->socket, buffer, size, 0, dest, sizeof(*dest));
+
+static inline void PrimeArpIfMissing(uint32_t ip)
+{
+    if (xIsIPInARPCache(ip) == pdFALSE)
+    {
+        FreeRTOS_OutputARPRequest(ip);
+        vTaskDelay(ARP_RESOLUTION_WAIT_TICKS);   // 50 ms
+    }
+}
+```
+
+Slice 3b.1 (#295) confirmed FreeRTOS-Plus-TCP doesn't queue datagrams while
+ARP resolves: a sendto to an unresolved peer drops at the IP layer.
+Linux/Windows kernels mask this with internal ARP queuing; Plus-TCP doesn't.
+Without this slice, the very first message after every cold start (and after
+any endpoint-version transition that changes the destination IP) would
+silently disappear — every consumer of the FreeRTOS UDP path would have had
+to send a throwaway first message or accept a missed one. Slice 3b.2's QEMU
+smoke and the eventual S08.06 BDD job were both blocked on this.
+
+### Design calls
+
+**Fire-and-forget over retry.** UDP is best-effort at every layer and the
+library already has store-and-forward as a separate concern (Buffer / Store).
+Imposing TCP-like reliability inside the datagram adapter would have meant
+retry budgets, exponential backoff, and a state machine — none of which
+belongs at this layer. If `vTaskDelay(50ms)` isn't long enough for ARP to
+resolve, the sendto is allowed to fail or drop. The S&F layer above retries.
+
+**Transparent on every call, not one-shot at Create.** Every SendTo runs the
+same probe-yield-send sequence on a cache miss, so cold start, endpoint
+reconfiguration (S04), ARP cache eviction during long idle, and sender
+restart all benefit without state in the adapter.
+
+**`xIsIPInARPCache` over `eARPGetCacheEntry`.** Plus-TCP exposes both;
+`xIsIPInARPCache` returns a single `BaseType_t` boolean while
+`eARPGetCacheEntry` returns a tri-state with two out-params (MAC + endpoint)
+we'd discard. The age-refresh side effect of `eARPGetCacheEntry` is harmless
+to skip — the IP layer's internal lookup inside `FreeRTOS_sendto` does the
+refresh anyway.
+
+**`FreeRTOS_OutputARPRequest` over `_Multi`.** Single-arg variant fans out
+internally; the `_Multi` variant needs a `NetworkEndPoint*` the adapter
+doesn't have (resolver returns a sockaddr, not an endpoint). Keeps the
+adapter ignorant of endpoint topology.
+
+**`vTaskDelay` direct, not via injected sleep callback.** The adapter is
+already FreeRTOS-specific by definition (calls `FreeRTOS_socket` etc. at
+several points). Adding a `SolidSyslogSleepFunction` config field would
+widen the public Create signature and force every integrator to wire a
+companion `SolidSyslogFreeRtosSleep` for one internal yield. Direct call
+matches the existing pattern in `SolidSyslogFreeRtosStaticResolver` and the
+rest of the file.
+
+**ARP fakes split from sockets fakes.** `Tests/Support/FreeRtosFakes/` grew
+two new files: `FreeRtosArpFake.{c,h}` for `xIsIPInARPCache` /
+`FreeRTOS_OutputARPRequest` (Plus-TCP ARP subsystem) and
+`FreeRtosTaskFake.{c,h}` for `vTaskDelay` (Kernel scheduler primitive).
+Splits along the natural seam (Plus-TCP vs Kernel) — a single combined
+"FreeRtosFake" file would have mixed unrelated upstream subsystems.
+
+### TDD progression
+
+Five red→green→refactor cycles in ZOMBIES order, against the existing
+`SolidSyslogFreeRtosDatagramTest` exe:
+
+1. `SendToChecksIfIpIsInArpCache` — drives the `xIsIPInARPCache` call and
+   IP-arg correctness.
+2. `SendToFiresArpProbeOnCacheMiss` — drives the `FreeRTOS_OutputARPRequest`
+   call and IP-arg correctness on miss; introduces the cache-miss branch.
+3. `SendToYieldsAfterArpProbeOnCacheMiss` — drives the `vTaskDelay` call.
+   Refactor: extract `static const TickType_t ARP_RESOLUTION_WAIT_TICKS = pdMS_TO_TICKS(50);`
+   with comment justifying the value.
+4. `SendToSkipsArpProbeAndYieldOnCacheHit` — drives the new
+   `FreeRtosArpFake_SetCacheHit(bool)` API; locks in that the if-branch
+   correctly excludes hit cases (no probe, no delay, sendto still called).
+5. `SendToReChecksArpCacheOnEachCall` — three SendTo calls alternating
+   hit/miss/hit; locks in "no stale state" — would fail if anyone added a
+   "remember we already probed" optimization that bypassed
+   `xIsIPInARPCache`.
+
+Final hygiene pass extracted the `static inline PrimeArpIfMissing(uint32_t ip)`
+helper so SendTo reads top-down at one level of abstraction (open-check, get
+destination, prime ARP, send-and-map). The Plus-TCP behaviour comment moved
+to the helper definition where the code it explains lives. A
+`openAndSendOnce()` method on the TEST_GROUP collapsed the repeated
+`Open() + SendTo("x", 1, addr)` boilerplate in the three tests where it
+appears unconditionally (tests 1, 2, 3); tests 4 and 5 keep their inline
+shape because they interleave fake-state changes between the two calls.
+
+`SolidSyslogFreeRtosDatagramTest` exe: 16 → 21 tests, 32 → 42 checks.
+Existing tests untouched (default fake state is cache-miss, so existing
+miss-path tests like `SendToSendsBufferToDestinationAfterOpen` continue to
+exercise the same end-to-end path).
+
+### What this leaves for slice 3b.2
+
+Now that the ARP-cold case is handled inside the adapter, slice 3b.2's
+QEMU smoke can `SolidSyslog_Log` once and expect the host listener to
+receive it — no warm-up message, no tolerance for first-message loss. The
+S08.06 BDD job (when it points at the FreeRTOS target) inherits the same
+guarantee.
+
 ## 2026-05-08 — refactor — Common/ hoist for FreeRTOS examples
 
 Moved the shared infrastructure that slice 2 introduced

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -4,7 +4,9 @@
 #include "SolidSyslogFreeRtosDatagram.h"
 
 #include "FreeRTOS.h"
+#include "FreeRTOS_ARP.h"
 #include "FreeRTOS_Sockets.h"
+#include "task.h"
 
 #include "SolidSyslogAddressInternal.h"
 #include "SolidSyslogDatagramDefinition.h"
@@ -22,6 +24,13 @@ struct SolidSyslogFreeRtosDatagram
 SOLIDSYSLOG_STATIC_ASSERT(sizeof(FreeRtosDatagram) <= SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE,
                           "SOLIDSYSLOG_FREERTOSDATAGRAM_SIZE is too small for SolidSyslogFreeRtosDatagram layout");
 
+/* Time the calling task yields after issuing an ARP probe so the IP task can
+ * receive the reply and populate the cache before we attempt FreeRTOS_sendto.
+ * 50 ms is generous against typical sub-millisecond LAN ARP RTT but short
+ * enough that the first send latency stays tolerable. If the reply hasn't
+ * arrived in time the sendto is allowed to fail or be dropped — UDP semantics. */
+static const TickType_t ARP_RESOLUTION_WAIT_TICKS = pdMS_TO_TICKS(50);
+
 static bool                               FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
 static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size,
                                                                   const struct SolidSyslogAddress* addr);
@@ -29,6 +38,7 @@ static size_t                             FreeRtosDatagram_MaxPayload(struct Sol
 static void                               FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
 static inline FreeRtosDatagram*           FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
 static inline bool                        FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
+static inline void                        PrimeArpIfMissing(uint32_t ip);
 
 static const FreeRtosDatagram DEFAULT_INSTANCE = {
     {FreeRtosDatagram_Open, FreeRtosDatagram_SendTo, FreeRtosDatagram_MaxPayload, FreeRtosDatagram_Close},
@@ -77,13 +87,29 @@ static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(struct SolidSy
     if (FreeRtosDatagram_IsOpen(datagram))
     {
         const struct freertos_sockaddr* dest = SolidSyslogAddress_AsConstFreertosSockaddr(addr);
-        int32_t                         sent = FreeRTOS_sendto(datagram->socket, buffer, size, 0, dest, sizeof(*dest));
+        PrimeArpIfMissing(dest->sin_address.ulIP_IPv4);
+        int32_t sent = FreeRTOS_sendto(datagram->socket, buffer, size, 0, dest, sizeof(*dest));
         if (sent > 0)
         {
             result = SOLIDSYSLOG_DATAGRAM_SENT;
         }
     }
     return result;
+}
+
+/* FreeRTOS-Plus-TCP does not queue datagrams while ARP resolves: a sendto to
+ * an unresolved peer drops at the IP layer. Linux/Windows kernels mask this
+ * with internal ARP queuing; FreeRTOS does not. So on cache miss we issue a
+ * probe and yield once for the reply to land. If the reply hasn't arrived in
+ * time the sendto is allowed to fail or be dropped — UDP is best-effort and
+ * retry belongs in the store-and-forward layer above, not here. */
+static inline void PrimeArpIfMissing(uint32_t ip)
+{
+    if (xIsIPInARPCache(ip) == pdFALSE)
+    {
+        FreeRTOS_OutputARPRequest(ip);
+        vTaskDelay(ARP_RESOLUTION_WAIT_TICKS);
+    }
 }
 
 static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)

--- a/Tests/FreeRtos/CMakeLists.txt
+++ b/Tests/FreeRtos/CMakeLists.txt
@@ -16,6 +16,8 @@ else()
         main.cpp
         ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
         ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Source/FreeRtosSocketsFake.c
+        ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Source/FreeRtosArpFake.c
+        ${CMAKE_SOURCE_DIR}/Tests/Support/FreeRtosFakes/Source/FreeRtosTaskFake.c
     )
 
     target_link_libraries(SolidSyslogFreeRtosDatagramTest PRIVATE

--- a/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp
@@ -5,7 +5,9 @@
 #include "SolidSyslogFreeRtosDatagram.h"
 #include "SolidSyslogUdpPayload.h"
 
+#include "FreeRtosArpFake.h"
 #include "FreeRtosSocketsFake.h"
+#include "FreeRtosTaskFake.h"
 
 #include "FreeRTOS.h"
 #include "FreeRTOS_IP.h"
@@ -23,6 +25,8 @@ TEST_GROUP(SolidSyslogFreeRtosDatagram)
     void setup() override
     {
         FreeRtosSocketsFake_Reset();
+        FreeRtosArpFake_Reset();
+        FreeRtosTaskFake_Reset();
         datagram = SolidSyslogFreeRtosDatagram_Create(&storage);
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- char-type aliasing into platform layout, storage is intptr_t-aligned
@@ -32,6 +36,12 @@ TEST_GROUP(SolidSyslogFreeRtosDatagram)
         sin->sin_address.ulIP_IPv4 = FreeRTOS_inet_addr_quick(127, 0, 0, 1);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, see above
         addr = reinterpret_cast<struct SolidSyslogAddress*>(&addrStorage);
+    }
+
+    void openAndSendOnce()
+    {
+        SolidSyslogDatagram_Open(datagram);
+        SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
     }
 };
 
@@ -149,6 +159,58 @@ TEST(SolidSyslogFreeRtosDatagram, SendToSendsBufferToDestinationAfterOpen)
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- platform-layout cast, see setup
     POINTERS_EQUAL(reinterpret_cast<const struct freertos_sockaddr*>(addr), FreeRtosSocketsFake_LastSendtoDestination());
     LONGS_EQUAL(sizeof(struct freertos_sockaddr), FreeRtosSocketsFake_LastSendtoDestinationLength());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToChecksIfIpIsInArpCache)
+{
+    openAndSendOnce();
+
+    LONGS_EQUAL(1, FreeRtosArpFake_IsIpInArpCacheCallCount());
+    LONGS_EQUAL(FreeRTOS_inet_addr_quick(127, 0, 0, 1), FreeRtosArpFake_LastIsIpInArpCacheArg());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToFiresArpProbeOnCacheMiss)
+{
+    openAndSendOnce();
+
+    LONGS_EQUAL(1, FreeRtosArpFake_OutputArpRequestCallCount());
+    LONGS_EQUAL(FreeRTOS_inet_addr_quick(127, 0, 0, 1), FreeRtosArpFake_LastOutputArpRequestArg());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToYieldsAfterArpProbeOnCacheMiss)
+{
+    openAndSendOnce();
+
+    LONGS_EQUAL(1, FreeRtosTaskFake_VTaskDelayCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToSkipsArpProbeAndYieldOnCacheHit)
+{
+    SolidSyslogDatagram_Open(datagram);
+    FreeRtosArpFake_SetCacheHit(true);
+
+    SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+
+    LONGS_EQUAL(0, FreeRtosArpFake_OutputArpRequestCallCount());
+    LONGS_EQUAL(0, FreeRtosTaskFake_VTaskDelayCallCount());
+    LONGS_EQUAL(1, FreeRtosSocketsFake_SendtoCallCount());
+}
+
+TEST(SolidSyslogFreeRtosDatagram, SendToReChecksArpCacheOnEachCall)
+{
+    SolidSyslogDatagram_Open(datagram);
+
+    FreeRtosArpFake_SetCacheHit(true);
+    SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+    LONGS_EQUAL(0, FreeRtosArpFake_OutputArpRequestCallCount());
+
+    FreeRtosArpFake_SetCacheHit(false);
+    SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+    LONGS_EQUAL(1, FreeRtosArpFake_OutputArpRequestCallCount());
+
+    FreeRtosArpFake_SetCacheHit(true);
+    SolidSyslogDatagram_SendTo(datagram, "x", 1, addr);
+    LONGS_EQUAL(1, FreeRtosArpFake_OutputArpRequestCallCount());
 }
 
 TEST(SolidSyslogFreeRtosDatagram, SendToForwardsLengthVerbatim)

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosArpFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosArpFake.h
@@ -1,0 +1,29 @@
+#ifndef FREERTOSARPFAKE_H
+#define FREERTOSARPFAKE_H
+
+#include "ExternC.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    void FreeRtosArpFake_Reset(void);
+
+    /* xIsIPInARPCache configuration */
+    void FreeRtosArpFake_SetCacheHit(bool hit);
+
+    /* xIsIPInARPCache accessors */
+    unsigned FreeRtosArpFake_IsIpInArpCacheCallCount(void);
+    uint32_t FreeRtosArpFake_LastIsIpInArpCacheArg(void);
+
+    /* FreeRTOS_OutputARPRequest accessors */
+    unsigned FreeRtosArpFake_OutputArpRequestCallCount(void);
+    uint32_t FreeRtosArpFake_LastOutputArpRequestArg(void);
+
+EXTERN_C_END
+
+#endif /* FREERTOSARPFAKE_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosTaskFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosTaskFake.h
@@ -1,0 +1,19 @@
+#ifndef FREERTOSTASKFAKE_H
+#define FREERTOSTASKFAKE_H
+
+#include "ExternC.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+EXTERN_C_BEGIN
+
+    void FreeRtosTaskFake_Reset(void);
+
+    /* vTaskDelay accessors */
+    unsigned   FreeRtosTaskFake_VTaskDelayCallCount(void);
+    TickType_t FreeRtosTaskFake_LastVTaskDelayTicks(void);
+
+EXTERN_C_END
+
+#endif /* FREERTOSTASKFAKE_H */

--- a/Tests/Support/FreeRtosFakes/Source/FreeRtosArpFake.c
+++ b/Tests/Support/FreeRtosFakes/Source/FreeRtosArpFake.c
@@ -1,0 +1,58 @@
+#include "FreeRtosArpFake.h"
+
+#include "FreeRTOS_ARP.h"
+
+static unsigned isIpInArpCacheCallCount = 0;
+static uint32_t lastIsIpInArpCacheArg   = 0;
+static bool     cacheHit                = false;
+
+static unsigned outputArpRequestCallCount = 0;
+static uint32_t lastOutputArpRequestArg   = 0;
+
+void FreeRtosArpFake_Reset(void)
+{
+    isIpInArpCacheCallCount = 0;
+    lastIsIpInArpCacheArg   = 0;
+    cacheHit                = false;
+
+    outputArpRequestCallCount = 0;
+    lastOutputArpRequestArg   = 0;
+}
+
+void FreeRtosArpFake_SetCacheHit(bool hit)
+{
+    cacheHit = hit;
+}
+
+unsigned FreeRtosArpFake_IsIpInArpCacheCallCount(void)
+{
+    return isIpInArpCacheCallCount;
+}
+
+uint32_t FreeRtosArpFake_LastIsIpInArpCacheArg(void)
+{
+    return lastIsIpInArpCacheArg;
+}
+
+BaseType_t xIsIPInARPCache(uint32_t ulAddressToLookup)
+{
+    ++isIpInArpCacheCallCount;
+    lastIsIpInArpCacheArg = ulAddressToLookup;
+    return cacheHit ? pdTRUE : pdFALSE;
+}
+
+unsigned FreeRtosArpFake_OutputArpRequestCallCount(void)
+{
+    return outputArpRequestCallCount;
+}
+
+uint32_t FreeRtosArpFake_LastOutputArpRequestArg(void)
+{
+    return lastOutputArpRequestArg;
+}
+
+void FreeRTOS_OutputARPRequest(uint32_t ulIPAddress)
+{
+    ++outputArpRequestCallCount;
+    lastOutputArpRequestArg = ulIPAddress;
+}

--- a/Tests/Support/FreeRtosFakes/Source/FreeRtosTaskFake.c
+++ b/Tests/Support/FreeRtosFakes/Source/FreeRtosTaskFake.c
@@ -1,0 +1,26 @@
+#include "FreeRtosTaskFake.h"
+
+static unsigned   vTaskDelayCallCount = 0;
+static TickType_t lastVTaskDelayTicks = 0;
+
+void FreeRtosTaskFake_Reset(void)
+{
+    vTaskDelayCallCount = 0;
+    lastVTaskDelayTicks = 0;
+}
+
+unsigned FreeRtosTaskFake_VTaskDelayCallCount(void)
+{
+    return vTaskDelayCallCount;
+}
+
+TickType_t FreeRtosTaskFake_LastVTaskDelayTicks(void)
+{
+    return lastVTaskDelayTicks;
+}
+
+void vTaskDelay(const TickType_t xTicksToDelay)
+{
+    ++vTaskDelayCallCount;
+    lastVTaskDelayTicks = xTicksToDelay;
+}


### PR DESCRIPTION
## Purpose

Slice 3b.1.5 of S08.03 (#268), closes #298. Sits between #295 (slice 3b.1, just merged) and #296 (slice 3b.2, next).

Fixes the FreeRTOS-Plus-TCP "first-packet ARP drop" inside `SolidSyslogFreeRtosDatagram` so every consumer of the FreeRTOS UDP path inherits the fix transparently. Without this slice, slice 3b.2's QEMU smoke and the eventual S08.06 BDD job would have to send a throwaway first message or accept first-message loss after every cold start / endpoint-version transition.

## Change Description

**Production** (`Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c`)
- New `static inline PrimeArpIfMissing(uint32_t ip)` helper. SendTo delegates to it; the function now reads at one level of abstraction (open-check, get destination, prime ARP, send-and-map).
- On `xIsIPInARPCache(ip) == pdFALSE`: fires `FreeRTOS_OutputARPRequest(ip)`, yields via `vTaskDelay(ARP_RESOLUTION_WAIT_TICKS)` (50 ms), then `FreeRTOS_sendto`. Hit path skips both probe and yield. Fire-and-forget — no retry loop, UDP best-effort semantics.
- Multi-line comment on the helper explains the Plus-TCP behaviour vs Linux/Windows kernel ARP queuing, and why retry belongs in the store-and-forward layer above.
- `xIsIPInARPCache` over `eARPGetCacheEntry` (boolean vs tri-state with two unused out-params); single-arg `FreeRTOS_OutputARPRequest` over `_Multi` (no endpoint pointer needed); `vTaskDelay` direct (FreeRTOS-only adapter, no abstraction warranted).
- Public header unchanged. `SolidSyslogFreeRtosDatagram_Create` signature unchanged.

**Tests** (`Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp`)
- Five new tests, ZOMBIES order, red→green→refactor each cycle:
  - `SendToChecksIfIpIsInArpCache` — drives the cache check + IP-arg correctness.
  - `SendToFiresArpProbeOnCacheMiss` — drives the probe + IP-arg correctness; introduces the cache-miss branch.
  - `SendToYieldsAfterArpProbeOnCacheMiss` — drives the yield. Refactor: extract `static const TickType_t ARP_RESOLUTION_WAIT_TICKS = pdMS_TO_TICKS(50);` with comment.
  - `SendToSkipsArpProbeAndYieldOnCacheHit` — drives `FreeRtosArpFake_SetCacheHit(bool)`; locks in branch correctness.
  - `SendToReChecksArpCacheOnEachCall` — three SendTo calls alternating hit/miss/hit; locks in "no stale state".
- New `openAndSendOnce()` method on the TEST_GROUP collapses the repeated `Open + SendTo("x", 1, addr)` boilerplate in tests 1/2/3 (tests 4/5 keep their inline shape because they interleave fake-state changes between the two calls).
- Existing tests untouched (default fake state is cache-miss; existing miss-path tests continue to exercise the same end-to-end path).
- Test exe: 16 → 21 tests, 32 → 42 checks.

**Test infrastructure** (`Tests/Support/FreeRtosFakes/`)
- `FreeRtosArpFake.{c,h}` — Plus-TCP ARP subsystem. Implements `xIsIPInARPCache` (configurable hit/miss return) and `FreeRTOS_OutputARPRequest` (call counter + last-arg capture). Default returns `pdFALSE` (miss) so existing tests continue to exercise the same end-to-end path.
- `FreeRtosTaskFake.{c,h}` — Kernel scheduler primitive. Implements `vTaskDelay` (call counter + last-ticks capture).
- Split is along the natural seam (Plus-TCP vs Kernel) — a single combined fake file would have mixed unrelated upstream subsystems.

**Documentation**
- DEVLOG entry covers all design calls and the TDD progression.
- Memory file `project_freertos_arp_first_packet.md` updated to "resolved in slice 3b.1.5" with PR pointer.

## Test Evidence

Local validation in `cpputest-freertos-cross`:
- `cmake --preset debug && cmake --build --preset debug --target SolidSyslogFreeRtosDatagramTest && ./Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest` — **21 tests / 42 checks**, all green.
- `cmake --build --preset debug --target junit` — full host suite OK (1088 tests / 2345 checks across the SolidSyslog main exe).
- `clang-format --dry-run --Werror` on all changed/new C/H files — clean.
- `cmake --preset freertos-cross && cmake --build --preset freertos-cross` — `SolidSyslogFreeRtosSingleTask.elf` links clean. (Adapter is host-tested only; the cross build confirms no syntax drift between host and target compilers.)

`build-linux-gcc/clang/sanitize/coverage/tidy/cppcheck` are CI's job — they need a different container and most exclude FreeRTOS sources from local execution paths anyway.

## Areas Affected

- Modified: `Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c` — new helper + delegated SendTo.
- Modified: `Tests/FreeRtos/SolidSyslogFreeRtosDatagramTest.cpp` — 5 new tests, openAndSendOnce helper, fake resets.
- Modified: `Tests/FreeRtos/CMakeLists.txt` — adds the two new fake source files to `SolidSyslogFreeRtosDatagramTest`.
- Modified: `DEVLOG.md`.
- New: `Tests/Support/FreeRtosFakes/{Interface,Source}/{FreeRtosArpFake,FreeRtosTaskFake}.{c,h}`.

No changes to `Core/`, `Platform/Posix/`, `Platform/Windows/`, `Bdd/`, public headers, or any example. Slice scope respected.

## What this leaves for slice 3b.2

Slice 3b.2's QEMU smoke can `SolidSyslog_Log` once and expect the host listener to receive it — no warm-up message, no tolerance for first-message loss. The S08.06 BDD job (when it points at the FreeRTOS target) inherits the same guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * UDP datagram transmission now probes the ARP cache before sending to an IPv4 peer, avoiding first-message loss when the destination address is not yet cached.

* **Tests**
  * Extended test coverage for ARP cache hit/miss scenarios during datagram transmission.
  * Added test support for tracking ARP and task delay behavior.

* **Documentation**
  * Updated development log with ARP priming implementation details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/300)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->