### PR TITLE
feat: S08.03 slice 7 wire Origin SD into FreeRTOS example (untag origin.feature)

### DIFF
--- a/Bdd/features/origin.feature
+++ b/Bdd/features/origin.feature
@@ -1,5 +1,4 @@
 @udp
-@freertoswip
 Feature: Structured data — origin
   The library includes origin metadata identifying the software component.
 
@@ -23,6 +22,7 @@ Feature: Structured data — origin
     When the example program sends a syslog message
     Then the structured data contains ip "192.0.2.1"
 
+  @freertoswip
   Scenario: All standard structured data present
     Given the syslog oracle is running
     When the example program sends a syslog message

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,73 @@
 # Dev Log
 
+## 2026-05-10 — S08.03 slice 7 — Origin SD wiring in FreeRTOS example (#308)
+
+Slice 6 closed the cmdline→`set` translation gap so the FreeRTOS BDD
+runner reached 4 features / 10 scenarios green. Slice 7 wires the
+first structured-data element — Origin — into
+`Example/FreeRtos/SingleTask/main.c`, untags 4 of 5 `origin.feature`
+scenarios, and brings the runner to **5 features / 14 scenarios
+green**.
+
+### Decisions
+
+- **Reuse `Example/Common/ExampleIps.c` via CMakeLists addition.**
+  The Linux/Windows examples already use `ExampleIps_Count` /
+  `ExampleIps_At` returning the documentation IP "192.0.2.1"; reusing
+  the same source on FreeRTOS keeps the BDD assertion target-agnostic
+  and avoids a divergent local getter. One line in the FreeRTOS
+  source list (`Example/Common/ExampleIps.c`) — the include path was
+  already wired in slice 4 for `ExampleInteractive.h`.
+- **Hardcode `software` / `swVersion` in main.c.** Linux/Windows
+  hardcode them in their own `main.c` (`SolidSyslogExample` /
+  `0.7.0`); slice 7 stays consistent rather than lifting to a shared
+  `Example/Common` constant. Lifting is a separate cleanup that
+  would touch all three examples in one go.
+- **Real-IP enumeration deferred.** David flagged that
+  `ExampleIps.c` is a fake fixture (its file comment notes that "in
+  real deployments this comes from `getifaddrs(3)` on POSIX,
+  `GetAdaptersAddresses` on Windows"). The honest path on FreeRTOS
+  is `FreeRTOS_GetEndPoints` returning the actual configured IP
+  (10.0.2.15) — but doing that in one example creates a divergent
+  honesty level vs. Linux/Windows and breaks the BDD's `ip
+  "192.0.2.1"` assertion. The right rollout is across all three
+  examples plus a target-aware BDD layer; that conversation is
+  flagged in memory to surface at S08.03 (#268) closure (memory:
+  `project_origin_sd_real_ip_enumeration`).
+- **Per-scenario `@freertoswip` tagging on origin.feature.**
+  Scenarios 1–4 (software, swVersion, enterpriseId, ip) untag at
+  feature level. Scenario 5 (`All standard structured data
+  present`) keeps the tag because it also asserts `sequenceId` and
+  `tzKnown` — those need meta SD + timeQuality SD, which are
+  separate slices.
+
+### Local verification
+
+- `cmake --build --preset freertos-cross --target
+  SolidSyslogFreeRtosSingleTask` clean.
+- `behave --tags='not @wip and not @freertoswip and @udp' Bdd/
+  features/origin.feature` against `syslog-ng-freertos`: 4
+  scenarios pass, 1 skipped.
+- Full FreeRTOS BDD sweep: 5 features / 14 scenarios pass / 32
+  skipped (slice 6 baseline 4 / 10 / 36; +1 feature / +4 scenarios
+  / -4 skipped).
+- `clang-format --dry-run --Werror` on touched C files: clean.
+- Linux unit tests / cppcheck / tidy / iwyu / sanitize / coverage:
+  not run locally (cross-only devcontainer); CI's responsibility.
+
+### Deferred
+
+- Real-IP enumeration across Linux/Windows/FreeRTOS examples
+  (separate epic; surface at #268 close — see memory entry).
+- Lifting `software` / `swVersion` to `Example/Common` (cosmetic
+  cleanup; touches three examples).
+- Untag the `All standard structured data present` scenario —
+  needs meta SD + timeQuality SD wiring.
+
+### Open questions
+
+- None for this slice.
+
 ## 2026-05-09 — S08.03 slice 6 — cmdline → `set` translation in BDD target driver (#306)
 
 Slice 5 left eight `@udp` features tagged `@freertoswip` because the

--- a/Example/FreeRtos/SingleTask/CMakeLists.txt
+++ b/Example/FreeRtos/SingleTask/CMakeLists.txt
@@ -147,6 +147,7 @@ add_executable(SolidSyslogFreeRtosSingleTask
     ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
     ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
     ${CMAKE_SOURCE_DIR}/Example/Common/ExampleInteractive.c
+    ${CMAKE_SOURCE_DIR}/Example/Common/ExampleIps.c
     $<TARGET_OBJECTS:solid_syslog_freertos_upstream>
 )
 

--- a/Example/FreeRtos/SingleTask/main.c
+++ b/Example/FreeRtos/SingleTask/main.c
@@ -15,7 +15,9 @@
  * datagrams to {10.0.2.2, port=g_port}. */
 
 #include "CmsdkUart.h"
+#include "ExampleEnterpriseId.h"
 #include "ExampleInteractive.h"
+#include "ExampleIps.h"
 #include "SolidSyslog.h"
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogEndpoint.h"
@@ -24,6 +26,7 @@
 #include "SolidSyslogFreeRtosStaticResolver.h"
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogNullStore.h"
+#include "SolidSyslogOriginSd.h"
 #include "SolidSyslogPrival.h"
 #include "SolidSyslogTimestamp.h"
 #include "SolidSyslogUdpSender.h"
@@ -331,6 +334,16 @@ static void InteractiveTask(void* argument)
     struct SolidSyslogBuffer* buffer = SolidSyslogNullBuffer_Create(sender);
     struct SolidSyslogStore*  store  = SolidSyslogNullStore_Create();
 
+    struct SolidSyslogOriginSdConfig originConfig = {
+        .software     = "SolidSyslogExample",
+        .swVersion    = "0.7.0",
+        .enterpriseId = EXAMPLE_ENTERPRISE_ID,
+        .getIpCount   = ExampleIps_Count,
+        .getIpAt      = ExampleIps_At,
+    };
+    struct SolidSyslogStructuredData* originSd = SolidSyslogOriginSd_Create(&originConfig);
+    struct SolidSyslogStructuredData* sdList[] = {originSd};
+
     struct SolidSyslogConfig config = {
         .buffer       = buffer,
         .sender       = NULL,
@@ -339,14 +352,15 @@ static void InteractiveTask(void* argument)
         .getAppName   = GetAppName,
         .getProcessId = GetProcessId,
         .store        = store,
-        .sd           = NULL,
-        .sdCount      = 0U,
+        .sd           = sdList,
+        .sdCount      = sizeof(sdList) / sizeof(sdList[0]),
     };
     SolidSyslog_Create(&config);
 
     ExampleInteractive_Run(&g_message, stdin, NULL, OnSet);
 
     SolidSyslog_Destroy();
+    SolidSyslogOriginSd_Destroy();
     SolidSyslogNullStore_Destroy();
     SolidSyslogNullBuffer_Destroy();
     SolidSyslogUdpSender_Destroy();


### PR DESCRIPTION
Closes #308. Refs #268.

## Summary

- Wire `SolidSyslogOriginSd` into `Example/FreeRtos/SingleTask/main.c::InteractiveTask` with the same fixture values as the Linux/Windows examples: `software = "SolidSyslogExample"`, `swVersion = "0.7.0"`, `enterpriseId = EXAMPLE_ENTERPRISE_ID`, IP getters from `Example/Common/ExampleIps`.
- CMakeLists.txt: add `Example/Common/ExampleIps.c` to the FreeRTOS source list (one line; the Common include path was already wired in slice 4).
- `origin.feature`: drop the feature-level `@freertoswip`; keep scenario-level `@freertoswip` on `All standard structured data present` only — that scenario also asserts `sequenceId` / `tzKnown` which need meta SD + timeQuality SD wiring (separate slices).
- DEVLOG: append slice 7 entry covering the IP-fixture decision. Real-IP enumeration via `FreeRTOS_GetEndPoints` / `getifaddrs` / `GetAdaptersAddresses` is deferred to surface at S08.03 (#268) closure.
- After this slice the FreeRTOS BDD sweep is **5 features / 14 scenarios passing** (slice 6 baseline 4 / 10).

## Test plan

- [x] `cmake --build --preset freertos-cross --target SolidSyslogFreeRtosSingleTask` clean.
- [x] `behave --tags='not @wip and not @freertoswip and @udp' Bdd/features/origin.feature` against `syslog-ng-freertos` — 4 scenarios pass, 1 skipped, 0 failed.
- [x] Full FreeRTOS sweep — 5 features / 14 scenarios pass, 32 skipped, 0 failed.
- [x] `clang-format --dry-run --Werror` on touched C files clean.
- [ ] CI: `bdd-linux-syslog-ng` regression — Linux suite unchanged (only origin.feature tag movement; the example wiring change is FreeRTOS-only).
- [ ] CI: `bdd-freertos-qemu` — 14 passing scenarios.
- [ ] CI: `analyze-tidy`, `analyze-cppcheck`, `analyze-iwyu`, `analyze-format`, `build-linux-gcc/clang`, `sanitize-linux-gcc`, `coverage-linux-gcc`, `build-windows-msvc`, `bdd-windows-otel` — Linux/Windows side, not runnable from the freertos-target devcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)