### PR TITLE
chore: split MinSize out of TestUtils.h to drop #ifdef __cplusplus

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5447,3 +5447,53 @@ unchanged.
 - Rebased onto main after the S12.18 DEVLOG (#320) squash-merged, and
   pruned five `[gone]`-tracking local branches that survived earlier
   squash merges.
+
+## 2026-05-10 — Split MinSize out of TestUtils.h
+
+### Summary
+
+S24.02 review caught an `#ifdef __cplusplus` block at the top of
+`Tests/Support/TestUtils.h`. The whole codebase is supposed to be
+free of preprocessor conditionals outside header guards and the
+single authorised C/C++ interop case in `Core/Interface/ExternC.h`,
+so the deviation was worth fixing rather than carrying.
+
+The guard existed because `TestUtils.h` mixed two audiences: a tiny C
+helper (`MinSize`) needed by three test fakes (`StoreFake.c`,
+`SenderFake.c`, `BufferFake.c`), and the C++-only `CososoTesting`
+namespace + `CALLED_*` macros used by the test bodies. Splitting them
+removes the conditional cleanly:
+
+- New `Tests/Support/MinSize.h` — just the `MinSize` inline.
+  C-compatible, no guard needed.
+- `Tests/Support/TestUtils.h` — now pure C++ from line 1. No
+  `#ifdef __cplusplus`, no comment explaining why C consumers needed
+  to be shielded.
+- The three fake `.c` files swap their include from `TestUtils.h` to
+  `MinSize.h`.
+
+Four files modified, one added. 1088 tests still pass; format / tidy
+/ cppcheck all clean.
+
+### Decisions
+
+- **One header, one audience.** The `#ifdef __cplusplus` was load-
+  bearing only because two unrelated helpers shared a file. Splitting
+  is cheaper than carrying an exception, and it leaves the
+  no-conditional-compilation rule strict (now exactly one authorised
+  case: `extern "C"` in `Core/Interface/ExternC.h`).
+- **No story, one-off chore PR.** The change is mechanical and tiny
+  (4 files, ~15 lines net); CLAUDE.md's E24 charter explicitly carves
+  out "one-off chore PRs that don't need a tracked story" from epic
+  scope. Going through the issue / sub-issue / project-board recipe
+  for a 15-line diff would be ceremony for ceremony's sake.
+
+### Deferred
+
+- **`Tests/Support/TestAtomicOps.h:8`** — the genuine
+  `#if defined(SOLIDSYSLOG_TEST_USE_WINDOWS_ATOMIC_OPS)` build-time
+  selection between `SolidSyslogWindowsAtomicOps` and
+  `SolidSyslogStdAtomicOps`. Same review caught it; the clean fix is
+  a CMake-selected `TestAtomicOpsWindows.c` / `TestAtomicOpsStd.c`
+  shim mirroring the `SafeString*.c` pattern. Left to a follow-up so
+  this PR stays focused on the one deviation Code Review surfaced.

--- a/Tests/BufferFake.c
+++ b/Tests/BufferFake.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "SolidSyslogBufferDefinition.h"
-#include "TestUtils.h"
+#include "MinSize.h"
 
 enum
 {

--- a/Tests/SenderFake.c
+++ b/Tests/SenderFake.c
@@ -6,7 +6,7 @@
 
 #include "SolidSyslog.h"
 #include "SolidSyslogSenderDefinition.h"
-#include "TestUtils.h"
+#include "MinSize.h"
 
 struct SenderFake
 {

--- a/Tests/StoreFake.c
+++ b/Tests/StoreFake.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "SolidSyslogStoreDefinition.h"
-#include "TestUtils.h"
+#include "MinSize.h"
 
 enum
 {

--- a/Tests/Support/MinSize.h
+++ b/Tests/Support/MinSize.h
@@ -1,0 +1,11 @@
+#ifndef MINSIZE_H
+#define MINSIZE_H
+
+#include <stddef.h>
+
+static inline size_t MinSize(size_t a, size_t b)
+{
+    return (a < b) ? a : b;
+}
+
+#endif /* MINSIZE_H */

--- a/Tests/Support/TestUtils.h
+++ b/Tests/Support/TestUtils.h
@@ -1,16 +1,7 @@
 #ifndef TESTUTILS_H
 #define TESTUTILS_H
 
-#include <stddef.h>
-
-static inline size_t MinSize(size_t a, size_t b)
-{
-    return (a < b) ? a : b;
-}
-
-#ifdef __cplusplus
-
-#include "CppUTest/TestHarness.h" // IWYU pragma: keep — only used by the C++ macros below; placed inside the __cplusplus guard so C consumers don't pull in C++ headers.
+#include "CppUTest/TestHarness.h" // IWYU pragma: keep -- needed by the CALLED_* macros below
 
 namespace CososoTesting
 {
@@ -46,7 +37,5 @@ enum
 #define CALLED_FAKE(getter, count) LONGS_EQUAL((count), getter##CallCount())
 #define CALLED_FAKE_ON(getter, instance, count) LONGS_EQUAL((count), getter##CallCount(instance))
 // NOLINTEND(cppcoreguidelines-macro-usage)
-
-#endif /* __cplusplus */
 
 #endif /* TESTUTILS_H */


### PR DESCRIPTION
## Purpose

S24.02 review caught an `#ifdef __cplusplus` block at the top of
`Tests/Support/TestUtils.h`. The project rule is "no preprocessor
conditionals outside header guards", with one authorised exception
(`Core/Interface/ExternC.h` for `extern "C"` linkage). This was a
second deviation worth fixing rather than carrying.

## Change Description

`TestUtils.h` mixed two audiences: a tiny C helper (`MinSize`) used
by three test fakes, and the C++-only `CososoTesting` namespace +
`CALLED_*` macros used by the test bodies. The `#ifdef __cplusplus`
was load-bearing only because they shared a file. Splitting them
removes the conditional cleanly:

- New `Tests/Support/MinSize.h` — just the `MinSize` inline.
  C-compatible, no guard needed.
- `Tests/Support/TestUtils.h` — pure C++ from line 1. No
  `#ifdef __cplusplus`, no comment explaining why C consumers needed
  to be shielded.
- `Tests/StoreFake.c`, `Tests/SenderFake.c`, `Tests/BufferFake.c`
  swap their include from `TestUtils.h` to `MinSize.h`.

After this PR the test base has zero non-`ExternC` preprocessor
conditionals except for the known
`Tests/Support/TestAtomicOps.h:8` build-time-selection deviation
(tracked separately for a follow-up).

## Test Evidence

Pure mechanical split; no test changes.

- `cmake --build --preset debug --target junit` — 1088 tests pass.
- `cmake --build --preset tidy` — clean.
- `cmake --build --preset cppcheck` — clean.
- `clang-format --dry-run --Werror` over Core/Tests/Example — clean.

## Areas Affected

- **`Tests/Support/`** — one new header (`MinSize.h`), one trimmed
  header (`TestUtils.h`).
- **3 fake `.c` files** — include swap only.
- No production code touched. No effect on derived projects.