### PR TITLE
chore: route CmsdkUart headers through EXTERN_C_BEGIN/_END macros

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5497,3 +5497,56 @@ Four files modified, one added. 1088 tests still pass; format / tidy
   a CMake-selected `TestAtomicOpsWindows.c` / `TestAtomicOpsStd.c`
   shim mirroring the `SafeString*.c` pattern. Left to a follow-up so
   this PR stays focused on the one deviation Code Review surfaced.
+
+## 2026-05-11 — CmsdkUart extern "C" idiom via EXTERN_C macros
+
+### Summary
+
+Two CMSDK UART headers (`Example/FreeRtos/Common/CmsdkUart.h` and its
+fake `Tests/FreeRtos/CmsdkUartFake.h`) carried inline
+`#ifdef __cplusplus extern "C" {` / `#endif` blocks for the same C/C++
+interop reason as `Core/Interface/ExternC.h`, but written out by hand
+rather than reusing the `EXTERN_C_BEGIN` / `EXTERN_C_END` macros. The
+intent was identical; this PR just routes both headers through the
+canonical macro pair so the test base's preprocessor-conditional
+inventory is "ExternC.h, and one TestAtomicOps deviation, and nothing
+else".
+
+Include-path additions needed:
+
+- `Example/FreeRtos/HelloWorld/CMakeLists.txt` — adds
+  `${CMAKE_SOURCE_DIR}/Core/Interface` to pick up `ExternC.h` via
+  `CmsdkUart.h`.
+- `Tests/FreeRtos/CMakeLists.txt` (CmsdkUartTest target) — same.
+- `Example/FreeRtos/SingleTask` already had `Core/Interface` on its
+  include path; no change.
+
+### Decisions
+
+- **Reuse the macro rather than copy the idiom.** A canonical
+  `EXTERN_C_BEGIN` / `EXTERN_C_END` exists; carrying a second
+  copy-paste version of the same `#ifdef __cplusplus` pattern in two
+  more headers was drift in disguise. One macro, one place,
+  consistent across the project.
+- **Kept HelloWorld working rather than retiring it now.** Memory
+  flagged HelloWorld as a retirement candidate; the one-line include
+  bump is much smaller than a retirement, and retiring HelloWorld is
+  a separate decision with its own blast radius (top-level CMake
+  gate, docs references, example wiring). Surface the question
+  again next time HelloWorld is touched.
+
+### Verified
+
+- gcc host preset: 1088 tests pass.
+- freertos-host preset: CmsdkUartTest (15 tests) green.
+- freertos-cross ARM build: both `SolidSyslogFreeRtosHelloWorld` and
+  `SolidSyslogFreeRtosSingleTask` link clean. (Couldn't run the QEMU
+  smoke locally; relying on CI's `bdd-freertos-qemu` job for that.)
+- clang-format / tidy / cppcheck: clean.
+
+### Deferred
+
+- `Tests/Support/TestAtomicOps.h:8` — still the one remaining
+  non-authorised preprocessor conditional in the codebase. Same fix
+  outlined in the previous entry; not done in this PR to keep scope
+  tight.

--- a/Example/FreeRtos/Common/CmsdkUart.h
+++ b/Example/FreeRtos/Common/CmsdkUart.h
@@ -4,10 +4,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
 
     typedef uint32_t (*CmsdkUartRead32Function)(uintptr_t address);
     typedef void (*CmsdkUartWrite32Function)(uintptr_t address, uint32_t value);
@@ -25,8 +24,6 @@ extern "C"
     void CmsdkUart_Write(const char* buffer, size_t length);
     char CmsdkUart_GetChar(void);
 
-#ifdef __cplusplus
-}
-#endif
+EXTERN_C_END
 
 #endif

--- a/Example/FreeRtos/HelloWorld/CMakeLists.txt
+++ b/Example/FreeRtos/HelloWorld/CMakeLists.txt
@@ -41,6 +41,7 @@ target_compile_options(SolidSyslogFreeRtosHelloWorld PRIVATE
 target_include_directories(SolidSyslogFreeRtosHelloWorld PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h
     ${SOLID_SYSLOG_FREERTOS_EXAMPLE_COMMON_DIR}       # CmsdkUart.h
+    ${CMAKE_SOURCE_DIR}/Core/Interface                # ExternC.h (via CmsdkUart.h)
     ${FREERTOS_KERNEL_PATH}/include
     ${FREERTOS_PORT_DIR}                              # portmacro.h
 )

--- a/Tests/FreeRtos/CMakeLists.txt
+++ b/Tests/FreeRtos/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(CmsdkUartTest PRIVATE
 
 target_include_directories(CmsdkUartTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Example/FreeRtos/Common
+    ${CMAKE_SOURCE_DIR}/Core/Interface                # ExternC.h (via CmsdkUart.h)
     ${CMAKE_SOURCE_DIR}/Tests/Support
 )
 

--- a/Tests/FreeRtos/CmsdkUartFake.h
+++ b/Tests/FreeRtos/CmsdkUartFake.h
@@ -2,14 +2,12 @@
 #define CMSDK_UART_FAKE_H
 
 #include "CmsdkUart.h"
+#include "ExternC.h"
 
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+EXTERN_C_BEGIN
 
     /* Reset the fake's internal state. baseAddress must match the value passed
      * to CmsdkUart_Init so the fake can decode register offsets. */
@@ -46,8 +44,6 @@ extern "C"
      * value to force the driver to spin on STATE before reading DATA. */
     void CmsdkUartFake_SetReadsBeforeRxReady(int reads);
 
-#ifdef __cplusplus
-}
-#endif
+EXTERN_C_END
 
 #endif


### PR DESCRIPTION
## Purpose

Follow-up to #323. The codebase had two more inline `#ifdef __cplusplus
extern "C" {` / `#endif` blocks (one in
`Example/FreeRtos/Common/CmsdkUart.h`, one in its fake
`Tests/FreeRtos/CmsdkUartFake.h`) for the same C/C++ interop reason as
`Core/Interface/ExternC.h`. Same intent, three copy-pastes of the same
five lines — drift in disguise. Routing both headers through the
canonical `EXTERN_C_BEGIN` / `EXTERN_C_END` macros keeps the
preprocessor-conditional inventory consistent and minimal.

## Change Description

- `Example/FreeRtos/Common/CmsdkUart.h` and
  `Tests/FreeRtos/CmsdkUartFake.h` swap their inline `#ifdef __cplusplus`
  open/close pairs for `EXTERN_C_BEGIN` / `EXTERN_C_END`, with
  `#include "ExternC.h"` added.
- `Example/FreeRtos/HelloWorld/CMakeLists.txt` and the
  `CmsdkUartTest` target in `Tests/FreeRtos/CMakeLists.txt` pick up
  `${CMAKE_SOURCE_DIR}/Core/Interface` so `ExternC.h` resolves.
  `Example/FreeRtos/SingleTask` already had `Core/Interface` on its
  include path; no change.

After this PR the only remaining non-authorised preprocessor
conditional in the codebase is
`Tests/Support/TestAtomicOps.h:8` (deferred for a follow-up).

## Test Evidence

Pure idiom-swap; no test changes.

- gcc host preset: 1088 tests pass.
- freertos-host preset: `CmsdkUartTest` (15 tests) green.
- freertos-cross ARM build: both `SolidSyslogFreeRtosHelloWorld` and
  `SolidSyslogFreeRtosSingleTask` link clean. (QEMU smoke not run
  locally; relying on CI's `bdd-freertos-qemu` job.)
- `clang-format --dry-run --Werror`, tidy, cppcheck: clean.

## Areas Affected

- `Example/FreeRtos/Common/CmsdkUart.h` — 2 small replacements.
- `Tests/FreeRtos/CmsdkUartFake.h` — same.
- 2 `CMakeLists.txt` files — one-line include-path additions.
- No production code (Tier 1/2) touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized C++ compatibility macros in UART interface headers for improved code consistency and maintainability. No functional changes to APIs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/324)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->