### PR TITLE
feat: S12.04 nil-object defaults for SolidSyslog singleton (exemplar pattern)

### DIFF
--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -5,10 +5,13 @@
 #include <stddef.h>
 
 #include "SolidSyslogBuffer.h"
+#include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
+#include "SolidSyslogSenderDefinition.h"
 #include "SolidSyslogStore.h"
+#include "SolidSyslogStoreDefinition.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogMacros.h"
 #include "SolidSyslogSender.h"
@@ -46,8 +49,6 @@ static inline void        FormatTimestamp(struct SolidSyslogFormatter* f, SolidS
 static inline void        FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
 static inline bool        IsServiceEnabled(void);
 static inline uint8_t     MakePrival(const struct SolidSyslogMessage* message);
-static void               NilClock(struct SolidSyslogTimestamp* ts);
-static void               NilStringFunction(struct SolidSyslogFormatter* formatter);
 static inline bool        PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
 static void               ProcessMessages(void);
 static inline bool        SeverityIsValid(uint8_t severity);
@@ -68,12 +69,21 @@ struct SolidSyslog
     size_t                             sdCount;
 };
 
-static struct SolidSyslog instance = {
-    .clock        = NilClock,
-    .getHostname  = NilStringFunction,
-    .getAppName   = NilStringFunction,
-    .getProcessId = NilStringFunction,
-};
+/* === Nil collaborators ===
+ *
+ * Private no-op vtables that occupy every instance slot at file load and
+ * after _Destroy. Vtable dispatch never NULL-checks — the nils make every
+ * collaborator pointer safe to call. NilBuffer and NilSender report one
+ * error via SolidSyslog_Error on first use (audible-once); _Destroy re-arms
+ * those flags. NilStore is silent — its absence is a valid integrator
+ * choice and visible in the wire output anyway.
+ *
+ * The public SolidSyslogNull* family is for integrator-chosen no-ops with
+ * different semantics (e.g. NullBuffer is a direct-send shim); these
+ * internal nils are crash-safe defaults only. */
+
+static bool nilBufferHasReported = false;
+static bool nilSenderHasReported = false;
 
 static void NilClock(struct SolidSyslogTimestamp* ts)
 {
@@ -85,19 +95,139 @@ static void NilStringFunction(struct SolidSyslogFormatter* formatter)
     (void) formatter;
 }
 
+static void NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, size_t size)
+{
+    (void) self;
+    (void) data;
+    (void) size;
+    if (!nilBufferHasReported)
+    {
+        nilBufferHasReported = true;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+    }
+}
+
+static bool NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+{
+    (void) self;
+    (void) data;
+    (void) maxSize;
+    *bytesRead = 0;
+    return false;
+}
+
+static struct SolidSyslogBuffer NilBuffer = {
+    .Write = NilBufferWrite,
+    .Read  = NilBufferRead,
+};
+
+static bool NilSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+{
+    (void) self;
+    (void) buffer;
+    (void) size;
+    if (!nilSenderHasReported)
+    {
+        nilSenderHasReported = true;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
+    }
+    return true;
+}
+
+static void NilSenderDisconnect(struct SolidSyslogSender* self)
+{
+    (void) self;
+}
+
+static struct SolidSyslogSender NilSender = {
+    .Send       = NilSenderSend,
+    .Disconnect = NilSenderDisconnect,
+};
+
+static bool NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_t size)
+{
+    (void) self;
+    (void) data;
+    (void) size;
+    return false;
+}
+
+static bool NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+{
+    (void) self;
+    (void) data;
+    (void) maxSize;
+    *bytesRead = 0;
+    return false;
+}
+
+static void NilStoreMarkSent(struct SolidSyslogStore* self)
+{
+    (void) self;
+}
+
+static bool NilStoreHasUnsent(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static bool NilStoreIsHalted(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static size_t NilStoreGetTotalBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
+}
+
+static size_t NilStoreGetUsedBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
+}
+
+static struct SolidSyslogStore NilStore = {
+    .Write          = NilStoreWrite,
+    .ReadNextUnsent = NilStoreReadNextUnsent,
+    .MarkSent       = NilStoreMarkSent,
+    .HasUnsent      = NilStoreHasUnsent,
+    .IsHalted       = NilStoreIsHalted,
+    .GetTotalBytes  = NilStoreGetTotalBytes,
+    .GetUsedBytes   = NilStoreGetUsedBytes,
+};
+
+static struct SolidSyslog instance = {
+    .buffer       = &NilBuffer,
+    .sender       = &NilSender,
+    .clock        = NilClock,
+    .getHostname  = NilStringFunction,
+    .getAppName   = NilStringFunction,
+    .getProcessId = NilStringFunction,
+    .store        = &NilStore,
+};
+
+static void InstallConfig(const struct SolidSyslogConfig* config)
+{
+    ASSIGN_OR_REPORT(instance.buffer, config->buffer, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
+    ASSIGN_OR_REPORT(instance.sender, config->sender, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
+    ASSIGN_OR_REPORT(instance.store, config->store, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
+    ASSIGN_IF_NON_NULL(instance.clock, config->clock);
+    ASSIGN_IF_NON_NULL(instance.getHostname, config->getHostname);
+    ASSIGN_IF_NON_NULL(instance.getAppName, config->getAppName);
+    ASSIGN_IF_NON_NULL(instance.getProcessId, config->getProcessId);
+    instance.sd      = config->sd;
+    instance.sdCount = config->sdCount;
+}
+
 void SolidSyslog_Create(const struct SolidSyslogConfig* config)
 {
     if (config != NULL)
     {
-        instance.buffer = config->buffer;
-        instance.sender = config->sender;
-        ASSIGN_IF_NON_NULL(instance.clock, config->clock);
-        ASSIGN_IF_NON_NULL(instance.getHostname, config->getHostname);
-        ASSIGN_IF_NON_NULL(instance.getAppName, config->getAppName);
-        ASSIGN_IF_NON_NULL(instance.getProcessId, config->getProcessId);
-        instance.store   = config->store;
-        instance.sd      = config->sd;
-        instance.sdCount = config->sdCount;
+        InstallConfig(config);
     }
     else
     {
@@ -107,15 +237,17 @@ void SolidSyslog_Create(const struct SolidSyslogConfig* config)
 
 void SolidSyslog_Destroy(void)
 {
-    instance.buffer       = NULL;
-    instance.sender       = NULL;
+    instance.buffer       = &NilBuffer;
+    instance.sender       = &NilSender;
     instance.clock        = NilClock;
     instance.getHostname  = NilStringFunction;
     instance.getAppName   = NilStringFunction;
     instance.getProcessId = NilStringFunction;
-    instance.store        = NULL;
+    instance.store        = &NilStore;
     instance.sd           = NULL;
     instance.sdCount      = 0;
+    nilBufferHasReported  = false;
+    nilSenderHasReported  = false;
 }
 
 void SolidSyslog_Service(void)
@@ -172,11 +304,18 @@ static inline void SendOneFromStore(void)
 
 void SolidSyslog_Log(const struct SolidSyslogMessage* message)
 {
-    SolidSyslogFormatterStorage  storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
-    struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+    if (message != NULL)
+    {
+        SolidSyslogFormatterStorage  storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
+        struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
-    FormatMessage(f, message);
-    SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsFormattedBuffer(f), SolidSyslogFormatter_Length(f));
+        FormatMessage(f, message);
+        SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsFormattedBuffer(f), SolidSyslogFormatter_Length(f));
+    }
+    else
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
+    }
 }
 
 static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -1,22 +1,21 @@
 #include "SolidSyslog.h"
 
 #include <stdbool.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogSender.h"
 #include "SolidSyslogSenderDefinition.h"
 #include "SolidSyslogStore.h"
 #include "SolidSyslogStoreDefinition.h"
-#include "SolidSyslogFormatter.h"
-#include "SolidSyslogMacros.h"
-#include "SolidSyslogSender.h"
-#include "SolidSyslogStructuredData.h"
 #include "SolidSyslogStringFunction.h"
+#include "SolidSyslogStructuredData.h"
 #include "SolidSyslogTimestamp.h"
 
 struct SolidSyslogFormatter;
@@ -30,6 +29,61 @@ enum
     SOLIDSYSLOG_MAX_PROCESS_ID_SIZE = 129
 };
 
+struct SolidSyslog
+{
+    struct SolidSyslogBuffer*          buffer;
+    struct SolidSyslogSender*          sender;
+    SolidSyslogClockFunction           clock;
+    SolidSyslogStringFunction          getHostname;
+    SolidSyslogStringFunction          getAppName;
+    SolidSyslogStringFunction          getProcessId;
+    struct SolidSyslogStore*           store;
+    struct SolidSyslogStructuredData** sd;
+    size_t                             sdCount;
+};
+
+/* Forward declarations for the Nil "class" defined at the bottom of the file.
+ * The Nil objects act as default collaborators that make the singleton
+ * crash-safe pre-Create and post-Destroy; the file-static instance below and
+ * the NilInstance template both reference these by address. The Nil
+ * implementations live below SolidSyslog so this file reads as two cooperating
+ * "classes" — SolidSyslog first, then the Nil collaborators it depends on. */
+static void                     NilClock(struct SolidSyslogTimestamp* ts);
+static void                     NilStringFunction(struct SolidSyslogFormatter* formatter);
+static struct SolidSyslogBuffer NilBuffer;
+static struct SolidSyslogSender NilSender;
+static struct SolidSyslogStore  NilStore;
+static bool                     nilBufferReportArmed;
+static bool                     nilSenderReportArmed;
+static bool                     instanceInitialised;
+
+static struct SolidSyslog instance = {
+    .buffer       = &NilBuffer,
+    .sender       = &NilSender,
+    .clock        = NilClock,
+    .getHostname  = NilStringFunction,
+    .getAppName   = NilStringFunction,
+    .getProcessId = NilStringFunction,
+    .store        = &NilStore,
+};
+
+/* Template used by _Create and _Destroy to reset every slot to its nil. C99
+ * forbids initialising one file-static from another, so the same literal
+ * appears once above and once here; both sites stay in sync trivially because
+ * the values are nil-object addresses. */
+static const struct SolidSyslog NilInstance = {
+    .buffer       = &NilBuffer,
+    .sender       = &NilSender,
+    .clock        = NilClock,
+    .getHostname  = NilStringFunction,
+    .getAppName   = NilStringFunction,
+    .getProcessId = NilStringFunction,
+    .store        = &NilStore,
+};
+
+/* SolidSyslog helpers forward-declared so the public functions and
+ * _Create/_Destroy can call them; each is defined immediately beneath its
+ * first caller below. */
 static inline int16_t     AbsoluteInt16(int16_t value);
 static inline bool        CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock);
 static inline uint8_t     CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
@@ -47,6 +101,15 @@ static inline void        FormatStringField(struct SolidSyslogFormatter* f, Soli
 static inline void        FormatStructuredData(struct SolidSyslogFormatter* f, struct SolidSyslogStructuredData** sd, size_t sdCount);
 static inline void        FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock);
 static inline void        FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
+static void               InstallAppName(SolidSyslogStringFunction configured);
+static void               InstallBuffer(struct SolidSyslogBuffer* configured);
+static void               InstallClock(SolidSyslogClockFunction configured);
+static void               InstallConfig(const struct SolidSyslogConfig* config);
+static void               InstallHostname(SolidSyslogStringFunction configured);
+static void               InstallProcessId(SolidSyslogStringFunction configured);
+static void               InstallSender(struct SolidSyslogSender* configured);
+static void               InstallStore(struct SolidSyslogStore* configured);
+static void               InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count);
 static inline bool        IsServiceEnabled(void);
 static inline uint8_t     MakePrival(const struct SolidSyslogMessage* message);
 static inline bool        PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
@@ -56,198 +119,116 @@ static inline const char* SkipLeadingBom(const char* msg);
 static inline bool        StringIsValid(const char* value);
 static inline bool        TimestampIsValid(const struct SolidSyslogTimestamp* ts);
 
-struct SolidSyslog
-{
-    struct SolidSyslogBuffer*          buffer;
-    struct SolidSyslogSender*          sender;
-    SolidSyslogClockFunction           clock;
-    SolidSyslogStringFunction          getHostname;
-    SolidSyslogStringFunction          getAppName;
-    SolidSyslogStringFunction          getProcessId;
-    struct SolidSyslogStore*           store;
-    struct SolidSyslogStructuredData** sd;
-    size_t                             sdCount;
-};
-
-/* === Nil collaborators ===
- *
- * Private no-op vtables that occupy every instance slot at file load and
- * after _Destroy. Vtable dispatch never NULL-checks — the nils make every
- * collaborator pointer safe to call. NilBuffer and NilSender report one
- * error via SolidSyslog_Error on first use (audible-once); _Destroy re-arms
- * those flags. NilStore is silent — its absence is a valid integrator
- * choice and visible in the wire output anyway.
- *
- * The public SolidSyslogNull* family is for integrator-chosen no-ops with
- * different semantics (e.g. NullBuffer is a direct-send shim); these
- * internal nils are crash-safe defaults only. */
-
-static bool nilBufferHasReported = false;
-static bool nilSenderHasReported = false;
-
-static void NilClock(struct SolidSyslogTimestamp* ts)
-{
-    (void) ts;
-}
-
-static void NilStringFunction(struct SolidSyslogFormatter* formatter)
-{
-    (void) formatter;
-}
-
-static void NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, size_t size)
-{
-    (void) self;
-    (void) data;
-    (void) size;
-    if (!nilBufferHasReported)
-    {
-        nilBufferHasReported = true;
-        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
-    }
-}
-
-static bool NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
-{
-    (void) self;
-    (void) data;
-    (void) maxSize;
-    *bytesRead = 0;
-    return false;
-}
-
-static struct SolidSyslogBuffer NilBuffer = {
-    .Write = NilBufferWrite,
-    .Read  = NilBufferRead,
-};
-
-static bool NilSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
-{
-    (void) self;
-    (void) buffer;
-    (void) size;
-    if (!nilSenderHasReported)
-    {
-        nilSenderHasReported = true;
-        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
-    }
-    return true;
-}
-
-static void NilSenderDisconnect(struct SolidSyslogSender* self)
-{
-    (void) self;
-}
-
-static struct SolidSyslogSender NilSender = {
-    .Send       = NilSenderSend,
-    .Disconnect = NilSenderDisconnect,
-};
-
-static bool NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_t size)
-{
-    (void) self;
-    (void) data;
-    (void) size;
-    return false;
-}
-
-static bool NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
-{
-    (void) self;
-    (void) data;
-    (void) maxSize;
-    *bytesRead = 0;
-    return false;
-}
-
-static void NilStoreMarkSent(struct SolidSyslogStore* self)
-{
-    (void) self;
-}
-
-static bool NilStoreHasUnsent(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return false;
-}
-
-static bool NilStoreIsHalted(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return false;
-}
-
-static size_t NilStoreGetTotalBytes(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return 0;
-}
-
-static size_t NilStoreGetUsedBytes(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return 0;
-}
-
-static struct SolidSyslogStore NilStore = {
-    .Write          = NilStoreWrite,
-    .ReadNextUnsent = NilStoreReadNextUnsent,
-    .MarkSent       = NilStoreMarkSent,
-    .HasUnsent      = NilStoreHasUnsent,
-    .IsHalted       = NilStoreIsHalted,
-    .GetTotalBytes  = NilStoreGetTotalBytes,
-    .GetUsedBytes   = NilStoreGetUsedBytes,
-};
-
-static struct SolidSyslog instance = {
-    .buffer       = &NilBuffer,
-    .sender       = &NilSender,
-    .clock        = NilClock,
-    .getHostname  = NilStringFunction,
-    .getAppName   = NilStringFunction,
-    .getProcessId = NilStringFunction,
-    .store        = &NilStore,
-};
-
-static void InstallConfig(const struct SolidSyslogConfig* config)
-{
-    ASSIGN_OR_REPORT(instance.buffer, config->buffer, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
-    ASSIGN_OR_REPORT(instance.sender, config->sender, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
-    ASSIGN_OR_REPORT(instance.store, config->store, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
-    ASSIGN_IF_NON_NULL(instance.clock, config->clock);
-    ASSIGN_IF_NON_NULL(instance.getHostname, config->getHostname);
-    ASSIGN_IF_NON_NULL(instance.getAppName, config->getAppName);
-    ASSIGN_IF_NON_NULL(instance.getProcessId, config->getProcessId);
-    instance.sd      = config->sd;
-    instance.sdCount = config->sdCount;
-}
-
 void SolidSyslog_Create(const struct SolidSyslogConfig* config)
 {
-    if (config != NULL)
+    if (instanceInitialised)
     {
-        InstallConfig(config);
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_CREATE_ALREADY_INITIALISED);
     }
-    else
+    else if (config == NULL)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_CONFIG);
     }
+    else
+    {
+        InstallConfig(config);
+        instanceInitialised = true;
+    }
+}
+
+static void InstallConfig(const struct SolidSyslogConfig* config)
+{
+    instance = NilInstance;
+    InstallBuffer(config->buffer);
+    InstallSender(config->sender);
+    InstallStore(config->store);
+    InstallClock(config->clock);
+    InstallHostname(config->getHostname);
+    InstallAppName(config->getAppName);
+    InstallProcessId(config->getProcessId);
+    InstallStructuredData(config->sd, config->sdCount);
+}
+
+static void InstallBuffer(struct SolidSyslogBuffer* configured)
+{
+    if (configured == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
+    }
+    else
+    {
+        instance.buffer = configured;
+    }
+}
+
+static void InstallSender(struct SolidSyslogSender* configured)
+{
+    if (configured == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
+    }
+    else
+    {
+        instance.sender = configured;
+    }
+}
+
+static void InstallStore(struct SolidSyslogStore* configured)
+{
+    if (configured == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
+    }
+    else
+    {
+        instance.store = configured;
+    }
+}
+
+static void InstallClock(SolidSyslogClockFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.clock = configured;
+    }
+}
+
+static void InstallHostname(SolidSyslogStringFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.getHostname = configured;
+    }
+}
+
+static void InstallAppName(SolidSyslogStringFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.getAppName = configured;
+    }
+}
+
+static void InstallProcessId(SolidSyslogStringFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.getProcessId = configured;
+    }
+}
+
+static void InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count)
+{
+    instance.sd      = configured;
+    instance.sdCount = count;
 }
 
 void SolidSyslog_Destroy(void)
 {
-    instance.buffer       = &NilBuffer;
-    instance.sender       = &NilSender;
-    instance.clock        = NilClock;
-    instance.getHostname  = NilStringFunction;
-    instance.getAppName   = NilStringFunction;
-    instance.getProcessId = NilStringFunction;
-    instance.store        = &NilStore;
-    instance.sd           = NULL;
-    instance.sdCount      = 0;
-    nilBufferHasReported  = false;
-    nilSenderHasReported  = false;
+    instance             = NilInstance;
+    nilBufferReportArmed = true;
+    nilSenderReportArmed = true;
+    instanceInitialised  = false;
 }
 
 void SolidSyslog_Service(void)
@@ -304,17 +285,17 @@ static inline void SendOneFromStore(void)
 
 void SolidSyslog_Log(const struct SolidSyslogMessage* message)
 {
-    if (message != NULL)
+    if (message == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
+    }
+    else
     {
         SolidSyslogFormatterStorage  storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
         struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
         FormatMessage(f, message);
         SolidSyslogBuffer_Write(instance.buffer, SolidSyslogFormatter_AsFormattedBuffer(f), SolidSyslogFormatter_Length(f));
-    }
-    else
-    {
-        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
     }
 }
 
@@ -545,3 +526,145 @@ static inline void FormatNilvalue(struct SolidSyslogFormatter* f)
 {
     SolidSyslogFormatter_AsciiCharacter(f, '-');
 }
+
+/* ============================================================================
+ * Nil collaborators
+ *
+ * Private no-op vtables that occupy every instance slot at file load, after
+ * _Destroy, and for any required slot the integrator left NULL in their
+ * config. Vtable dispatch never NULL-checks — the nils make every collaborator
+ * pointer safe to call.
+ *
+ * NilBuffer and NilSender report one error via SolidSyslog_Error on first
+ * use, then silently consume; _Destroy re-arms the flags. NilStore is silent
+ * — its absence is a valid integrator choice (matches SolidSyslogNullStore
+ * semantics: drain proceeds, fall-through to direct send).
+ *
+ * The public SolidSyslogNull* family is for integrator-chosen no-ops with
+ * different semantics (e.g. NullBuffer is a direct-send shim); these
+ * internal nils are crash-safe defaults only.
+ * ============================================================================ */
+
+static bool nilBufferReportArmed = true;
+static bool nilSenderReportArmed = true;
+
+static void NilClock(struct SolidSyslogTimestamp* ts)
+{
+    (void) ts;
+}
+
+static void NilStringFunction(struct SolidSyslogFormatter* formatter)
+{
+    (void) formatter;
+}
+
+/* NilBuffer */
+
+static void NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, size_t size)
+{
+    (void) self;
+    (void) data;
+    (void) size;
+    if (nilBufferReportArmed)
+    {
+        nilBufferReportArmed = false;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+    }
+}
+
+static bool NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+{
+    (void) self;
+    (void) data;
+    (void) maxSize;
+    *bytesRead = 0;
+    return false;
+}
+
+static struct SolidSyslogBuffer NilBuffer = {
+    .Write = NilBufferWrite,
+    .Read  = NilBufferRead,
+};
+
+/* NilSender */
+
+static bool NilSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+{
+    (void) self;
+    (void) buffer;
+    (void) size;
+    if (nilSenderReportArmed)
+    {
+        nilSenderReportArmed = false;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
+    }
+    return true;
+}
+
+static void NilSenderDisconnect(struct SolidSyslogSender* self)
+{
+    (void) self;
+}
+
+static struct SolidSyslogSender NilSender = {
+    .Send       = NilSenderSend,
+    .Disconnect = NilSenderDisconnect,
+};
+
+/* NilStore */
+
+static bool NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_t size)
+{
+    (void) self;
+    (void) data;
+    (void) size;
+    return false;
+}
+
+static bool NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+{
+    (void) self;
+    (void) data;
+    (void) maxSize;
+    *bytesRead = 0;
+    return false;
+}
+
+static void NilStoreMarkSent(struct SolidSyslogStore* self)
+{
+    (void) self;
+}
+
+static bool NilStoreHasUnsent(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static bool NilStoreIsHalted(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static size_t NilStoreGetTotalBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
+}
+
+static size_t NilStoreGetUsedBytes(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return 0;
+}
+
+static struct SolidSyslogStore NilStore = {
+    .Write          = NilStoreWrite,
+    .ReadNextUnsent = NilStoreReadNextUnsent,
+    .MarkSent       = NilStoreMarkSent,
+    .HasUnsent      = NilStoreHasUnsent,
+    .IsHalted       = NilStoreIsHalted,
+    .GetTotalBytes  = NilStoreGetTotalBytes,
+    .GetUsedBytes   = NilStoreGetUsedBytes,
+};

--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -2,5 +2,11 @@
 #define SOLIDSYSLOGERRORMESSAGES_H
 
 #define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_CONFIG "SolidSyslog_Create called with NULL config"
+#define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER "SolidSyslog_Create config.buffer is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER "SolidSyslog_Create config.sender is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE "SolidSyslog_Create config.store is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE "SolidSyslog_Log called with NULL message"
+#define SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED "SolidSyslog_Log called with no buffer configured"
+#define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -5,6 +5,7 @@
 #define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER "SolidSyslog_Create config.buffer is NULL"
 #define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER "SolidSyslog_Create config.sender is NULL"
 #define SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE "SolidSyslog_Create config.store is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_CREATE_ALREADY_INITIALISED "SolidSyslog_Create called while already initialised - call _Destroy first"
 #define SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE "SolidSyslog_Log called with NULL message"
 #define SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED "SolidSyslog_Log called with no buffer configured"
 #define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"

--- a/Core/Source/SolidSyslogMacros.h
+++ b/Core/Source/SolidSyslogMacros.h
@@ -1,40 +1,6 @@
 #ifndef SOLIDSYSLOGMACROS_H
 #define SOLIDSYSLOGMACROS_H
 
-#include <stddef.h>
-
-#include "SolidSyslogError.h"
-
-/* Deviation from MISRA Dir 4.9: type-generic NULL guard cannot be expressed
-   as an inline function without void* casts (Rule 11.5). Macro is preferred
-   over repeated if-blocks or type-unsafe alternatives. */
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */
-#define ASSIGN_IF_NON_NULL(field, value) \
-    do                                   \
-    {                                    \
-        if ((value) != NULL)             \
-        {                                \
-            (field) = (value);           \
-        }                                \
-    } while (0)
-
-/* Same deviation as ASSIGN_IF_NON_NULL — type-generic NULL guard needs a macro.
-   Used in _Create paths to install a required collaborator or report exactly
-   which slot the integrator left NULL. */
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */
-#define ASSIGN_OR_REPORT(field, value, errorMessage)                     \
-    do                                                                   \
-    {                                                                    \
-        if ((value) != NULL)                                             \
-        {                                                                \
-            (field) = (value);                                           \
-        }                                                                \
-        else                                                             \
-        {                                                                \
-            SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, (errorMessage)); \
-        }                                                                \
-    } while (0)
-
 /* Portable compile-time assertion. Uses the negative-array-size trick
    which works from C89 through C23 and all C++ versions — no C11 required. */
 /* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */

--- a/Core/Source/SolidSyslogMacros.h
+++ b/Core/Source/SolidSyslogMacros.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+#include "SolidSyslogError.h"
+
 /* Deviation from MISRA Dir 4.9: type-generic NULL guard cannot be expressed
    as an inline function without void* casts (Rule 11.5). Macro is preferred
    over repeated if-blocks or type-unsafe alternatives. */
@@ -14,6 +16,23 @@
         {                                \
             (field) = (value);           \
         }                                \
+    } while (0)
+
+/* Same deviation as ASSIGN_IF_NON_NULL — type-generic NULL guard needs a macro.
+   Used in _Create paths to install a required collaborator or report exactly
+   which slot the integrator left NULL. */
+/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) */
+#define ASSIGN_OR_REPORT(field, value, errorMessage)                     \
+    do                                                                   \
+    {                                                                    \
+        if ((value) != NULL)                                             \
+        {                                                                \
+            (field) = (value);                                           \
+        }                                                                \
+        else                                                             \
+        {                                                                \
+            SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, (errorMessage)); \
+        }                                                                \
     } while (0)
 
 /* Portable compile-time assertion. Uses the negative-array-size trick

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -69,8 +69,14 @@ struct SolidSyslogSender* SolidSyslogStreamSender_Create(SolidSyslogStreamSender
     *sender                                = DEFAULT_INSTANCE;
     sender->config.resolver                = config->resolver;
     sender->config.stream                  = config->stream;
-    ASSIGN_IF_NON_NULL(sender->config.endpoint, config->endpoint);
-    ASSIGN_IF_NON_NULL(sender->config.endpointVersion, config->endpointVersion);
+    if (config->endpoint != NULL)
+    {
+        sender->config.endpoint = config->endpoint;
+    }
+    if (config->endpointVersion != NULL)
+    {
+        sender->config.endpointVersion = config->endpointVersion;
+    }
     return &sender->base;
 }
 

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -46,8 +46,14 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     instance                 = DEFAULT_INSTANCE;
     instance.config.resolver = config->resolver;
     instance.config.datagram = config->datagram;
-    ASSIGN_IF_NON_NULL(instance.config.endpoint, config->endpoint);
-    ASSIGN_IF_NON_NULL(instance.config.endpointVersion, config->endpointVersion);
+    if (config->endpoint != NULL)
+    {
+        instance.config.endpoint = config->endpoint;
+    }
+    if (config->endpointVersion != NULL)
+    {
+        instance.config.endpointVersion = config->endpointVersion;
+    }
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;
     return &instance.base;

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -4,7 +4,6 @@
 
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
-#include "SolidSyslogMacros.h"
 #include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5623,3 +5623,112 @@ Include-path additions needed:
   non-authorised preprocessor conditional in the codebase. Same fix
   outlined in the previous entry; not done in this PR to keep scope
   tight.
+
+## 2026-05-11 — S12.04 nil-object defaults for SolidSyslog singleton
+
+Re-scoped #115 from "two NULL guards" into the exemplar nil-object
+pattern that the rest of E12 (UdpSender, MetaSd, OriginSd,
+AtomicCounter NULL-guard stories) will copy. Original story body
+described two crash sites (`Create(NULL config)`, `Log(NULL message)`)
+but the audit also caught pre-Create and post-Destroy: the static
+`instance` had buffer/sender/store as NULL, so `Service()` and `Log()`
+crashed at vtable dispatch in both states. S12.18 had already
+shipped the `Create(NULL config)` case via the new error-reporting
+channel; this story does the rest.
+
+### Pattern
+
+For every singleton-or-handle class with vtable collaborators:
+
+1. Private nils as file-static structs inside the class's `.c` —
+   fully-populated vtables of file-static no-op functions. Not in
+   any public header; the public `SolidSyslogNull*` family is for
+   integrator-chosen no-ops with different semantics. These private
+   nils are crash-safe defaults only.
+2. Static instance points at the nils at file load.
+3. `_Create(config)`:
+   - `config == NULL` → `Error(MSG_CREATE_NULL_CONFIG)`, return.
+   - Required field NULL → `Error(MSG_CREATE_NULL_<FIELD>)`, leave
+     the nil in place.
+   - Optional field NULL → `ASSIGN_IF_NON_NULL` (nil stays).
+4. `_Destroy()` resets every slot to its nil. Idempotent. Re-arms
+   audible-once flags.
+5. Public entry points other than `_Create` dispatch through
+   `instance.*` unconditionally — no NULL checks on collaborators.
+6. Parameter NULL guards on entry points that take pointers
+   (e.g. `_Log(message)`).
+7. Audible-once nils for collaborators where absence leaves no
+   visible trace — `NilBuffer.Write` and `NilSender.Send` each
+   report one `SolidSyslog_Error` on first use, then silently
+   consume. `NilStore`, `NilClock`, `NilStringFunction` are silent
+   (their absence shows up elsewhere — fallthrough, `-` in the wire
+   output).
+
+### Decisions
+
+- **Private nils inside the .c, not a separate module.** Considered
+  extracting `Core/Source/SolidSyslogNilBuffer.{c,h}` etc. so each
+  nil could get its own white-box test file and hit 100% line
+  coverage on every vtable method (matching how the public
+  `SolidSyslogNullStore` is tested). Held off — the story scope is
+  "set the pattern", and extracting is a bigger restructure best
+  done if a second class reuses the same nil. Current line coverage
+  on `SolidSyslog.c` is 95.3% (filtered-overall 99.5%, well above
+  the 90% gate); the uncovered slots are vtable-contract padding
+  (NilStore HasUnsent / GetTotalBytes / GetUsedBytes / MarkSent,
+  NilSender Disconnect) which `SolidSyslog.c` never calls and
+  integrators can't reach because the nils are file-static.
+- **`NilSender.Send` returns `true` (consumed).** If it returned
+  `false`, the store would keep replaying the message forever for
+  an integrator who had already been told once "no sender
+  configured". Returning `true` settles the system into a steady
+  state after the audible warning.
+- **`NilStore.IsHalted` returns `false`.** Matches public
+  `SolidSyslogNullStore` semantics — drain proceeds, `Store.Write`
+  returns `false`, fallthrough to direct `Sender.Send`. Lets the
+  integrator wire only buffer+sender (no S&F) and still get
+  messages through. Tried `true` for the literal minimum on the
+  first red-green-refactor but flipped to `false` once the next
+  test required drain to run.
+- **Audible-once flags reset on `_Destroy` (not on `_Create`).**
+  Contract is "one warning per Destroy cycle". Tests cover
+  re-arming after Destroy. Resetting on Create as well would be a
+  no-op for the typical Create-once-Destroy-once lifecycle; the
+  shape stays simple.
+- **Per-field NULL-config diagnostics.** New
+  `MSG_CREATE_NULL_BUFFER` / `_SENDER` / `_STORE` constants and a
+  new `ASSIGN_OR_REPORT(field, value, errorMsg)` macro in
+  `SolidSyslogMacros.h`, parallel to `ASSIGN_IF_NON_NULL`. Macro is
+  MISRA Dir-4.9-deviated for the same reason as
+  `ASSIGN_IF_NON_NULL`. `_Create` body now reads as a table of
+  required-vs-optional installs.
+- **Cognitive-complexity fix via `InstallConfig` helper.** Inlining
+  three `ASSIGN_OR_REPORT` + four `ASSIGN_IF_NON_NULL` macros into
+  `_Create` pushed it past the clang-tidy threshold (40 > 25);
+  extracting the per-field work to `static void InstallConfig`
+  brings `_Create` back to the simple `if(config) install; else
+  error;` shape.
+
+### Verified
+
+- `debug`, `clang-debug`, `sanitize` presets: 1101 tests pass.
+- `coverage` preset: 99.5% line coverage filtered to
+  Core+Platform/*/Source. `SolidSyslog.c` itself at 95.3%, with the
+  gap entirely on never-called vtable padding inside the private
+  Nils (documented above).
+- `tidy`, `cppcheck`, `format` (clang-format `--Werror`): clean.
+
+### Deferred
+
+- **Extract Nils to dedicated modules** for 100% vtable coverage —
+  open if a second class adopts the same pattern and the
+  duplication starts to bite. For now SolidSyslog's private nils
+  stay in `SolidSyslog.c` as file-static.
+- **SD per-element NULL guards** — `FormatStructuredData` still
+  derefs each `sd[i]` unconditionally. Belongs in S12.06 (SD
+  NULL-guard story) since it touches the SD vtable, not the
+  Solidsyslog singleton.
+- **Apply the same pattern** to UdpSender (S12.05), MetaSd / OriginSd
+  (S12.06), AtomicCounter. Each gets its own private nil(s), per-
+  field Create diagnostics, and audible-once on the unwireable
+  outputs.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5732,3 +5732,105 @@ For every singleton-or-handle class with vtable collaborators:
   (S12.06), AtomicCounter. Each gets its own private nil(s), per-
   field Create diagnostics, and audible-once on the unwireable
   outputs.
+
+## 2026-05-11 — S12.04 corrections (review pass)
+
+Review of the initial S12.04 commit (#115 work) caught four things to
+fix before the PR opens. Force-pushing onto the same feature branch
+because none of the existing review comments live on the old commit
+yet and the squash-merge workflow makes mid-branch history
+disposable — but pausing before push to confirm.
+
+### Corrections
+
+1. **Test location.** The new NULL-guard / lifecycle tests
+   originally sat in `SolidSyslogErrorTest.cpp` because that file
+   already had the captured-handler fixture. Wrong target-of-test
+   axis — those are `SolidSyslog` tests that *use* the error
+   channel as their observation mechanism, not Error-API tests.
+   Moved them into a new `TEST_GROUP(SolidSyslogLifecycle)` in
+   `SolidSyslogTest.cpp`, alongside the existing `TEST_GROUP(SolidSyslog)`
+   and `TEST_GROUP(SolidSyslogServiceEagerDrain)`. The earlier
+   `SolidSyslogCreateWithNullConfigReportsError` (from S12.18) moved
+   too for consistency. `SolidSyslogErrorTest.cpp` is now three
+   tests of the Error-API surface itself.
+
+2. **Stale IGNORE_TEST.** The `IGNORE_TEST(SolidSyslog, HappyPathOnly)`
+   block tracked "Create with NULL config" (now implemented) and
+   "MSG preceded by UTF-8 BOM" (S12.13 implemented this). Tests
+   aren't a backlog. Block deleted; a separate watching-brief
+   memory captures a related defect (BOM emitted on empty MSG
+   body) for follow-up at S12.04 close-out.
+
+3. **Macros out of production.** Both `ASSIGN_OR_REPORT` (added by
+   the first pass of this story) and the grandfathered
+   `ASSIGN_IF_NON_NULL` are gone. Replaced by:
+   - A `const struct SolidSyslog NilInstance` template + struct
+     copy: every Create commit and every Destroy now does
+     `instance = NilInstance;` first, so the optional-field
+     branches are just `if (config->x != NULL) instance.x = config->x;`.
+   - Per-type `Install{Buffer,Sender,Store}` helpers: each is
+     procedural ("if NULL, report; else assign") — the "fall back
+     to nil" arm dissolves because the struct copy already placed
+     the nil there.
+   - `SolidSyslogUdpSender.c` and `SolidSyslogStreamSender.c`
+     swept too — they were the only other in-tree users of
+     `ASSIGN_IF_NON_NULL`. Macro deleted from
+     `SolidSyslogMacros.h` (only `SOLIDSYSLOG_STATIC_ASSERT`
+     remains).
+
+4. **Reusable ErrorHandlerFake.** New `Tests/Support/ErrorHandlerFake.{c,h}`
+   wired through `Tests/Support/CMakeLists.txt` and linked into
+   `SolidSyslogTests`. Matches the existing `SenderFake` /
+   `BufferFake` shape — `Install(context)`, `Uninstall()`,
+   `HandleCallCount()`, `LastSeverity/Message/Context()`. Tests
+   now use `CALLED_FAKE(ErrorHandlerFake_Handle, ONCE)` instead of
+   the bare `CALLED_FUNCTION(handler, ONCE)` macro that depended on
+   a file-static `handlerCallCount` variable. Same fake will serve
+   every future class under E12 that reports through `SolidSyslog_Error`.
+
+### New behaviour: re-Create rejection
+
+Took the opportunity to settle the overwrite-vs-preserve question
+on Create-then-Create-without-Destroy. **Reject the second Create
+as its own failure mode**: integrator must `_Destroy` first to
+reconfigure.
+
+- New `instanceInitialised` flag, set on the commit path of
+  `_Create`, cleared by `_Destroy`.
+- New `SOLIDSYSLOG_ERROR_MSG_CREATE_ALREADY_INITIALISED`.
+- Detection is commit-based: `_Create(NULL)` is a *hard rejection*
+  (state unchanged, flag stays false, integrator may retry).
+  `_Create(valid)` and `_Create(partially-NULL)` are *commits*
+  (flag set, second Create rejected, state preserved).
+- Drove four TDD tests: rejection reports the new message;
+  rejection leaves first config intact (verified via separate
+  sender capturing the post-rejection Log); `Create(NULL) +
+  Create(valid)` lets the second succeed; `Create + Destroy +
+  Create` likewise.
+
+### Verified
+
+- `debug`, `clang-debug`, `sanitize` presets: 1105 tests pass.
+- `coverage`: 99.5% line filtered to Core+Platform/*/Source.
+  `SolidSyslog.c` up to 95.7% (was 95.3%). The remaining gap is
+  the same vtable-padding methods on `NilStore` / `NilSender`
+  that the library never calls internally.
+- `tidy`, `cppcheck`, `format`: clean. cppcheck needed a couple of
+  `unreadVariable` suppressions on TEST_GROUP fixture members
+  consumed via CppUTest macros — same pattern as the existing
+  `TEST_GROUP(SolidSyslog)`.
+
+### Decisions
+
+- **Reject second Create rather than overwrite** (semantic
+  question David flagged): cleaner mental model than the
+  optionals-preserve question. Each Create runs against a fresh
+  nil baseline; reconfiguration is an explicit Destroy-then-Create
+  cycle.
+- **Two-classes-one-file layout** for `SolidSyslog.c`: forward-
+  declare the Nil objects as tentative definitions near the top,
+  then put SolidSyslog's full implementation, then the Nil
+  collaborators' implementation at the bottom. Reads like two
+  cooperating "classes" sharing a translation unit. Allowed by C99
+  (tentative definitions of file-scope objects).

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -117,7 +117,7 @@ endif()
 
 add_executable(${PROJECT_NAME}Tests ${TEST_SOURCES})
 
-target_link_libraries(${PROJECT_NAME}Tests PRIVATE ${PROJECT_NAME} CppUTest CppUTestExt Threads::Threads)
+target_link_libraries(${PROJECT_NAME}Tests PRIVATE ${PROJECT_NAME} ErrorHandlerFake CppUTest CppUTestExt Threads::Threads)
 target_include_directories(${PROJECT_NAME}Tests PRIVATE ${CMAKE_SOURCE_DIR}/Core/Source ${CMAKE_CURRENT_SOURCE_DIR}/Support)
 
 if(SOLIDSYSLOG_POSIX)

--- a/Tests/SolidSyslogErrorTest.cpp
+++ b/Tests/SolidSyslogErrorTest.cpp
@@ -1,59 +1,22 @@
 #include "CppUTest/TestHarness.h"
 
-#include "BufferFake.h"
-#include "SenderFake.h"
-#include "SolidSyslog.h"
-#include "SolidSyslogConfig.h"
+#include "ErrorHandlerFake.h"
 #include "SolidSyslogError.h"
-#include "SolidSyslogErrorMessages.h"
-#include "SolidSyslogNullStore.h"
 #include "SolidSyslogPrival.h"
 #include "TestUtils.h"
 
 using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
                                // macros
 
-static int                       handlerCallCount;
-static enum SolidSyslog_Severity capturedSeverity;
-static const char*               capturedMessage;
-static void*                     capturedContext;
-
-static void TestErrorHandler(void* context, enum SolidSyslog_Severity severity, const char* message)
-{
-    handlerCallCount++;
-    capturedSeverity = severity;
-    capturedMessage  = message;
-    capturedContext  = context;
-}
-
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
-#define CHECK_EXPECTED_SEVERITY(expected) LONGS_EQUAL((expected), capturedSeverity)
-#define CHECK_EXPECTED_MESSAGE(expected) STRCMP_EQUAL((expected), capturedMessage)
-#define CHECK_EXPECTED_CONTEXT(expected) POINTERS_EQUAL((expected), capturedContext)
-
-// NOLINTEND(cppcoreguidelines-macro-usage)
-
 // clang-format off
 TEST_GROUP(SolidSyslogError)
 {
+    // cppcheck-suppress unreadVariable -- read via context-propagation test through CppUTest macros
     int sentinel = 0;
-
-    void setup() override
-    {
-        handlerCallCount = 0;
-        capturedSeverity = SOLIDSYSLOG_SEVERITY_DEBUG;
-        capturedMessage  = nullptr;
-        capturedContext  = nullptr;
-    }
 
     void teardown() override
     {
-        SolidSyslog_SetErrorHandler(nullptr, nullptr);
-    }
-
-    void installHandler()
-    {
-        SolidSyslog_SetErrorHandler(TestErrorHandler, &sentinel);
+        ErrorHandlerFake_Uninstall();
     }
 };
 
@@ -66,230 +29,22 @@ TEST(SolidSyslogError, ErrorWithDefaultHandlerDoesNotCrash)
 
 TEST(SolidSyslogError, InstalledHandlerReceivesSeverityMessageAndContext)
 {
-    installHandler();
+    ErrorHandlerFake_Install(&sentinel);
+
     SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, "warning message");
 
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_WARNING);
-    CHECK_EXPECTED_MESSAGE("warning message");
-    CHECK_EXPECTED_CONTEXT(&sentinel);
+    CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);
+    LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_WARNING, ErrorHandlerFake_LastSeverity());
+    STRCMP_EQUAL("warning message", ErrorHandlerFake_LastMessage());
+    POINTERS_EQUAL(&sentinel, ErrorHandlerFake_LastContext());
 }
 
 TEST(SolidSyslogError, SetErrorHandlerWithNullHandlerRestoresDefault)
 {
-    installHandler();
+    ErrorHandlerFake_Install(&sentinel);
 
     SolidSyslog_SetErrorHandler(nullptr, &sentinel);
     SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, "should not be observed");
 
-    CALLED_FUNCTION(handler, NEVER);
-}
-
-TEST(SolidSyslogError, SolidSyslogCreateWithNullConfigReportsError)
-{
-    installHandler();
-
-    SolidSyslog_Create(nullptr);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_CONFIG);
-}
-
-// clang-format off
-TEST_GROUP(SolidSyslogLifecycle)
-{
-    SolidSyslogMessage message{};
-    SolidSyslogBuffer* buffer = nullptr;
-    SolidSyslogSender* sender = nullptr;
-    SolidSyslogStore*  store  = nullptr;
-    int                sentinel = 0;
-
-    void setup() override
-    {
-        handlerCallCount = 0;
-        capturedSeverity = SOLIDSYSLOG_SEVERITY_DEBUG;
-        capturedMessage  = nullptr;
-        capturedContext  = nullptr;
-        SolidSyslog_Destroy();
-        message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
-        sender  = SenderFake_Create();
-        buffer  = BufferFake_Create();
-        store   = SolidSyslogNullStore_Create();
-    }
-
-    void teardown() override
-    {
-        SolidSyslog_Destroy();
-        SolidSyslog_SetErrorHandler(nullptr, nullptr);
-        SolidSyslogNullStore_Destroy();
-        BufferFake_Destroy();
-        SenderFake_Destroy(sender);
-    }
-
-    void installHandler()
-    {
-        SolidSyslog_SetErrorHandler(TestErrorHandler, &sentinel);
-    }
-
-    [[nodiscard]] SolidSyslogConfig validConfig() const
-    {
-        return {buffer, sender, nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
-    }
-};
-
-// clang-format on
-
-TEST(SolidSyslogLifecycle, ServiceBeforeCreateDoesNotCrash)
-{
-    SolidSyslog_Service();
-}
-
-TEST(SolidSyslogLifecycle, LogBeforeCreateDoesNotCrash)
-{
-    SolidSyslog_Log(&message);
-}
-
-TEST(SolidSyslogLifecycle, LogBeforeCreateReportsNilBufferUsedOnce)
-{
-    installHandler();
-
-    SolidSyslog_Log(&message);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
-}
-
-TEST(SolidSyslogLifecycle, RepeatedLogBeforeCreateReportsNilBufferUsedOnlyOnce)
-{
-    installHandler();
-
-    SolidSyslog_Log(&message);
-    SolidSyslog_Log(&message);
-    SolidSyslog_Log(&message);
-
-    CALLED_FUNCTION(handler, ONCE);
-}
-
-TEST(SolidSyslogLifecycle, DestroyReArmsNilBufferReporter)
-{
-    SolidSyslog_Log(&message);
-    installHandler();
-
-    SolidSyslog_Destroy();
-    SolidSyslog_Log(&message);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
-}
-
-TEST(SolidSyslogLifecycle, LogWithNullMessageReportsError)
-{
-    installHandler();
-
-    SolidSyslog_Log(nullptr);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
-}
-
-TEST(SolidSyslogLifecycle, CreateWithNullBufferReportsError)
-{
-    installHandler();
-    SolidSyslogConfig config = validConfig();
-    config.buffer            = nullptr;
-
-    SolidSyslog_Create(&config);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
-}
-
-TEST(SolidSyslogLifecycle, CreateWithNullSenderReportsError)
-{
-    installHandler();
-    SolidSyslogConfig config = validConfig();
-    config.sender            = nullptr;
-
-    SolidSyslog_Create(&config);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
-}
-
-TEST(SolidSyslogLifecycle, CreateWithNullStoreReportsError)
-{
-    installHandler();
-    SolidSyslogConfig config = validConfig();
-    config.store             = nullptr;
-
-    SolidSyslog_Create(&config);
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
-}
-
-TEST(SolidSyslogLifecycle, ServiceWithNilSenderReportsNilSenderUsed)
-{
-    SolidSyslogConfig config = validConfig();
-    config.sender            = nullptr;
-    SolidSyslog_Create(&config);
-    SolidSyslog_Log(&message);
-    installHandler();
-
-    SolidSyslog_Service();
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
-}
-
-TEST(SolidSyslogLifecycle, RepeatedServiceWithNilSenderReportsNilSenderUsedOnlyOnce)
-{
-    SolidSyslogConfig config = validConfig();
-    config.sender            = nullptr;
-    SolidSyslog_Create(&config);
-    SolidSyslog_Log(&message);
-    SolidSyslog_Service();
-    installHandler();
-
-    SolidSyslog_Log(&message);
-    SolidSyslog_Service();
-    SolidSyslog_Log(&message);
-    SolidSyslog_Service();
-
-    CALLED_FUNCTION(handler, NEVER);
-}
-
-TEST(SolidSyslogLifecycle, ServiceWithNilStoreDrainsThroughToRealSender)
-{
-    SolidSyslogConfig config = validConfig();
-    config.store             = nullptr;
-    SolidSyslog_Create(&config);
-    SolidSyslog_Log(&message);
-
-    SolidSyslog_Service();
-
-    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
-}
-
-TEST(SolidSyslogLifecycle, DestroyReArmsNilSenderReporter)
-{
-    SolidSyslogConfig config = validConfig();
-    config.sender            = nullptr;
-    SolidSyslog_Create(&config);
-    SolidSyslog_Log(&message);
-    SolidSyslog_Service();
-
-    SolidSyslog_Destroy();
-    SolidSyslog_Create(&config);
-    SolidSyslog_Log(&message);
-    installHandler();
-    SolidSyslog_Service();
-
-    CALLED_FUNCTION(handler, ONCE);
-    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
+    CHECK_NOTHING_REPORTED();
 }

--- a/Tests/SolidSyslogErrorTest.cpp
+++ b/Tests/SolidSyslogErrorTest.cpp
@@ -1,8 +1,12 @@
 #include "CppUTest/TestHarness.h"
 
+#include "BufferFake.h"
+#include "SenderFake.h"
+#include "SolidSyslog.h"
 #include "SolidSyslogConfig.h"
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
+#include "SolidSyslogNullStore.h"
 #include "SolidSyslogPrival.h"
 #include "TestUtils.h"
 
@@ -90,4 +94,202 @@ TEST(SolidSyslogError, SolidSyslogCreateWithNullConfigReportsError)
     CALLED_FUNCTION(handler, ONCE);
     CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
     CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_CONFIG);
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogLifecycle)
+{
+    SolidSyslogMessage message{};
+    SolidSyslogBuffer* buffer = nullptr;
+    SolidSyslogSender* sender = nullptr;
+    SolidSyslogStore*  store  = nullptr;
+    int                sentinel = 0;
+
+    void setup() override
+    {
+        handlerCallCount = 0;
+        capturedSeverity = SOLIDSYSLOG_SEVERITY_DEBUG;
+        capturedMessage  = nullptr;
+        capturedContext  = nullptr;
+        SolidSyslog_Destroy();
+        message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
+        sender  = SenderFake_Create();
+        buffer  = BufferFake_Create();
+        store   = SolidSyslogNullStore_Create();
+    }
+
+    void teardown() override
+    {
+        SolidSyslog_Destroy();
+        SolidSyslog_SetErrorHandler(nullptr, nullptr);
+        SolidSyslogNullStore_Destroy();
+        BufferFake_Destroy();
+        SenderFake_Destroy(sender);
+    }
+
+    void installHandler()
+    {
+        SolidSyslog_SetErrorHandler(TestErrorHandler, &sentinel);
+    }
+
+    [[nodiscard]] SolidSyslogConfig validConfig() const
+    {
+        return {buffer, sender, nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogLifecycle, ServiceBeforeCreateDoesNotCrash)
+{
+    SolidSyslog_Service();
+}
+
+TEST(SolidSyslogLifecycle, LogBeforeCreateDoesNotCrash)
+{
+    SolidSyslog_Log(&message);
+}
+
+TEST(SolidSyslogLifecycle, LogBeforeCreateReportsNilBufferUsedOnce)
+{
+    installHandler();
+
+    SolidSyslog_Log(&message);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+}
+
+TEST(SolidSyslogLifecycle, RepeatedLogBeforeCreateReportsNilBufferUsedOnlyOnce)
+{
+    installHandler();
+
+    SolidSyslog_Log(&message);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Log(&message);
+
+    CALLED_FUNCTION(handler, ONCE);
+}
+
+TEST(SolidSyslogLifecycle, DestroyReArmsNilBufferReporter)
+{
+    SolidSyslog_Log(&message);
+    installHandler();
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Log(&message);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+}
+
+TEST(SolidSyslogLifecycle, LogWithNullMessageReportsError)
+{
+    installHandler();
+
+    SolidSyslog_Log(nullptr);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullBufferReportsError)
+{
+    installHandler();
+    SolidSyslogConfig config = validConfig();
+    config.buffer            = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullSenderReportsError)
+{
+    installHandler();
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullStoreReportsError)
+{
+    installHandler();
+    SolidSyslogConfig config = validConfig();
+    config.store             = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
+}
+
+TEST(SolidSyslogLifecycle, ServiceWithNilSenderReportsNilSenderUsed)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    installHandler();
+
+    SolidSyslog_Service();
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_SEVERITY(SOLIDSYSLOG_SEVERITY_ERR);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
+}
+
+TEST(SolidSyslogLifecycle, RepeatedServiceWithNilSenderReportsNilSenderUsedOnlyOnce)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+    installHandler();
+
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    CALLED_FUNCTION(handler, NEVER);
+}
+
+TEST(SolidSyslogLifecycle, ServiceWithNilStoreDrainsThroughToRealSender)
+{
+    SolidSyslogConfig config = validConfig();
+    config.store             = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+
+    SolidSyslog_Service();
+
+    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
+}
+
+TEST(SolidSyslogLifecycle, DestroyReArmsNilSenderReporter)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    installHandler();
+    SolidSyslog_Service();
+
+    CALLED_FUNCTION(handler, ONCE);
+    CHECK_EXPECTED_MESSAGE(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
 }

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -15,7 +15,6 @@
 #include "SolidSyslogStructuredDataDefinition.h"
 #include "BufferFake.h"
 #include "ErrorHandlerFake.h"
-#include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
 #include "StoreFake.h"
 #include "SenderFake.h"
@@ -110,6 +109,7 @@ class TEST_SolidSyslog_ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark_Te
 class TEST_SolidSyslog_SeverityAppearsInPrival_Test;
 struct SolidSyslogAtomicCounter;
 struct SolidSyslogBuffer;
+struct SolidSyslogSender;
 struct SolidSyslogStore;
 
 // clang-format off

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -1578,9 +1578,6 @@ TEST(SolidSyslog, LogAfterDestroyAndRecreateWithNullFunctionsProducesNilvalues)
 IGNORE_TEST(SolidSyslog, HappyPathOnly)
 
 {
-    // Error handling not yet implemented — see Epic #31
-    //   SolidSyslog_Create with a NULL config does not crash
-    //
     // Optional header fields not yet driven in — see Epic #8
     //   MSG is preceded by UTF-8 BOM
 }

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -14,6 +14,9 @@
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogStructuredDataDefinition.h"
 #include "BufferFake.h"
+#include "ErrorHandlerFake.h"
+#include "SolidSyslogError.h"
+#include "SolidSyslogErrorMessages.h"
 #include "StoreFake.h"
 #include "SenderFake.h"
 #include "StringFake.h"
@@ -1575,9 +1578,247 @@ TEST(SolidSyslog, LogAfterDestroyAndRecreateWithNullFunctionsProducesNilvalues)
     CHECK_PROCID("-");
 }
 
-IGNORE_TEST(SolidSyslog, HappyPathOnly)
-
+// clang-format off
+TEST_GROUP(SolidSyslogLifecycle)
 {
-    // Optional header fields not yet driven in — see Epic #8
-    //   MSG is preceded by UTF-8 BOM
+    SolidSyslogMessage message{};
+    SolidSyslogBuffer* buffer = nullptr;
+    SolidSyslogSender* sender = nullptr;
+    SolidSyslogStore*  store  = nullptr;
+
+    void setup() override
+    {
+        SolidSyslog_Destroy();
+        // cppcheck-suppress unreadVariable -- read via Log() in tests; cppcheck does not model CppUTest macros
+        message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFO, nullptr, nullptr};
+        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
+        sender = SenderFake_Create();
+        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
+        buffer = BufferFake_Create();
+        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
+        store = SolidSyslogNullStore_Create();
+    }
+
+    void teardown() override
+    {
+        SolidSyslog_Destroy();
+        ErrorHandlerFake_Uninstall();
+        SolidSyslogNullStore_Destroy();
+        BufferFake_Destroy();
+        SenderFake_Destroy(sender);
+    }
+
+    [[nodiscard]] SolidSyslogConfig validConfig() const
+    {
+        return {buffer, sender, nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogLifecycle, ServiceBeforeCreateDoesNotCrash)
+{
+    SolidSyslog_Service();
+}
+
+TEST(SolidSyslogLifecycle, LogBeforeCreateDoesNotCrash)
+{
+    SolidSyslog_Log(&message);
+}
+
+TEST(SolidSyslogLifecycle, LogBeforeCreateReportsNilBufferUsedOnce)
+{
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Log(&message);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+}
+
+TEST(SolidSyslogLifecycle, RepeatedLogBeforeCreateReportsNilBufferUsedOnlyOnce)
+{
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Log(&message);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Log(&message);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+}
+
+TEST(SolidSyslogLifecycle, DestroyReArmsNilBufferReporter)
+{
+    SolidSyslog_Log(&message);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Log(&message);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED);
+}
+
+TEST(SolidSyslogLifecycle, LogWithNullMessageReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Log(nullptr);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullConfigReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Create(nullptr);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_CONFIG);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullBufferReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogConfig config = validConfig();
+    config.buffer            = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_BUFFER);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullSenderReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_SENDER);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullStoreReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogConfig config = validConfig();
+    config.store             = nullptr;
+
+    SolidSyslog_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_CREATE_NULL_STORE);
+}
+
+TEST(SolidSyslogLifecycle, ServiceWithNilStoreDrainsThroughToRealSender)
+{
+    SolidSyslogConfig config = validConfig();
+    config.store             = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+
+    SolidSyslog_Service();
+
+    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
+}
+
+TEST(SolidSyslogLifecycle, ServiceWithNilSenderReportsNilSenderUsed)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Service();
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
+}
+
+TEST(SolidSyslogLifecycle, RepeatedServiceWithNilSenderReportsNilSenderUsedOnlyOnce)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    CHECK_NOTHING_REPORTED();
+}
+
+TEST(SolidSyslogLifecycle, SecondCreateWithoutDestroyReportsAlreadyInitialised)
+{
+    SolidSyslogConfig config = validConfig();
+    SolidSyslog_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_CREATE_ALREADY_INITIALISED);
+}
+
+TEST(SolidSyslogLifecycle, SecondCreateLeavesFirstConfigInstalled)
+{
+    SolidSyslogConfig firstConfig = validConfig();
+    SolidSyslog_Create(&firstConfig);
+    SolidSyslogSender* otherSender  = SenderFake_Create();
+    SolidSyslogConfig  secondConfig = validConfig();
+    secondConfig.sender             = otherSender;
+
+    SolidSyslog_Create(&secondConfig);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
+    CALLED_FAKE_ON(SenderFake_Send, otherSender, NEVER);
+
+    SenderFake_Destroy(otherSender);
+}
+
+TEST(SolidSyslogLifecycle, CreateWithNullConfigDoesNotBlockSubsequentCreate)
+{
+    SolidSyslog_Create(nullptr);
+    SolidSyslogConfig config = validConfig();
+
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
+}
+
+TEST(SolidSyslogLifecycle, DestroyClearsInitialisedFlagSoCreateSucceedsAgain)
+{
+    SolidSyslogConfig config = validConfig();
+    SolidSyslog_Create(&config);
+    SolidSyslog_Destroy();
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    CHECK_NOTHING_REPORTED();
+    CALLED_FAKE_ON(SenderFake_Send, sender, ONCE);
+}
+
+TEST(SolidSyslogLifecycle, DestroyReArmsNilSenderReporter)
+{
+    SolidSyslogConfig config = validConfig();
+    config.sender            = nullptr;
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    SolidSyslog_Service();
+
+    SolidSyslog_Destroy();
+    SolidSyslog_Create(&config);
+    SolidSyslog_Log(&message);
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslog_Service();
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED);
 }

--- a/Tests/Support/CMakeLists.txt
+++ b/Tests/Support/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_library(ErrorHandlerFake STATIC ErrorHandlerFake.c)
+target_include_directories(ErrorHandlerFake PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(ErrorHandlerFake PUBLIC ${PROJECT_NAME})
+
 if(SOLIDSYSLOG_POSIX)
     add_library(PosixFakes STATIC
         ClockFake.c

--- a/Tests/Support/ErrorHandlerFake.c
+++ b/Tests/Support/ErrorHandlerFake.c
@@ -1,0 +1,52 @@
+#include "ErrorHandlerFake.h"
+
+#include <stddef.h>
+
+#include "SolidSyslogError.h"
+
+static int                       handleCallCount;
+static enum SolidSyslog_Severity lastSeverity;
+static const char*               lastMessage;
+static const void*               lastContext;
+
+static void Handle(void* context, enum SolidSyslog_Severity severity, const char* message)
+{
+    handleCallCount++;
+    lastSeverity = severity;
+    lastMessage  = message;
+    lastContext  = context;
+}
+
+void ErrorHandlerFake_Install(void* context)
+{
+    handleCallCount = 0;
+    lastSeverity    = SOLIDSYSLOG_SEVERITY_DEBUG;
+    lastMessage     = NULL;
+    lastContext     = NULL;
+    SolidSyslog_SetErrorHandler(Handle, context);
+}
+
+void ErrorHandlerFake_Uninstall(void)
+{
+    SolidSyslog_SetErrorHandler(NULL, NULL);
+}
+
+int ErrorHandlerFake_HandleCallCount(void)
+{
+    return handleCallCount;
+}
+
+enum SolidSyslog_Severity ErrorHandlerFake_LastSeverity(void)
+{
+    return lastSeverity;
+}
+
+const char* ErrorHandlerFake_LastMessage(void)
+{
+    return lastMessage;
+}
+
+const void* ErrorHandlerFake_LastContext(void)
+{
+    return lastContext;
+}

--- a/Tests/Support/ErrorHandlerFake.h
+++ b/Tests/Support/ErrorHandlerFake.h
@@ -16,6 +16,7 @@ EXTERN_C_BEGIN
 EXTERN_C_END
 
 #ifdef __cplusplus
+#include "CppUTest/TestHarness.h"
 #include "TestUtils.h"
 
 /* Assertion macros for tests that observe SolidSyslog_Error through the fake.

--- a/Tests/Support/ErrorHandlerFake.h
+++ b/Tests/Support/ErrorHandlerFake.h
@@ -1,0 +1,37 @@
+#ifndef ERRORHANDLERFAKE_H
+#define ERRORHANDLERFAKE_H
+
+#include "ExternC.h"
+#include "SolidSyslogPrival.h"
+
+EXTERN_C_BEGIN
+
+    void                      ErrorHandlerFake_Install(void* context);
+    void                      ErrorHandlerFake_Uninstall(void);
+    int                       ErrorHandlerFake_HandleCallCount(void);
+    enum SolidSyslog_Severity ErrorHandlerFake_LastSeverity(void);
+    const char*               ErrorHandlerFake_LastMessage(void);
+    const void*               ErrorHandlerFake_LastContext(void);
+
+EXTERN_C_END
+
+#ifdef __cplusplus
+#include "TestUtils.h"
+
+/* Assertion macros for tests that observe SolidSyslog_Error through the fake.
+ * Callers must bring CALLED_FAKE / ONCE / NEVER into scope with
+ * `using namespace CososoTesting;` (existing convention in this codebase). */
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ in test failure output
+#define CHECK_REPORTED_ERROR(expectedMessage)                                   \
+    do                                                                          \
+    {                                                                           \
+        CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                             \
+        LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_ERR, ErrorHandlerFake_LastSeverity()); \
+        STRCMP_EQUAL((expectedMessage), ErrorHandlerFake_LastMessage());        \
+    } while (0)
+
+#define CHECK_NOTHING_REPORTED() CALLED_FAKE(ErrorHandlerFake_Handle, NEVER)
+// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+#endif
+
+#endif /* ERRORHANDLERFAKE_H */


### PR DESCRIPTION
## Purpose

Closes #115. Re-scope and implement S12.04 as the **exemplar nil-object pattern** for the rest of E12 (UdpSender, MetaSd, OriginSd, AtomicCounter NULL-guard stories will copy this shape).

Audit at the start of the story found three crash sites in `SolidSyslog.c`, not the two the original story body listed:

- `Service()` or `Log()` called pre-`Create` — the static `instance` held NULL `store`/`buffer`/`sender`, vtable dispatch derefs.
- `Service()` or `Log()` called post-`Destroy` — `_Destroy` reset to NULL.
- `Log(NULL message)` — derefs `message->facility`.

S12.18 (#317) had already shipped the `Create(NULL config)` case via the new `SolidSyslog_Error` reporting channel; this story closes the rest and establishes the pattern to apply elsewhere.

## Change Description

**The pattern (referenced by future E12 stories):**

1. Private nils as file-static structs inside the class's `.c` — fully-populated vtables of no-op functions. Not in any public header (the public `SolidSyslogNull*` family is for integrator-chosen no-ops with different semantics — these internal nils are crash-safe defaults).
2. Static instance points at the nils at file load.
3. `_Create(config)` rejects `instanceInitialised` first, then `config == NULL`, otherwise commits via `InstallConfig`. Per-field `Install{Buffer,Sender,Store}` helpers each report their own NULL message; per-field `Install{Clock,Hostname,AppName,ProcessId,StructuredData}` helpers silently fall through to the nil baseline.
4. `_Destroy` resets via struct copy (`instance = NilInstance;`) and re-arms the audible flags.
5. Public entry points dispatch through `instance.*` unconditionally — no NULL checks on collaborators. Parameter pointers (e.g. `_Log(message)`) get a single guard at entry.
6. **Audible-once classification**: `NilBuffer.Write` and `NilSender.Send` report exactly one `Error` per Destroy cycle (audible — silent drop would be invisible failure). `NilStore`, `NilClock`, `NilStringFunction` are silent (their absence shows up elsewhere — direct-send fallthrough, `-` in the wire output).
7. **Re-Create rejection**: a second `Create` without an intervening `Destroy` reports `MSG_CREATE_ALREADY_INITIALISED` and leaves the existing config untouched. Detection is commit-based — `Create(NULL config)` is a hard rejection (state unchanged, may retry); `Create(valid)` or `Create(partially-NULL)` is a commit.

**Other corrections in this PR (from review pass):**

- New `Tests/Support/ErrorHandlerFake.{c,h}` — matches the `SenderFake` / `BufferFake` idiom. Hosts `CHECK_REPORTED_ERROR(msg)` and `CHECK_NOTHING_REPORTED()` assertion macros (inside `#ifdef __cplusplus`) for any future test file observing `SolidSyslog_Error`.
- All `SolidSyslog` lifecycle/NULL-guard tests relocated from `SolidSyslogErrorTest.cpp` into a new `TEST_GROUP(SolidSyslogLifecycle)` in `SolidSyslogTest.cpp`. `SolidSyslogErrorTest.cpp` now holds only the three Error-API tests (default-silent, captured-args, NULL-handler-restores).
- `ASSIGN_OR_REPORT` (added by the first pass of this story) and the grandfathered `ASSIGN_IF_NON_NULL` deleted from `SolidSyslogMacros.h` — both replaced by a `const NilInstance` template + struct copy + per-field `Install*` helpers. `SolidSyslogUdpSender.c` and `SolidSyslogStreamSender.c` swept (they were the only other in-tree users).
- Stale `IGNORE_TEST(SolidSyslog, HappyPathOnly)` deleted (both items in it are now implemented).
- Clarity: `_Create`/`_Log` rewritten with error cases first, happy path in the trailing `else`. Audible-once flags renamed `nilBuffer/SenderHasReported` → `nilBuffer/SenderReportArmed` so the conditions are positive (`if (armed) { disarm; report; }`).
- File layout: `SolidSyslog.c` is now arranged as two cooperating "classes" — SolidSyslog at the top, Nil collaborators at the bottom, joined by tentative declarations near the file-static `instance` initializer.

## Test Evidence

TDD progression (red → green → refactor):

1. `Service()` before `Create()` doesn't crash → drives `NilStore`.
2. `Log()` before `Create()` doesn't crash → drives `NilBuffer`.
3. `Log` before `Create` reports `MSG_NIL_BUFFER_USED` → audible-once on `NilBuffer.Write`.
4. Repeated Log reports only once → once-flag.
5. `_Destroy` re-arms the flag → audible-once contract complete.
6. `Log(NULL message)` reports `MSG_LOG_NULL_MESSAGE` → entry guard.
7. Per-field NULL-config diagnostics (buffer / sender / store).
8. `Service` with `NilStore` falls through to real sender.
9. `Service` with `NilSender` reports `MSG_NIL_SENDER_USED` → audible-once on `NilSender.Send`.
10. Second `Create` without Destroy reports `MSG_CREATE_ALREADY_INITIALISED`.
11. Second Create leaves first config installed (verified via a second `SenderFake`).
12. `Create(NULL) + Create(valid)` → second succeeds (commit-based detection).
13. `Create + Destroy + Create` → second succeeds.

Local gates:

- [x] `build-linux-gcc` — 1105 tests pass.
- [x] `build-linux-clang` — 1105 tests pass.
- [x] `sanitize-linux-gcc` — 1105 tests pass.
- [x] `coverage-linux-gcc` — 99.5% filtered line coverage (90% gate); `SolidSyslog.c` at 95.7% (the rest is `NilStore`/`NilSender` vtable padding the library never calls internally).
- [x] `analyze-tidy` — clean.
- [x] `analyze-cppcheck` — clean.
- [x] `analyze-format` — clean.

## Areas Affected

- `Core/Source/SolidSyslog.c` — restructured; NilInstance template; Install* helpers; re-Create rejection.
- `Core/Source/SolidSyslogErrorMessages.h` — new per-field and re-Create error messages.
- `Core/Source/SolidSyslogMacros.h` — both `ASSIGN_*` macros deleted; only `SOLIDSYSLOG_STATIC_ASSERT` remains.
- `Core/Source/SolidSyslogUdpSender.c`, `SolidSyslogStreamSender.c` — swept for `ASSIGN_IF_NON_NULL` usage (no behavioural change).
- `Tests/Support/ErrorHandlerFake.{c,h}` (new) + `Tests/Support/CMakeLists.txt` + `Tests/CMakeLists.txt`.
- `Tests/SolidSyslogTest.cpp` — new `TEST_GROUP(SolidSyslogLifecycle)`; stale `IGNORE_TEST` removed.
- `Tests/SolidSyslogErrorTest.cpp` — trimmed to Error-API tests only.
- `DEVLOG.md` — two entries (initial + review-pass corrections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error validation for null inputs and missing configuration parameters.
  * Improved robustness with safe default behavior when operations fail.
  * Protection against invalid usage patterns such as double initialization.

* **Tests**
  * Added comprehensive lifecycle and error-handling test coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->