### PR TITLE
feat: S12.05 nil-object defaults + NULL guards for UdpSender

### DIFF
--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -10,4 +10,6 @@
 #define SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED "SolidSyslog_Log called with no buffer configured"
 #define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"
 
+#define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG "SolidSyslogUdpSender_Create called with NULL config"
+
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -11,5 +11,9 @@
 #define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"
 
 #define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG "SolidSyslogUdpSender_Create called with NULL config"
+#define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_RESOLVER "SolidSyslogUdpSender_Create config.resolver is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_DATAGRAM "SolidSyslogUdpSender_Create config.datagram is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDP_NIL_RESOLVER_USED "SolidSyslogUdpSender_Send tried to resolve with no resolver configured"
+#define SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED "SolidSyslogUdpSender_Send tried to open with no datagram configured"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -15,5 +15,6 @@
 #define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_DATAGRAM "SolidSyslogUdpSender_Create config.datagram is NULL"
 #define SOLIDSYSLOG_ERROR_MSG_UDP_NIL_RESOLVER_USED "SolidSyslogUdpSender_Send tried to resolve with no resolver configured"
 #define SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED "SolidSyslogUdpSender_Send tried to open with no datagram configured"
+#define SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_ALREADY_INITIALISED "SolidSyslogUdpSender_Create called while already initialised - call _Destroy first"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -289,6 +289,12 @@ static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct Solid
  * Destroy/Create cycle produces a fresh warning. The endpoint and endpoint-
  * version nils are silent — supplying neither is a valid integrator choice
  * (matches NoEndpointConfiguredSendsToPortZero coverage).
+ *
+ * NilDatagram.SendTo and NilDatagram.MaxPayload are vacuously defensive: the
+ * vtable struct contract requires every slot to be non-NULL so dispatch never
+ * crashes, but from the public Send path they are unreachable —
+ * NilDatagramOpen returns false, so Reconcile short-circuits before
+ * TransmitDatagram is ever entered. The bodies exist for vtable safety only.
  * ============================================================================ */
 
 static bool NilResolverResolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -3,12 +3,15 @@
 #include <stdbool.h>
 
 #include "SolidSyslogEndpoint.h"
+#include "SolidSyslogError.h"
+#include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
 #include "SolidSyslogAddress.h"
 #include "SolidSyslogDatagram.h"
+#include "SolidSyslogPrival.h"
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogTransport.h"
 
@@ -21,6 +24,7 @@ struct SolidSyslogUdpSender
     uint32_t                          lastEndpointVersion;
 };
 
+static struct SolidSyslogSender*                 InstallConfig(const struct SolidSyslogUdpSenderConfig* config);
 static bool                                      Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
 static inline bool                               Reconcile(struct SolidSyslogUdpSender* udp);
 static inline void                               DisconnectIfStale(struct SolidSyslogUdpSender* udp);
@@ -41,6 +45,22 @@ static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoin
 static struct SolidSyslogUdpSender       instance;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
+{
+    struct SolidSyslogSender* result = NULL;
+
+    if (config == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG);
+    }
+    else
+    {
+        result = InstallConfig(config);
+    }
+
+    return result;
+}
+
+static struct SolidSyslogSender* InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
     instance                 = DEFAULT_INSTANCE;
     instance.config.resolver = config->resolver;

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -17,6 +17,8 @@
 #include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
 
+struct SolidSyslogAddress;
+
 struct SolidSyslogUdpSender
 {
     struct SolidSyslogSender          base;

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -2,18 +2,20 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "SolidSyslogAddress.h"
+#include "SolidSyslogDatagram.h"
+#include "SolidSyslogDatagramDefinition.h"
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
-#include "SolidSyslogUdpPayload.h"
-#include "SolidSyslogUdpSender.h"
-#include "SolidSyslogSenderDefinition.h"
-#include "SolidSyslogAddress.h"
-#include "SolidSyslogDatagram.h"
 #include "SolidSyslogPrival.h"
 #include "SolidSyslogResolver.h"
+#include "SolidSyslogResolverDefinition.h"
+#include "SolidSyslogSenderDefinition.h"
 #include "SolidSyslogTransport.h"
+#include "SolidSyslogUdpPayload.h"
+#include "SolidSyslogUdpSender.h"
 
 struct SolidSyslogUdpSender
 {
@@ -24,7 +26,21 @@ struct SolidSyslogUdpSender
     uint32_t                          lastEndpointVersion;
 };
 
+/* Forward declarations for the Nil "class" defined at the bottom of the file.
+ * The Nil objects act as default collaborators that make the singleton
+ * crash-safe pre-Create and after a Create that left required slots NULL;
+ * the file-static instance below and the NilInstance template both reference
+ * these by address. */
+static struct SolidSyslogResolver NilResolver;
+static struct SolidSyslogDatagram NilDatagram;
+static void                       NilEndpoint(struct SolidSyslogEndpoint* endpoint);
+static uint32_t                   NilEndpointVersion(void);
+
 static struct SolidSyslogSender*                 InstallConfig(const struct SolidSyslogUdpSenderConfig* config);
+static void                                      InstallResolver(struct SolidSyslogResolver* configured);
+static void                                      InstallDatagram(struct SolidSyslogDatagram* configured);
+static void                                      InstallEndpoint(SolidSyslogEndpointFunction configured);
+static void                                      InstallEndpointVersion(SolidSyslogEndpointVersionFunction configured);
 static bool                                      Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
 static inline bool                               Reconcile(struct SolidSyslogUdpSender* udp);
 static inline void                               DisconnectIfStale(struct SolidSyslogUdpSender* udp);
@@ -38,11 +54,24 @@ static inline struct SolidSyslogAddress*         Address(struct SolidSyslogUdpSe
 static inline void                               CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                               TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
 static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
-static void                                      NilEndpoint(struct SolidSyslogEndpoint* endpoint);
-static uint32_t                                  NilEndpointVersion(void);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
-static struct SolidSyslogUdpSender       instance;
+/* Template used by _Create and _Destroy to reset every slot to its nil.
+ * C99 forbids initialising one file-static from another, so the same
+ * literal appears once below for the live instance and once here; both
+ * sites stay in sync trivially because the values are nil-object
+ * addresses and well-known no-op function pointers. */
+static const struct SolidSyslogUdpSender NilInstance = {
+    .base   = {.Send = Send, .Disconnect = Disconnect},
+    .config = {.resolver = &NilResolver, .datagram = &NilDatagram, .endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion},
+};
+
+static struct SolidSyslogUdpSender instance = {
+    .base   = {.Send = Send, .Disconnect = Disconnect},
+    .config = {.resolver = &NilResolver, .datagram = &NilDatagram, .endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion},
+};
+
+static bool nilResolverReportArmed = true;
+static bool nilDatagramReportArmed = true;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
@@ -62,26 +91,60 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
 
 static struct SolidSyslogSender* InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
-    instance                 = DEFAULT_INSTANCE;
-    instance.config.resolver = config->resolver;
-    instance.config.datagram = config->datagram;
-    if (config->endpoint != NULL)
-    {
-        instance.config.endpoint = config->endpoint;
-    }
-    if (config->endpointVersion != NULL)
-    {
-        instance.config.endpointVersion = config->endpointVersion;
-    }
-    instance.base.Send       = Send;
-    instance.base.Disconnect = Disconnect;
+    instance = NilInstance;
+    InstallResolver(config->resolver);
+    InstallDatagram(config->datagram);
+    InstallEndpoint(config->endpoint);
+    InstallEndpointVersion(config->endpointVersion);
     return &instance.base;
+}
+
+static void InstallResolver(struct SolidSyslogResolver* configured)
+{
+    if (configured == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_RESOLVER);
+    }
+    else
+    {
+        instance.config.resolver = configured;
+    }
+}
+
+static void InstallDatagram(struct SolidSyslogDatagram* configured)
+{
+    if (configured == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_DATAGRAM);
+    }
+    else
+    {
+        instance.config.datagram = configured;
+    }
+}
+
+static void InstallEndpoint(SolidSyslogEndpointFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.config.endpoint = configured;
+    }
+}
+
+static void InstallEndpointVersion(SolidSyslogEndpointVersionFunction configured)
+{
+    if (configured != NULL)
+    {
+        instance.config.endpointVersion = configured;
+    }
 }
 
 void SolidSyslogUdpSender_Destroy(void)
 {
     Disconnect(&instance.base);
-    instance = DEFAULT_INSTANCE;
+    instance               = NilInstance;
+    nilResolverReportArmed = true;
+    nilDatagramReportArmed = true;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
@@ -204,6 +267,78 @@ static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct Solid
     }
     return result;
 }
+
+/* ============================================================================
+ * Nil collaborators
+ *
+ * Private no-op vtables and function-pointer defaults occupying every config
+ * slot at file load and after _Destroy, plus any required slot the integrator
+ * left NULL in their config. Vtable dispatch from Send never NULL-checks —
+ * the nils make every collaborator pointer safe to call.
+ *
+ * NilResolver and NilDatagram each report one error via SolidSyslog_Error on
+ * first dispatch, then silently consume; _Destroy re-arms the flags so a
+ * Destroy/Create cycle produces a fresh warning. The endpoint and endpoint-
+ * version nils are silent — supplying neither is a valid integrator choice
+ * (matches NoEndpointConfiguredSendsToPortZero coverage).
+ * ============================================================================ */
+
+static bool NilResolverResolve(struct SolidSyslogResolver* self, enum SolidSyslogTransport transport, const char* host, uint16_t port,
+                               struct SolidSyslogAddress* address)
+{
+    (void) self;
+    (void) transport;
+    (void) host;
+    (void) port;
+    (void) address;
+    if (nilResolverReportArmed)
+    {
+        nilResolverReportArmed = false;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_NIL_RESOLVER_USED);
+    }
+    return false;
+}
+
+static struct SolidSyslogResolver NilResolver = {.Resolve = NilResolverResolve};
+
+static bool NilDatagramOpen(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+    if (nilDatagramReportArmed)
+    {
+        nilDatagramReportArmed = false;
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED);
+    }
+    return false;
+}
+
+static enum SolidSyslogDatagramSendResult NilDatagramSendTo(struct SolidSyslogDatagram* self, const void* buffer, size_t size,
+                                                            const struct SolidSyslogAddress* address)
+{
+    (void) self;
+    (void) buffer;
+    (void) size;
+    (void) address;
+    return SOLIDSYSLOG_DATAGRAM_FAILED;
+}
+
+static size_t NilDatagramMaxPayload(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+    return 0;
+}
+
+static void NilDatagramClose(struct SolidSyslogDatagram* self)
+{
+    (void) self;
+}
+
+static struct SolidSyslogDatagram NilDatagram = {
+    .Open       = NilDatagramOpen,
+    .SendTo     = NilDatagramSendTo,
+    .MaxPayload = NilDatagramMaxPayload,
+    .Close      = NilDatagramClose,
+};
 
 static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
 {

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -72,18 +72,25 @@ static struct SolidSyslogUdpSender instance = {
 
 static bool nilResolverReportArmed = true;
 static bool nilDatagramReportArmed = true;
+static bool instanceInitialised;
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
     struct SolidSyslogSender* result = NULL;
 
-    if (config == NULL)
+    if (instanceInitialised)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_ALREADY_INITIALISED);
+        result = &instance.base;
+    }
+    else if (config == NULL)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG);
     }
     else
     {
-        result = InstallConfig(config);
+        result              = InstallConfig(config);
+        instanceInitialised = true;
     }
 
     return result;
@@ -145,6 +152,7 @@ void SolidSyslogUdpSender_Destroy(void)
     instance               = NilInstance;
     nilResolverReportArmed = true;
     nilDatagramReportArmed = true;
+    instanceInitialised    = false;
 }
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,78 @@
 # Dev Log
 
+## 2026-05-11 — S12.05 NULL guards for UdpSender (#116)
+
+First copy of the S12.04 exemplar pattern onto a sibling singleton.
+The story body only required a guard for `Create(NULL config)`; the
+implementation went further and aligned the file with the
+`SolidSyslog.c` shape so S12.06 (MetaSd, OriginSd, AtomicCounter) can
+follow the same template mechanically.
+
+### Decisions
+
+- **Three slices, one PR.** Slice 1: top-level `Create(NULL)` guard,
+  with the install body extracted into an `InstallConfig` helper for
+  the per-field expansion in slice 2 (issue scope). Slice 2: private
+  `NilResolver` and `NilDatagram` vtables with audible-once dispatch
+  reporting, per-field `InstallResolver` / `InstallDatagram` /
+  `InstallEndpoint` / `InstallEndpointVersion` helpers, replace
+  `DEFAULT_INSTANCE` with `NilInstance`. Slice 3: `instanceInitialised`
+  flag rejecting re-Create without an intervening `_Destroy`, mirroring
+  S12.04. Each slice committed separately to keep the diff reviewable.
+- **Audible nils for both required collaborators.** `NilResolverResolve`
+  and `NilDatagramOpen` each report once via `SolidSyslog_Error` on
+  first dispatch from `Send`, then silently consume; `_Destroy` re-arms
+  both flags so a Destroy/Create cycle produces a fresh warning.
+  Reporting from `Open` rather than every nil method keeps the wire to
+  one report-per-mistake even though `Send` walks `Reconcile → Connect
+  → OpenSocket → ResolveDestination → CloseSocket` and would otherwise
+  fire several times. NilEndpoint and NilEndpointVersion stay silent —
+  not configuring an endpoint is a valid integrator choice and is
+  already covered by `NoEndpointConfiguredSendsToPortZero`.
+- **`Create(NULL config)` returns NULL, re-Create returns the active
+  sender pointer.** Two reject paths, two different signals. `NULL`
+  signals "no sender was created" so the integrator's call site sees
+  the failure explicitly. Re-Create returning the *already-active*
+  pointer means an integrator who overwrites their handle with the
+  rejected Create's return value gets transparent fallthrough to the
+  first config, which is the safest possible degraded behaviour. The
+  S12.04 exemplar's `Create` is void so this asymmetry doesn't arise
+  there; for the UdpSender's `struct SolidSyslogSender*` return I
+  picked per-path semantics rather than uniform NULL.
+- **Tentative-definition forward declarations for the nil structs.**
+  C99 lets a file-scope `static T x;` (no initializer) sit at the top
+  of the file with `static T x = {...};` at the bottom. `instance`'s
+  initialiser at the top of the file then captures `&NilResolver` /
+  `&NilDatagram` as link-time addresses, with the structs' contents
+  filled in below. Same pattern the S12.04 exemplar uses for
+  `NilBuffer` / `NilSender` / `NilStore`.
+
+### Deferred
+
+- **No `Send`-side NULL guard for the sender pointer.** Integrators
+  who call `SolidSyslogSender_Send(NULL, ...)` crash. The exemplar
+  doesn't guard at this level either — `Send` derefs `sender->Send`
+  directly. Cross-cutting NULL-safety for the public `_Send`/
+  `_Disconnect` entry points belongs in its own story if it lands at
+  all.
+- **Same pattern on `StreamSender` / `SwitchingSender`.** Not in
+  scope for #116. Likely a single follow-up story rather than per-
+  class once UdpSender shows the template is tight.
+- **100% coverage on UdpSender.c.** Landed at 96.6% line / 92.6%
+  function. `NilDatagram.SendTo` and `NilDatagram.MaxPayload` are
+  vacuously defensive — the vtable struct requires non-NULL slots but
+  the public Send path can't reach them (Open returns false, Reconcile
+  short-circuits). The S24.03 whitebox-include trick that worked for
+  AtomicCounter doesn't compose here: SolidSyslogUdpSender.c uses
+  designated initializers throughout, and the project's C++17 standard
+  rejects those as `-Werror=c++20-extensions` when the file is pulled
+  into a `.cpp` translation unit. Documented in the nil-section
+  comment in the source. Still above the 90% CI gate.
+
+### Open questions
+
+- None.
+
 ## 2026-05-11 — S24.03 drop AtomicOps vtable; select atomics at link time (#326)
 
 E24 close-out story. The vtable through which AtomicCounter reached

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -18,6 +18,10 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
+struct SolidSyslogDatagram;
+struct SolidSyslogResolver;
+struct SolidSyslogSender;
+
 using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
                                // macros
 

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 
 #include "DatagramFake.h"
+#include "ErrorHandlerFake.h"
 #include "SolidSyslogEndpoint.h"
+#include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
 #include "SolidSyslogPosixDatagram.h"
@@ -722,4 +724,32 @@ TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureReturnsFalse)
 {
     DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogUdpSenderLifecycle)
+{
+    void setup() override
+    {
+        SocketFake_Reset();
+        endpointGetHost = GetDefaultHost;
+        endpointGetPort = GetDefaultPort;
+        endpointVersion = 0;
+        ErrorHandlerFake_Install(nullptr);
+    }
+
+    void teardown() override
+    {
+        SolidSyslogUdpSender_Destroy();
+        ErrorHandlerFake_Uninstall();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogUdpSenderLifecycle, CreateWithNullConfigReportsError)
+{
+    SolidSyslogUdpSender_Create(nullptr);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG);
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -729,19 +729,32 @@ TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureReturnsFalse)
 // clang-format off
 TEST_GROUP(SolidSyslogUdpSenderLifecycle)
 {
+    SolidSyslogResolver* resolver = nullptr;
+    SolidSyslogDatagram* datagram = nullptr;
+
     void setup() override
     {
         SocketFake_Reset();
         endpointGetHost = GetDefaultHost;
         endpointGetPort = GetDefaultPort;
         endpointVersion = 0;
-        ErrorHandlerFake_Install(nullptr);
+        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
+        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
+        datagram = SolidSyslogPosixDatagram_Create();
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
+        SolidSyslogGetAddrInfoResolver_Destroy();
         ErrorHandlerFake_Uninstall();
+    }
+
+    [[nodiscard]] SolidSyslogUdpSenderConfig validConfig() const
+    {
+        return {resolver, datagram, TestEndpoint, TestEndpointVersion};
     }
 };
 
@@ -749,7 +762,102 @@ TEST_GROUP(SolidSyslogUdpSenderLifecycle)
 
 TEST(SolidSyslogUdpSenderLifecycle, CreateWithNullConfigReportsError)
 {
+    ErrorHandlerFake_Install(nullptr);
+
     SolidSyslogUdpSender_Create(nullptr);
 
     CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_CONFIG);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, CreateWithNullResolverReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.resolver                   = nullptr;
+
+    SolidSyslogUdpSender_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_RESOLVER);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, CreateWithNullDatagramReportsError)
+{
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.datagram                   = nullptr;
+
+    SolidSyslogUdpSender_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_NULL_DATAGRAM);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, SendAfterCreateWithNullResolverReportsNilResolverUsed)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.resolver                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_NIL_RESOLVER_USED);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, SendAfterCreateWithNullDatagramReportsNilDatagramUsed)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.datagram                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, RepeatedSendAfterCreateWithNullDatagramReportsOnce)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.datagram                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, DestroyReArmsNilDatagramReporter)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.datagram                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    SolidSyslogUdpSender_Destroy();
+    sender = SolidSyslogUdpSender_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_NIL_DATAGRAM_USED);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, SendAfterCreateWithNullDatagramReturnsFalse)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.datagram                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, SendAfterCreateWithNullResolverReturnsFalse)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    config.resolver                   = nullptr;
+    SolidSyslogSender* sender         = SolidSyslogUdpSender_Create(&config);
+
+    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -861,3 +861,52 @@ TEST(SolidSyslogUdpSenderLifecycle, SendAfterCreateWithNullResolverReturnsFalse)
 
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
+
+TEST(SolidSyslogUdpSenderLifecycle, SecondCreateWithoutDestroyReportsAlreadyInitialised)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    SolidSyslogUdpSender_Create(&config);
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslogUdpSender_Create(&config);
+
+    CHECK_REPORTED_ERROR(SOLIDSYSLOG_ERROR_MSG_UDP_CREATE_ALREADY_INITIALISED);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, SecondCreateLeavesFirstConfigInstalled)
+{
+    SolidSyslogUdpSenderConfig firstConfig = validConfig();
+    SolidSyslogSender*         sender      = SolidSyslogUdpSender_Create(&firstConfig);
+    SolidSyslogUdpSenderConfig secondConfig{nullptr, nullptr, TestEndpoint, TestEndpointVersion};
+
+    SolidSyslogUdpSender_Create(&secondConfig);
+    bool sent = SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_TRUE(sent);
+    CALLED_FAKE(SocketFake_Sendto, ONCE);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, CreateWithNullConfigDoesNotBlockSubsequentCreate)
+{
+    SolidSyslogUdpSender_Create(nullptr);
+    SolidSyslogUdpSenderConfig config = validConfig();
+
+    SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    bool               sent   = SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_TRUE(sent);
+}
+
+TEST(SolidSyslogUdpSenderLifecycle, DestroyClearsInitialisedFlagSoCreateSucceedsAgain)
+{
+    SolidSyslogUdpSenderConfig config = validConfig();
+    SolidSyslogUdpSender_Create(&config);
+    SolidSyslogUdpSender_Destroy();
+    ErrorHandlerFake_Install(nullptr);
+
+    SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    bool               sent   = SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+
+    CHECK_NOTHING_REPORTED();
+    CHECK_TRUE(sent);
+}


### PR DESCRIPTION
## Summary

Apply the S12.04 nil-object exemplar to `SolidSyslogUdpSender`:

- Top-level `Create(NULL config)` guard reports `MSG_UDP_CREATE_NULL_CONFIG` and returns `NULL`.
- Private `NilResolver` and `NilDatagram` vtables occupy the `config.resolver` / `config.datagram` slots at file load, after `_Destroy`, and whenever the integrator's config leaves a required slot NULL. `NilResolver.Resolve` and `NilDatagram.Open` each report once on first dispatch (`MSG_UDP_NIL_RESOLVER_USED` / `MSG_UDP_NIL_DATAGRAM_USED`); `_Destroy` re-arms the flags.
- Per-field `InstallResolver` / `InstallDatagram` / `InstallEndpoint` / `InstallEndpointVersion` helpers report `MSG_UDP_CREATE_NULL_RESOLVER` / `MSG_UDP_CREATE_NULL_DATAGRAM` and leave the matching nil in place; optional endpoint slots stay silent (already covered by `NoEndpointConfiguredSendsToPortZero`).
- `instanceInitialised` flag rejects a second `_Create` without an intervening `_Destroy`, returning the already-active sender pointer with `MSG_UDP_CREATE_ALREADY_INITIALISED`. A `Create(NULL)` does *not* set the flag, so a subsequent valid `Create` still succeeds.

## Test plan

Local gates run inside the gcc/clang container images (Windows clone bind-mounted; the gcc/clang compose containers are owned by a parallel session on FreeRTOS work):

- [x] build-linux-gcc (1118 ran, all pass)
- [x] build-linux-clang (1118 ran, all pass)
- [x] sanitize-linux-gcc (ASan/UBSan clean)
- [x] coverage-linux-gcc — overall 99.4% line / 98.5% func
- [x] analyze-tidy
- [x] analyze-cppcheck
- [x] analyze-format
- [ ] build-windows-msvc (CI)
- [ ] integration-linux-openssl (CI)
- [ ] bdd-linux-syslog-ng / bdd-windows-otel (CI)

## Heads-up for review

`Core/Source/SolidSyslogUdpSender.c` lands at **96.6% line / 92.6% function** (was 100% on `main`). The two uncovered functions are `NilDatagram.SendTo` and `NilDatagram.MaxPayload`: the vtable contract requires non-NULL slots, but `NilDatagramOpen` returns false so `Reconcile` short-circuits before `TransmitDatagram` is reached. Documented in the Nil-collaborators block of the source and in the S12.05 DEVLOG entry.

The S24.03 whitebox-include trick (`#include "<name>.c"` in a `.cpp` test) does not compose here — `SolidSyslogUdpSender.c` uses C99 designated initializers throughout, and the project's C++17 standard rejects them as `-Werror=c++20-extensions` when the file is pulled into a `.cpp` TU. David accepted the reduced coverage in lieu of the alternatives.

Closes #116