### PR TITLE
ci: surface FreeRTOS host TDD in Quality Summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,25 @@ jobs:
       - name: Build and test
         run: cmake --build --preset debug --target junit BddTargetTests SolidSyslogBddTarget
 
+      - name: Run BDD target tests
+        run: cd build/debug && ./Tests/Bdd/Targets/BddTargetTests -ojunit -k BddTargetTests
+
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: Test Results (FreeRTOS host)
+          path: build/debug/cpputest_*.xml
+          reporter: java-junit
+
+      - name: Upload JUnit XML
+        if: success() || failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: junit-build-freertos-host-tdd
+          path: build/debug/cpputest_*.xml
+          retention-days: 1
+
   build-freertos-target:
     runs-on: ubuntu-latest
     permissions:
@@ -809,6 +828,11 @@ jobs:
                     "id": "junit",
                     "name": "build-linux-gcc",
                     "pattern": "**/junit-build-linux-gcc/cpputest_*.xml"
+                  },
+                  {
+                    "id": "junit",
+                    "name": "build-freertos-host-tdd",
+                    "pattern": "**/junit-build-freertos-host-tdd/cpputest_*.xml"
                   },
                   {
                     "id": "junit",

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -154,6 +154,40 @@ add_custom_target(junit
     COMMENT "Running tests with JUnit XML output"
 )
 
+# Each registered executable runs through run_junit.cmake as a POST_BUILD step
+# on the `junit` custom target, so its cpputest_<group>.xml lands in the build
+# dir alongside SolidSyslogTests' output. CI's junit-* upload-artifact then
+# picks them all up for the Quality Summary panel. The `if(TARGET ...)` guard
+# keeps the list authoritative without duplicating the FREERTOS_KERNEL_PATH /
+# FREERTOS_PLUS_TCP_PATH env-var guards that already gate the test
+# executables' definition in Tests/FreeRtos/CMakeLists.txt — a missing target
+# is silently skipped, so jobs running outside a FreeRTOS-aware container
+# just run SolidSyslogTests as before.
+function(register_junit_test test_target)
+    add_custom_command(TARGET junit POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DEXECUTABLE=$<TARGET_FILE:${test_target}>
+            -DDIR=${CMAKE_BINARY_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/run_junit.cmake
+        COMMENT "Running ${test_target} with JUnit XML output"
+        VERBATIM
+    )
+    add_dependencies(junit ${test_target})
+endfunction()
+
+foreach(freertos_test_target IN ITEMS
+    SolidSyslogFreeRtosMutexTest
+    SolidSyslogFreeRtosSysUpTimeTest
+    CmsdkUartTest
+    SolidSyslogFreeRtosDatagramTest
+    SolidSyslogFreeRtosTcpStreamTest
+    SolidSyslogFreeRtosStaticResolverTest
+)
+    if(TARGET ${freertos_test_target})
+        register_junit_test(${freertos_test_target})
+    endif()
+endforeach()
+
 # Code coverage report using lcov/genhtml.
 # Requires the coverage preset: cmake --preset coverage && cmake --build --preset coverage --target coverage
 # lcov and genhtml must be installed (available in both container images).


### PR DESCRIPTION
## Summary

Closes the gap captured in memory `project_freertos_tdd_quality_summary_gap`: the six FreeRTOS host-side TDD suites (`SolidSyslogFreeRtosDatagramTest`, `SolidSyslogFreeRtosTcpStreamTest`, `SolidSyslogFreeRtosStaticResolverTest`, `SolidSyslogFreeRtosMutexTest`, `SolidSyslogFreeRtosSysUpTimeTest`, `CmsdkUartTest`) were registered with CTest but the `junit` cmake target only ran `SolidSyslogTests`, so no `cpputest_<group>.xml` was produced for them and the Quality Summary panel had no rows for `build-freertos-host-tdd`.

- **Tests/CMakeLists.txt:** add `register_junit_test()` helper that drives each registered test through `run_junit.cmake` as a POST_BUILD on the `junit` target. Guarded by `if(TARGET ${test_target})` so jobs without `FREERTOS_KERNEL_PATH` (e.g. `build-linux-gcc`) silently skip them — no env-var guard duplication.
- **`.github/workflows/ci.yml` `build-freertos-host-tdd`:** mirror `build-linux-gcc`'s shape — separate `BddTargetTests` run step, `dorny/test-reporter`, and `upload-artifact: junit-build-freertos-host-tdd`.
- **`summary` job's quality-monitor config:** add a `tools` entry pointing at the new artifact pattern.

## Test plan

- [x] `cmake --preset debug && cmake --build --preset debug --target junit` locally produces `cpputest_SolidSyslogFreeRtosDatagram.xml`, `cpputest_SolidSyslogFreeRtosMutex.xml`, `cpputest_SolidSyslogFreeRtosStaticResolver.xml`, `cpputest_SolidSyslogFreeRtosSysUpTime.xml`, `cpputest_SolidSyslogFreeRtosTcpStream.xml`, `cpputest_CmsdkUart.xml` alongside the existing 70+ XMLs.
- [x] YAML lints.
- [ ] CI's `build-freertos-host-tdd` produces the artifact; Quality Summary on this PR shows a new `build-freertos-host-tdd` row.
- [ ] No regression on other jobs — the cmake change is silently a no-op when FreeRTOS tests aren't defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)