### PR TITLE
chore: bump container image to sha-bbc958b

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     command: sleep infinity
 
   freertos-host:
-    image: ghcr.io/davidcozens/cpputest-freertos:sha-10a14ae
+    image: ghcr.io/davidcozens/cpputest-freertos:sha-bbc958b
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
@@ -153,7 +153,7 @@ services:
           - syslog-ng
 
   freertos-target:
-    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-10a14ae
+    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-bbc958b
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - syslog-ng-ctl-freertos:/var/lib/syslog-ng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,7 +724,7 @@ jobs:
       contents: read
       checks: write
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-10a14ae
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-bbc958b
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -768,7 +768,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-10a14ae
+      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-bbc958b
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1

--- a/Platform/FreeRtos/CMakeLists.txt
+++ b/Platform/FreeRtos/CMakeLists.txt
@@ -1,10 +1,10 @@
 # FreeRTOS adapter pack — shipped as sources, not a precompiled library.
 #
-# FreeRTOS, FreeRTOS-Plus-FAT, and Mbed TLS are header-configured: the
-# integrator's FreeRTOSConfig.h / ffconf.h / mbedtls_config.h flows through
-# upstream headers and changes the size/layout of TCBs, semaphores, file
-# handles, and SSL contexts. Compiling our adapters once into libSolidSyslog.a
-# would silently break consumers that use a different config.
+# FreeRTOS and Mbed TLS are header-configured: the integrator's
+# FreeRTOSConfig.h / mbedtls_config.h flows through upstream headers and
+# changes the size/layout of TCBs, semaphores, and SSL contexts. Compiling
+# our adapters once into libSolidSyslog.a would silently break consumers
+# that use a different config.
 #
 # Instead, this is an INTERFACE library — each consumer (Example/FreeRtos/*,
 # Tests/FreeRtos/*Test, downstream integrator apps) recompiles the adapter

--- a/ci/docker-compose.bdd.yml
+++ b/ci/docker-compose.bdd.yml
@@ -87,7 +87,7 @@ services:
 
   behave-freertos:
     # Cross image carries qemu-system-arm + python3 + behave.
-    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-10a14ae
+    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-bbc958b
     user: "0"
     volumes:
       - ..:/workspaces/SolidSyslog

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -6,8 +6,8 @@
 |---|---|---|
 | `ghcr.io/davidcozens/cpputest` | `sha-18f19e1` | devcontainer (`gcc` service), most CI jobs |
 | `ghcr.io/davidcozens/cpputest-clang` | `sha-7eac3ab` | `clang` compose service, `build-linux-clang` CI job, `analyze-iwyu` CI job |
-| `ghcr.io/davidcozens/cpputest-freertos` | `sha-10a14ae` | `freertos-host` compose service, `build-freertos-host-tdd` CI job — adds FreeRTOS-Kernel / Plus-TCP / Plus-FAT / Mbed TLS sources for host-TDD of FreeRTOS adapters against fakes |
-| `ghcr.io/davidcozens/cpputest-freertos-cross` | `sha-10a14ae` | `freertos-target` compose service, `build-freertos-target` CI job, `behave-freertos` BDD service, `bdd-freertos-qemu` CI job — adds `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `gdb-multiarch` (aliased as `arm-none-eabi-gdb`), `qemu-system-arm`, `python3` + `behave` for cross builds, on-QEMU runs, and BDD scenarios driving a QEMU target |
+| `ghcr.io/davidcozens/cpputest-freertos` | `sha-bbc958b` | `freertos-host` compose service, `build-freertos-host-tdd` CI job — adds FreeRTOS-Kernel / Plus-TCP / FatFs / Mbed TLS sources for host-TDD of FreeRTOS adapters against fakes |
+| `ghcr.io/davidcozens/cpputest-freertos-cross` | `sha-bbc958b` | `freertos-target` compose service, `build-freertos-target` CI job, `behave-freertos` BDD service, `bdd-freertos-qemu` CI job — adds `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `gdb-multiarch` (aliased as `arm-none-eabi-gdb`), `qemu-system-arm`, `python3` + `behave` for cross builds, on-QEMU runs, and BDD scenarios driving a QEMU target |
 | `balabit/syslog-ng` | `4.8.2` | `syslog-ng-linux` and `syslog-ng-freertos` services — BDD test oracles, one per target pair. Pinned to the 4.8 LTS line; 4.11.0 (`latest` as of 2026-02-24) regressed by aborting on `STATS` over the control socket, which crashed the oracle and cascaded to the dev-container network when `freertos-target` shares the namespace. |
 | `ghcr.io/davidcozens/behave` | `sha-3faff14` | `behave-linux` service — Debian trixie + Python 3.12 + Behave for Linux BDD scenarios. The FreeRTOS BDD runner uses the `cpputest-freertos-cross` image instead (which carries QEMU + Behave). |
 


### PR DESCRIPTION
## Purpose

Picks up the FatFs R0.16 swap from [CppUTestFreertosDocker#1](https://github.com/DavidCozens/CppUTestFreertosDocker/pull/1). Plus-FAT is gone from the image; FatFs is now at \`/opt/fatfs\` with \`FATFS_PATH\` set.

Prerequisite for #270 (S08.05 — Store-and-forward on FatFs), which targets FatFs as its embedded persistent-store backend.

## Change Description

Per the [\`docs/containers.md\`](docs/containers.md) "Updating an image" checklist:

- **\`.devcontainer/docker-compose.yml\`** — \`freertos-host\` and \`freertos-target\` services.
- **\`.github/workflows/ci.yml\`** — \`build-freertos-host-tdd\` and \`build-freertos-target\` jobs.
- **\`ci/docker-compose.bdd.yml\`** — \`behave-freertos\` service.
- **\`docs/containers.md\`** — both image rows; "Plus-FAT" → "FatFs" in the env-vars text.
- **\`Platform/FreeRtos/CMakeLists.txt\`** — drops the Plus-FAT mention from the header-configured rationale, since Plus-FAT is no longer in the image. The header-configured INTERFACE-library pattern still applies to FreeRTOS itself; FatFs (when S08.05 adds \`Platform/FatFs/\`) will be its own peer pack with its own \`ffconf.h\` rationale.

DEVLOG entries from 2026-04-21 (S08.01) that historically mention "Plus-FAT" are left alone — those describe the state at the time and shouldn't be rewritten.

## Test Evidence

Pre-push verification on the new image:

\`\`\`
$ docker run --rm ghcr.io/davidcozens/cpputest-freertos:sha-bbc958b bash -c 'env | grep -E "FATFS|FREERTOS|MBEDTLS" | sort && ls /opt/fatfs/source/'
FATFS_PATH=/opt/fatfs
FREERTOS_KERNEL_PATH=/opt/freertos/kernel
FREERTOS_PLUS_TCP_PATH=/opt/freertos/plus-tcp
MBEDTLS_DIR=/opt/mbedtls
00history.txt  00readme.txt  diskio.c  diskio.h  ff.c  ff.h  ffconf.h  ffsystem.c  ffunicode.c
\`\`\`

\`/opt/freertos/plus-fat\` correctly absent. CI on this PR rebuilds the FreeRTOS host TDD and cross-build jobs against the new image SHA — that's the integration check.

## Areas Affected

Devcontainer, CI workflow, BDD compose file, container reference docs, FreeRTOS adapter pack rationale comment. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and CI container images to latest versions for FreeRTOS build environments.
  * Updated build system documentation to clarify configuration approach.

* **Documentation**
  * Updated container reference documentation with current image details and contents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->