### PR TITLE
feat: S12.06 MetaSd NULL guards via nil-object + WARNING reporting

### DIFF
--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -9,5 +9,7 @@
 #define SOLIDSYSLOG_ERROR_MSG_LOG_NULL_MESSAGE "SolidSyslog_Log called with NULL message"
 #define SOLIDSYSLOG_ERROR_MSG_NIL_BUFFER_USED "SolidSyslog_Log called with no buffer configured"
 #define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"
+#define SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_CONFIG "SolidSyslogMetaSd_Create called with NULL config"
+#define SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_COUNTER "SolidSyslogMetaSd_Create config.counter is NULL"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogMetaSd.c
+++ b/Core/Source/SolidSyslogMetaSd.c
@@ -3,7 +3,10 @@
 #include <stddef.h>
 
 #include "SolidSyslogAtomicCounter.h"
+#include "SolidSyslogError.h"
+#include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogPrival.h"
 #include "SolidSyslogStructuredDataDefinition.h"
 
 struct SolidSyslogFormatter;
@@ -17,19 +20,34 @@ struct SolidSyslogMetaSd
 };
 
 static void        Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static void        NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
 static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
 static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
 static inline void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
 
-static struct SolidSyslogMetaSd instance;
+static struct SolidSyslogMetaSd         instance;
+static struct SolidSyslogStructuredData NilMetaSd = {.Format = NilMetaSdFormat};
 
 struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(const struct SolidSyslogMetaSdConfig* config)
 {
-    instance.base.Format  = Format;
-    instance.counter      = config->counter;
-    instance.getSysUpTime = config->getSysUpTime;
-    instance.getLanguage  = config->getLanguage;
-    return &instance.base;
+    struct SolidSyslogStructuredData* result = &NilMetaSd;
+    if (config == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_CONFIG);
+    }
+    else if (config->counter == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_COUNTER);
+    }
+    else
+    {
+        instance.base.Format  = Format;
+        instance.counter      = config->counter;
+        instance.getSysUpTime = config->getSysUpTime;
+        instance.getLanguage  = config->getLanguage;
+        result                = &instance.base;
+    }
+    return result;
 }
 
 void SolidSyslogMetaSd_Destroy(void)
@@ -38,6 +56,12 @@ void SolidSyslogMetaSd_Destroy(void)
     instance.counter      = NULL;
     instance.getSysUpTime = NULL;
     instance.getLanguage  = NULL;
+}
+
+static void NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
+{
+    (void) self;
+    (void) formatter;
 }
 
 static const char SD_PREFIX[]      = "[meta";
@@ -58,12 +82,9 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
 
 static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
-    if (meta->counter != NULL)
-    {
-        SolidSyslogFormatter_BoundedString(formatter, SEQUENCE_ID_SD, sizeof(SEQUENCE_ID_SD) - 1);
-        SolidSyslogFormatter_Uint32(formatter, SolidSyslogAtomicCounter_Increment(meta->counter));
-        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
-    }
+    SolidSyslogFormatter_BoundedString(formatter, SEQUENCE_ID_SD, sizeof(SEQUENCE_ID_SD) - 1);
+    SolidSyslogFormatter_Uint32(formatter, SolidSyslogAtomicCounter_Increment(meta->counter));
+    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
 static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,64 @@
 # Dev Log
 
+## 2026-05-14 — S12.06 MetaSd NULL guards (#117)
+
+First story under the new "skip the SD on bad setup, report once at
+detection time" contract for `meta@...` structured data. `MetaSd_Create`
+no longer dereferences `config->counter` when `config` is NULL, and no
+longer dereferences `NULL` at format time when `config->counter` is
+NULL: both detect-and-misconfigure paths now return a static
+`NilMetaSd` whose `Format` is a no-op, so the wire message is still
+emitted without the `[meta ...]` element. Both detection points report
+once via `SolidSyslog_Error` at `_Create` time, with a new severity
+convention to distinguish "delivered in degraded form" from "could not
+deliver at all".
+
+### Decisions
+
+- **Severity ladder starts here.** Every prior `SolidSyslog_Error` call
+  site uses `SOLIDSYSLOG_SEVERITY_ERR` (3) — and they all describe
+  situations where the library cannot deliver as configured (null
+  buffer, null sender, null store, null message, nil-collaborator-used).
+  This story introduces `SOLIDSYSLOG_SEVERITY_WARNING` (4) for the new
+  "library delivers, but in degraded form" class. The ladder going
+  forward: ERR = can't send; WARNING = sending with something dropped.
+- **Nil-object vtable, not internal null checks.** Bad-config detection
+  in `_Create` swaps the returned handle to a static
+  `NilMetaSd = {.Format = NilMetaSdFormat}`. No `broken` flag at
+  format time, no per-call null checks — Format dispatch goes to the
+  no-op. Matches the `NilBuffer`/`NilSender`/`NilInstance` pattern in
+  `SolidSyslog.c`. (Lesson from #116 / PR #331: avoid singleton-shaped
+  reporter state for per-instance SDs.)
+- **`sequenceId` is mandatory; `sysUpTime` / `language` are not.**
+  RFC 5424 §7.3.1 names `sequenceId` as the parameter that makes a
+  `meta@...` SD meaningful — without it, the SD has no semantic value.
+  Configuring MetaSd with `config->counter == NULL` is therefore a
+  setup error (whole SD skipped + warning). `getSysUpTime` /
+  `getLanguage` staying NULL remains valid (existing format-time
+  guards skip those params individually) — partial configuration is
+  legitimate, missing the mandatory field is not.
+- **Per-class hardening cadence.** E12's audit (2026-05-10) listed
+  `MetaSd`, `OriginSd`, `UdpSender`, and `AtomicCounter` as needing
+  guards. We're working through them one class at a time rather than
+  sweeping — each class can pick the right behaviour shape for its
+  own role. UdpSender (#116) needs the multi-instance story sorted
+  first; OriginSd and AtomicCounter remain in the E12 backlog.
+
+### Deferred
+
+- **OriginSd, AtomicCounter, UdpSender NULL guards** — out of scope
+  for this story; tracked under E12 (#31) for separate stories as the
+  hardening cadence reaches each class.
+- **`CHECK_REPORTED_ERROR` macro extension for non-ERR severities** —
+  considered while wiring slice 2 / 4 tests. Today the macro hard-codes
+  `SOLIDSYSLOG_SEVERITY_ERR`. Tests inline three assertions (call count,
+  severity, message) instead. Worth extending the macro when a third
+  WARNING-emitting class lands — refactor under green.
+
+### Open questions
+
+- *(none)*
+
 ## 2026-05-13 — S08.05 store-and-forward on FreeRTOS-Plus-FAT (#270)
 
 The store-and-forward stack now runs unchanged on the QEMU mps2-an385

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -1,11 +1,16 @@
 #include <cstdint>
 #include <cstring>
 
+#include "ErrorHandlerFake.h"
 #include "SolidSyslogAtomicCounter.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogMetaSd.h"
+#include "SolidSyslogPrival.h"
 #include "SolidSyslogStructuredData.h"
+#include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
+
+using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for the CALLED_FAKE macro
 
 class TEST_SolidSyslogMetaSd_FirstFormatProducesSequenceId1_Test;
 class TEST_SolidSyslogMetaSd_FormatEscapesBackslashInLanguage_Test;
@@ -61,9 +66,12 @@ TEST_GROUP(SolidSyslogMetaSd)
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
     // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogFormatter* formatter;
+    // cppcheck-suppress unreadVariable -- read via context-propagation through ErrorHandlerFake_Install
+    int sentinel = 0;
 
     void setup() override
     {
+        ErrorHandlerFake_Install(&sentinel);
         formatter = SolidSyslogFormatter_Create(storage, TEST_BUFFER_SIZE);
         counter = SolidSyslogAtomicCounter_Create();
         fakeSysUpTimeValue = 0;
@@ -78,12 +86,18 @@ TEST_GROUP(SolidSyslogMetaSd)
     {
         SolidSyslogMetaSd_Destroy();
         SolidSyslogAtomicCounter_Destroy();
+        ErrorHandlerFake_Uninstall();
+    }
+
+    void recreateWith(const SolidSyslogMetaSdConfig* configPtr)
+    {
+        SolidSyslogMetaSd_Destroy();
+        sd = SolidSyslogMetaSd_Create(configPtr);
     }
 
     void recreate()
     {
-        SolidSyslogMetaSd_Destroy();
-        sd = SolidSyslogMetaSd_Create(&config);
+        recreateWith(&config);
     }
 
     void useSysUpTime(uint32_t value)
@@ -226,19 +240,37 @@ TEST(SolidSyslogMetaSd, FormatWithAllThreeParamsEmitsAllThree)
     STRCMP_EQUAL("[meta sequenceId=\"1\" sysUpTime=\"12345\" language=\"en-GB\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
-TEST(SolidSyslogMetaSd, FormatWithoutCounterOmitsSequenceId)
+TEST(SolidSyslogMetaSd, FormatEmitsNothingWhenConfigCounterIsNullEvenIfOtherFieldsPresent)
 {
     config.counter = nullptr;
     useSysUpTime(12345);
     useLanguage("en-GB");
     format();
-    STRCMP_EQUAL("[meta sysUpTime=\"12345\" language=\"en-GB\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
 }
 
-TEST(SolidSyslogMetaSd, FormatWithNoConfiguredParamsEmitsBareMetaElement)
+TEST(SolidSyslogMetaSd, FormatEmitsNothingWhenCreatedWithNullConfig)
+{
+    recreateWith(nullptr);
+    format();
+    STRCMP_EQUAL("", SolidSyslogFormatter_AsFormattedBuffer(formatter));
+}
+
+TEST(SolidSyslogMetaSd, CreateWithNullConfigReportsWarning)
+{
+    recreateWith(nullptr);
+
+    CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);
+    LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_WARNING, ErrorHandlerFake_LastSeverity());
+    STRCMP_EQUAL("SolidSyslogMetaSd_Create called with NULL config", ErrorHandlerFake_LastMessage());
+}
+
+TEST(SolidSyslogMetaSd, CreateWithNullCounterReportsWarning)
 {
     config.counter = nullptr;
     recreate();
-    format();
-    STRCMP_EQUAL("[meta]", SolidSyslogFormatter_AsFormattedBuffer(formatter));
+
+    CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);
+    LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_WARNING, ErrorHandlerFake_LastSeverity());
+    STRCMP_EQUAL("SolidSyslogMetaSd_Create config.counter is NULL", ErrorHandlerFake_LastMessage());
 }


### PR DESCRIPTION
## Purpose

Closes #117 (part of E12 #31). `SolidSyslogMetaSd_Create` previously
crashed when called with a NULL config or with `config->counter == NULL`.
This story is the first under the per-class hardening contract for SD
implementations: never crash on bad setup, skip the SD element on the
wire, report once at detection time.

## Change Description

- `_Create(NULL config)` and `_Create(config with NULL counter)` both
  now return a static `NilMetaSd` whose `Format` vtable slot points at
  a no-op. The `[meta ...]` block is omitted entirely from the wire
  message; the log line itself is still emitted with whatever other
  SDs are healthy.
- Each detection point reports once via
  `SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, …)`. This
  establishes a severity ladder: existing call sites use ERR (3) for
  "can't deliver as configured"; this story introduces WARNING (4) for
  "delivered, but in degraded form". Two new error-message constants
  follow the existing `SOLIDSYSLOG_ERROR_MSG_*` naming.
- Nil-object via vtable swap, not internal `broken` flag — matches the
  `NilBuffer` / `NilSender` / `NilInstance` pattern in `SolidSyslog.c`.
  Lesson from #116 / PR #331: avoid singleton-shaped reporter state
  for per-instance SDs.
- `sequenceId` is the mandatory parameter of `meta@…` per RFC 5424
  §7.3.1, so `config->counter == NULL` is treated as setup error
  (whole SD skipped). `getSysUpTime` / `getLanguage` staying NULL
  remains valid — the existing format-time guards handle those
  independently optional params.
- Removed the now-unreachable `if (meta->counter != NULL)` guard in
  `EmitSequenceId` — the nil-object swap intercepts the bad case at
  Create time, so counter is guaranteed non-NULL inside `Format`.

## Test Evidence

Four TDD red→green slices on `SolidSyslogMetaSdTest`, all run inside
the `cpputest:sha-18f19e1` devcontainer:

| # | Test | Red signal | Green code |
|---|---|---|---|
| 1 | `FormatEmitsNothingWhenCreatedWithNullConfig` | SIGSEGV at `config->counter` deref | `NilMetaSd` returned when `config == NULL` |
| 2 | `CreateWithNullConfigReportsWarning` | call count 0 vs 1 | `SolidSyslog_Error(WARNING, NULL_CONFIG_MSG)` |
| 3 | `FormatEmitsNothingWhenConfigCounterIsNullEvenIfOtherFieldsPresent` | got `[meta sysUpTime="…" language="…"]`, expected `""` | `else if (counter != NULL)` flipped to install-only-when-valid |
| 4 | `CreateWithNullCounterReportsWarning` | call count 0 vs 1 | second `SolidSyslog_Error(WARNING, NULL_COUNTER_MSG)` branch |

Two stale tests retired in slice 3 (`FormatWithoutCounterOmitsSequenceId`,
`FormatWithNoConfiguredParamsEmitsBareMetaElement`) — they documented
the previous "emit SD with mandatory field missing" behaviour which is
no longer valid under the new contract.

Refactor under green: `ErrorHandlerFake_Install` / `_Uninstall` lifted
into TEST_GROUP setup/teardown; new `recreateWith(const
SolidSyslogMetaSdConfig*)` helper unifies the destroy+create pattern
so each test reads as one arrange line plus assertions.

Local CI gate (all green):

- `cmake --preset debug && cmake --build --preset debug --target junit` — 1112 tests pass
- `cmake --preset clang-debug && cmake --build --preset clang-debug --target junit` — 1112 tests pass
- `cmake --preset sanitize && cmake --build --preset sanitize --target junit` — 1112 tests pass (ASan + UBSan)
- `cmake --preset coverage && cmake --build --preset coverage --target coverage` — 99.5% (all MetaSd lines covered; both new error branches hit)
- `cmake --preset tidy && cmake --build --preset tidy` — clean
- `cmake --preset cppcheck && cmake --build --preset cppcheck` — clean
- `clang-format --dry-run --Werror` — clean

## Areas Affected

- `Core/Source/SolidSyslogMetaSd.c` — `_Create` branching + `NilMetaSd` static + EmitSequenceId simplified
- `Core/Source/SolidSyslogErrorMessages.h` — two new METASD error-message constants
- `Tests/SolidSyslogMetaSdTest.cpp` — 4 new tests, 2 retired, fixture refactor
- `DEVLOG.md` — 2026-05-14 session entry

No public-header changes. No impact on derived projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for NULL configuration inputs during MetaSd initialization. The system now validates configuration pointers and returns an empty structured-data instance with appropriate warning messages instead of proceeding with invalid state.

* **Tests**
  * Updated test suite to verify proper validation and error reporting for NULL configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/355)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->