### PR TITLE
feat: S12.05 UdpSender NULL guards via nil-object + ERR reporting

### DIFF
--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -11,5 +11,9 @@
 #define SOLIDSYSLOG_ERROR_MSG_NIL_SENDER_USED "SolidSyslog_Service tried to send with no sender configured"
 #define SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_CONFIG "SolidSyslogMetaSd_Create called with NULL config"
 #define SOLIDSYSLOG_ERROR_MSG_METASD_CREATE_NULL_COUNTER "SolidSyslogMetaSd_Create config.counter is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_CONFIG "SolidSyslogUdpSender_Create called with NULL config"
+#define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_RESOLVER "SolidSyslogUdpSender_Create config.resolver is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_DATAGRAM "SolidSyslogUdpSender_Create config.datagram is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_ENDPOINT "SolidSyslogUdpSender_Create config.endpoint is NULL"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogErrorMessages.h
+++ b/Core/Source/SolidSyslogErrorMessages.h
@@ -15,5 +15,6 @@
 #define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_RESOLVER "SolidSyslogUdpSender_Create config.resolver is NULL"
 #define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_DATAGRAM "SolidSyslogUdpSender_Create config.datagram is NULL"
 #define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_ENDPOINT "SolidSyslogUdpSender_Create config.endpoint is NULL"
+#define SOLIDSYSLOG_ERROR_MSG_UDPSENDER_SEND_NULL_BUFFER "SolidSyslogUdpSender_Send called with NULL buffer"
 
 #endif /* SOLIDSYSLOGERRORMESSAGES_H */

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -3,6 +3,8 @@
 #include <stdbool.h>
 
 #include "SolidSyslogEndpoint.h"
+#include "SolidSyslogError.h"
+#include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
@@ -34,28 +36,48 @@ static inline struct SolidSyslogAddress*         Address(struct SolidSyslogUdpSe
 static inline void                               CloseSocket(struct SolidSyslogUdpSender* udp);
 static inline bool                               TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
 static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
-static void                                      NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 static uint32_t                                  NilEndpointVersion(void);
+static bool                                      NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static void                                      NilUdpSenderDisconnect(struct SolidSyslogSender* self);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpoint = NilEndpoint, .endpointVersion = NilEndpointVersion}};
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpointVersion = NilEndpointVersion}};
 static struct SolidSyslogUdpSender       instance;
+static struct SolidSyslogSender          NilUdpSender = {.Send = NilUdpSenderSend, .Disconnect = NilUdpSenderDisconnect};
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
-    instance                 = DEFAULT_INSTANCE;
-    instance.config.resolver = config->resolver;
-    instance.config.datagram = config->datagram;
-    if (config->endpoint != NULL)
+    struct SolidSyslogSender* result = &NilUdpSender;
+    if (config == NULL)
     {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_CONFIG);
+    }
+    else if (config->resolver == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_RESOLVER);
+    }
+    else if (config->datagram == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_DATAGRAM);
+    }
+    else if (config->endpoint == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_ENDPOINT);
+    }
+    else
+    {
+        instance                 = DEFAULT_INSTANCE;
+        instance.config.resolver = config->resolver;
+        instance.config.datagram = config->datagram;
         instance.config.endpoint = config->endpoint;
+        if (config->endpointVersion != NULL)
+        {
+            instance.config.endpointVersion = config->endpointVersion;
+        }
+        instance.base.Send       = Send;
+        instance.base.Disconnect = Disconnect;
+        result                   = &instance.base;
     }
-    if (config->endpointVersion != NULL)
-    {
-        instance.config.endpointVersion = config->endpointVersion;
-    }
-    instance.base.Send       = Send;
-    instance.base.Disconnect = Disconnect;
-    return &instance.base;
+    return result;
 }
 
 void SolidSyslogUdpSender_Destroy(void)
@@ -185,13 +207,20 @@ static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct Solid
     return result;
 }
 
-static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
-{
-    SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
-    endpoint->port = 0;
-}
-
 static uint32_t NilEndpointVersion(void)
 {
     return 0;
+}
+
+static bool NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+{
+    (void) self;
+    (void) buffer;
+    (void) size;
+    return true;
+}
+
+static void NilUdpSenderDisconnect(struct SolidSyslogSender* self)
+{
+    (void) self;
 }

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -6,6 +6,7 @@
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrorMessages.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogPrival.h"
 #include "SolidSyslogUdpPayload.h"
 #include "SolidSyslogUdpSender.h"
 #include "SolidSyslogSenderDefinition.h"
@@ -13,6 +14,8 @@
 #include "SolidSyslogDatagram.h"
 #include "SolidSyslogResolver.h"
 #include "SolidSyslogTransport.h"
+
+struct SolidSyslogFormatter;
 
 struct SolidSyslogUdpSender
 {

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -150,9 +150,13 @@ static bool Connect(struct SolidSyslogUdpSender* udp)
     SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
     uint16_t                     port          = QueryEndpointPort(udp, hostFormatter);
+    const char*                  host          = SolidSyslogFormatter_AsFormattedBuffer(hostFormatter);
 
-    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), port);
-    if (!Connected(udp))
+    if (OpenSocket(udp) && ResolveDestination(udp, host, port))
+    {
+        udp->connected = true;
+    }
+    else
     {
         CloseSocket(udp);
     }

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -86,13 +86,11 @@ static bool IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
 
 static void InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
-    instance                 = DEFAULT_INSTANCE;
-    instance.config.resolver = config->resolver;
-    instance.config.datagram = config->datagram;
-    instance.config.endpoint = config->endpoint;
-    if (config->endpointVersion != NULL)
+    instance        = DEFAULT_INSTANCE;
+    instance.config = *config;
+    if (instance.config.endpointVersion == NULL)
     {
-        instance.config.endpointVersion = config->endpointVersion;
+        instance.config.endpointVersion = NilEndpointVersion;
     }
     instance.base.Send       = Send;
     instance.base.Disconnect = Disconnect;

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -104,8 +104,17 @@ void SolidSyslogUdpSender_Destroy(void)
 
 static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
-    struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
-    return Reconcile(udp) && TransmitDatagram(udp, buffer, size);
+    bool result = false;
+    if (buffer == NULL)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_SEND_NULL_BUFFER);
+    }
+    else
+    {
+        struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
+        result                           = Reconcile(udp) && TransmitDatagram(udp, buffer, size);
+    }
+    return result;
 }
 
 static void Disconnect(struct SolidSyslogSender* self)

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -23,13 +23,16 @@ struct SolidSyslogUdpSender
     uint32_t                          lastEndpointVersion;
 };
 
+static bool                                      IsValidConfig(const struct SolidSyslogUdpSenderConfig* config);
+static void                                      InstallConfig(const struct SolidSyslogUdpSenderConfig* config);
 static bool                                      Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static void                                      Disconnect(struct SolidSyslogSender* self);
 static inline bool                               Reconcile(struct SolidSyslogUdpSender* udp);
 static inline void                               DisconnectIfStale(struct SolidSyslogUdpSender* udp);
 static inline bool                               EnsureConnected(struct SolidSyslogUdpSender* udp);
 static inline bool                               Connected(struct SolidSyslogUdpSender* udp);
 static bool                                      Connect(struct SolidSyslogUdpSender* udp);
-static void                                      Disconnect(struct SolidSyslogSender* self);
+static inline uint16_t                           QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter);
 static inline bool                               OpenSocket(struct SolidSyslogUdpSender* udp);
 static bool                                      ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
 static inline struct SolidSyslogAddress*         Address(struct SolidSyslogUdpSender* udp);
@@ -47,6 +50,17 @@ static struct SolidSyslogSender          NilUdpSender = {.Send = NilUdpSenderSen
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
     struct SolidSyslogSender* result = &NilUdpSender;
+    if (IsValidConfig(config))
+    {
+        InstallConfig(config);
+        result = &instance.base;
+    }
+    return result;
+}
+
+static bool IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
+{
+    bool valid = false;
     if (config == NULL)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_ERR, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_CREATE_NULL_CONFIG);
@@ -65,19 +79,23 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     }
     else
     {
-        instance                 = DEFAULT_INSTANCE;
-        instance.config.resolver = config->resolver;
-        instance.config.datagram = config->datagram;
-        instance.config.endpoint = config->endpoint;
-        if (config->endpointVersion != NULL)
-        {
-            instance.config.endpointVersion = config->endpointVersion;
-        }
-        instance.base.Send       = Send;
-        instance.base.Disconnect = Disconnect;
-        result                   = &instance.base;
+        valid = true;
     }
-    return result;
+    return valid;
+}
+
+static void InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
+{
+    instance                 = DEFAULT_INSTANCE;
+    instance.config.resolver = config->resolver;
+    instance.config.datagram = config->datagram;
+    instance.config.endpoint = config->endpoint;
+    if (config->endpointVersion != NULL)
+    {
+        instance.config.endpointVersion = config->endpointVersion;
+    }
+    instance.base.Send       = Send;
+    instance.base.Disconnect = Disconnect;
 }
 
 void SolidSyslogUdpSender_Destroy(void)
@@ -90,6 +108,16 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
 {
     struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
     return Reconcile(udp) && TransmitDatagram(udp, buffer, size);
+}
+
+static void Disconnect(struct SolidSyslogSender* self)
+{
+    struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
+
+    if (Connected(udp))
+    {
+        CloseSocket(udp);
+    }
 }
 
 static inline bool Reconcile(struct SolidSyslogUdpSender* udp)
@@ -123,28 +151,21 @@ static bool Connect(struct SolidSyslogUdpSender* udp)
 {
     SolidSyslogFormatterStorage  hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
-    struct SolidSyslogEndpoint   endpoint      = {.host = hostFormatter, .port = 0};
+    uint16_t                     port          = QueryEndpointPort(udp, hostFormatter);
 
-    udp->config.endpoint(&endpoint);
-
-    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), endpoint.port);
-
+    udp->connected = OpenSocket(udp) && ResolveDestination(udp, SolidSyslogFormatter_AsFormattedBuffer(hostFormatter), port);
     if (!Connected(udp))
     {
         CloseSocket(udp);
     }
-
     return Connected(udp);
 }
 
-static void Disconnect(struct SolidSyslogSender* self)
+static inline uint16_t QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter)
 {
-    struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
-
-    if (Connected(udp))
-    {
-        CloseSocket(udp);
-    }
+    struct SolidSyslogEndpoint endpoint = {.host = hostFormatter, .port = 0};
+    udp->config.endpoint(&endpoint);
+    return endpoint.port;
 }
 
 static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
@@ -168,18 +189,6 @@ static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
     udp->connected = false;
 }
 
-/* Connected UDP fail/swallow contract:
- *   First Send fails non-OVERSIZE   → return false (transient — caller retries).
- *   First Send returns OVERSIZE     → trim and retry; propagate retry's verdict.
- *   Retry trimmed length is 0       → message can't physically fit the path;
- *                                     swallow and return true so the buffered
- *                                     algorithm doesn't loop on an undeliverable.
- *   Retry second Send succeeds      → return true.
- *   Retry second Send fails OVERSIZE→ kernel disagrees with its own reported
- *                                     MaxPayload — should be impossible. Swallow
- *                                     to avoid a permanent retry loop further up.
- *   Retry second Send fails other   → return false (transient).
- */
 static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
@@ -192,15 +201,19 @@ static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void
 
 static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
-    size_t                             maxPayload = SolidSyslogDatagram_MaxPayload(udp->config.datagram);
-    size_t                             clipLimit  = (size < maxPayload) ? size : maxPayload;
-    size_t                             trimmed    = SolidSyslogUdpPayload_TrimToCodepointBoundary((const uint8_t*) buffer, clipLimit);
-    enum SolidSyslogDatagramSendResult result     = SOLIDSYSLOG_DATAGRAM_SENT;
+    size_t maxPayload = SolidSyslogDatagram_MaxPayload(udp->config.datagram);
+    size_t clipLimit  = (size < maxPayload) ? size : maxPayload;
+    size_t trimmed    = SolidSyslogUdpPayload_TrimToCodepointBoundary((const uint8_t*) buffer, clipLimit);
+    /* Default SENT swallows trimmed == 0 (path can't carry the message) so the
+     * Service algorithm doesn't loop on an undeliverable. */
+    enum SolidSyslogDatagramSendResult result = SOLIDSYSLOG_DATAGRAM_SENT;
     if (trimmed > 0)
     {
         result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, trimmed, Address(udp));
         if (result == SOLIDSYSLOG_DATAGRAM_OVERSIZE)
         {
+            /* Retry still OVERSIZE means the kernel disagrees with its own
+             * MaxPayload — swallow for the same reason. */
             result = SOLIDSYSLOG_DATAGRAM_SENT;
         }
     }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,82 @@
 # Dev Log
 
+## 2026-05-14 — S12.05 UdpSender NULL guards (#116)
+
+Second pass at the E12 bad-setup contract, this time on the UDP sender.
+`SolidSyslogUdpSender_Create` no longer crashes on any of `config`,
+`config->resolver`, `config->datagram`, or `config->endpoint` being
+NULL — each reports once via `SolidSyslog_Error(SEVERITY_ERR, …)` and
+returns a static `NilUdpSender` whose `Send` is a swallowing no-op
+(returns `true`) and whose `Disconnect` is a no-op. A Send-time guard
+also detects NULL buffer and reports without reaching the datagram
+layer. Bundled with a clarity refactor across both
+`SolidSyslogUdpSender.c` and the test file.
+
+### Decisions
+
+- **Severity is `ERR`, not S12.06's `WARNING`.** WARNING is "delivered
+  in degraded form" (the line still goes out, minus one SD). UdpSender
+  with a NULL collaborator can't deliver *anything* — that's ERR. This
+  fixes the ERR/WARNING ladder against the bad-setup contract: ERR =
+  can't deliver, WARNING = delivered degraded.
+- **Endpoint became required.** The original audit had `endpoint` as
+  out-of-scope ("already optional via NilEndpoint fallback"), but the
+  fallback emitted `host="" port=0` — a permanently broken sender that
+  silently shipped. Tightened to required, with the now-dead
+  `NilEndpoint` helper removed. The existing
+  `NoEndpointConfiguredSendsToPortZero` test asserting the old
+  behaviour was deleted. `endpointVersion` stays optional — its
+  fallback of "version 0 forever" is a legitimate "destination never
+  changes" mode for single-destination embedded deployments.
+- **Nil-Send returns `true` (swallow), not `false`.** Matches the
+  existing `TransmitDatagram` "undeliverable in principle → swallow
+  so the Service algorithm doesn't loop on an undeliverable"
+  precedent. There is no recovery from a NULL-at-Create-time config,
+  so retries would spin forever.
+- **Send-time NULL buffer guard added.** Beyond the original Create-only
+  S12.05 scope. NULL buffer should never reach Send from the library's
+  own code path (the formatter always writes a real buffer), but it's
+  a programmer error severe enough to surface — defensive guard reports
+  `ERR` and returns false without invoking the datagram layer. Zero
+  length stays valid (RFC 768 permits zero-length UDP datagrams) and
+  flows through to sendto; characterised by test.
+- **Refactor sweep landed in the same PR.** Touched
+  `SolidSyslogUdpSender.c` enough that a clarity pass was natural:
+  extract `IsValidConfig` + `InstallConfig` from `_Create`,
+  `InstallConfig` uses struct-assign so future config fields flow
+  through automatically, extract `QueryEndpointPort` from `Connect`,
+  reshape Connect to positive logic, restore the project's top-down
+  function order, replace the 12-line `TransmitDatagram` block comment
+  with two targeted `Why:` comments at the actual swallow sites in
+  `RetryAfterOversize`.
+- **Test sweep too.** `TEST_BASE(UdpSenderTestBase)` lifts shared
+  fixture out of six groups; `Send()` returns bool so
+  `CHECK_TRUE(Send())` works; 28 sites of
+  `SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN)`
+  collapse to `Send()`. Retry-group `firstSendReturns(result)` /
+  `retrySendReturns(result)` / `maxPayload(bytes)` / `retrySendSize()`
+  helpers replace the positional-index magic numbers in
+  `DatagramFake_SetSendResult(datagram, 0|1, …)`. The `getHostFn` /
+  `getPortFn` indirection in the Config group, which pre-dated the
+  unified Endpoint callback, is gone. `IGNORE_TEST(HappyPathOnly)`
+  removed — every backlog item is now covered or declared
+  out-of-scope.
+
+### Deferred
+
+- **Project-wide static-prefix naming sweep** — discussed during
+  this PR (`UdpSender_Send` etc. per MISRA 5.9). In practice only
+  TlsStream consistently applies the prefix; `SolidSyslog…` names
+  are already long, and David is torn. Rolled into the broader
+  naming sweep (`project_naming_sweep_deferred`). Don't retro-apply
+  when touching a file that uses the bare-name pattern.
+- **Other E12 NULL guards** — OriginSd and AtomicCounter remain in
+  the E12 backlog. Per the per-class cadence established by S12.06.
+
+### Open questions
+
+- *(none)*
+
 ## 2026-05-14 — S12.06 MetaSd NULL guards (#117)
 
 First story under the new "skip the SD on bad setup, report once at

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "DatagramFake.h"
+#include "ErrorHandlerFake.h"
 #include "SolidSyslogEndpoint.h"
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogGetAddrInfoResolver.h"
@@ -559,17 +560,6 @@ TEST(SolidSyslogUdpSenderFailure, SendRecoversAfterTransientResolveFailure)
     CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }
 
-TEST(SolidSyslogUdpSenderFailure, NoEndpointConfiguredSendsToPortZero)
-{
-    resolver                                           = SolidSyslogGetAddrInfoResolver_Create();
-    datagram                                           = SolidSyslogPosixDatagram_Create();
-    struct SolidSyslogUdpSenderConfig configNoEndpoint = {resolver, datagram, nullptr, nullptr};
-    sender                                             = SolidSyslogUdpSender_Create(&configNoEndpoint);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE(SocketFake_Sendto, ONCE);
-    LONGS_EQUAL(0, SocketFake_LastPort());
-}
-
 // clang-format off
 TEST_GROUP(SolidSyslogUdpSenderRetry)
 {
@@ -723,4 +713,81 @@ TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureReturnsFalse)
 {
     DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
     CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+// clang-format off
+TEST_GROUP(SolidSyslogUdpSenderBadSetup)
+{
+    struct SolidSyslogResolver* resolver = nullptr;
+    struct SolidSyslogDatagram* datagram = nullptr;
+    SolidSyslogUdpSenderConfig config{};
+    // cppcheck-suppress unreadVariable -- read via context-propagation through ErrorHandlerFake_Install
+    int sentinel = 0;
+
+    void setup() override
+    {
+        SocketFake_Reset();
+        ErrorHandlerFake_Install(&sentinel);
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
+        datagram = SolidSyslogPosixDatagram_Create();
+        // cppcheck-suppress unreadVariable -- read by tests via TEST_GROUP fixture; cppcheck does not model CppUTest macros
+        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
+    }
+
+    void teardown() override
+    {
+        SolidSyslogUdpSender_Destroy();
+        SolidSyslogPosixDatagram_Destroy();
+        SolidSyslogGetAddrInfoResolver_Destroy();
+        ErrorHandlerFake_Uninstall();
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullConfigReportsError)
+{
+    SolidSyslogUdpSender_Create(nullptr);
+    CHECK_REPORTED_ERROR("SolidSyslogUdpSender_Create called with NULL config");
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, SendOnBadSetupSenderReturnsTrue)
+{
+    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(nullptr);
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, DisconnectOnBadSetupSenderDoesNotCrash)
+{
+    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(nullptr);
+    SolidSyslogSender_Disconnect(sender);
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullResolverReportsError)
+{
+    config.resolver = nullptr;
+    SolidSyslogUdpSender_Create(&config);
+    CHECK_REPORTED_ERROR("SolidSyslogUdpSender_Create config.resolver is NULL");
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullDatagramReportsError)
+{
+    config.datagram = nullptr;
+    SolidSyslogUdpSender_Create(&config);
+    CHECK_REPORTED_ERROR("SolidSyslogUdpSender_Create config.datagram is NULL");
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullEndpointReportsError)
+{
+    config.endpoint = nullptr;
+    SolidSyslogUdpSender_Create(&config);
+    CHECK_REPORTED_ERROR("SolidSyslogUdpSender_Create config.endpoint is NULL");
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, NullEndpointVersionIsOptional)
+{
+    config.endpointVersion           = nullptr;
+    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    CHECK_NOTHING_REPORTED();
+    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -21,6 +21,12 @@
 using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
                                // macros
 
+class TEST_SolidSyslogUdpSenderRetry_DoubleOversizeDoesNotSendThird_Test;
+class TEST_SolidSyslogUdpSenderRetry_NonOversizeFailureDoesNotRetry_Test;
+class TEST_SolidSyslogUdpSenderRetry_OversizeQueriesMaxPayloadAndRetries_Test;
+class TEST_SolidSyslogUdpSenderRetry_SuccessfulSendDoesNotQueryMaxPayload_Test;
+class TEST_SolidSyslogUdpSenderRetry_ZeroMaxPayloadSkipsRetrySend_Test;
+
 // clang-format off
 static const char* const TEST_MESSAGE          = "hello";
 static const size_t      TEST_MESSAGE_LEN      = 5;

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -61,11 +61,10 @@ static int SpyGetPort()
     return TEST_DEFAULT_PORT;
 }
 
-// Endpoint stubs — delegate to per-test function pointers so existing
-// callback-spy tests in TEST_GROUP(SolidSyslogUdpSenderConfig) keep counting
-// callback invocations through the new endpoint path. endpointVersion is the
-// per-test version reported by TestEndpointVersion; bump it between Sends to
-// drive fingerprint-reconnection tests.
+// Endpoint stubs — file-scope because TestEndpoint is a free function that
+// the sender invokes via udp->config.endpoint(). Tests mutate these globals
+// between Sends to drive endpoint-changed and callback-spy scenarios; the
+// TEST_BASE resets them in setup so groups don't leak state between tests.
 static const char* (*endpointGetHost)() = GetDefaultHost;
 static int (*endpointGetPort)()         = GetDefaultPort;
 static uint32_t endpointVersion         = 0;
@@ -81,44 +80,85 @@ static uint32_t TestEndpointVersion() // NOLINT(modernize-use-trailing-return-ty
     return endpointVersion;
 }
 
+/* Shared fixture for every UdpSender test group. Lifts the SocketFake reset,
+ * endpoint-stub reset, resolver/datagram create+destroy, and the Send helpers
+ * out of every group. Derived groups choose between PosixDatagram (real) and
+ * DatagramFake (Retry-only) and add any group-specific state. */
 // clang-format off
-TEST_GROUP(SolidSyslogUdpSender)
+TEST_BASE(UdpSenderTestBase)
 {
     struct SolidSyslogResolver* resolver = nullptr;
     struct SolidSyslogDatagram* datagram = nullptr;
-    struct SolidSyslogUdpSenderConfig config;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-    struct SolidSyslogSender* sender = nullptr;
+    SolidSyslogUdpSenderConfig  config{};
+    struct SolidSyslogSender*   sender = nullptr;
 
-    void setup() override
+    static void resetEndpointStubs()
+    {
+        endpointGetHost     = GetDefaultHost;
+        endpointGetPort     = GetDefaultPort;
+        endpointVersion     = 0;
+        SpyGetHostCallCount = 0;
+        SpyGetPortCallCount = 0;
+    }
+
+    void setupFakesWithPosixDatagram()
     {
         SocketFake_Reset();
-        endpointGetHost = GetDefaultHost;
-        endpointVersion = 0;
-        endpointGetPort = GetDefaultPort;
+        resetEndpointStubs();
         resolver = SolidSyslogGetAddrInfoResolver_Create();
         datagram = SolidSyslogPosixDatagram_Create();
-        config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
+        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
+    }
+
+    void setupFakesWithDatagramFake()
+    {
+        SocketFake_Reset();
+        resetEndpointStubs();
+        resolver = SolidSyslogGetAddrInfoResolver_Create();
+        datagram = DatagramFake_Create();
+        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
+    }
+
+    static void teardownFakesWithPosixDatagram()
+    {
+        SolidSyslogPosixDatagram_Destroy();
+        SolidSyslogGetAddrInfoResolver_Destroy();
+    }
+
+    void teardownFakesWithDatagramFake() const
+    {
+        DatagramFake_Destroy(datagram);
+        SolidSyslogGetAddrInfoResolver_Destroy();
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- many test bodies intentionally discard the return
+    bool Send() const
+    {
+        return Send(TEST_MESSAGE, TEST_MESSAGE_LEN);
+    }
+
+    // NOLINTNEXTLINE(modernize-use-nodiscard) -- many test bodies intentionally discard the return
+    bool Send(const void* buffer, size_t size) const
+    {
+        return SolidSyslogSender_Send(sender, buffer, size);
+    }
+};
+
+// clang-format on
+
+// clang-format off
+TEST_GROUP_BASE(SolidSyslogUdpSender, UdpSenderTestBase)
+{
+    void setup() override
+    {
+        setupFakesWithPosixDatagram();
         sender = SolidSyslogUdpSender_Create(&config);
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
-        SolidSyslogPosixDatagram_Destroy();
-        SolidSyslogGetAddrInfoResolver_Destroy();
-    }
-
-    void Send() const
-    {
-        SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    }
-
-    void Send(const void* buffer, size_t size) const
-    {
-        SolidSyslogSender_Send(sender, buffer, size);
+        teardownFakesWithPosixDatagram();
     }
 };
 
@@ -135,13 +175,13 @@ TEST(SolidSyslogUdpSender, CreateDoesNotOpenSocket)
 
 TEST(SolidSyslogUdpSender, SendReturnsTrueOnSuccess)
 {
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_TRUE(Send());
 }
 
 TEST(SolidSyslogUdpSender, SendReturnsFalseOnSendtoFailure)
 {
     SocketFake_SetSendtoFails(true);
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_FALSE(Send());
 }
 
 TEST(SolidSyslogUdpSender, SingleSendResultsInOneSendtoCall)
@@ -287,41 +327,23 @@ IGNORE_TEST(SolidSyslogUdpSender, HappyPathOnly)
 
 {
     // Error handling not yet implemented — see Epic #31
-    //   Create with NULL config returns NULL
-    //   Create with valid config returns non-NULL sender
-    //   Destroy with NULL sender does nothing, does not crash
     //   Send called with NULL buffer does nothing, does not crash
     //   Send called with zero length does nothing, does not crash
-    //   socket() returning -1 handled gracefully — Create returns NULL or Send is a no-op
-    //   Unreachable host does not crash
-    //
-    // Address resolution strategy (getaddrinfo vs inet_pton, malloc policy, ADR) — see Story #34
 }
 
-// Destroy tests manage their own sender lifetime — no teardown Destroy needed.
+// Destroy tests manage their own sender lifetime — base teardown does
+// not call _Destroy because tests already did.
 // clang-format off
-TEST_GROUP(SolidSyslogUdpSenderDestroy)
+TEST_GROUP_BASE(SolidSyslogUdpSenderDestroy, UdpSenderTestBase)
 {
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogDatagram* datagram = nullptr;
-    struct SolidSyslogUdpSenderConfig config;
-
     void setup() override
     {
-        SocketFake_Reset();
-        endpointGetHost = GetDefaultHost;
-        endpointVersion = 0;
-        endpointGetPort = GetDefaultPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create();
-        datagram        = SolidSyslogPosixDatagram_Create();
-        // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
-        config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
+        setupFakesWithPosixDatagram();
     }
 
     void teardown() override
     {
-        SolidSyslogPosixDatagram_Destroy();
-        SolidSyslogGetAddrInfoResolver_Destroy();
+        teardownFakesWithPosixDatagram();
     }
 
     void CreateAndDestroy() const
@@ -341,8 +363,8 @@ TEST(SolidSyslogUdpSenderDestroy, DestroyWithoutSendDoesNotClose)
 
 TEST(SolidSyslogUdpSenderDestroy, DestroyAfterSendClosesSocket)
 {
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    sender = SolidSyslogUdpSender_Create(&config);
+    Send();
     SolidSyslogUdpSender_Destroy();
     CALLED_FAKE(SocketFake_Close, ONCE);
     LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd());
@@ -350,8 +372,8 @@ TEST(SolidSyslogUdpSenderDestroy, DestroyAfterSendClosesSocket)
 
 TEST(SolidSyslogUdpSenderDestroy, DestroyAfterDisconnectDoesNotDoubleClose)
 {
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    sender = SolidSyslogUdpSender_Create(&config);
+    Send();
     SolidSyslogSender_Disconnect(sender);
     SolidSyslogUdpSender_Destroy();
     CALLED_FAKE(SocketFake_Close, ONCE);
@@ -359,8 +381,8 @@ TEST(SolidSyslogUdpSenderDestroy, DestroyAfterDisconnectDoesNotDoubleClose)
 
 TEST(SolidSyslogUdpSenderDestroy, SimpleScenario)
 {
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    sender = SolidSyslogUdpSender_Create(&config);
+    Send();
     SolidSyslogUdpSender_Destroy();
 
     CALLED_FAKE(SocketFake_Socket, ONCE);
@@ -373,46 +395,18 @@ TEST(SolidSyslogUdpSenderDestroy, SimpleScenario)
 }
 
 // clang-format off
-TEST_GROUP(SolidSyslogUdpSenderConfig)
+TEST_GROUP_BASE(SolidSyslogUdpSenderConfig, UdpSenderTestBase)
 {
-    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
-    const char* (*getHostFn)(void) = GetDefaultHost; // NOLINT(modernize-redundant-void-arg) -- C idiom
-    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
-    int (*getPortFn)(void) = GetDefaultPort; // NOLINT(modernize-redundant-void-arg) -- C idiom
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-    struct SolidSyslogSender* sender = nullptr;
-
     void setup() override
     {
-        SocketFake_Reset();
-        SpyGetPortCallCount = 0;
-        SpyGetHostCallCount = 0;
-        endpointGetHost  = GetDefaultHost;
-        endpointVersion  = 0;
-        endpointGetPort  = GetDefaultPort;
+        setupFakesWithPosixDatagram();
+        sender = SolidSyslogUdpSender_Create(&config);
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
-        SolidSyslogPosixDatagram_Destroy();
-        SolidSyslogGetAddrInfoResolver_Destroy();
-    }
-
-    void CreateSender()
-    {
-        endpointGetHost = getHostFn;
-        endpointGetPort = getPortFn;
-        struct SolidSyslogResolver*       resolver = SolidSyslogGetAddrInfoResolver_Create();
-        struct SolidSyslogDatagram*       datagram = SolidSyslogPosixDatagram_Create();
-        struct SolidSyslogUdpSenderConfig config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
-        sender                                     = SolidSyslogUdpSender_Create(&config);
-    }
-
-    void Send() const
-    {
-        SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+        teardownFakesWithPosixDatagram();
     }
 };
 
@@ -420,8 +414,7 @@ TEST_GROUP(SolidSyslogUdpSenderConfig)
 
 TEST(SolidSyslogUdpSenderConfig, GetPortCalledOnFirstSend)
 {
-    getPortFn = SpyGetPort;
-    CreateSender();
+    endpointGetPort = SpyGetPort;
     CALLED_FUNCTION(SpyGetPort, NEVER);
     Send();
     CALLED_FUNCTION(SpyGetPort, ONCE);
@@ -429,8 +422,7 @@ TEST(SolidSyslogUdpSenderConfig, GetPortCalledOnFirstSend)
 
 TEST(SolidSyslogUdpSenderConfig, GetPortNotCalledOnSecondSend)
 {
-    getPortFn = SpyGetPort;
-    CreateSender();
+    endpointGetPort = SpyGetPort;
     Send();
     Send();
     CALLED_FUNCTION(SpyGetPort, ONCE);
@@ -438,16 +430,14 @@ TEST(SolidSyslogUdpSenderConfig, GetPortNotCalledOnSecondSend)
 
 TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithConfiguredPort)
 {
-    getPortFn = GetAlternatePort;
-    CreateSender();
+    endpointGetPort = GetAlternatePort;
     Send();
     LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketFake_LastPort());
 }
 
 TEST(SolidSyslogUdpSenderConfig, GetHostCalledOnFirstSend)
 {
-    getHostFn = SpyGetHost;
-    CreateSender();
+    endpointGetHost = SpyGetHost;
     CALLED_FUNCTION(SpyGetHost, NEVER);
     Send();
     CALLED_FUNCTION(SpyGetHost, ONCE);
@@ -455,8 +445,7 @@ TEST(SolidSyslogUdpSenderConfig, GetHostCalledOnFirstSend)
 
 TEST(SolidSyslogUdpSenderConfig, GetHostNotCalledOnSecondSend)
 {
-    getHostFn = SpyGetHost;
-    CreateSender();
+    endpointGetHost = SpyGetHost;
     Send();
     Send();
     CALLED_FUNCTION(SpyGetHost, ONCE);
@@ -464,8 +453,7 @@ TEST(SolidSyslogUdpSenderConfig, GetHostNotCalledOnSecondSend)
 
 TEST(SolidSyslogUdpSenderConfig, GetAddrInfoCalledWithHostnameFromGetHost)
 {
-    getHostFn = SpyGetHost;
-    CreateSender();
+    endpointGetHost = SpyGetHost;
     Send();
     CALLED_FAKE(SocketFake_GetAddrInfo, ONCE);
     STRCMP_EQUAL(TEST_DEFAULT_HOST, SocketFake_LastGetAddrInfoHostname());
@@ -473,43 +461,30 @@ TEST(SolidSyslogUdpSenderConfig, GetAddrInfoCalledWithHostnameFromGetHost)
 
 TEST(SolidSyslogUdpSenderConfig, SendtoCalledWithResolvedAddress)
 {
-    CreateSender();
     Send();
     STRCMP_EQUAL(TEST_DEFAULT_HOST, SocketFake_LastAddrAsString());
 }
 
+// Failure tests defer sender creation so fault flags can be set first
+// (resolver/datagram allocation doesn't trigger fakes; sockets are hit
+// at Send time).
 // clang-format off
-TEST_GROUP(SolidSyslogUdpSenderFailure)
+TEST_GROUP_BASE(SolidSyslogUdpSenderFailure, UdpSenderTestBase)
 {
-    struct SolidSyslogResolver*       resolver = nullptr;
-    struct SolidSyslogDatagram*       datagram = nullptr;
-    struct SolidSyslogUdpSenderConfig config;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
-    struct SolidSyslogSender*         sender = nullptr;
-
     void setup() override
     {
-        SocketFake_Reset();
-        endpointGetHost = GetDefaultHost;
-        endpointVersion = 0;
-        endpointGetPort = GetDefaultPort;
+        setupFakesWithPosixDatagram();
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
-        SolidSyslogPosixDatagram_Destroy();
-        SolidSyslogGetAddrInfoResolver_Destroy();
+        teardownFakesWithPosixDatagram();
     }
 
     void CreateSender()
     {
-        resolver = SolidSyslogGetAddrInfoResolver_Create();
-        datagram = SolidSyslogPosixDatagram_Create();
-        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest macros
-        sender   = SolidSyslogUdpSender_Create(&config);
+        sender = SolidSyslogUdpSender_Create(&config);
     }
 };
 
@@ -519,21 +494,21 @@ TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenResolverFails)
 {
     SocketFake_SetGetAddrInfoFails(true);
     CreateSender();
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_FALSE(Send());
 }
 
 TEST(SolidSyslogUdpSenderFailure, SendReturnsFalseWhenSocketFails)
 {
     SocketFake_SetSocketFails(true);
     CreateSender();
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_FALSE(Send());
 }
 
 TEST(SolidSyslogUdpSenderFailure, DoesNotResolveWhenSocketFails)
 {
     SocketFake_SetSocketFails(true);
     CreateSender();
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     CALLED_FAKE(SocketFake_GetAddrInfo, NEVER);
 }
 
@@ -541,52 +516,63 @@ TEST(SolidSyslogUdpSenderFailure, SendDoesNotCallSendtoWhenResolverFailed)
 {
     SocketFake_SetGetAddrInfoFails(true);
     CreateSender();
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
+    Send();
     CALLED_FAKE(SocketFake_Sendto, NEVER);
 }
 
 TEST(SolidSyslogUdpSenderFailure, SendReturnsTrueWhenResolverAndSocketSucceed)
 {
     CreateSender();
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_TRUE(Send());
 }
 
 TEST(SolidSyslogUdpSenderFailure, SendRecoversAfterTransientResolveFailure)
 {
     SocketFake_SetGetAddrInfoFails(true);
     CreateSender();
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_FALSE(Send());
     SocketFake_SetGetAddrInfoFails(false);
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_TRUE(Send());
 }
 
-// clang-format off
-TEST_GROUP(SolidSyslogUdpSenderRetry)
-{
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogDatagram* datagram = nullptr;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
-    struct SolidSyslogSender* sender = nullptr;
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
+#define CALLED_DATAGRAM_SEND(times) CALLED_FAKE_ON(DatagramFake_Send, datagram, times)
+#define CALLED_DATAGRAM_MAX_PAYLOAD(times) CALLED_FAKE_ON(DatagramFake_MaxPayload, datagram, times)
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
+// clang-format off
+TEST_GROUP_BASE(SolidSyslogUdpSenderRetry, UdpSenderTestBase)
+{
     void setup() override
     {
-        SocketFake_Reset();
-        endpointGetHost = GetDefaultHost;
-        endpointVersion = 0;
-        endpointGetPort = GetDefaultPort;
-        resolver        = SolidSyslogGetAddrInfoResolver_Create();
-        datagram        = DatagramFake_Create();
-        struct SolidSyslogUdpSenderConfig config = {resolver, datagram, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by tests; cppcheck does not model CppUTest lifecycle
+        setupFakesWithDatagramFake();
         sender = SolidSyslogUdpSender_Create(&config);
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
-        DatagramFake_Destroy(datagram);
-        SolidSyslogGetAddrInfoResolver_Destroy();
+        teardownFakesWithDatagramFake();
+    }
+
+    void firstSendReturns(enum SolidSyslogDatagramSendResult result) const
+    {
+        DatagramFake_SetSendResult(datagram, 0, result);
+    }
+
+    void retrySendReturns(enum SolidSyslogDatagramSendResult result) const
+    {
+        DatagramFake_SetSendResult(datagram, 1, result);
+    }
+
+    void maxPayload(size_t bytes) const
+    {
+        DatagramFake_SetMaxPayload(datagram, bytes);
+    }
+
+    [[nodiscard]] size_t retrySendSize() const
+    {
+        return DatagramFake_SendSize(datagram, 1);
     }
 };
 
@@ -594,35 +580,35 @@ TEST_GROUP(SolidSyslogUdpSenderRetry)
 
 TEST(SolidSyslogUdpSenderRetry, SuccessfulSendDoesNotQueryMaxPayload)
 {
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE_ON(DatagramFake_MaxPayload, datagram, NEVER);
+    Send();
+    CALLED_DATAGRAM_MAX_PAYLOAD(NEVER);
 }
 
 TEST(SolidSyslogUdpSenderRetry, OversizeQueriesMaxPayloadAndRetries)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE_ON(DatagramFake_MaxPayload, datagram, ONCE);
-    CALLED_FAKE_ON(DatagramFake_Send, datagram, TWICE);
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_SENT);
+    maxPayload(3);
+    Send();
+    CALLED_DATAGRAM_MAX_PAYLOAD(ONCE);
+    CALLED_DATAGRAM_SEND(TWICE);
 }
 
 TEST(SolidSyslogUdpSenderRetry, OversizeRetryTrimsBufferToMaxPayload)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    LONGS_EQUAL(3, DatagramFake_SendSize(datagram, 1));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_SENT);
+    maxPayload(3);
+    Send();
+    LONGS_EQUAL(3, retrySendSize());
 }
 
 TEST(SolidSyslogUdpSenderRetry, OversizeRetrySucceedsReturnsTrue)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_SENT);
+    maxPayload(3);
+    CHECK_TRUE(Send());
 }
 
 /* Buffer "ab" + é (0xC3 0xA9): MaxPayload=3 cuts mid-é at the start byte,
@@ -630,11 +616,11 @@ TEST(SolidSyslogUdpSenderRetry, OversizeRetrySucceedsReturnsTrue)
 TEST(SolidSyslogUdpSenderRetry, OversizeRetryWalksBackToCodepointBoundary)
 {
     const uint8_t payload[] = {0x61, 0x62, 0xC3, 0xA9};
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    SolidSyslogSender_Send(sender, payload, sizeof(payload));
-    LONGS_EQUAL(2, DatagramFake_SendSize(datagram, 1));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_SENT);
+    maxPayload(3);
+    Send(payload, sizeof(payload));
+    LONGS_EQUAL(2, retrySendSize());
 }
 
 /* Double-OVERSIZE means the kernel disagreed with its own reported
@@ -643,27 +629,27 @@ TEST(SolidSyslogUdpSenderRetry, OversizeRetryWalksBackToCodepointBoundary)
  * Swallow: drop the message and return true so the caller moves on. */
 TEST(SolidSyslogUdpSenderRetry, DoubleOversizeReturnsTrueToAvoidPermanentLoop)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    maxPayload(3);
+    CHECK_TRUE(Send());
 }
 
 TEST(SolidSyslogUdpSenderRetry, DoubleOversizeDoesNotSendThird)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE_ON(DatagramFake_Send, datagram, TWICE);
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    maxPayload(3);
+    Send();
+    CALLED_DATAGRAM_SEND(TWICE);
 }
 
 TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadSkipsRetrySend)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetMaxPayload(datagram, 0);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE_ON(DatagramFake_Send, datagram, ONCE);
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    maxPayload(0);
+    Send();
+    CALLED_DATAGRAM_SEND(ONCE);
 }
 
 /* Trimmed length 0 means the message physically can't fit the path —
@@ -671,9 +657,9 @@ TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadSkipsRetrySend)
  * Service algorithm discards rather than retrying forever. */
 TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadReturnsTrueToAvoidPermanentLoop)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetMaxPayload(datagram, 0);
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    maxPayload(0);
+    CHECK_TRUE(Send());
 }
 
 /* Retry sendto failing with non-OVERSIZE error (e.g. ECONNREFUSED on
@@ -681,10 +667,10 @@ TEST(SolidSyslogUdpSenderRetry, ZeroMaxPayloadReturnsTrueToAvoidPermanentLoop)
  * Buffered/Service algorithm keeps the message for retry. */
 TEST(SolidSyslogUdpSenderRetry, RetryFailedNonOversizeReturnsFalse)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_FAILED);
-    DatagramFake_SetMaxPayload(datagram, 3);
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_FAILED);
+    maxPayload(3);
+    CHECK_FALSE(Send());
 }
 
 TEST(SolidSyslogUdpSenderRetry, MaxPayloadLargerThanMessageCapsTrimToMessageSize)
@@ -694,51 +680,42 @@ TEST(SolidSyslogUdpSenderRetry, MaxPayloadLargerThanMessageCapsTrimToMessageSize
      * the original message. The trim must cap at the message size to
      * avoid reading past the buffer. */
     const uint8_t payload[] = {0x61, 0x62, 0x63};
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_OVERSIZE);
-    DatagramFake_SetSendResult(datagram, 1, SOLIDSYSLOG_DATAGRAM_SENT);
-    DatagramFake_SetMaxPayload(datagram, 9999);
-    SolidSyslogSender_Send(sender, payload, sizeof(payload));
-    LONGS_EQUAL(sizeof(payload), DatagramFake_SendSize(datagram, 1));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_OVERSIZE);
+    retrySendReturns(SOLIDSYSLOG_DATAGRAM_SENT);
+    maxPayload(9999);
+    Send(payload, sizeof(payload));
+    LONGS_EQUAL(sizeof(payload), retrySendSize());
 }
 
 TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureDoesNotRetry)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
-    SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN);
-    CALLED_FAKE_ON(DatagramFake_Send, datagram, ONCE);
-    CALLED_FAKE_ON(DatagramFake_MaxPayload, datagram, NEVER);
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_FAILED);
+    Send();
+    CALLED_DATAGRAM_SEND(ONCE);
+    CALLED_DATAGRAM_MAX_PAYLOAD(NEVER);
 }
 
 TEST(SolidSyslogUdpSenderRetry, NonOversizeFailureReturnsFalse)
 {
-    DatagramFake_SetSendResult(datagram, 0, SOLIDSYSLOG_DATAGRAM_FAILED);
-    CHECK_FALSE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    firstSendReturns(SOLIDSYSLOG_DATAGRAM_FAILED);
+    CHECK_FALSE(Send());
 }
 
 // clang-format off
-TEST_GROUP(SolidSyslogUdpSenderBadSetup)
+TEST_GROUP_BASE(SolidSyslogUdpSenderBadSetup, UdpSenderTestBase)
 {
-    struct SolidSyslogResolver* resolver = nullptr;
-    struct SolidSyslogDatagram* datagram = nullptr;
-    SolidSyslogUdpSenderConfig config{};
-    // cppcheck-suppress unreadVariable -- read via context-propagation through ErrorHandlerFake_Install
     int sentinel = 0;
 
     void setup() override
     {
-        SocketFake_Reset();
+        setupFakesWithPosixDatagram();
         ErrorHandlerFake_Install(&sentinel);
-        resolver = SolidSyslogGetAddrInfoResolver_Create();
-        datagram = SolidSyslogPosixDatagram_Create();
-        // cppcheck-suppress unreadVariable -- read by tests via TEST_GROUP fixture; cppcheck does not model CppUTest macros
-        config   = {resolver, datagram, TestEndpoint, TestEndpointVersion};
     }
 
     void teardown() override
     {
         SolidSyslogUdpSender_Destroy();
-        SolidSyslogPosixDatagram_Destroy();
-        SolidSyslogGetAddrInfoResolver_Destroy();
+        teardownFakesWithPosixDatagram();
         ErrorHandlerFake_Uninstall();
     }
 };
@@ -753,13 +730,13 @@ TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullConfigReportsError)
 
 TEST(SolidSyslogUdpSenderBadSetup, SendOnBadSetupSenderReturnsTrue)
 {
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(nullptr);
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    sender = SolidSyslogUdpSender_Create(nullptr);
+    CHECK_TRUE(Send());
 }
 
 TEST(SolidSyslogUdpSenderBadSetup, DisconnectOnBadSetupSenderDoesNotCrash)
 {
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(nullptr);
+    sender = SolidSyslogUdpSender_Create(nullptr);
     SolidSyslogSender_Disconnect(sender);
 }
 
@@ -786,8 +763,8 @@ TEST(SolidSyslogUdpSenderBadSetup, CreateWithNullEndpointReportsError)
 
 TEST(SolidSyslogUdpSenderBadSetup, NullEndpointVersionIsOptional)
 {
-    config.endpointVersion           = nullptr;
-    struct SolidSyslogSender* sender = SolidSyslogUdpSender_Create(&config);
+    config.endpointVersion = nullptr;
+    sender                 = SolidSyslogUdpSender_Create(&config);
     CHECK_NOTHING_REPORTED();
-    CHECK_TRUE(SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN));
+    CHECK_TRUE(Send());
 }

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -323,12 +323,11 @@ TEST(SolidSyslogUdpSender, EndpointVersionChangeUsesNewPortOnReconnect)
     LONGS_EQUAL(TEST_ALTERNATE_PORT, SocketFake_LastPort());
 }
 
-IGNORE_TEST(SolidSyslogUdpSender, HappyPathOnly)
-
+TEST(SolidSyslogUdpSender, ZeroLengthSendPassesThrough)
 {
-    // Error handling not yet implemented — see Epic #31
-    //   Send called with NULL buffer does nothing, does not crash
-    //   Send called with zero length does nothing, does not crash
+    Send(TEST_MESSAGE, 0);
+    CALLED_FAKE(SocketFake_Sendto, ONCE);
+    LONGS_EQUAL(0, SocketFake_LastLen());
 }
 
 // Destroy tests manage their own sender lifetime — base teardown does
@@ -767,4 +766,12 @@ TEST(SolidSyslogUdpSenderBadSetup, NullEndpointVersionIsOptional)
     sender                 = SolidSyslogUdpSender_Create(&config);
     CHECK_NOTHING_REPORTED();
     CHECK_TRUE(Send());
+}
+
+TEST(SolidSyslogUdpSenderBadSetup, SendWithNullBufferReportsErrorAndDoesNotSend)
+{
+    sender = SolidSyslogUdpSender_Create(&config);
+    CHECK_FALSE(Send(nullptr, 5));
+    CHECK_REPORTED_ERROR("SolidSyslogUdpSender_Send called with NULL buffer");
+    CALLED_FAKE(SocketFake_Sendto, NEVER);
 }


### PR DESCRIPTION
## Purpose

Closes #116. Second pass at the E12 bad-setup contract (after S12.06 #117 for MetaSd), this time for UDP sender. `SolidSyslogUdpSender_Create` no longer dereferences NULL on any of the four required collaborators, and a Send-time defensive guard catches the never-should-happen NULL buffer case.

## Change Description

### Create-time guards (`SolidSyslogUdpSender_Create`)

Each of these now reports once via `SolidSyslog_Error(SEVERITY_ERR, …)` and returns a static `NilUdpSender` whose `Send` is a swallowing no-op (returns `true`) and whose `Disconnect` is a no-op:

- `config == NULL`
- `config->resolver == NULL`
- `config->datagram == NULL`
- `config->endpoint == NULL` *(previously silently fell back to a broken `host="" port=0` sender — now flagged)*

Severity is **ERR** not S12.06's WARNING: UdpSender with a NULL collaborator can't deliver *anything* (ERR = can't deliver), unlike MetaSd where the line still went out minus one SD (WARNING = delivered degraded). `endpointVersion` stays optional — its "version 0 forever" fallback is a valid "destination never changes" mode for single-destination embedded deployments.

### Send-time guard (`Send`)

- `Send(self, NULL, …)` → reports `_SEND_NULL_BUFFER` (ERR), returns false, does not reach the datagram layer. Should never happen from library-internal code paths, but defensive guard surfaces the programmer error.
- `Send(self, buffer, 0)` → passes through to sendto with len 0. RFC 768 permits zero-length UDP datagrams; characterised by test.

### Refactor sweep (bundled in same PR — Grenning "if you touch it, leave it cleaner")

`SolidSyslogUdpSender.c`:
- Extract `IsValidConfig` + `InstallConfig` from `_Create` (35 lines → 9). `InstallConfig` uses struct-assign so future config fields flow through automatically.
- Extract `QueryEndpointPort` from `Connect`. Reshape Connect to positive logic.
- Function ordering restored to project's top-down convention.
- 12-line `TransmitDatagram` block comment → two targeted `Why:` comments at the actual swallow sites in `RetryAfterOversize`.
- Dead `NilEndpoint` helper removed.

`Tests/SolidSyslogUdpSenderTest.cpp`:
- `TEST_BASE(UdpSenderTestBase)` lifts shared fixture (SocketFake reset, endpoint-stub reset, resolver/datagram create+destroy, `Send()` helpers) out of all six groups.
- `Send()` returns bool — 28 sites of `SolidSyslogSender_Send(sender, TEST_MESSAGE, TEST_MESSAGE_LEN)` collapse to `Send()`.
- Retry-group helpers `firstSendReturns(result)` / `retrySendReturns(result)` / `maxPayload(bytes)` / `retrySendSize()` replace positional-index magic numbers in `DatagramFake_SetSendResult(datagram, 0|1, …)`.
- `CALLED_DATAGRAM_SEND(times)` / `CALLED_DATAGRAM_MAX_PAYLOAD(times)` macros drop the repeated `datagram` argument from count assertions.
- `getHostFn` / `getPortFn` indirection in Config group (pre-dated unified Endpoint callback) removed.
- `IGNORE_TEST(HappyPathOnly)` removed — every backlog item is now covered or out-of-scope.

## Test Evidence

TDD-driven for every NULL guard (RED → minimal GREEN → refactor inside cycle). New tests:

- `TEST_GROUP(SolidSyslogUdpSenderBadSetup)` with `ErrorHandlerFake`:
  - `CreateWithNullConfigReportsError`
  - `CreateWithNullResolverReportsError`
  - `CreateWithNullDatagramReportsError`
  - `CreateWithNullEndpointReportsError`
  - `SendOnBadSetupSenderReturnsTrue`
  - `DisconnectOnBadSetupSenderDoesNotCrash`
  - `NullEndpointVersionIsOptional`
  - `SendWithNullBufferReportsErrorAndDoesNotSend`
- `TEST(SolidSyslogUdpSender, ZeroLengthSendPassesThrough)` — characterises the audit's "already safe" claim for zero-length passthrough.

Removed: `NoEndpointConfiguredSendsToPortZero` (asserted the now-defunct contract that endpoint=NULL silently fell back).

Local CI matrix (all green):
- [x] `cmake --preset debug` — 1120 tests pass
- [x] `cmake --preset clang-debug` — 1120 tests pass
- [x] `cmake --preset sanitize` — 1120 tests pass (ASan + UBSan)
- [x] `cmake --preset tidy` — clean
- [x] `cmake --preset cppcheck` — clean
- [x] `clang-format --dry-run -Werror` — clean
- [x] `cmake --preset coverage` — `SolidSyslogUdpSender.c` at **100% line / 100% function** coverage

## Areas Affected

- `Core/Source/SolidSyslogUdpSender.c` — new guards, `NilUdpSender` static, refactor pass, dead `NilEndpoint` removed
- `Core/Source/SolidSyslogErrorMessages.h` — five new error-message constants (`_UDPSENDER_CREATE_NULL_{CONFIG,RESOLVER,DATAGRAM,ENDPOINT}`, `_UDPSENDER_SEND_NULL_BUFFER`)
- `Tests/SolidSyslogUdpSenderTest.cpp` — full refactor + 8 new bad-setup/bad-input tests + 1 characterisation test
- `DEVLOG.md` — entry for this story

No public-header API change. Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * UDP sender now gracefully handles invalid or missing configuration values without crashing, with improved error reporting.
  * Enhanced validation during initialization and message transmission to prevent null-related failures.

* **Documentation**
  * Updated development log documenting recent UDP sender improvements and implementation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->