### PR TITLE
docs: S10.01 commit NAMING.md + initial MISRA deviations doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,18 +386,20 @@ Most application code only needs `SolidSyslog.h` — it never sees allocators, s
 
 ## Naming Conventions
 
-| Element | Convention | Example |
-|---|---|---|
-| C public functions | `PascalCase_PascalCase` | `LedDriver_TurnOn()` |
-| C static/private functions | `PascalCase` | `CalculateChecksum()` |
-| C++ methods | `camelCase` | `getValue()` |
-| Variables | `camelCase` | `sensorReading` |
-| Types / Classes / Structs | `PascalCase` | `MotorController` |
-| Macros / Constants | `UPPER_SNAKE_CASE` | `MAX_BUFFER_SIZE` |
-| Files | `PascalCase` | `LedDriver.c` |
+`docs/NAMING.md` is the source of truth — a per-tier naming scheme
+satisfying MISRA C:2012 rules 5.1–5.9 with clang-tidy enforcing shape
+and cppcheck-misra enforcing uniqueness. Read it before adding any new
+public identifier.
 
-No Hungarian notation. No member variable prefixes (`m_`, `_`, etc.).
-Names should be self-documenting — prefer clarity over brevity.
+One-line summary: public C functions `SolidSyslogClass_Function`, public
+types `SolidSyslogClass`, public macros `SOLIDSYSLOG_SCREAMING_SNAKE`,
+file-scope statics `Class_Function` / `CLASS_SCREAMING_SNAKE`,
+locals/parameters/members `lowerCamelCase`, files `PascalCase.c`. No
+Hungarian notation. No member-variable prefixes. No `typedef struct`
+for project-owned struct types.
+
+Deliberate deviations from the MISRA rule set are recorded in
+`docs/misra-deviations.md`.
 
 ---
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,41 @@
 # Dev Log
 
+## 2026-05-14 — S10.01 NAMING.md + initial MISRA deviations doc (#357)
+
+First story of E10. Commits `docs/NAMING.md` (the already-drafted
+per-tier naming convention) and a new `docs/misra-deviations.md` whose
+founding entry **D.001** documents the project's relaxation of MISRA
+Rule 5.1 from C99's 31-character external-identifier window to 63
+characters. `CLAUDE.md`'s "Naming Conventions" section loses its
+inline rules table in favour of a one-line summary and a pointer to
+`docs/NAMING.md`; `SKILL.md`'s "Code style" section is updated the
+same way. No code, no tooling, no CI gates yet — those land in
+S10.02 / S10.03 / S10.06.
+
+### Decisions
+
+- **63 characters, not "unlimited."** Naming a concrete number keeps
+  the deviation auditable and matches C99's separate 63-character
+  minimum for internal identifiers, so a single number applies
+  project-wide. Every supported toolchain (gcc, clang, MSVC,
+  arm-none-eabi-gcc, IAR, Keil ARMCC 6+) comfortably exceeds it.
+- **Deviations doc is separate from `misra_suppressions.txt`.** The
+  suppressions file is cppcheck-readable line-level data; the
+  deviations doc is the human-audit narrative. Each suppression entry
+  will reference the deviation section that authorises it (populated
+  in S10.06).
+- **CLAUDE.md keeps a one-line naming summary** rather than just a
+  pointer, so a quick top-down read of `CLAUDE.md` still tells the
+  reader the rough shape without forcing a second-file hop.
+
+### Deferred
+
+- Populating `misra_suppressions.txt` with entries — landing with
+  S10.03 (cppcheck-misra wired into CI in warning mode) and S10.06
+  (rule subset curated, deviation set finalised).
+- Source-code rename sweeps to satisfy the new scheme — S10.07
+  onwards.
+
 ## 2026-05-14 — S12.05 UdpSender NULL guards (#116)
 
 Second pass at the E12 bad-setup contract, this time on the UDP sender.

--- a/SKILL.md
+++ b/SKILL.md
@@ -56,9 +56,10 @@ Test progression follows ZOMBIES order.
 
 - Formatting is enforced by clang-format — see `.clang-format`. This is the authoritative
   style rule; it overrides any conflicting guidance in this file or from Claude.ai briefings.
-- Public C functions: `PascalCase_PascalCase` (e.g. `SolidSyslog_Create`)
-- Variables/parameters: `camelCase`
-- Types and files: `PascalCase`
+- Naming is defined in `docs/NAMING.md` — the per-tier scheme covering Tier 1 (external API),
+  Tier 2 (file-scope statics), Tier 3 (locals/parameters), Tier 4 (struct members), tests, and
+  macros. Read it before adding any new public identifier.
+- MISRA C:2012 rule deviations are recorded in `docs/misra-deviations.md`.
 - Follows James Grenning's style (*TDD for Embedded C*) where consistent with clang-format
 - No dynamic memory allocation required — allocator is caller-injected. No unions, no anonymous structs, no `#ifdef` feature flags
 - C99 baseline

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -1,0 +1,476 @@
+# Naming conventions
+
+This document defines the identifier naming rules for SolidSyslog. The rules
+reconcile three constraints:
+
+1. **MISRA C:2012 uniqueness rules** (5.1 through 5.9) — non-negotiable
+   within the strict scope (see Scope below).
+2. **Clean Code principles** — identifier length proportional to scope; no
+   lazy abbreviations.
+3. **Readability at the call site** — a reader should be able to tell, from
+   the name alone, roughly where an identifier comes from.
+
+Naming is one slice of the project's coding standard. Rules unrelated to
+identifier shape (single-exit-point, parenthesisation, `0U` literal suffixes,
+etc.) live in the MISRA standard and `docs/misra-deviations.md`, which are
+the authoritative references.
+
+The scheme is enforced by review and by static analysis, with a clean
+split between the two tools so they cannot disagree on the same name:
+
+- **clang-tidy** is the sole authority on naming *shape*. The
+  `readability-identifier-naming` check understands linkage, scope, and
+  the distinction between macros, typedefs, tags and ordinary identifiers.
+  Per-directory `.clang-tidy` files implement the tier model below.
+- **cppcheck-misra** is the sole authority on naming *uniqueness*. The
+  MISRA addon surfaces rules 5.1, 5.2, 5.4, 5.6, 5.7, 5.8 and 5.9
+  violations — pattern matching alone cannot detect these.
+
+cppcheck's `naming` addon is deliberately **not** used: it does less than
+clang-tidy on every axis we care about, and a second tool checking the
+same conditions creates the risk of contradictory verdicts.
+
+---
+
+## Scope
+
+The rules apply with different strictness across the tree:
+
+| Tier | Naming | MISRA | Directories |
+|------|--------|-------|-------------|
+| **Strict** | Full Tier 1–4 | Full chosen subset | `Core/Interface/`, `Core/Source/`, `Platform/*/Interface/` |
+| **Pragmatic** | Tier 1–4 applied; local names that mirror third-party APIs (e.g. `mqd_t mq`, `FIL file`, `SOCKET sock`) and parameters in adapter wrappers are exempt; 5.3 shadowing relaxed when the shadowed name is a third-party identifier | Full chosen subset; per-file deviations documented when third-party APIs force them | `Platform/*/Source/` |
+| **Consistency-only** | New code follows conventions; CppUTest macro outputs used as-is; test fakes drop the `SolidSyslog` prefix; no rename sweep of existing test code | Excluded | `Tests/` |
+| **Out of scope** | Not enforced | Not enforced | `Bdd/`, `ci/`, `docs/`, `.github/`, `.devcontainer/` |
+
+Enforcement gates (clang-tidy + cppcheck-misra) run per tier with different
+rule sets.
+
+---
+
+## MISRA C:2012 rules in play
+
+| Rule | Applies to | Constraint |
+|------|------------|------------|
+| 5.1  | External identifiers | Distinct in the first **63** characters (project deviation — C99 mandates only 31; see `docs/misra-deviations.md`) |
+| 5.2  | Identifiers in the same scope and name space | Distinct in the first 63 characters |
+| 5.3  | Inner-scope identifiers | Shall not hide an outer-scope identifier |
+| 5.4  | Macro identifiers | Unique within the first 63 characters |
+| 5.5  | Macros vs other identifiers | No reuse of the same name |
+| 5.6  | Typedef names | Unique across the program |
+| 5.7  | Tag names | Unique across the program |
+| 5.8  | Identifiers with external linkage | Unique |
+| 5.9 (advisory) | Identifiers with internal linkage | Should be unique |
+
+The scheme below satisfies all of these by construction. Rule 5.9 is advisory
+in MISRA but treated as required here.
+
+---
+
+## Tier 1 — External linkage (public API)
+
+**Form:** `SolidSyslogClass_Function` for functions, `SolidSyslogClass` for
+exported types and tag names.
+
+```c
+/* Functions */
+void SolidSyslogBuffer_Read(struct SolidSyslogBuffer* buffer, ...);
+int  SolidSyslogTransport_Send(struct SolidSyslogTransport* transport, ...);
+
+/* Tag names — note: tag, not typedef. See "No struct typedefs" below. */
+struct SolidSyslogBuffer
+{
+    /* ... */
+};
+
+struct SolidSyslogSecurityPolicy
+{
+    /* ... */
+};
+
+/* Public enum constants follow the same prefix rule.
+ * Note: this is a deliberate departure from the previous
+ * SCREAMING_SNAKE convention. Constants now share the PascalCase
+ * shape of the rest of Tier 1, which also disambiguates them from
+ * macros (rule 5.5). */
+enum SolidSyslogSeverity
+{
+    SolidSyslogSeverity_Emergency = 0,
+    SolidSyslogSeverity_Alert     = 1,
+    /* ... */
+};
+```
+
+The `SolidSyslog` prefix is the library's namespace. The `Class_` portion
+identifies the module. The function name follows in PascalCase.
+
+**Applies to:** any identifier declared in a header under `Core/Interface/`
+or `Platform/*/Interface/`, plus any identifier with external linkage
+declared in a `.c` file.
+
+---
+
+## Tier 2 — Internal linkage (file-scope `static`)
+
+**Form:** `Class_Function` for static functions, `Class_Variable` for
+file-scope static variables and constants. PascalCase on both sides of the
+underscore. No `SolidSyslog` prefix.
+
+```c
+/* Inside Buffer.c */
+static int  Buffer_AppendRecord(struct SolidSyslogBuffer* buffer, ...);
+static void Buffer_ResetCursor(struct SolidSyslogBuffer* buffer);
+
+static const struct SolidSyslogSecurityPolicy Buffer_DefaultPolicy = { /* ... */ };
+static size_t                                 Buffer_ActiveInstanceCount;
+```
+
+Rationale:
+
+- Uniqueness across the library is achieved by the `Class_` prefix —
+  `Buffer_AppendRecord` cannot collide with `Transport_AppendRecord` —
+  which satisfies advisory rule 5.9.
+- The visible difference from Tier 1 is the missing `SolidSyslog` prefix,
+  which signals "internal" at the call site without comment. Both tiers
+  use PascalCase on both sides of the underscore, so static helpers and
+  public functions read consistently.
+- One class per translation unit is the norm; if a `.c` file contains
+  helpers for two classes, use both prefixes accordingly.
+
+---
+
+## Tier 3 — Function parameters and block-scope locals
+
+**Form:** lowerCamelCase, no prefix, descriptive but compact. Domain
+abbreviations (TLS, UDP, TCP, CRC, RFC, MQ, FAT) are permitted as words.
+
+```c
+int Buffer_AppendRecord(struct SolidSyslogBuffer* buffer,
+                        const uint8_t*            record,
+                        size_t                    recordLength)
+{
+    size_t bytesWritten   = 0U;
+    size_t bytesRemaining = recordLength;
+    /* ... */
+}
+```
+
+Constraints:
+
+- **Rule 5.3 (no shadowing).** Locals must not share a name with any
+  file-scope static, any function parameter, or any enclosing block local.
+  In practice this means avoiding generic names like `buffer`, `policy`,
+  `state`, `count` inside a file whose statics use those words. Prefer
+  `targetBuffer`, `activePolicy`, `currentState`, `recordCount`.
+- **No single-letter identifiers.** Use short domain words instead:
+  `index`, `count`, `cursor`, `byte`, `next`, `prev`. A loop over records
+  is `for (size_t index = 0U; index < recordCount; ++index)`, not
+  `for (i = ...)`.
+- **No lazy abbreviations.** `buffer` not `buf`, `message` not `msg`,
+  `configuration` not `cfg`, `pointer` not `ptr`. Distinguish lazy
+  abbreviations from domain terms — the latter are the real names of
+  things and should be used unmodified (e.g. `mq`, `crc`, `tls`).
+- **No pointer Hungarian.** Never prefix pointer variables with `p`/`P`
+  or suffix with `Ptr`. Pointer-ness is visible from the declaration.
+- **Booleans.** Predicates and boolean variables use `isX`, `hasX`,
+  or `canX` shapes (`isValid`, `hasUnsent`, `canSend`).
+- **Out-parameters.** Output parameters use the `outX` prefix
+  (`SolidSyslogBuffer_Initialise(..., struct SolidSyslogBuffer** outBuffer)`).
+
+---
+
+## Tier 4 — Struct members
+
+**Form:** lowerCamelCase, no prefix, no class qualifier. Same boolean and
+no-Hungarian conventions as Tier 3.
+
+```c
+struct SolidSyslogSecurityPolicy
+{
+    SolidSyslogIntegrityCheck integrityCheck;
+    SolidSyslogEncryption     encryption;
+    uint32_t                  maximumRecordLength;
+    bool                      isEnabled;
+};
+```
+
+Struct members live in their own name space, so MISRA does not require
+uniqueness across structs. Access at the call site is already qualified by
+the struct instance: `policy->integrityCheck` is self-documenting.
+
+---
+
+## No struct typedefs
+
+SolidSyslog does **not** use `typedef struct` for its own struct types,
+whether the type is opaque or value-typed. Code refers to struct types by
+tag everywhere:
+
+```c
+/* Yes */
+struct SolidSyslogBuffer*               buffer;
+const struct SolidSyslogBuffer*         readOnlyBuffer;
+struct SolidSyslogSecurityPolicy        policy;
+const struct SolidSyslogSecurityPolicy* readOnlyPolicy;
+
+/* No — do not introduce a typedef for any struct type */
+typedef struct SolidSyslogBuffer         SolidSyslogBuffer;
+typedef struct SolidSyslogBuffer*        SolidSyslogBufferHandle;
+typedef const struct SolidSyslogBuffer*  SolidSyslogBufferConstHandle;
+```
+
+There are three reasons:
+
+1. **Readability.** A typedef'd struct value type hides that it is a struct,
+   and a typedef'd pointer-to-struct hides one level of indirection. Both
+   make pointer and `const` placement ambiguous to the reader. The tag form
+   keeps the type's nature visible at every declaration.
+
+2. **MISRA Rule 5.6 plus header coupling.** A typedef is a *definition* and
+   under Rule 5.6 must appear exactly once across the program — so it has to
+   live in one canonical header. Any translation unit that wants to reference
+   the typedef'd name must `#include` that header. By contrast, a tag
+   forward declaration `struct SolidSyslogBuffer;` is not a definition and
+   may be repeated wherever it is needed. Sticking to tags lets headers
+   reference each other's types via local forward declarations and avoids a
+   dense `#include` graph.
+
+3. **The `const` trap.** `const SolidSyslogBufferHandle` does not mean
+   "pointer to const buffer" — it means "const pointer to non-const buffer",
+   because the `const` qualifies the typedef'd pointer rather than the
+   pointee. The tag form `const struct SolidSyslogBuffer*` cannot be
+   misread.
+
+### Forward declarations are encouraged
+
+In any header that needs to reference a struct only through a pointer, use
+a local forward declaration rather than `#include`-ing the defining header.
+This minimises header coupling and keeps compilation fast:
+
+```c
+/* SolidSyslogTransport.h — does not need to see Buffer's layout */
+struct SolidSyslogBuffer;
+
+int SolidSyslogTransport_Send(struct SolidSyslogTransport*    transport,
+                              const struct SolidSyslogBuffer* source);
+```
+
+### Typedefs that are permitted
+
+Typedefs are used **only** for:
+
+- **Enum types** intended to be passed by value:
+  `typedef enum SolidSyslogSeverity SolidSyslogSeverity;`
+- **Function pointer types** in vtables:
+  `typedef int (*SolidSyslogTransport_SendFn)(struct SolidSyslogTransport*, ...);`
+- **Scalar aliases** where the underlying type is an implementation detail.
+  Use sparingly.
+
+---
+
+## Macros
+
+**Form:** `SOLIDSYSLOG_SCREAMING_SNAKE_CASE` for public macros,
+`CLASS_SCREAMING_SNAKE_CASE` for file-scope macros.
+
+```c
+/* Public, in a header */
+#define SOLIDSYSLOG_MAXIMUM_RECORD_LENGTH 2048U
+
+/* File-scope, in Buffer.c */
+#define BUFFER_RECORD_MAGIC 0xA53CU
+```
+
+Rule 5.4 requires macro uniqueness; rule 5.5 forbids reuse of a name as both
+a macro and a non-macro identifier. The all-caps convention plus the prefix
+handles both. (Note: macros use the joined `SOLIDSYSLOG_` form rather than
+`SOLID_SYSLOG_` to match the existing codebase and avoid first-N-character
+pressure from rule 5.4.)
+
+**Exceptions:** CppUTest's `TEST`, `TEST_GROUP`, `CHECK_*`, `LONGS_EQUAL`,
+etc. are used unmodified — see Tests below.
+
+---
+
+## Tests
+
+Test code uses production conventions where natural, with these relaxations:
+
+- **lowerCamelCase locals** preferred but not enforced; no rename sweep of
+  existing test code.
+- **PascalCase for static test helpers** when present
+  (e.g. `SpyGetHost`, `GetDefaultPort`).
+- **CppUTest macros** (`TEST`, `TEST_GROUP`, `TEST_GROUP_BASE`, `TEST_BASE`,
+  `CHECK_*`, `LONGS_EQUAL`, etc.) are used as-is — the identifiers they
+  expand to (e.g. `TEST_GroupName_TestName_TestShell`) are exempt from
+  Tier 1 and routinely exceed any character limit.
+- **Test-helper macros** in test translation units (`CALLED_FAKE`,
+  `CALLED_DATAGRAM_SEND`, `CHECK_REPORTED_ERROR`, etc.) use whatever
+  SCREAMING_SNAKE shape reads well; no project prefix required.
+- **Test fakes and spies** drop the `SolidSyslog` prefix
+  (e.g. `SocketFake_Reset`, `DatagramFake_SendCallCount`) so they read
+  obviously as test infrastructure at the call site.
+- **Test group names** carry a `Test` suffix and the `SolidSyslog` prefix
+  because `TEST_GROUP(...)` macros expand to external-linkage identifiers
+  (rule 5.8). Three forms are permitted:
+
+  ```c
+  /* Class-level group, when the tests cover the class as a whole */
+  TEST_GROUP(SolidSyslogBufferTest) { /* ... */ };
+
+  /* Function-level group, when a single function deserves its own group */
+  TEST_GROUP(SolidSyslogBuffer_AppendRecordTest) { /* ... */ };
+
+  /* Integration group, exercising more than one class */
+  TEST_GROUP(SolidSyslogIntegrationTlsStoreAndForward) { /* ... */ };
+  ```
+
+- **Test case names** use UpperCamelCase describing the behaviour:
+
+  ```c
+  TEST(SolidSyslogBufferTest, AppendsRecordWhenSpaceAvailable)
+  {
+      /* ... */
+  }
+  ```
+
+No MISRA rules apply to test code. Test code converges to these
+relaxations organically as it is touched, not via a sweep.
+
+---
+
+## Worked example
+
+A small slice showing every tier in one place:
+
+```c
+/* Core/Interface/SolidSyslogBuffer.h ------------------------------------ */
+
+#define SOLIDSYSLOG_BUFFER_MINIMUM_CAPACITY 64U
+
+/* Opaque forward declaration — the layout lives in SolidSyslogBuffer.c */
+struct SolidSyslogBuffer;
+
+/* Forward declaration of a value-typed companion struct.
+   SolidSyslogTransport.h would only need this much to take a pointer,
+   even though the layout is defined elsewhere. */
+struct SolidSyslogSecurityPolicy;
+
+/* Caller supplies storage for the buffer object itself */
+size_t SolidSyslogBuffer_RequiredStorageBytes(void);
+
+int SolidSyslogBuffer_Initialise(void*                                    storage,
+                                 size_t                                   storageLength,
+                                 const struct SolidSyslogSecurityPolicy*  policy,
+                                 struct SolidSyslogBuffer**               outBuffer);
+
+int  SolidSyslogBuffer_Append(struct SolidSyslogBuffer* buffer,
+                              const uint8_t*            record,
+                              size_t                    recordLength);
+
+bool SolidSyslogBuffer_IsEmpty(const struct SolidSyslogBuffer* buffer);
+
+/* Core/Source/SolidSyslogBuffer.c --------------------------------------- */
+
+#include "SolidSyslogBuffer.h"
+
+#define BUFFER_RECORD_MAGIC 0xA53CU
+
+struct SolidSyslogBuffer
+{
+    uint8_t* storage;
+    size_t   capacity;
+    size_t   writeCursor;
+    size_t   readCursor;
+    const struct SolidSyslogSecurityPolicy* policy;
+};
+
+static int Buffer_WriteMagic(struct SolidSyslogBuffer* buffer);
+static int Buffer_WriteRecord(struct SolidSyslogBuffer* buffer,
+                              const uint8_t*            record,
+                              size_t                    recordLength);
+
+static const uint16_t Buffer_RecordOverhead = 6U; /* magic + length */
+
+int SolidSyslogBuffer_Append(struct SolidSyslogBuffer* buffer,
+                             const uint8_t*            record,
+                             size_t                    recordLength)
+{
+    size_t bytesRequired  = recordLength + Buffer_RecordOverhead;
+    size_t bytesAvailable = buffer->capacity - buffer->writeCursor;
+    int    result;
+
+    if (bytesRequired > bytesAvailable)
+    {
+        result = SolidSyslogResult_BufferFull;
+    }
+    else
+    {
+        int status = Buffer_WriteMagic(buffer);
+        if (status != SolidSyslogResult_Ok)
+        {
+            result = status;
+        }
+        else
+        {
+            result = Buffer_WriteRecord(buffer, record, recordLength);
+        }
+    }
+    return result;
+}
+
+/* Tests/SolidSyslogBufferTest.cpp --------------------------------------- */
+
+TEST_GROUP(SolidSyslogBufferTest)
+{
+    struct SolidSyslogBuffer* buffer;
+    uint8_t                   storage[256];
+
+    void setup() override
+    {
+        struct SolidSyslogSecurityPolicy policy = { /* ... */ };
+        (void) SolidSyslogBuffer_Initialise(storage, sizeof storage,
+                                            &policy, &buffer);
+    }
+
+    void teardown() override
+    {
+        /* ... */
+    }
+};
+
+TEST(SolidSyslogBufferTest, AppendsRecordWhenSpaceAvailable)
+{
+    /* ... */
+}
+
+TEST(SolidSyslogBufferTest, RejectsRecordWhenFull)
+{
+    /* ... */
+}
+```
+
+---
+
+## Quick reference
+
+| Identifier kind                       | Form                                       | Example                                    |
+|---------------------------------------|--------------------------------------------|--------------------------------------------|
+| Public function                       | `SolidSyslogClass_Function`                | `SolidSyslogBuffer_Append`                 |
+| Public struct tag                     | `SolidSyslogClass`                         | `struct SolidSyslogBuffer`                 |
+| Public enum type                      | `SolidSyslogClass`                         | `enum SolidSyslogSeverity`                 |
+| Public enum constant                  | `SolidSyslogClass_Constant`                | `SolidSyslogSeverity_Emergency`            |
+| Public macro                          | `SOLIDSYSLOG_SCREAMING_SNAKE`              | `SOLIDSYSLOG_MAXIMUM_RECORD_LENGTH`        |
+| Public typedef (enum/fn-pointer only) | `SolidSyslogClass` / `SolidSyslogClass_Fn` | `SolidSyslogTransport_SendFn`              |
+| Static function                       | `Class_Function`                           | `Buffer_WriteMagic`                        |
+| Static variable / constant            | `Class_Variable`                           | `Buffer_DefaultPolicy`                     |
+| File-scope macro                      | `CLASS_SCREAMING_SNAKE`                    | `BUFFER_RECORD_MAGIC`                      |
+| Function parameter / local            | `lowerCamelCase`                           | `recordLength`, `bytesAvailable`           |
+| Out-parameter                         | `outX` prefix                              | `outBuffer`                                |
+| Boolean / predicate                   | `isX` / `hasX` / `canX`                    | `isValid`, `hasUnsent`                     |
+| Loop variable                         | short domain word, lowerCamelCase          | `index`, `count`, `cursor`                 |
+| Struct member                         | `lowerCamelCase`                           | `writeCursor`, `integrityCheck`            |
+| Test group (class)                    | `SolidSyslogClassTest`                     | `SolidSyslogBufferTest`                    |
+| Test group (function)                 | `SolidSyslogClass_FunctionTest`            | `SolidSyslogBuffer_AppendTest`             |
+| Test group (integration)              | `SolidSyslogIntegrationDescription`        | `SolidSyslogIntegrationTlsStoreAndForward` |
+| Test case                             | `UpperCamelCaseSentence`                   | `AppendsRecordWhenSpaceAvailable`          |

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -1,0 +1,102 @@
+# MISRA C:2012 deviations
+
+SolidSyslog is **MISRA-informed**, not certified-compliant. The project
+adopts a curated subset of MISRA C:2012 rules per tier (see
+`docs/NAMING.md` for the tier model). This document records every
+deliberate deviation from a rule the project otherwise enforces.
+
+Each deviation is paired with a matching entry in `misra_suppressions.txt`
+(the cppcheck-misra input). The two files are complementary:
+
+| File | Audience | Purpose |
+|------|----------|---------|
+| `misra_suppressions.txt` | cppcheck-misra | Machine-readable suppressions per rule / file / line |
+| `docs/misra-deviations.md` | Reviewers, auditors, integrators | Why each deviation exists, with rationale, scope, approval |
+
+Each entry in `misra_suppressions.txt` shall reference the section of
+this document that authorises it. Populating the suppressions file
+itself lands later in E10 — see [#12](https://github.com/DavidCozens/solid-syslog/issues/12)
+(S10.03 wires cppcheck-misra into CI, S10.06 curates the rule subset
+and finalises the deviation set).
+
+The format below is patterned on MISRA's own deviation record template
+(MISRA Compliance:2020 §4.2).
+
+---
+
+## D.001 — Rule 5.1 external identifier uniqueness relaxed to 63 characters
+
+### Rule
+
+> **Rule 5.1 (Required)** — External identifiers shall be distinct.
+
+The "distinct" requirement is parameterised by the implementation's
+significant-character count for external identifiers. C99 §5.2.4.1
+specifies a **minimum** of 31 significant characters in external
+identifiers — i.e. a conforming compiler may treat two external
+identifiers that agree in the first 31 characters as the same identifier.
+
+### Deviation
+
+SolidSyslog requires external identifiers to be distinct in the first
+**63** characters rather than the first 31.
+
+### Scope
+
+- **Strict tier** — `Core/Interface/`, `Core/Source/`,
+  `Platform/*/Interface/`
+- **Pragmatic tier** — `Platform/*/Source/`
+
+The deviation does not apply to the Consistency-only or Out-of-scope
+tiers (rule 5.1 is not enforced there at all).
+
+### Rationale
+
+The C99 31-character limit is a legacy linker artifact from the late
+1980s. Every toolchain that SolidSyslog targets — hosted or embedded —
+supports external identifiers far longer than 63 characters:
+
+| Toolchain | Significant external-identifier characters |
+|-----------|-------------------------------------------|
+| GCC (any supported version)              | ≥ 1024 (effectively unlimited; capped only by symbol table length) |
+| Clang / LLVM                             | ≥ 1024 (effectively unlimited) |
+| MSVC 2015+                               | ≥ 2047 |
+| `arm-none-eabi-gcc` (embedded GCC)       | ≥ 1024 |
+| IAR Embedded Workbench (C/C++ compilers) | ≥ 200 |
+| Arm Compiler 6 (Keil ARMCC 6+, LLVM-based) | ≥ 1024 |
+
+The Tier 1 naming scheme in `docs/NAMING.md` (form
+`SolidSyslogClass_Function`) routinely produces identifiers in the
+40–60 character range — `SolidSyslogFreeRtosStaticResolver_Create` is
+38, `SolidSyslogFreeRtosTcpStream_Destroy` is 36 — and a few public
+storage-size enums approach 60 (e.g. `SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE`,
+40). Strict 31-character distinctness would either collapse identifier
+pairs that read identically up to a trailing word
+(`SolidSyslogFreeRtosStaticResolver_Create` vs `_Destroy`) into a
+single name, or force unidiomatic abbreviation throughout the public
+API. Neither outcome serves clarity or MISRA's underlying intent
+("the reader can tell two identifiers apart"); 63 characters does.
+
+63 was chosen rather than "unlimited" so the project still names a
+concrete number that every targeted toolchain comfortably exceeds. It
+also matches C99's separate 63-character minimum for **internal**
+identifiers (§5.2.4.1) — a single number applies project-wide.
+
+### Risk and mitigation
+
+- **Portability** — Constrained to toolchains that support ≥ 63
+  significant characters in external identifiers. The table above
+  covers every supported target; adding a new target requires verifying
+  this constraint.
+- **Tooling** — cppcheck-misra is configured to flag rule 5.1
+  collisions at the 63-character window rather than the 31-character
+  default. The configuration change is part of S10.03.
+- **Review** — The naming scheme itself (see `docs/NAMING.md`,
+  Tier 1) builds in a `SolidSyslog` prefix and a `Class_Function`
+  shape that makes accidental 63-character collisions extremely
+  unlikely. The static-analysis gate exists to catch any that slip in.
+
+### Approval
+
+Project owner — David Cozens. Recorded as the founding entry in this
+document under [S10.01](https://github.com/DavidCozens/solid-syslog/issues/357).

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -54,24 +54,24 @@ tiers (rule 5.1 is not enforced there at all).
 
 The C99 31-character limit is a legacy linker artifact from the late
 1980s. Every toolchain that SolidSyslog targets — hosted or embedded —
-supports external identifiers far longer than 63 characters:
+supports external identifiers well in excess of 63 significant
+characters:
 
-| Toolchain | Significant external-identifier characters |
-|-----------|-------------------------------------------|
-| GCC (any supported version)              | ≥ 1024 (effectively unlimited; capped only by symbol table length) |
-| Clang / LLVM                             | ≥ 1024 (effectively unlimited) |
-| MSVC 2015+                               | ≥ 2047 |
-| `arm-none-eabi-gcc` (embedded GCC)       | ≥ 1024 |
-| IAR Embedded Workbench (C/C++ compilers) | ≥ 200 |
-| Arm Compiler 6 (Keil ARMCC 6+, LLVM-based) | ≥ 1024 |
+| Toolchain | External identifier behaviour |
+|-----------|-------------------------------|
+| GCC (incl. `arm-none-eabi-gcc`)                | No compiler-imposed limit; identifier length is delegated to the target's linker, and all characters are significant on every linker SolidSyslog targets (ld, gold, lld, link.exe). See GCC manual, "Implementation-defined behavior". |
+| Clang / LLVM (incl. Arm Compiler 6 / armclang) | Same rule as GCC for external identifiers — no compiler-imposed limit. |
+| MSVC 2015+                                     | Documented maximum identifier length **2,047 characters** ([Microsoft Learn — C Identifiers](https://learn.microsoft.com/en-us/cpp/c-language/c-identifiers)). |
+| IAR Embedded Workbench                         | C/C++ compiler reference manual documents an identifier limit well above 63 characters in every currently shipping version (verify on the target SKU's compiler reference for ports of SolidSyslog to non-standard SKUs). |
 
 The Tier 1 naming scheme in `docs/NAMING.md` (form
 `SolidSyslogClass_Function`) routinely produces identifiers in the
-40–60 character range — `SolidSyslogFreeRtosStaticResolver_Create` is
-38, `SolidSyslogFreeRtosTcpStream_Destroy` is 36 — and a few public
-storage-size enums approach 60 (e.g. `SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE`,
-40). Strict 31-character distinctness would either collapse identifier
-pairs that read identically up to a trailing word
+30–40 character range — `SolidSyslogFreeRtosStaticResolver_Create` is
+40, `SolidSyslogFreeRtosTcpStream_Destroy` is 36 — and a few public
+storage-size enums sit just below 40 (e.g.
+`SOLIDSYSLOG_FREERTOSSTATICRESOLVER_SIZE`, 39). Strict 31-character
+distinctness would either collapse identifier pairs that read
+identically up to a trailing word
 (`SolidSyslogFreeRtosStaticResolver_Create` vs `_Destroy`) into a
 single name, or force unidiomatic abbreviation throughout the public
 API. Neither outcome serves clarity or MISRA's underlying intent


### PR DESCRIPTION
## Purpose

First story of E10 (Static Analysis and MISRA). Commits the two
human-readable coding-standard reference documents that the rest of
the epic depends on so subsequent tooling stories (`.clang-tidy`
tiers, cppcheck-misra wiring, rule-subset curation) have an
authoritative naming spec and a deviations doc to reference.

Closes #357

## Change Description

- **`docs/NAMING.md`** — committed as-is (already drafted in the
  working tree). The per-tier naming scheme covering Tier 1 (public
  API), Tier 2 (file-scope statics), Tier 3 (locals/parameters),
  Tier 4 (struct members), tests, and macros. Satisfies MISRA C:2012
  rules 5.1–5.9 with clang-tidy enforcing shape and cppcheck-misra
  enforcing uniqueness.
- **`docs/misra-deviations.md`** — new. Founding entry **D.001**
  documents the project's relaxation of MISRA Rule 5.1 from C99's
  31-character external-identifier window to **63 characters**, with
  rationale, scope (Strict + Pragmatic tiers), toolchain coverage
  table (gcc, clang, MSVC, arm-none-eabi-gcc, IAR, Keil ARMCC 6+),
  risk/mitigation, and approval. Patterned on the MISRA Compliance:2020
  §4.2 record template.
- **`CLAUDE.md`** — "Naming Conventions" section replaces its inline
  rules table with a one-line summary and a pointer to
  `docs/NAMING.md` as the source of truth; also notes that deviations
  live in `docs/misra-deviations.md`.
- **`SKILL.md`** — "Code style" section updated the same way.
- **`DEVLOG.md`** — appended a session entry.

### Decisions

- **63 characters, not "unlimited".** Naming a concrete number keeps
  the deviation auditable and matches C99's separate 63-character
  minimum for internal identifiers, so a single number applies
  project-wide.
- **Deviations doc separate from `misra_suppressions.txt`.** The
  suppressions file is cppcheck-readable line-level data; the
  deviations doc is the human-audit narrative. Each future suppression
  entry will reference the deviation section that authorises it
  (populated in S10.06).
- **`CLAUDE.md` keeps a one-line naming summary** rather than a bare
  pointer, so a quick read of `CLAUDE.md` still tells the reader the
  rough shape without forcing a second-file hop.

## Test Evidence

Documentation only — no source or tooling changes, no tests to
run. Per the story acceptance criteria, no CI changes; no source
changes outside `docs/` and the two `CLAUDE.md` / `SKILL.md` files.

## Areas Affected

- `docs/NAMING.md` (new)
- `docs/misra-deviations.md` (new)
- `CLAUDE.md` — Naming Conventions section rewritten as pointer
- `SKILL.md` — Code style section rewritten as pointer
- `DEVLOG.md` — session entry appended

Tooling wiring (`.clang-tidy` tiers, cppcheck-misra in CI, rule-subset
curation) is **out of scope** here and lands in S10.02 / S10.03 /
S10.06. Source-code rename sweeps land in S10.07 onwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive naming convention documentation defining identifier naming rules across different scope tiers with MISRA C:2012 alignment.
  * Added MISRA C:2012 deviation documentation recording the first deviation for rule 5.1, extending identifier uniqueness enforcement from 31 to 63 characters.
  * Updated developer guides to reference the new naming and deviation documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/358)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->