### PR TITLE
feat: S10.02 tier-model .clang-tidy files in warning mode

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,11 @@
 ---
 # Enable via CMake: cmake --preset tidy
 # Requires clang-tidy in the base image (see .devcontainer/Dockerfile).
+#
+# Root config — Strict tier per docs/NAMING.md, applies to Core/* and
+# Platform/*/Interface/. Pragmatic / Consistency-only / out-of-scope tiers
+# layer per-directory overrides on top (see Platform/*/Source/.clang-tidy,
+# Tests/.clang-tidy, Bdd/.clang-tidy).
 Checks: >
   bugprone-*,
   clang-analyzer-*,
@@ -25,11 +30,68 @@ Checks: >
   -modernize-deprecated-headers,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
 
-# Treat all clang-tidy warnings as errors.
-WarningsAsErrors: '*'
+# Treat all clang-tidy warnings as errors EXCEPT the new naming check,
+# which lands in warning mode for the duration of E10's soft-freeze
+# (S10.02 through S10.18). S10.18 will flip it back to error mode once
+# the sweeps in S10.07 onwards have cleared the backlog.
+WarningsAsErrors: '*,-readability-identifier-naming'
 
 # Only apply to project headers, not third-party or system headers.
 HeaderFilterRegex: '.*Interface/.*'
 
 # Use the project .clang-format style for suggested fixes.
 FormatStyle: file
+
+# readability-identifier-naming — Tier 1–4 scheme per docs/NAMING.md.
+#
+# Option A from the S10.02 design discussion: clang-tidy enforces the
+# SolidSyslog prefix and the case style; the Class_Function shape past
+# the prefix is left to review + cppcheck-misra 5.1 distinctness
+# (landing in S10.03). clang-tidy does not natively support a positive
+# must-match regex for identifier shape, and the inverted-polarity
+# IgnoredRegexp hack was rejected for misleading diagnostics.
+CheckOptions:
+  # Tier 1 — public (external-linkage) functions: SolidSyslogClass_Function
+  - { key: readability-identifier-naming.GlobalFunctionCase,    value: aNy_CasE    }
+  - { key: readability-identifier-naming.GlobalFunctionPrefix,  value: SolidSyslog }
+
+  # Tier 1 — public struct tags: SolidSyslogClass
+  - { key: readability-identifier-naming.StructCase,            value: CamelCase   }
+  - { key: readability-identifier-naming.StructPrefix,          value: SolidSyslog }
+
+  # Tier 1 — public enum tags: SolidSyslogClass
+  - { key: readability-identifier-naming.EnumCase,              value: CamelCase   }
+  - { key: readability-identifier-naming.EnumPrefix,            value: SolidSyslog }
+
+  # Tier 1 — public enum constants: SolidSyslogClass_Constant
+  - { key: readability-identifier-naming.EnumConstantCase,      value: aNy_CasE    }
+  - { key: readability-identifier-naming.EnumConstantPrefix,    value: SolidSyslog }
+
+  # Tier 1 — public typedefs (enum / function-pointer only per NAMING.md):
+  # SolidSyslogClass or SolidSyslogClass_Fn
+  - { key: readability-identifier-naming.TypedefCase,           value: aNy_CasE    }
+  - { key: readability-identifier-naming.TypedefPrefix,         value: SolidSyslog }
+
+  # Macros — UPPER_CASE shape only. clang-tidy cannot distinguish public
+  # (SOLIDSYSLOG_*) from file-scope (CLASS_*) macros syntactically, so
+  # the SOLIDSYSLOG_ prefix on public macros is not enforced by tidy.
+  # Review + cppcheck-misra 5.4 distinctness cover the rest.
+  - { key: readability-identifier-naming.MacroDefinitionCase,   value: UPPER_CASE  }
+
+  # Tier 2 — file-scope static functions: Class_Function (no SolidSyslog
+  # prefix; class part is the source-file basename and varies per file).
+  - { key: readability-identifier-naming.StaticFunctionCase,    value: aNy_CasE    }
+
+  # Tier 2 — file-scope static variables / constants: Class_Variable
+  - { key: readability-identifier-naming.StaticVariableCase,    value: aNy_CasE    }
+  - { key: readability-identifier-naming.StaticConstantCase,    value: aNy_CasE    }
+
+  # Tier 3 — function parameters: lowerCamelCase
+  - { key: readability-identifier-naming.ParameterCase,         value: camelBack   }
+
+  # Tier 3 — local variables / constants: lowerCamelCase
+  - { key: readability-identifier-naming.LocalVariableCase,     value: camelBack   }
+  - { key: readability-identifier-naming.LocalConstantCase,     value: camelBack   }
+
+  # Tier 4 — struct members: lowerCamelCase
+  - { key: readability-identifier-naming.MemberCase,            value: camelBack   }

--- a/Bdd/.clang-tidy
+++ b/Bdd/.clang-tidy
@@ -1,0 +1,12 @@
+---
+# Out-of-scope (for naming) per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy and disables readability-identifier-naming
+# only — the BDD targets use whatever shape reads well at the test site
+# (WaitForUdpServer, MainLoop, etc.) and were never intended to follow
+# the SolidSyslog* scheme. The other safety checks (bugprone-*,
+# clang-analyzer-*, cppcoreguidelines-*, etc.) continue to apply — these
+# binaries ship to CI hardware and we rely on those checks finding real
+# bugs, so we deliberately do not fully disable clang-tidy here.
+InheritParentConfig: true
+Checks: '-readability-identifier-naming'

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,96 @@
 # Dev Log
 
+## 2026-05-14 — S10.02 tier-model .clang-tidy files (warning mode) (#359)
+
+Stands up the per-tier `.clang-tidy` configuration described in
+`docs/NAMING.md` and turns the `readability-identifier-naming` check
+on in warning mode, ready for the rest of E10 to audit and sweep
+against.
+
+### Changes
+
+- **Root `.clang-tidy`** — adds a `CheckOptions` block configuring
+  `readability-identifier-naming` per the Tier 1–4 scheme: public
+  functions / structs / enums / typedefs / enum constants get the
+  `SolidSyslog` prefix; macros enforce `UPPER_CASE`; static functions
+  / variables / constants use `aNy_CasE` (no prefix); parameters /
+  locals / struct members use `camelBack`. `WarningsAsErrors` is
+  changed from `'*'` to `'*,-readability-identifier-naming'` so the
+  new check surfaces as warning only.
+- **`Platform/{Atomics,Posix,Windows,OpenSsl,FreeRtos,FatFs}/Source/.clang-tidy`**
+  — six Pragmatic-tier placeholders, each inheriting the parent. Real
+  third-party-API exemptions land here as discovered. Files exist
+  from S10.02 to mark the tier boundary even when empty of overrides.
+- **`Tests/.clang-tidy`** — Consistency-only; inherits parent and
+  disables `readability-identifier-naming` outright. Other safety
+  checks (bugprone, clang-analyzer, cppcoreguidelines) stay on.
+- **`Bdd/.clang-tidy`** — out-of-scope-for-naming; same shape as
+  Tests/, also keeps safety checks. We deliberately do **not** fully
+  disable clang-tidy on BDD targets — those binaries ship to CI
+  hardware and we rely on bugprone/cppcoreguidelines on them.
+- **`docs/NAMING.md`** — appended a note that
+  `readability-identifier-naming` enforces prefix + case but not
+  positive shape regex; `SolidSyslogClass_Function` past the prefix
+  is left to review and cppcheck-misra 5.1 (S10.03).
+
+### Decisions
+
+- **Option A enforcement.** clang-tidy gets `GlobalFunctionPrefix:
+  SolidSyslog` + `GlobalFunctionCase: aNy_CasE`. The `Class_Function`
+  shape past the prefix is uncovered by tidy — picked up by
+  cppcheck-misra 5.1 distinctness in S10.03. The inverted-polarity
+  `IgnoredRegexp` hack discussed in the design review was rejected
+  for misleading diagnostics ("invalid case style; should be
+  lower_case" when the actual rule is "missing underscore").
+- **Six Pragmatic placeholders, not three.** The S10.02 issue only
+  named Posix/Windows/OpenSsl, but `docs/NAMING.md` puts every
+  `Platform/*/Source/` in the Pragmatic tier and that includes
+  Atomics, FreeRtos, FatFs as well. Added all six for symmetry. The
+  three INTERFACE platforms (FreeRtos, FatFs and parts of Atomics)
+  only get analysed transitively when consumers compile them, but
+  the file location on disk is what clang-tidy walks up from, so the
+  placement is correct regardless.
+- **`Bdd/.clang-tidy` disables only the naming check.** Memory of
+  the design discussion: BDD targets ship to CI hardware and the
+  existing bugprone/cppcoreguidelines coverage matters. NAMING.md's
+  "Out of scope — Not enforced" stance applies to naming + MISRA,
+  not all of clang-tidy.
+- **Macro prefix not enforced.** clang-tidy cannot syntactically
+  distinguish public (`SOLIDSYSLOG_*`) from file-scope (`CLASS_*`)
+  macros, so the `MacroDefinitionCase` rule is `UPPER_CASE` only;
+  prefix is left to review + cppcheck-misra 5.4.
+
+### Verification
+
+`cmake --preset tidy && cmake --build --preset tidy` succeeds. The
+new check surfaces **404 naming warnings**, all under Strict tier
+(`Core/*`, 383) and Pragmatic tier (`Platform/Posix/*`, 18;
+`Platform/OpenSsl/*`, 3). **Zero** naming warnings on `Tests/*` —
+the Consistency-only exemption works. **Zero** naming warnings on
+`Bdd/*` — the out-of-scope exemption works. Zero errors. The
+existing error-mode checks (bugprone, cppcoreguidelines, etc.) still
+pass cleanly.
+
+The 404 warnings are real drift — vtable members like
+`SolidSyslogStreamDefinition::Open` / `Send` / `Close` are PascalCase
+not lowerCamelCase; `SOLIDSYSLOG_*_SIZE` enum constants don't carry
+the `SolidSyslog` prefix the EnumConstant rule wants; etc. These are
+exactly what the S10.05 audit will catalogue and S10.07+ will sweep.
+
+### Deferred
+
+- The Pragmatic placeholder files contain no real `IgnoredRegexp`
+  exemptions yet — they're stubs. Real exemptions land as they
+  surface during the sweeps in S10.07+.
+- Re-enabling `magic-numbers` (currently disabled in the root
+  Checks): tracked in the rule-subset curation story S10.06, not
+  here.
+- Flip back to error mode: S10.18.
+- A CI grep step over `Core/Interface/*.h` and
+  `Platform/*/Interface/*.h` to enforce the `SolidSyslogClass_Function`
+  shape positively (Option C from the design discussion): deferred,
+  to be raised only if drift surfaces post-S10.03 cppcheck-misra.
+
 ## 2026-05-14 — S10.01 NAMING.md + initial MISRA deviations doc (#357)
 
 First story of E10. Commits `docs/NAMING.md` (the already-drafted

--- a/Platform/Atomics/Source/.clang-tidy
+++ b/Platform/Atomics/Source/.clang-tidy
@@ -1,0 +1,10 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# atomic-primitive APIs (stdatomic.h, Windows Interlocked) and parameters
+# in adapter wrappers are exempt from the lowerCamelCase rule when the
+# upstream name would force a different shape. Add IgnoredRegexp entries
+# here as real exemptions surface; the file exists from S10.02 to mark
+# the tier boundary even when empty of overrides.
+InheritParentConfig: true

--- a/Platform/FatFs/Source/.clang-tidy
+++ b/Platform/FatFs/Source/.clang-tidy
@@ -1,0 +1,16 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# ChaN FatFs identifiers (FIL file, FATFS, FRESULT, f_* wrappers) and
+# parameters in adapter wrappers are exempt from the lowerCamelCase
+# rule when the upstream name would force a different shape.
+#
+# Note: Platform/FatFs/ is shipped as an INTERFACE library — sources
+# are recompiled by each consumer (tests, BDD targets, integrator apps)
+# with that consumer's ffconf.h. clang-tidy analyses these files
+# whenever they are compiled in a tidy-enabled target.
+#
+# Add IgnoredRegexp entries here as real exemptions surface; the file
+# exists from S10.02 to mark the tier boundary even when empty of overrides.
+InheritParentConfig: true

--- a/Platform/FreeRtos/Source/.clang-tidy
+++ b/Platform/FreeRtos/Source/.clang-tidy
@@ -1,0 +1,17 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# FreeRTOS identifiers (StaticSemaphore_t, TaskHandle_t xTask, Socket_t
+# xSocket, FreeRTOS_*) and parameters in adapter wrappers are exempt
+# from the lowerCamelCase rule when the upstream name would force a
+# different shape (notably the FreeRTOS Hungarian "x" prefix).
+#
+# Note: Platform/FreeRtos/ is shipped as an INTERFACE library — sources
+# are recompiled by each consumer (tests, BDD targets, integrator apps)
+# with that consumer's FreeRTOSConfig.h. clang-tidy analyses these files
+# whenever they are compiled in a tidy-enabled target.
+#
+# Add IgnoredRegexp entries here as real exemptions surface; the file
+# exists from S10.02 to mark the tier boundary even when empty of overrides.
+InheritParentConfig: true

--- a/Platform/OpenSsl/Source/.clang-tidy
+++ b/Platform/OpenSsl/Source/.clang-tidy
@@ -1,0 +1,10 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# OpenSSL identifiers (SSL_CTX, BIO, EVP_*, etc.) and parameters in
+# adapter wrappers are exempt from the lowerCamelCase rule when the
+# upstream name would force a different shape. Add IgnoredRegexp entries
+# here as real exemptions surface; the file exists from S10.02 to mark
+# the tier boundary even when empty of overrides.
+InheritParentConfig: true

--- a/Platform/Posix/Source/.clang-tidy
+++ b/Platform/Posix/Source/.clang-tidy
@@ -1,0 +1,11 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# POSIX-API identifiers (mqd_t mq, struct sockaddr_in addr, pthread_*
+# wrappers, etc.) and parameters in adapter wrappers are exempt from
+# the lowerCamelCase rule when the upstream name would force a different
+# shape. Add IgnoredRegexp entries here as real exemptions surface;
+# the file exists from S10.02 to mark the tier boundary even when empty
+# of overrides.
+InheritParentConfig: true

--- a/Platform/Windows/Source/.clang-tidy
+++ b/Platform/Windows/Source/.clang-tidy
@@ -1,0 +1,11 @@
+---
+# Pragmatic tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy. Local names that mirror third-party
+# Win32 / Winsock identifiers (SOCKET sock, HANDLE, CRITICAL_SECTION,
+# WSADATA wsaData, etc.) and parameters in adapter wrappers are exempt
+# from the lowerCamelCase rule when the upstream name would force a
+# different shape. Add IgnoredRegexp entries here as real exemptions
+# surface; the file exists from S10.02 to mark the tier boundary even
+# when empty of overrides.
+InheritParentConfig: true

--- a/Tests/.clang-tidy
+++ b/Tests/.clang-tidy
@@ -1,0 +1,15 @@
+---
+# Consistency-only tier per docs/NAMING.md.
+#
+# Inherits the root .clang-tidy and disables readability-identifier-naming
+# outright — CppUTest's TEST_GROUP / TEST / CHECK_* macros expand to
+# external-linkage identifiers (TEST_GroupName_TestName_TestShell etc.)
+# that routinely exceed any reasonable identifier window, and test code
+# uses a documented set of relaxations (lowerCamelCase preferred but not
+# enforced; PascalCase helpers; SolidSyslog prefix dropped on fakes /
+# spies; SCREAMING_SNAKE on test-only macros without a project prefix).
+#
+# The other safety checks (bugprone-*, clang-analyzer-*, cppcoreguidelines-*,
+# etc.) continue to apply — they catch real bugs in test code too.
+InheritParentConfig: true
+Checks: '-readability-identifier-naming'

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -22,6 +22,11 @@ split between the two tools so they cannot disagree on the same name:
   `readability-identifier-naming` check understands linkage, scope, and
   the distinction between macros, typedefs, tags and ordinary identifiers.
   Per-directory `.clang-tidy` files implement the tier model below.
+  Note: `readability-identifier-naming` enforces case style + prefix +
+  suffix per identifier kind, but does **not** support a positive
+  must-match regex. The `SolidSyslogClass_Function` shape past the
+  `SolidSyslog` prefix is therefore enforced by review and by
+  cppcheck-misra rule 5.1 distinctness, not by clang-tidy directly.
 - **cppcheck-misra** is the sole authority on naming *uniqueness*. The
   MISRA addon surfaces rules 5.1, 5.2, 5.4, 5.6, 5.7, 5.8 and 5.9
   violations — pattern matching alone cannot detect these.


### PR DESCRIPTION
## Purpose

Stands up the per-tier `.clang-tidy` configuration model defined in
`docs/NAMING.md` and turns `readability-identifier-naming` on in
warning mode, so the rest of E10 has something concrete to enforce
against. No source-code changes — the audit (S10.05) and sweep
(S10.07+) stories pick up from here.

Closes #359

## Change Description

### Root `.clang-tidy`

- New `CheckOptions` block configuring `readability-identifier-naming`
  per the Tier 1–4 scheme:
  - **Tier 1** (public API) — `SolidSyslog` prefix on functions,
    structs, enums, typedefs, enum constants; `aNy_CasE` shape.
  - **Macros** — `UPPER_CASE` only. clang-tidy cannot syntactically
    distinguish public (`SOLIDSYSLOG_*`) from file-scope (`CLASS_*`)
    macros, so the prefix is left to review + cppcheck-misra 5.4.
  - **Tier 2** (file-scope statics) — `aNy_CasE`, no prefix.
  - **Tier 3** (parameters, locals) — `camelBack`.
  - **Tier 4** (struct members) — `camelBack`.
- `WarningsAsErrors` changes from `'*'` to
  `'*,-readability-identifier-naming'` so the new check surfaces as
  warning only. Existing error-mode checks (bugprone,
  cppcoreguidelines, etc.) are unchanged.

### Pragmatic-tier placeholders

Six new `.clang-tidy` files under `Platform/*/Source/` — Atomics,
Posix, Windows, OpenSsl, FreeRtos, FatFs. Each inherits the parent
via `InheritParentConfig: true`. Real third-party-API
`IgnoredRegexp` exemptions land here as discovered (e.g. `mqd_t mq`
on Posix, `SOCKET sock` on Windows, FreeRTOS Hungarian-style `xTask`,
etc.) — these files mark the tier boundary even when empty of
overrides.

Note: six files rather than the three named in the issue (Posix /
Windows / OpenSsl). `docs/NAMING.md` puts every `Platform/*/Source/`
in the Pragmatic tier, including the INTERFACE platforms
(FreeRtos, FatFs) which only get analysed transitively when test /
BDD consumers compile them — but their on-disk location is what
clang-tidy walks up from, so placement is correct regardless.

### Consistency-only and out-of-scope (for naming)

- **`Tests/.clang-tidy`** — inherits parent; disables
  `readability-identifier-naming` outright. CppUTest's `TEST_GROUP` /
  `TEST` / `CHECK_*` macros expand to identifiers that blow past any
  reasonable window, and test code uses a documented set of
  relaxations. Bugprone / clang-analyzer / cppcoreguidelines safety
  checks continue to apply — they catch real bugs in test code.
- **`Bdd/.clang-tidy`** — same shape. BDD targets ship to CI
  hardware, so we deliberately do **not** fully disable clang-tidy;
  only the naming check is silenced. NAMING.md's "Out of scope —
  Not enforced" stance applies to naming + MISRA, not all of
  clang-tidy.

### `docs/NAMING.md`

Appended a note under the tool-split section that
`readability-identifier-naming` enforces prefix + case but not a
positive must-match regex; the `SolidSyslogClass_Function` shape
past the `SolidSyslog` prefix is therefore enforced by review and
by cppcheck-misra 5.1 distinctness (landing in S10.03), not by
clang-tidy directly.

### Decisions

- **Option A enforcement** from the design discussion: prefix + case
  only, no shape regex hack. The inverted-polarity `IgnoredRegexp`
  approach was rejected for misleading diagnostics.
- **Six Pragmatic placeholders, not three** — for parity with
  NAMING.md's `Platform/*/Source/` definition.
- **`Bdd/.clang-tidy` disables only the naming check** — safety
  coverage on the shipping BDD binaries is preserved.

## Test Evidence

`cmake --preset tidy && cmake --build --preset tidy` (full preset
including library, all tests, BDD targets, OpenSSL integration tests)
succeeds.

Warning census from the build log:

| Location | `readability-identifier-naming` warnings |
|----------|------------------------------------------|
| `Core/Interface/`     | 339 |
| `Core/Source/`        | 44 |
| `Platform/Posix/*`    | 18 |
| `Platform/OpenSsl/*`  | 3 |
| `Tests/*`             | **0** — Consistency-only exemption verified |
| `Bdd/*`               | **0** — Out-of-scope exemption verified |
| **Total**             | **404** |

Errors: **0**. Existing error-mode checks (bugprone,
cppcoreguidelines, modernize, etc.) continue to pass.

The 404 warnings are real drift — vtable members like
`SolidSyslogStreamDefinition::Open`/`Send`/`Read`/`Close` declared
as PascalCase not lowerCamelCase, `SOLIDSYSLOG_*_SIZE` enum
constants without the `SolidSyslog` prefix the EnumConstant rule
wants, etc. These are precisely what the S10.05 audit will
catalogue and the S10.07+ sweeps will clear.

Other pre-PR local checks (gcc/clang/sanitize/coverage/cppcheck/format)
are unaffected — `CMAKE_C_CLANG_TIDY` is only set in the `tidy`
preset, so `.clang-tidy` changes cannot break those builds.

## Areas Affected

- `.clang-tidy` (root, modified) — Tier 1–4 naming options, WarningsAsErrors exclusion
- `Platform/Atomics/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Platform/Posix/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Platform/Windows/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Platform/OpenSsl/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Platform/FreeRtos/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Platform/FatFs/Source/.clang-tidy` (new) — Pragmatic placeholder
- `Tests/.clang-tidy` (new) — Consistency-only; disables naming check
- `Bdd/.clang-tidy` (new) — Out-of-scope-for-naming; disables naming check
- `docs/NAMING.md` — note on what `readability-identifier-naming` can / cannot enforce
- `DEVLOG.md` — session entry appended

No CI workflow changes. No source-code changes outside `.clang-tidy`,
`docs/NAMING.md`, and `DEVLOG.md`. The follow-ups (S10.03
cppcheck-misra wiring, S10.05 audit, S10.06 rule subset, S10.07+
sweeps, S10.18 flip to error mode) carry the rest of E10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration across development directories to enforce naming conventions with tier-specific exemptions.
  * Organized linting rules by code maturity levels (Strict and Pragmatic tiers).

* **Documentation**
  * Added development log entry documenting naming rule enforcement strategy.
  * Updated naming guidelines documentation with clarification on identifier case-style and prefix/suffix enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/360)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->