### PR TITLE
feat: S10.03 wire cppcheck-misra addon into CI (warning mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,79 @@ jobs:
           path: build/cppcheck/cppcheck-report.xml
           retention-days: 1
 
+      # ----------------------------------------------------------------
+      # cppcheck-misra addon — S10.03, warning mode.
+      #
+      # Runs the MISRA C:2012 addon over Strict + Pragmatic tiers
+      # (Core/Source/ + Platform/*/Source/). --error-exitcode=0 keeps
+      # the step non-fatal: diagnostics print to the CI log and an XML
+      # artifact uploads, but the job continues regardless.
+      #
+      # S10.18 will collapse this and the non-MISRA pass above into a
+      # single invocation when both reach the same weight (error mode);
+      # the existing pass's scope will widen to Platform/*/Source/ at
+      # that point — see project_e10_accumulated_scope.md.
+      # ----------------------------------------------------------------
+
+      - name: Run cppcheck-misra (warning mode)
+        if: success() || failure()
+        run: >
+          cppcheck
+          --addon=misra
+          --suppressions-list=misra_suppressions.txt
+          --error-exitcode=0
+          --inline-suppr
+          --std=c11
+          -ICore/Interface
+          -IPlatform/Atomics/Interface
+          -IPlatform/Posix/Interface
+          -IPlatform/Windows/Interface
+          -IPlatform/OpenSsl/Interface
+          -IPlatform/FreeRtos/Interface
+          -IPlatform/FatFs/Interface
+          Core/Source/
+          Platform/Atomics/Source/
+          Platform/Posix/Source/
+          Platform/Windows/Source/
+          Platform/OpenSsl/Source/
+          Platform/FreeRtos/Source/
+          Platform/FatFs/Source/
+
+      - name: Generate cppcheck-misra XML report
+        if: success() || failure()
+        run: |
+          mkdir -p build/cppcheck-misra
+          cppcheck \
+            --addon=misra \
+            --suppressions-list=misra_suppressions.txt \
+            --error-exitcode=0 \
+            --inline-suppr \
+            --std=c11 \
+            -ICore/Interface \
+            -IPlatform/Atomics/Interface \
+            -IPlatform/Posix/Interface \
+            -IPlatform/Windows/Interface \
+            -IPlatform/OpenSsl/Interface \
+            -IPlatform/FreeRtos/Interface \
+            -IPlatform/FatFs/Interface \
+            --xml --xml-version=2 \
+            Core/Source/ \
+            Platform/Atomics/Source/ \
+            Platform/Posix/Source/ \
+            Platform/Windows/Source/ \
+            Platform/OpenSsl/Source/ \
+            Platform/FreeRtos/Source/ \
+            Platform/FatFs/Source/ \
+            2> build/cppcheck-misra/cppcheck-misra-report.xml
+
+      - name: Upload cppcheck-misra report
+        if: success() || failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: cppcheck-misra-report
+          path: build/cppcheck-misra/cppcheck-misra-report.xml
+          retention-days: 1
+
   build-windows-msvc:
     runs-on: windows-latest
     permissions:

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,93 @@
 # Dev Log
 
+## 2026-05-14 — S10.03 cppcheck-misra wired into CI (warning mode) (#361)
+
+Third foundation story of E10. Layers a cppcheck MISRA-addon pass on
+top of the existing `analyze-cppcheck` CI job in warning mode, so the
+rest of the epic (audit in S10.05, rule curation in S10.06) has
+diagnostics to work from.
+
+### Changes
+
+- **`.github/workflows/ci.yml`** — three new steps appended to the
+  `analyze-cppcheck` job:
+  1. `Run cppcheck-misra (warning mode)` — invokes
+     `cppcheck --addon=misra --suppressions-list=misra_suppressions.txt
+     --error-exitcode=0` over `Core/Source/` + `Platform/*/Source/`.
+     Diagnostics print to the CI log; the step is non-fatal.
+  2. `Generate cppcheck-misra XML report` — re-runs with
+     `--xml --xml-version=2` redirecting stderr to
+     `build/cppcheck-misra/cppcheck-misra-report.xml`.
+  3. `Upload cppcheck-misra report` — uploads the XML as the
+     `cppcheck-misra-report` artifact.
+- No CMake preset changes (the existing `cppcheck` preset stays as is).
+- No source-code changes. No suppression entries added —
+  `misra_suppressions.txt` stays empty, populated by S10.06.
+- No container bump — `misra.py` is already present at
+  `/usr/lib/x86_64-linux-gnu/cppcheck/addons/misra.py` in
+  `ghcr.io/davidcozens/cpputest:sha-18f19e1` (cppcheck 2.10).
+
+### Decisions
+
+- **Single job, two passes.** The existing non-MISRA cppcheck pass
+  stays in error mode (`--error-exitcode=1`); the new MISRA pass
+  runs alongside in warning mode (`--error-exitcode=0`). They
+  collapse to one invocation at S10.18 when MISRA flips back to
+  error mode and both passes have the same weight.
+- **No `--enable=warning` on the MISRA pass.** The misra addon
+  emits its findings regardless of enable flags; the non-MISRA pass
+  already owns the `warning` / `style` / `performance` / `portability`
+  diagnostics over `Core/Source/`. Including `--enable=warning` on
+  the MISRA pass would have created duplicate non-MISRA findings.
+- **Includes paths cover every `Platform/*/Interface/`.** Some are
+  shipped as INTERFACE libraries (FreeRtos, FatFs); cppcheck still
+  needs the headers on the include path to analyse the sources
+  meaningfully.
+- **No `summary`-job plumbing.** The `cppcheck-misra-report` artifact
+  uploads but is not surfaced via Quality Monitor — wiring 574
+  warnings into the PR-summary badge during a soft-freeze would
+  create misleading noise. The artifact is available on each run's
+  artifacts page for anyone investigating; that's enough for
+  warning mode.
+
+### Verification
+
+Ran the exact `cppcheck --addon=misra ...` invocation locally in the
+gcc container. **574 MISRA findings** surface across 29 distinct
+rules and 80 files, exit code 0, XML report writes cleanly (1728
+lines, 199 KB).
+
+Findings by directory: `Core/Source/` 260, `Platform/Windows/` 117,
+`Platform/Posix/` 112, `Platform/FreeRtos/` 38, `Core/Interface/` 20,
+`Platform/OpenSsl/` 14, `Platform/Atomics/` 7, `Platform/FatFs/` 6.
+
+Top rules: 5.9 (168, internal-linkage uniqueness, advisory — falls
+out of our cross-TU `Buffer_*` static-helper naming), 11.3 (95,
+unrelated-pointer-type casts — vtable / caller-supplied storage
+pattern), 10.4 (91, mixed essential-type operands — mostly `U`
+suffix territory), 8.9 (56, file-scope statics that should be
+block-scope), 5.7 (54, tag-name uniqueness — by design under our
+no-typedef-struct convention, deviation territory not fix territory).
+
+A meaningful slice of the 574 is structural (will deviate) rather
+than behavioural (will fix). The real fix-target population is
+probably 100–150; S10.05's audit triages.
+
+### Deferred
+
+- **Rule 5.1 63-character window.** The addon currently checks
+  against C99's 31-char window. Honouring deviation D.001 in
+  `misra.py` is a S10.06 task (custom `rule-texts.txt` override,
+  suppression entries, or whatever the curation story settles on).
+- **Suppressions file content.** `misra_suppressions.txt` stays
+  empty; S10.06 populates after the rule subset is curated.
+- **Widen existing non-MISRA cppcheck scope** from `Core/Source/`
+  alone to `Core/Source/ + Platform/*/Source/`. Tracked in
+  `project_e10_accumulated_scope` memory — lands at S10.18
+  alongside the flip-to-error / merge-the-passes work.
+- **Quality Monitor / PR-summary integration of MISRA findings.**
+  Deferred to whenever MISRA moves to error mode (S10.18).
+
 ## 2026-05-14 — S10.02 tier-model .clang-tidy files (warning mode) (#359)
 
 Stands up the per-tier `.clang-tidy` configuration described in


### PR DESCRIPTION
## Purpose

Layers a cppcheck MISRA-addon pass on top of the existing
`analyze-cppcheck` CI job in warning mode, so the rest of E10
(audit in S10.05, rule curation in S10.06) has MISRA C:2012
diagnostics to work from.

Closes #361

## Change Description

### CI changes — `.github/workflows/ci.yml`

Three new steps appended to the existing `analyze-cppcheck` job
(no new job, no new dependency in `summary.needs`):

1. **Run cppcheck-misra (warning mode)** — `cppcheck --addon=misra
   --suppressions-list=misra_suppressions.txt --error-exitcode=0`
   over `Core/Source/` and `Platform/*/Source/`. Non-fatal;
   diagnostics print to the CI log.
2. **Generate cppcheck-misra XML report** — same invocation with
   `--xml --xml-version=2` redirected to
   `build/cppcheck-misra/cppcheck-misra-report.xml`.
3. **Upload cppcheck-misra report** — uploads as the
   `cppcheck-misra-report` CI artifact (retention 1 day, matching
   the existing pattern).

The existing non-MISRA cppcheck pass is **unchanged** — keeps
`--error-exitcode=1` so its `warning,style,performance,portability`
checks remain in error mode over `Core/Source/`.

### Decisions

- **Single job, two passes.** Splitting the job in two would have
  doubled the checkout / container spin-up cost for the same image
  and the same source tree. The two passes collapse to one
  invocation at S10.18 when MISRA flips to error mode and both
  passes have the same `--error-exitcode` weight.
- **No `--enable=warning` on the MISRA pass.** The misra addon
  emits findings regardless of `--enable=` flags. Including
  `warning`/`style` would have duplicated diagnostics the existing
  pass already owns on `Core/Source/`.
- **No `summary`-job plumbing of MISRA results.** Wiring 574
  warnings into the PR-summary badge during a soft-freeze would
  create misleading noise. The artifact is on the run page for
  anyone investigating — that's enough for warning mode.
- **No container bump** — `misra.py` is already present at
  `/usr/lib/x86_64-linux-gnu/cppcheck/addons/misra.py` in
  `ghcr.io/davidcozens/cpputest:sha-18f19e1` (cppcheck 2.10).

## Test Evidence

Ran the exact CI invocation locally in the gcc dev container:

```
cppcheck --addon=misra --suppressions-list=misra_suppressions.txt
  --error-exitcode=0 --inline-suppr --std=c11
  -ICore/Interface -IPlatform/Atomics/Interface
  -IPlatform/Posix/Interface -IPlatform/Windows/Interface
  -IPlatform/OpenSsl/Interface -IPlatform/FreeRtos/Interface
  -IPlatform/FatFs/Interface
  Core/Source/ Platform/Atomics/Source/ Platform/Posix/Source/
  Platform/Windows/Source/ Platform/OpenSsl/Source/
  Platform/FreeRtos/Source/ Platform/FatFs/Source/
```

Results: **574 MISRA findings** across 29 distinct rules and 80
files. Exit code **0** (warning mode behaves correctly). XML report
clean (1728 lines, 199 KB).

By directory:

| Path | Count |
|------|------:|
| `Core/Source/`       | 260 |
| `Platform/Windows/`  | 117 |
| `Platform/Posix/`    | 112 |
| `Platform/FreeRtos/` |  38 |
| `Core/Interface/`    |  20 |
| `Platform/OpenSsl/`  |  14 |
| `Platform/Atomics/`  |   7 |
| `Platform/FatFs/`    |   6 |

Top five rules: 5.9 (168 — internal-linkage uniqueness, advisory;
arises from cross-TU `static` helpers with the same name), 11.3
(95 — unrelated-pointer-type casts; the vtable / caller-supplied
storage pattern), 10.4 (91 — mixed essential-type operands),
8.9 (56 — file-scope statics that should be block-scope), 5.7 (54
— tag-name uniqueness, by design under our no-typedef-struct
convention).

A meaningful slice of the 574 is structural (will deviate, e.g.
5.7) rather than behavioural (will fix, e.g. 8.9). The real
fix-target population is probably 100–150 — S10.05's audit
triages.

## Areas Affected

- `.github/workflows/ci.yml` — three new steps in `analyze-cppcheck`
- `DEVLOG.md` — session entry appended

No source-code changes. No CMake preset changes. No suppression-file
entries — `misra_suppressions.txt` stays empty until S10.06. No
container bump. No `summary`-job changes.

Other pre-PR locals (gcc/clang/sanitize/coverage/tidy/cppcheck/format)
are unaffected — the workflow change is additive and only modifies
behaviour inside the `analyze-cppcheck` job.

## Deferred (tracked elsewhere)

- **Rule 5.1 63-character window** — S10.06 wires the D.001
  deviation into the addon.
- **`misra_suppressions.txt` contents** — S10.06 populates.
- **Widen the existing non-MISRA cppcheck scope** from `Core/Source/`
  to `Core/Source/ + Platform/*/Source/` — lands at S10.18 alongside
  the flip-to-error / merge-the-passes work
  (`project_e10_accumulated_scope` memory).
- **Quality Monitor integration of MISRA findings** — deferred to
  S10.18 when MISRA reaches error mode.