### PR TITLE
docs: S10.06 curate MISRA rule subset (D.002–D.010 + suppressions)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -7411,3 +7411,82 @@ tag in the same pass.
 ### Open questions
 
 - None.
+
+## 2026-05-14 — S10.06 MISRA rule subset curation
+
+### Decisions
+
+- **Five new deviations originally planned (D.002–D.006), four
+  more raised during curation (D.007 / D.008 / D.009 / D.010),
+  three audit verdicts revised.** The S10.05 audit had assigned
+  rules 11.8 (11 findings) as "Mixed" and 21.10 / 21.6 (4 findings
+  combined) as "Investigate"; per-site review against the actual
+  source confirmed all 15 are structural — captured as D.007 (11.8
+  cppcheck-misra false-positives on `const struct*` member access
+  plus the documented Winsock `select()` const-strip), D.008
+  (transitive `<wchar.h>` via `<time.h>` on glibc), D.009
+  (`<stdio.h>` solely for `SEEK_SET` / `SEEK_END` used by
+  `_lseeki64`). Adding D.010 was forced: the re-run of
+  cppcheck-misra with D.002–D.009 suppressions applied revealed
+  5 additional rule 2.4 findings that had been masked behind 5.7
+  (D.003) in the audit — all 6 sites are the project's anonymous
+  `enum { … };` named-constant idiom (≈31 such blocks tree-wide).
+  Verdict for 2.4 flipped from Fix (audit) to Deviate.
+
+- **Rule 5.1 63-character window — no cppcheck-misra configuration
+  change required.** S10.03 had deferred the wiring decision to
+  this story (three options: rule-text override, blanket suppress,
+  custom addon configuration). cppcheck-misra applies its default
+  31-character window and currently reports zero 5.1 findings; the
+  31-char enforcement is strictly stricter than the 63-char
+  deviation allows, so the existing setup is the safe direction.
+  The deviation only becomes load-bearing if a real collision ever
+  resolves at 63 chars but not at 31 — at which point that single
+  finding gets suppressed with rationale tying back to D.001.
+  Recorded in D.001's Risk-and-mitigation section.
+
+- **Rule 11.3 dual-rule sites.** The same opaque-impl cast at
+  `Address.c:5` and `Formatter.h:30` triggers both 11.2 (incomplete
+  type → pointer) and 11.3 (different object types). The original
+  audit recorded only one rule per site; in practice cppcheck-misra
+  reports both once one of them is suppressed. D.002 covers all
+  three rules; the suppressions file lists 11.2 and 11.3 entries
+  at the four dual-rule sites.
+
+- **Audit numerical reconciliation.** Headline count was 575
+  findings → 187 suppressed via D.002–D.010 + 388 remaining Fix
+  targets. The 575 vs 187 + 388 = 575 reconciles cleanly when the
+  five dual-rule sites (`Address.c:5` × 3 platforms + `Formatter.h:30`
+  + one previous overlap) are treated as single MISRA findings
+  reported under two rule IDs. The Fix-target backlog handed to
+  S10.07+ is 388 findings, not the 389 the audit projected; the
+  -1 is rule 2.4 graduating to Deviate.
+
+- **Suppressions file format.** cppcheck rejects suppression files
+  containing bare `#` lines (single-character comment markers with
+  no text). All comment dividers in `misra_suppressions.txt` use
+  `# ` (hash + space) — silent constraint discovered during the
+  first verification run that fired
+  `cppcheck: error: Failed to add suppression. No id.` Worth
+  remembering for any future suppression-file generator.
+
+### Deferred
+
+- **Rule 5.6 SOLIDSYSLOG_STATIC_ASSERT polyfill fix** (5 findings).
+  All five sites are the same polyfill macro expanding to a
+  duplicate `typedef char solidsyslog_static_assert_[…]`. Fixing
+  it is a one-line edit to `Core/Source/SolidSyslogMacros.h`
+  (append `__LINE__` via two-step concat). Out of S10.06's docs-only
+  scope; carried into the mechanical sweep story whose number is
+  assigned when raised.
+
+- **Two sibling stories slotted into E10's cross-cutting sweeps
+  section** but not raised yet (epic body updated by the issue
+  author when the audit landed): data-member PascalCase rename
+  (≈186 sites) and the tree-wide mechanical MISRA sweep (now ≈125
+  fixes across 9 rules — 2.4 graduated to Deviate, so the count
+  dropped by 1). Numbers assigned when raised.
+
+### Open questions
+
+- None.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -7465,7 +7465,7 @@ tag in the same pass.
 - **Suppressions file format.** cppcheck rejects suppression files
   containing bare `#` lines (single-character comment markers with
   no text). All comment dividers in `misra_suppressions.txt` use
-  `# ` (hash + space) — silent constraint discovered during the
+  `#` followed by a space — silent constraint discovered during the
   first verification run that fired
   `cppcheck: error: Failed to add suppression. No id.` Worth
   remembering for any future suppression-file generator.

--- a/docs/misra-conformance.md
+++ b/docs/misra-conformance.md
@@ -135,7 +135,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **Fix** — other rules (mechanical or per-component sweeps S10.07+) | 220 | 10.4, 8.9, 17.7, 10.1, 15.7, 8.4, 12.1, 17.8, 5.6, 15.5, 10.8, 22.10, 8.6, 2.5, 3.1, 7.1, 14.4 |
 | **Deviate** — landed in S10.06 (D.002–D.010) | 187 | 11.3, 11.2, 11.5 *(D.002)*; 5.7 *(D.003)*; 18.4 *(D.004)*; 18.7 *(D.005)*; 1.4 *(D.006)*; 11.8 *(D.007)*; 21.10 *(D.008)*; 21.6 *(D.009)*; 2.4 *(D.010)* |
 | **Disable** | 0 | — |
-| **Total reconciled** | **387 Fix + 187 Deviate = 574** + 5 dual-rule (same code site reported under two rules, e.g. 11.2 + 11.3 cast in `Address.c`) = 575 (matches the raw count, the 575 figure double-counts 5 dual-rule sites) |
+| **Total reconciled** | **388 Fix + 187 Deviate = 575** | Raw count includes 5 dual-rule overlaps (same code site reported under two rules, e.g. 11.2 + 11.3 cast in `Address.c`). |
 
 The verdict surface increased from the audit's headline by two rows
 (D.008 / D.009 resolving the Investigate items; D.010 added during

--- a/docs/misra-conformance.md
+++ b/docs/misra-conformance.md
@@ -102,7 +102,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **10.4** | 92 | Both operands of operator shall be in same essential type category | `SolidSyslogFormatter.c` (15), `SolidSyslog.c` (6), `SolidSyslogFileBlockDevice.c` (6) | **Fix** | Mostly `size_t + 1` where `1` is `int`. Add `U` suffix to literals; occasional explicit cast for mixed cases. Mechanical sweep. | **New sweep story** (no existing slot in epic — propose S10.09a essential-type cleanups, or roll into S10.09 abbreviation purge / a new dedicated story) |
 | **8.9** (advisory) | 56 | Object referenced in one function should have block scope | `SolidSyslogFormatter.c` (8), `SolidSyslogMetaSd.c` (5), `SolidSyslogOriginSd.c` (5) | **Fix** | File-scope statics that should be locals or `static const` block-scope. Per-site review. | **S10.09** (if "abbreviation purge" widens to "code-shape hygiene") or **new sweep story** |
 | **5.7** | 54 | Tag names unique | `BlockSequence.c` (2), `SolidSyslogFileBlockDevice.c` (2), `SolidSyslogBlockStore.h` (1), and so on across many forward-decl + definition pairs | **Deviate** | NAMING.md's no-typedef-struct convention deliberately repeats the same `struct SolidSyslogX` tag wherever it's used (forward-decl in headers, definition in source). 5.7 fires on every repetition. Document as deviation. | **S10.06** (deviation D.003) |
-| **11.8** | 11 | Cast shall not remove const/volatile qualification | `SolidSyslog.c` (8), `BlockSequence.c` (1), `SolidSyslogBlockStore.c` (1), `SolidSyslogWinsockTcpStream.c` (1) | **Mostly Deviate** | The Winsock `select()` site is a documented platform-API forced const-strip (already in code as a comment); some Core sites are real const-correctness drift and **Fix**. Split per-site in S10.06 review. | **S10.06** (some deviate, some fix) |
+| **11.8** | 11 | Cast shall not remove const/volatile qualification | `SolidSyslog.c` (8), `BlockSequence.c` (1), `SolidSyslogBlockStore.c` (1), `SolidSyslogWinsockTcpStream.c` (1) | **Deviate** *(resolved in S10.06: all 11 sites)* | All 10 Core sites are field-access "false positives" — accessing a non-const-pointer field through a `const struct*` parameter; C standard §6.5.2.3 ¶3 says the member-access yields an unqualified pointer rvalue, so this is not a real const-strip. The Winsock `select()` site is the documented platform-API const-strip already commented in source. Captured as **D.007**. | landed in **S10.06** |
 | **17.7** | 11 | Value returned by non-void function shall be used | `RecordStore.c` (5), `SolidSyslogCircularBuffer.c` (4), `SolidSyslog.c` (1) | **Fix** | Use the return value or cast to `(void)` with comment. | **New sweep story** or **S10.10** (Buffer pilot) where most concentrate |
 | **10.1** | 11 | Operands shall not be of inappropriate essential type | `SolidSyslogUtf8.h` (5), `SolidSyslogFormatter.c` (5), `SolidSyslogCrc16.c` (1) | **Fix** | Bool/char/int essential-type mixing — typically a one-line cast or refactor. | **S10.17** (core message pipeline) for Formatter; mixed for the rest |
 | **15.7** | 10 | All if/else-if shall be terminated with `else` | `BlockSequence.c` (3), `SolidSyslogFormatter.c` (2), `SolidSyslogTlsStream.c` (1) | **Fix** | Add trailing `else { /* exhaustive */ }`. Mechanical. | **New sweep story** |
@@ -114,7 +114,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **18.4** (advisory) | 4 | `+`, `-`, `+=`, `-=` shall not be applied to pointer types | `RecordStore.c` (4) | **Deviate** | RecordStore manipulates record buffers using pointer arithmetic by design (magic byte offset → length offset → message offset, etc.). This is the natural C expression for the algorithm. Document as deviation. | **S10.06** (D.004) |
 | **15.5** (advisory) | 4 | Function should have single exit point | `SolidSyslogFormatter.c` (3), `SolidSyslog.c` (1) | **Fix** | Already a documented project preference ("Production code (Tier 1, Core/Source/) — Single return per function" in CLAUDE.md). Real drift. | **S10.17** (core message pipeline) |
 | **11.5** | 4 | Conversion from pointer to void to pointer to object | `SolidSyslogWinsockTcpStream.c` (2), `SolidSyslogUdpSender.c` (1), `SolidSyslogWinsockDatagram.c` (1) | **Deviate** | Same opaque-type / vtable pattern as 11.3. | **S10.06** (with D.002) |
-| **21.10** | 3 | `wchar.h` shall not be used | `SolidSyslogPosixClock.c` (1), `SolidSyslogPosixSleep.c` (1), `SolidSyslogPosixSysUpTime.c` (1) | **Investigate** | We don't include `wchar.h` directly. The addon may be misfiring on something transitively pulled in via `time.h` on this glibc version. If it's a transitive include we can't help, **Deviate**; otherwise **Fix**. | **S10.06** (investigate during rule curation) |
+| **21.10** | 3 | `wchar.h` shall not be used | `SolidSyslogPosixClock.c` (1), `SolidSyslogPosixSleep.c` (1), `SolidSyslogPosixSysUpTime.c` (1) | **Deviate** *(resolved in S10.06)* | All three sites are `#include <time.h>` — glibc transitively pulls in `<wchar.h>` via `bits/types/struct_tm.h`. No direct `<wchar.h>` use anywhere in the project. Captured as **D.008**. | landed in **S10.06** |
 | **22.10** | 3 | The value of `errno` shall be checked only after a function that may set it | `SolidSyslogPosixTcpStream.c` (2), `SolidSyslogPosixDatagram.c` (1) | **Fix** | We currently read `errno` in some places where the preceding function isn't documented to set it (or we check before re-calling). Per-site review. | **S10.15** (sender platform impls) |
 | **8.6** | 3 | Identifier with external linkage shall have exactly one external definition | `SolidSyslogAddress.c` (1 each across Posix/Windows/FreeRtos) | **Fix** | Either missing definition or duplicate declaration of `Address` helpers — needs per-site investigation. | **S10.15** |
 | **10.8** | 2 | Composite-expression cast to wider essential type | `SolidSyslog.c` (2) | **Fix** | One-site fixes. | **S10.17** |
@@ -123,21 +123,24 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **2.5** (advisory) | 2 | Unused macro | `SolidSyslogCircularBuffer.h` (2) | **Fix** | Two declared macros that are never used. Delete them. | **S10.11** (sync primitives — CircularBuffer lives here) |
 | **3.1** | 1 | `/* */` shall not contain comment-start sequence | `SolidSyslogCrc16.c` (1) | **Fix** | A single nested-comment-like sequence. One-line fix. | **S10.11** |
 | **7.1** | 1 | Octal constants shall not be used | `SolidSyslogPosixMessageQueueBuffer.c` (1) | **Fix** | Probably `0644` or similar file-mode literal — change to hex or named constant. | **S10.10** (Buffers pilot) |
-| **21.6** | 1 | The Standard Library `stdio.h` shall not be used | `SolidSyslogWindowsFile.c` (1) | **Investigate** | We do not use `stdio.h` in production. Likely a Windows-API header transitively includes it. If transitive, **Deviate**; if direct, **Fix**. | **S10.06** |
+| **21.6** | 1 | The Standard Library `stdio.h` shall not be used | `SolidSyslogWindowsFile.c` (1) | **Deviate** *(resolved in S10.06)* | `WindowsFile.c` includes `<stdio.h>` solely for `SEEK_SET` / `SEEK_END` constants used by `_lseeki64` from `<io.h>`; no stdio function or type is referenced. Captured as **D.009**. | landed in **S10.06** |
 | **14.4** | 1 | Controlling expression shall have essentially Boolean type | `SolidSyslogWindowsHostname.c` (1) | **Fix** | Replace `if (some_int)` with `if (some_int != 0)`. | **S10.12** (config + platform helpers) |
-| **2.4** (advisory) | 1 | A project should not contain unused tag declarations | `SolidSyslogStreamSender.c` (1) | **Fix** | Remove the unused tag. | **S10.15** |
+| **2.4** (advisory) | 1 → 6 *(resolved in S10.06)* | A project should not contain unused tag declarations | Re-run with D.002–D.009 suppressions surfaced 5 more anonymous-`enum { … };` sites previously hidden behind 5.7 — the audit's original count understated the rule. All 6 sites are the project's anonymous-`enum` named-constant idiom (≈31 such blocks tree-wide). | **Deviate** | Captured as **D.010**. The anonymous-`enum` idiom is project-wide and intentional (type-safe constants without `#define`). | landed in **S10.06** |
 
 ### MISRA totals by verdict
 
 | Verdict | Count | Rules |
 |---------|------:|-------|
 | **Fix** — rule 5.9 (named sweep target S10.08) | 168 | 5.9 |
-| **Fix** — other rules (mechanical or per-component sweeps S10.07+) | 221 | 10.4, 8.9, 17.7, 10.1, 15.7, 8.4, 12.1, 17.8, 5.6, 15.5, 10.8, 22.10, 8.6, 2.5, 3.1, 7.1, 14.4, 2.4 |
-| **Deviate** — landed in S10.06 (D.002–D.006) | 171 | 11.3, 5.7, 11.2, 18.4, 11.5, 18.7, 1.4 |
-| **Mixed** — per-site split in S10.06 | 11 | 11.8 |
-| **Investigate** during S10.06 | 4 | 21.10, 21.6 |
+| **Fix** — other rules (mechanical or per-component sweeps S10.07+) | 220 | 10.4, 8.9, 17.7, 10.1, 15.7, 8.4, 12.1, 17.8, 5.6, 15.5, 10.8, 22.10, 8.6, 2.5, 3.1, 7.1, 14.4 |
+| **Deviate** — landed in S10.06 (D.002–D.010) | 187 | 11.3, 11.2, 11.5 *(D.002)*; 5.7 *(D.003)*; 18.4 *(D.004)*; 18.7 *(D.005)*; 1.4 *(D.006)*; 11.8 *(D.007)*; 21.10 *(D.008)*; 21.6 *(D.009)*; 2.4 *(D.010)* |
 | **Disable** | 0 | — |
-| **Total** | **575** | (matches the raw count) |
+| **Total reconciled** | **387 Fix + 187 Deviate = 574** + 5 dual-rule (same code site reported under two rules, e.g. 11.2 + 11.3 cast in `Address.c`) = 575 (matches the raw count, the 575 figure double-counts 5 dual-rule sites) |
+
+The verdict surface increased from the audit's headline by two rows
+(D.008 / D.009 resolving the Investigate items; D.010 added during
+S10.06 re-run when D.003 suppression revealed 5 more 2.4 findings
+previously hidden behind 5.7).
 
 ---
 

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -14,10 +14,10 @@ Each deviation is paired with a matching entry in `misra_suppressions.txt`
 | `docs/misra-deviations.md` | Reviewers, auditors, integrators | Why each deviation exists, with rationale, scope, approval |
 
 Each entry in `misra_suppressions.txt` shall reference the section of
-this document that authorises it. Populating the suppressions file
-itself lands later in E10 — see [#12](https://github.com/DavidCozens/solid-syslog/issues/12)
-(S10.03 wires cppcheck-misra into CI, S10.06 curates the rule subset
-and finalises the deviation set).
+this document that authorises it. The suppressions file was populated
+under [S10.06](https://github.com/DavidCozens/solid-syslog/issues/367)
+after the rule subset was curated; before then it carried only a
+header comment.
 
 The format below is patterned on MISRA's own deviation record template
 (MISRA Compliance:2020 §4.2).
@@ -88,9 +88,16 @@ identifiers (§5.2.4.1) — a single number applies project-wide.
   significant characters in external identifiers. The table above
   covers every supported target; adding a new target requires verifying
   this constraint.
-- **Tooling** — cppcheck-misra is configured to flag rule 5.1
-  collisions at the 63-character window rather than the 31-character
-  default. The configuration change is part of S10.03.
+- **Tooling** — cppcheck-misra applies its default 31-character
+  window for rule 5.1. The deviation only matters when a real
+  collision would resolve at 63 characters but not at 31 — at
+  which point the project would suppress that specific finding
+  with a rationale tying back to this section. Currently no rule
+  5.1 collisions occur (0 findings on the current tree), so no
+  cppcheck-misra configuration change is required; the
+  enforcement window is strictly stricter than the deviation
+  allows, which is the safe direction. (Decision recorded under
+  [S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).)
 - **Review** — The naming scheme itself (see `docs/NAMING.md`,
   Tier 1) builds in a `SolidSyslog` prefix and a `Class_Function`
   shape that makes accidental 63-character collisions extremely
@@ -100,3 +107,612 @@ identifiers (§5.2.4.1) — a single number applies project-wide.
 
 Project owner — David Cozens. Recorded as the founding entry in this
 document under [S10.01](https://github.com/DavidCozens/solid-syslog/issues/357).
+
+---
+
+## D.002 — Rules 11.2 / 11.3 / 11.5: opaque-impl + caller-supplied-storage
+
+### Rule
+
+> **Rule 11.3 (Required)** — A cast shall not be performed between a
+> pointer to object type and a pointer to a different object type.
+>
+> **Rule 11.2 (Required)** — Conversions shall not be performed between
+> a pointer to an incomplete type and any other type.
+>
+> **Rule 11.5 (Advisory)** — A conversion should not be performed from
+> pointer to `void` into pointer to object.
+
+### Deviation
+
+SolidSyslog accepts pointer conversions between caller-supplied storage
+buffers and the implementation struct that owns the storage. The
+conversion takes one of three shapes:
+
+```c
+struct SolidSyslogXImpl* impl = (struct SolidSyslogXImpl*) storage;
+```
+
+where `storage` is a `SolidSyslogXStorage*` (an opaque public type whose
+size is exposed via `SOLIDSYSLOG_X_STORAGE_SIZE`), or where the
+conversion goes via `void*` at vtable boundaries.
+
+### Scope
+
+- **Strict tier** — every `_Create` function in `Core/Source/` that
+  uses the caller-supplied-storage pattern (≈30 classes).
+- **Pragmatic tier** — every platform-specific `_Create` and `Address`
+  helper under `Platform/*/Source/`.
+
+### Rationale
+
+The caller-supplied-storage pattern is foundational to SolidSyslog's
+embedded-friendly design — every `_Create` takes a pointer to caller
+memory of the size advertised by the matching `SOLIDSYSLOG_X_STORAGE_SIZE`
+constant, places the implementation struct in that memory, and returns
+a pointer of the opaque public type. The alternatives all conflict with
+project constraints:
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Dynamic allocation (`malloc`) | Not available on bare-metal, FreeRTOS-static-allocation, or DO-178C-style targets. SolidSyslog is callable from boot before any heap exists. |
+| Public concrete types | Leaks the implementation through the public API; ties integrators to internal layout and breaks ABI stability. |
+| Pass-by-value structs | Doubles the parameter footprint of every `_Create`; breaks the vtable indirection that decouples Core from Platform. |
+
+`Address.h` (Strict tier, opaque `SolidSyslogAddress`) and every
+caller-storage class (BlockStore, CircularBuffer, Formatter, the
+FreeRTOS/Posix/Windows mutexes and streams, …) hit the same three
+rules for the same structural reason — one deviation document
+covers all of them.
+
+### Risk and mitigation
+
+- **Type safety** — Each `_Create` is the only place in the library
+  that knows the relationship between `SolidSyslogXStorage` and
+  `struct SolidSyslogXImpl`. A `_Static_assert` immediately below
+  every impl definition pins the relationship at build time:
+
+  ```c
+  SOLIDSYSLOG_STATIC_ASSERT(
+      sizeof(struct SolidSyslogX) <= sizeof(SolidSyslogXStorage),
+      "SOLIDSYSLOG_X_STORAGE_SIZE is too small for struct SolidSyslogX"
+  );
+  ```
+
+  An integrator who allocates undersized storage is caught at
+  compile time, not at runtime.
+- **Alignment** — The storage type is declared as
+  `intptr_t storage[N]` (or a struct of the same shape), giving
+  alignment at least as strict as any pointer or scalar the impl
+  contains. The cast is therefore well-defined per §6.3.2.3.
+- **Static analysis** — These rules are advisory (11.5) or required
+  (11.2, 11.3). All 109 findings are suppressed via
+  `misra_suppressions.txt` referencing this section. The pattern is
+  reviewed once here, not per call site.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.003 — Rule 5.7: repeating struct tags (no-typedef-struct convention)
+
+### Rule
+
+> **Rule 5.7 (Required)** — A tag name shall be a unique identifier.
+
+cppcheck-misra interprets this strictly — every repeated `struct X`
+declaration counts as a non-unique tag, including forward declarations
+in headers and the matching definition in source.
+
+### Deviation
+
+SolidSyslog uses `struct SolidSyslogX` directly throughout the public
+API and source rather than typedef'ing it (see `docs/NAMING.md`, Tier 1
+"No struct typedefs" rule). Each public class therefore necessarily
+repeats its tag at every forward-declaration and definition site.
+
+### Scope
+
+- **Strict tier** — every public `struct SolidSyslogX` declared as an
+  incomplete type in a header (`SolidSyslogBuffer.h`, `SolidSyslogStore.h`,
+  `SolidSyslogFile.h`, etc.) and re-declared with full body in the
+  matching source file.
+- **Pragmatic tier** — same pattern across all `Platform/*/Source/`
+  classes.
+
+### Rationale
+
+The no-typedef-struct convention serves two goals that survive
+unchanged from C89 onwards:
+
+1. **Discoverability at the call site.** A reader of
+   `SolidSyslog_Create(struct SolidSyslogConfig*)` sees immediately
+   that `SolidSyslogConfig` is a struct, not a typedef'd enum, integer,
+   or function pointer. Tag-prefixed names act as a one-character type
+   marker.
+2. **Forward-declaration freedom.** A header that needs to mention
+   `struct SolidSyslogX*` does not have to include the header that
+   defines the typedef — it just forward-declares the struct. The
+   alternative (typedef pulls in the body) creates header dependency
+   cycles in the vtable-rich Core.
+
+Both goals depend on the tag being identical in the forward declaration
+and in the definition. The repetition is the convention, not a defect.
+
+### Risk and mitigation
+
+- **Genuine name collisions.** Distinct from this deviation: a real
+  collision (two different `struct X` definitions with the same tag)
+  is a code defect. Rule 5.7 surfaces those too, and the deviation
+  scope is therefore limited to "repetition of the *same* tag across
+  forward declaration and definition." Per-site review catches
+  genuine collisions; the project's `SolidSyslog`-prefix convention
+  makes them statistically unlikely.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.004 — Rule 18.4: pointer arithmetic on record buffers
+
+### Rule
+
+> **Rule 18.4 (Advisory)** — The `+`, `-`, `+=` and `-=` operators
+> should not be applied to an expression of pointer type.
+
+### Deviation
+
+`Core/Source/RecordStore.c` traverses record buffers using
+`uint8_t*` pointer arithmetic to step from the magic-byte header to
+the length field to the message body.
+
+### Scope
+
+`Core/Source/RecordStore.c` only. Four call sites.
+
+### Rationale
+
+RecordStore implements a simple binary record layout
+(`[magic][length][message]`) that has to be walked byte-by-byte during
+read and written byte-by-byte during write. The natural C expression
+is pointer arithmetic on `uint8_t*`:
+
+```c
+uint8_t* cursor = buffer;
+cursor += MAGIC_SIZE;
+const uint16_t length = ReadLengthAt(cursor);
+cursor += LENGTH_SIZE;
+/* cursor now points at the message body */
+```
+
+The alternative (array-index arithmetic against the base pointer,
+`buffer[MAGIC_SIZE]`, `buffer[MAGIC_SIZE + LENGTH_SIZE]`, …) trades
+visually-obvious offsets at the call site for repeated arithmetic on
+the index; it produces the same compiled code with less-readable C.
+The advisory rule discourages pointer arithmetic to protect against
+out-of-bounds drift; the function-local nature of these cursors
+(initialised, walked, dropped — never stored or returned) makes that
+risk minimal.
+
+### Risk and mitigation
+
+- **Out-of-bounds walking.** Every `cursor += N` advance is paired
+  with a bound check against the buffer's known total length. The
+  unit tests in `Tests/RecordStoreTest.cpp` cover the boundary
+  cases (zero-length record, max-length record, truncated input).
+- **Future ports.** The deviation is RecordStore-local; other Core
+  classes use array indexing throughout.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.005 — Rule 18.7: flexible array members
+
+### Rule
+
+> **Rule 18.7 (Required)** — Flexible array members shall not be
+> declared.
+
+### Deviation
+
+`struct SolidSyslogFormatter` and `struct SolidSyslogCircularBuffer`
+each end with a flexible array member that holds the caller-supplied
+backing storage:
+
+```c
+struct SolidSyslogFormatter
+{
+    /* … bookkeeping … */
+    char buffer[];
+};
+```
+
+### Scope
+
+Two classes only:
+
+- `Core/Source/SolidSyslogFormatter.c`
+- `Core/Source/SolidSyslogCircularBuffer.c`
+
+### Rationale
+
+These two classes implement the variable-size variant of the
+caller-supplied-storage pattern (D.002). The integrator declares a
+storage buffer of arbitrary size (with a minimum enforced by
+`_Static_assert`), and the class lives inside that storage —
+bookkeeping fields at the start, payload bytes filling the rest.
+
+The flexible array member is C99's standard mechanism for exactly this
+shape (§6.7.2.1 ¶18). The alternatives all regress:
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Pointer to separately-allocated payload | Re-introduces dynamic allocation or a second storage parameter. |
+| Fixed-size payload (`char buffer[MAX]`) | Forces every integrator to pay for the worst-case footprint. |
+| Trailing `char buffer[1]` "struct hack" | Pre-C99 idiom, technically UB; flexible array members exist precisely because the hack was unsafe. |
+
+### Risk and mitigation
+
+- **Compiler support.** All target toolchains support C99 flexible
+  array members (gcc, clang, MSVC 2013+, IAR, Keil ARMCC 6). The
+  project's CI builds prove this on every push.
+- **Allocation surprise.** The `_Static_assert` accompanying each
+  flexible-array struct pins the storage-type-to-impl-type
+  relationship at build time; an undersized storage allocation is a
+  compile error.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.006 — Rule 1.4: emergent C language features (C11 `<stdatomic.h>`)
+
+### Rule
+
+> **Rule 1.4 (Required)** — Emergent language features, such as
+> non-standard extensions and deprecated features, shall not be used.
+
+cppcheck-misra's interpretation of "emergent" includes C11 features in
+projects that otherwise target C99. SolidSyslog's `--std=c11` build flag
+is set because two source files need `<stdatomic.h>`; the rest of the
+codebase is C99.
+
+### Deviation
+
+`Platform/Atomics/Source/SolidSyslogStdAtomicU32.c` includes
+`<stdatomic.h>` and uses `_Atomic uint32_t` plus
+`atomic_compare_exchange_strong_explicit`.
+`Platform/Windows/Source/SolidSyslogWindowsAtomicU32.c` is the
+non-C11 sibling that the Atomics CMake selector switches in on
+toolchains without `<stdatomic.h>`.
+
+### Scope
+
+Two source files:
+
+- `Platform/Atomics/Source/SolidSyslogStdAtomicU32.c`
+- `Platform/Windows/Source/SolidSyslogWindowsAtomicU32.c`
+
+(The Windows file does not itself use C11 features — it triggers the
+1.4 finding because the project compiles at `--std=c11` so cppcheck-misra
+treats every TU as a "C11 project" candidate. The deviation is recorded
+for both files to keep the suppression list complete.)
+
+### Rationale
+
+The atomic counter (`SolidSyslogAtomicCounter`) needs a portable
+compare-and-swap primitive across hosted POSIX, hosted Windows, and
+FreeRTOS targets. Three primitives are practical:
+
+1. **`<stdatomic.h>`** — the C11 standard. Available on gcc/clang
+   universally, on MSVC 2022+, and explicitly selected by the Atomics
+   CMake module when `HAVE_STDATOMIC_H` is set.
+2. **`InterlockedCompareExchange`** — Win32 API. Selected by the same
+   CMake module when `HAVE_WINDOWS_INTERLOCKED` is set (legacy MSVC,
+   pre-2022, and MinGW configurations without `<stdatomic.h>`).
+3. **Hand-rolled CAS in assembly** — rejected: not portable, requires
+   per-target maintenance.
+
+The C11 primitive is the only option that is both portable across all
+hosted targets and visible to the cppcheck-misra audit. The Atomics
+module makes the choice at configure time; integrators on toolchains
+without `<stdatomic.h>` automatically get the Win32 path with no
+source-code change.
+
+### Risk and mitigation
+
+- **C99 baseline drift.** The project's C99 baseline is preserved
+  everywhere except in these two TUs (and the macros that gate them).
+  No C11 feature leaks into public headers.
+- **Future C standards.** If C23's deprecation paths affect
+  `<stdatomic.h>`, the Atomics module is the single migration point.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.007 — Rule 11.8: `const` qualification under field access of `const struct*`
+
+### Rule
+
+> **Rule 11.8 (Required)** — A cast shall not be performed that
+> removes any `const` or `volatile` qualification from the type
+> pointed to by a pointer.
+
+### Deviation
+
+Two distinct site categories trigger this rule:
+
+1. **Field-access "false positive" (10 sites)** — reading a non-const
+   pointer field through a `const struct*` parameter:
+
+   ```c
+   void SolidSyslog_Create(const struct SolidSyslogConfig* config)
+   {
+       InstallBuffer(config->buffer);  /* config->buffer has type
+                                          struct SolidSyslogBuffer*, not
+                                          const-qualified */
+       …
+   }
+   ```
+
+   Per C11 §6.5.2.3 ¶3, the result of `->` is the type of the named
+   member; `config->buffer` evaluates to `struct SolidSyslogBuffer *`
+   with no `const` qualifier on the pointed-to object. cppcheck-misra
+   nonetheless flags the field access as a const-strip — it tracks the
+   outer `const` on `*config` rather than the type of the member
+   expression. The accepted interpretation in the MISRA community is
+   that 11.8 applies to *pointer casts*, not to member-access yielding
+   a non-`const`-qualified pointer rvalue.
+
+2. **Platform-API const-strip (1 site)** —
+   `Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:82`:
+
+   ```c
+   return select(nfds, readfds, writefds, exceptfds, (struct timeval*) timeout);
+   ```
+
+   Winsock's `select()` declares its timeout parameter as
+   `struct timeval*` (non-const) where POSIX `select()` declares it as
+   `const struct timeval*`. The seam keeps the SolidSyslog side
+   const-correct and forces the const-strip down to the platform-API
+   boundary. The code carries a comment explaining the cast.
+
+### Scope
+
+- **Strict tier** — 10 field-access sites in `Core/Source/SolidSyslog.c`
+  (`InstallBuffer` and siblings, 8 sites),
+  `Core/Source/BlockSequence.c:438`, `Core/Source/SolidSyslogBlockStore.c:62`.
+- **Pragmatic tier** — 1 site, `SolidSyslogWinsockTcpStream.c:82`.
+
+### Rationale
+
+The field-access sites are not genuine const violations under the C
+standard; reorganising the code to avoid the cppcheck-misra
+false-positive would either drop the outer `const` qualifier on
+`*config` / `*blockSequence` / `*config` (the wrong direction) or
+introduce a no-op `const_cast`-style explicit cast that the tool would
+still flag. A site-local deviation is the honest record.
+
+The Winsock site is the canonical example MISRA itself calls out
+("forced by an external interface") in the deviation guidance for
+rule 11.8. The Windows-side declaration is fixed by Microsoft; the
+SolidSyslog seam keeps the const-correctness contract on the caller's
+side of the boundary.
+
+### Risk and mitigation
+
+- **Genuine const-strip drift.** A new const-strip elsewhere in the
+  codebase would surface as a fresh 11.8 finding, not be silently
+  absorbed by the existing suppressions — the suppressions are
+  line-specific.
+- **Platform-API site.** The Winsock cast is the only one of its
+  kind in the codebase and is documented at the call site.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.008 — Rule 21.10: transitive `<wchar.h>` via `<time.h>`
+
+### Rule
+
+> **Rule 21.10 (Required)** — The Standard Library time and date
+> functions shall not be used. (cppcheck-misra also flags
+> `<wchar.h>` inclusion under this rule.)
+
+### Deviation
+
+Three POSIX platform sources include `<time.h>` for `struct timespec`
+and `clock_gettime`/`nanosleep`:
+
+- `Platform/Posix/Source/SolidSyslogPosixClock.c`
+- `Platform/Posix/Source/SolidSyslogPosixSleep.c`
+- `Platform/Posix/Source/SolidSyslogPosixSysUpTime.c`
+
+On glibc, `<time.h>` transitively includes `<wchar.h>` (via
+`bits/types/struct_tm.h` and the `__wchar_t` family in `bits/types.h`).
+cppcheck-misra reports the transitive inclusion as a direct 21.10
+violation in each of the three TUs.
+
+### Scope
+
+`Platform/Posix/Source/` — three files. The deviation does not apply
+to Windows or FreeRTOS sources, which use their own platform clocks
+and do not include `<time.h>`.
+
+### Rationale
+
+The POSIX time and sleep wrappers exist precisely to provide
+SolidSyslog's clock and sleep abstractions on POSIX targets. They
+must include `<time.h>` to use `clock_gettime` / `nanosleep` /
+`struct timespec`. None of the three files use any function or type
+from `<wchar.h>`; the transitive inclusion is glibc-specific and
+unavoidable on this platform.
+
+### Risk and mitigation
+
+- **Direct `<wchar.h>` use.** A future direct `#include <wchar.h>`
+  in any of these files would not be absorbed by the per-file
+  suppression — only line-1 `<time.h>` is suppressed.
+- **Non-glibc POSIX targets.** musl, Bionic and BSDs do not pull
+  `<wchar.h>` from `<time.h>`; the suppression is harmless on those
+  targets (it suppresses a finding that does not occur).
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.009 — Rule 21.6: `<stdio.h>` for `SEEK_SET` / `SEEK_END` only
+
+### Rule
+
+> **Rule 21.6 (Required)** — The Standard Library input/output
+> functions shall not be used.
+
+### Deviation
+
+`Platform/Windows/Source/SolidSyslogWindowsFile.c` includes `<stdio.h>`
+solely to obtain the `SEEK_SET` and `SEEK_END` constants used by
+`_lseeki64` (declared in `<io.h>`). No `<stdio.h>` function or type
+(`FILE`, `fopen`, `printf`, …) is referenced.
+
+### Scope
+
+`Platform/Windows/Source/SolidSyslogWindowsFile.c` only. One line —
+the `#include <stdio.h>` directive.
+
+### Rationale
+
+On MSVC, the `_lseeki64` function takes a "whence" parameter whose
+constants (`SEEK_SET = 0`, `SEEK_CUR = 1`, `SEEK_END = 2`) are
+defined exclusively in `<stdio.h>`. `<io.h>` declares `_lseeki64`
+itself but does not define the constants; `<sys/stat.h>` does not
+define them either. The three options considered:
+
+| Option | Trade-off |
+|--------|-----------|
+| `#define SEEK_SET 0` ourselves | Hard-codes the MSVC ABI; fragile if the toolchain ever changes the values. |
+| Inclusion of `<stdio.h>` | Pulls in the entire stdio API surface, but we use only two integer constants. |
+| Pass numeric literals (`0`, `2`) | Loses readability at the call site. |
+
+Inclusion of `<stdio.h>` is the lowest-risk option; the project's
+banned-API policy already forbids `printf`/`scanf`/etc. and the
+clang-tidy `bugprone-unsafe-functions` family catches accidental
+use. The deviation is narrow and visible.
+
+### Risk and mitigation
+
+- **Accidental stdio use.** A grep over `WindowsFile.c` for
+  `printf|scanf|fopen|FILE` proves the negative; CI's clang-tidy
+  step catches future accidental use of banned stdio APIs across
+  the whole tree.
+- **Cross-platform consistency.** POSIX `SolidSyslogPosixFile.c`
+  uses `<unistd.h>` for the same constants and does not need this
+  deviation.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+
+---
+
+## D.010 — Rule 2.4: anonymous `enum` used as named-constant container
+
+### Rule
+
+> **Rule 2.4 (Advisory)** — A project should not contain unused tag
+> declarations.
+
+cppcheck-misra interprets an anonymous `enum { ... };` declaration
+(no enum tag, no `typedef`) as a "tag declared but unused" — the
+enumerators are used as named constants but the enum type itself
+is never referenced.
+
+### Deviation
+
+SolidSyslog uses the anonymous-`enum` idiom across the codebase as
+a portable mechanism for declaring named integer constants in
+header and source scope:
+
+```c
+enum
+{
+    SOLIDSYSLOG_UDP_DEFAULT_PORT = 514, /* RFC 5426 */
+    SOLIDSYSLOG_TCP_DEFAULT_PORT = 601, /* RFC 6587 §3.2 */
+};
+```
+
+There are approximately 31 such declarations across `Core/` and
+`Platform/*/Source/`. cppcheck-misra surfaces a subset (currently
+6) under rule 2.4 once the rule 5.7 suppressions (D.003) take
+effect; before then, the 5.7 check absorbs the same sites and
+masks the 2.4 finding.
+
+### Scope
+
+- **Strict tier** — every anonymous-`enum` constants block in
+  `Core/Interface/` and `Core/Source/`.
+- **Pragmatic tier** — every anonymous-`enum` constants block in
+  `Platform/*/Source/`.
+
+### Rationale
+
+`enum { CONST = N };` is the project's preferred way to introduce
+named integer constants for two reasons:
+
+1. **Type-safety vs. `#define`.** Enum constants are first-class
+   integers with proper compile-time evaluation; `#define`
+   constants are token substitutions and the project's clang-tidy
+   `cppcoreguidelines-macro-usage` rule discourages them outside
+   the very small surface of true preprocessor macros (e.g.
+   `SOLIDSYSLOG_STATIC_ASSERT`, `SOLIDSYSLOG_X_STORAGE_SIZE`).
+2. **Local scoping.** A block-scope `enum { ... };` introduces
+   constants visible only inside the function or file, with no
+   global namespace pollution.
+
+The anonymous form (no tag) is correct because the enum *type*
+is never needed — only the enumerator *values*. Adding a tag
+solely to satisfy rule 2.4 would create an unused identifier
+that would itself need a suppression, and the tag-named enum
+would not be substitutable for any other type.
+
+### Risk and mitigation
+
+- **Constant collision.** Two enums declaring the same enumerator
+  name collide at compile time (a duplicate-identifier error from
+  the compiler). This deviation does not relax that compiler check.
+- **Missing values.** A typo in a constant name is caught at
+  compile time. The enum has no runtime cost.
+- **Future tag-need.** If a particular constant set ever needs
+  the enum *type* (e.g. to type a function parameter), the
+  anonymous form is upgraded to a named-tag form on a per-case
+  basis; the deviation does not preclude this.
+
+### Approval
+
+Project owner — David Cozens. Recorded under
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -1,3 +1,233 @@
 # MISRA C:2012 cppcheck suppressions
-# Each suppression must include a rationale comment explaining why it is acceptable.
-# Format: <rule> <file>:<line> // Rationale: <explanation>
+# 
+# Each suppression block is grouped by the deviation that authorises it.
+# Deviations are documented in docs/misra-deviations.md; the comment header
+# of each block names the deviation number and links to the corresponding
+# section. The suppressions themselves are line-specific so a new finding
+# in the same file (other than the documented site) still surfaces in CI.
+# 
+# Format: misra-c2012-<rule>:<file>:<line>
+# Lines starting with # are comments.
+
+# D.002 — Rules 11.2 / 11.3 / 11.5: opaque-impl + caller-supplied-storage
+# See docs/misra-deviations.md#d002
+misra-c2012-11.2:Core/Interface/SolidSyslogFormatter.h:30
+misra-c2012-11.2:Platform/FreeRtos/Source/SolidSyslogAddress.c:5
+misra-c2012-11.2:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:19
+misra-c2012-11.2:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:25
+misra-c2012-11.2:Platform/Posix/Source/SolidSyslogAddress.c:5
+misra-c2012-11.2:Platform/Posix/Source/SolidSyslogAddressInternal.h:17
+misra-c2012-11.2:Platform/Posix/Source/SolidSyslogAddressInternal.h:23
+misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddress.c:5
+misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddressInternal.h:17
+misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddressInternal.h:23
+misra-c2012-11.3:Core/Interface/SolidSyslogFormatter.h:30
+misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:59
+misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:79
+misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:56
+misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:67
+misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:79
+misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:135
+misra-c2012-11.3:Core/Source/SolidSyslogFileBlockDevice.c:90
+misra-c2012-11.3:Core/Source/SolidSyslogFileBlockDevice.c:101
+misra-c2012-11.3:Core/Source/SolidSyslogFormatter.c:93
+misra-c2012-11.3:Core/Source/SolidSyslogMetaSd.c:74
+misra-c2012-11.3:Core/Source/SolidSyslogNullBuffer.c:46
+misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:65
+misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:74
+misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:91
+misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:98
+misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:161
+misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:48
+misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:55
+misra-c2012-11.3:Core/Source/SolidSyslogTimeQualitySd.c:49
+misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:121
+misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:129
+misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicU32.c:26
+misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:54
+misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:74
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddress.c:5
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:20
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:26
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c:61
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c:75
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c:33
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c:50
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c:48
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c:65
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:95
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:109
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:86
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:94
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:135
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:390
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:412
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:436
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddress.c:5
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddressInternal.h:18
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddressInternal.h:24
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:63
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:81
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:116
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:132
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:55
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:62
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:74
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:81
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:92
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:98
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:104
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:110
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:116
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:123
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:67
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:78
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:25
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:34
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:42
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:48
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:80
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:87
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:94
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:223
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:243
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:269
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddress.c:5
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddressInternal.h:18
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddressInternal.h:24
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsAtomicU32.c:26
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:59
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:66
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:82
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:93
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:104
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:110
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:116
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:122
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:128
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:135
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:25
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:34
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:42
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:48
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:99
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:117
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:160
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:176
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:157
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:164
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:171
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:302
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:322
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:348
+misra-c2012-11.5:Core/Source/SolidSyslogUdpSender.c:229
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:124
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:303
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:323
+
+# D.003 — Rule 5.7: no-typedef-struct repeating tags
+# See docs/misra-deviations.md#d003
+misra-c2012-5.7:Core/Interface/SolidSyslogAddress.h:10
+misra-c2012-5.7:Core/Interface/SolidSyslogBlockStore.h:52
+misra-c2012-5.7:Core/Interface/SolidSyslogCircularBuffer.h:19
+misra-c2012-5.7:Core/Interface/SolidSyslogEndpoint.h:11
+misra-c2012-5.7:Core/Interface/SolidSyslogFileBlockDevice.h:14
+misra-c2012-5.7:Core/Interface/SolidSyslogFormatter.h:14
+misra-c2012-5.7:Core/Interface/SolidSyslogSecurityPolicyDefinition.h:13
+misra-c2012-5.7:Core/Interface/SolidSyslogStreamSender.h:22
+misra-c2012-5.7:Core/Interface/SolidSyslogTimeQuality.h:12
+misra-c2012-5.7:Core/Interface/SolidSyslogTransport.h:5
+misra-c2012-5.7:Core/Interface/SolidSyslogUdpPayload.h:15
+misra-c2012-5.7:Core/Source/BlockSequence.c:6
+misra-c2012-5.7:Core/Source/BlockSequence.c:92
+misra-c2012-5.7:Core/Source/RecordStore.c:9
+misra-c2012-5.7:Core/Source/RecordStore.h:14
+misra-c2012-5.7:Core/Source/SolidSyslog.c:26
+misra-c2012-5.7:Core/Source/SolidSyslogCircularBuffer.c:14
+misra-c2012-5.7:Core/Source/SolidSyslogCrc16.c:12
+misra-c2012-5.7:Core/Source/SolidSyslogCrc16Policy.c:10
+misra-c2012-5.7:Core/Source/SolidSyslogFileBlockDevice.c:14
+misra-c2012-5.7:Core/Source/SolidSyslogFileBlockDevice.c:21
+misra-c2012-5.7:Core/Source/SolidSyslogOriginSd.c:6
+misra-c2012-5.7:Core/Source/SolidSyslogUdpPayload.c:5
+misra-c2012-5.7:Platform/Atomics/Source/SolidSyslogStdAtomicU32.c:10
+misra-c2012-5.7:Platform/FatFs/Interface/SolidSyslogFatFsFile.h:20
+misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosDatagram.h:13
+misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosMutex.h:13
+misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h:13
+misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosTcpStream.h:13
+misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosSysUpTime.c:7
+misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:48
+misra-c2012-5.7:Platform/OpenSsl/Interface/SolidSyslogTlsStream.h:14
+misra-c2012-5.7:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:14
+misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixFile.h:13
+misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixMutex.h:13
+misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixTcpStream.h:13
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c:18
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixDatagram.c:19
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixFile.c:17
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixHostname.c:10
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:13
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixSleep.c:6
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixSysUpTime.c:6
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:23
+misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWindowsFile.h:11
+misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWindowsMutex.h:13
+misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWinsockTcpStream.h:11
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsAtomicU32.c:10
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsClock.c:21
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsFile.c:20
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsHostname.c:19
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c:18
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockResolver.c:33
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:91
+
+# D.004 — Rule 18.4: pointer arithmetic on record buffers
+# See docs/misra-deviations.md#d004
+misra-c2012-18.4:Core/Source/RecordStore.c:32
+misra-c2012-18.4:Core/Source/RecordStore.c:37
+misra-c2012-18.4:Core/Source/RecordStore.c:42
+misra-c2012-18.4:Core/Source/RecordStore.c:47
+
+# D.005 — Rule 18.7: flexible array members
+# See docs/misra-deviations.md#d005
+misra-c2012-18.7:Core/Source/SolidSyslogCircularBuffer.c:26
+misra-c2012-18.7:Core/Source/SolidSyslogFormatter.c:12
+
+# D.006 — Rule 1.4: C11 <stdatomic.h>
+# See docs/misra-deviations.md#d006
+misra-c2012-1.4:Platform/Atomics/Source/SolidSyslogStdAtomicU32.c:19
+misra-c2012-1.4:Platform/Windows/Source/SolidSyslogWindowsAtomicU32.c:19
+
+# D.007 — Rule 11.8: const-strip false-positives + Winsock platform-API
+# See docs/misra-deviations.md#d007
+misra-c2012-11.8:Core/Source/BlockSequence.c:438
+misra-c2012-11.8:Core/Source/SolidSyslog.c:147
+misra-c2012-11.8:Core/Source/SolidSyslog.c:148
+misra-c2012-11.8:Core/Source/SolidSyslog.c:149
+misra-c2012-11.8:Core/Source/SolidSyslog.c:150
+misra-c2012-11.8:Core/Source/SolidSyslog.c:151
+misra-c2012-11.8:Core/Source/SolidSyslog.c:152
+misra-c2012-11.8:Core/Source/SolidSyslog.c:153
+misra-c2012-11.8:Core/Source/SolidSyslog.c:154
+misra-c2012-11.8:Core/Source/SolidSyslogBlockStore.c:62
+misra-c2012-11.8:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:82
+
+# D.008 — Rule 21.10: transitive <wchar.h> via <time.h>
+# See docs/misra-deviations.md#d008
+misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixClock.c:4
+misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixSleep.c:3
+misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixSysUpTime.c:3
+
+# D.009 — Rule 21.6: <stdio.h> for SEEK_* constants only
+# See docs/misra-deviations.md#d009
+misra-c2012-21.6:Platform/Windows/Source/SolidSyslogWindowsFile.c:8
+
+# D.010 — Rule 2.4: anonymous enum used as named-constant container
+# See docs/misra-deviations.md#d010
+misra-c2012-2.4:Core/Interface/SolidSyslogBlockStore.h:52
+misra-c2012-2.4:Core/Interface/SolidSyslogSecurityPolicyDefinition.h:13
+misra-c2012-2.4:Core/Interface/SolidSyslogTransport.h:5
+misra-c2012-2.4:Core/Source/BlockSequence.c:6
+misra-c2012-2.4:Core/Source/BlockSequence.c:92
+misra-c2012-2.4:Core/Source/SolidSyslogStreamSender.c:27


### PR DESCRIPTION
## Purpose

Closes #367. S10.06 — apply the verdicts locked in by S10.05's
conformance audit. Pure curation story: no source-code changes;
the deliverables are deviation documentation plus the
machine-readable suppression entries.

## Change Description

**Five planned deviations (D.002–D.006), four raised during curation
(D.007–D.010), one audit verdict revised.**

| Deviation | Rules | Findings suppressed | Driver |
|-----------|-------|--------------------:|--------|
| **D.002** | 11.2 / 11.3 / 11.5 | 109 | Opaque-impl + caller-supplied-storage — the project's OO-in-C mechanism |
| **D.003** | 5.7 | 54 | No-typedef-struct convention repeats tags at every forward-decl / definition pair |
| **D.004** | 18.4 | 4 | `RecordStore.c` walks `[magic][length][message]` via pointer arithmetic |
| **D.005** | 18.7 | 2 | Flexible array members in `SolidSyslogFormatter` + `SolidSyslogCircularBuffer` |
| **D.006** | 1.4 | 2 | C11 `<stdatomic.h>` in the Atomics adapter (link-time selected on legacy MSVC) |
| **D.007** | 11.8 | 11 | Audit said Mixed — turned out 10 are cppcheck-misra false-positives on member access through `const struct*`, 1 is the documented Winsock `select()` const-strip |
| **D.008** | 21.10 | 3 | Audit said Investigate — confirmed `<wchar.h>` is transitively pulled by `<time.h>` on glibc |
| **D.009** | 21.6 | 1 | Audit said Investigate — `WindowsFile.c` needs `<stdio.h>` solely for `SEEK_SET`/`SEEK_END` used by `_lseeki64` |
| **D.010** | 2.4 | 6 | Audit said Fix (1 site); re-run with D.003 applied revealed 5 more — all are the project's anonymous-`enum { … };` named-constant idiom (≈31 such blocks tree-wide). Verdict flipped Fix → Deviate. |

**Rule 5.1 63-character window** — no cppcheck-misra configuration
change required. The default 31-char enforcement is strictly stricter
than the 63-char deviation allows, current tree has 0 findings, and
the deviation only matters if a real collision ever resolves at 63
chars but not at 31. Decision recorded in D.001.

**Dual-rule sites** — the same opaque-impl cast at `Address.c:5` (×3
platforms) and `Formatter.h:30` triggers both 11.2 and 11.3.
`misra_suppressions.txt` lists both rule IDs at those four sites.

**Suppression file format quirk** — cppcheck rejects bare `#` lines
(comment markers with no text). All comment dividers use `# ` (hash
+ space). Discovered during the first verification run; recorded in
the DEVLOG.

## Test Evidence

cppcheck-misra warning-mode pass, before and after, regenerated using
the same command CI runs (gcc dev container, cppcheck 2.10):

```
Before:  575 findings across 29 rules
After:   388 findings across 18 rules — all Fix-target sweep items
Suppressed: 187 findings via D.002–D.010, 0 suppressed-rule leaks
```

Reconciliation: 575 = 187 + 388 cleanly when the 5 dual-rule sites
(reported under two rule IDs) are counted once each in the headline
575.

`docs/misra-conformance.md` updated for the three verdict revisions
(11.8 → all Deviate, 21.10 / 21.6 → Deviate, 2.4 → Deviate) and the
revised MISRA totals row. Audit doc remains the source of truth for
which sweep story owns each remaining Fix target.

## Areas Affected

- `docs/misra-deviations.md` — D.002 through D.010 appended, D.001's
  Risk-and-mitigation updated for the no-config-change decision,
  intro paragraph updated.
- `docs/misra-conformance.md` — verdict revisions for rules 11.8,
  21.10, 21.6, 2.4, and the MISRA totals row.
- `misra_suppressions.txt` — 187 line-specific entries grouped by
  D.NNN, regenerated cleanly via a single Python pass that
  deduplicates dual-rule sites.
- `DEVLOG.md` — session entry.

No source-code changes. CI's `analyze-cppcheck` job's non-MISRA pass
is unaffected (it doesn't load `misra_suppressions.txt`); the
MISRA pass still runs at `--error-exitcode=0` (warning mode), now
emitting 388 warnings down from 575. The flip to error mode is
S10.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MISRA C:2012 conformance audit documentation with revised rule verdicts and reclassified deviation records
  * Restructured suppression file with explicit deviation references for improved traceability
  * Added comprehensive deviation documentation including rationale, scope, and risk mitigation details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/368)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->