### PR TITLE
refactor: S10.08 static-function Class_ prefix sweep (MISRA 5.9 + NAMING.md Tier 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,8 +445,9 @@ code should follow them; reviewers should call out drift.
 - **Intent-naming static-inline predicates.** When a composite condition is
   inlined into an `if` or a `return`, extract a `static inline bool IsXxx(...)`
   helper. The helper's *name* is the documentation. Examples:
-  `IsAboveThreshold`, `IsHandleAlreadyOpenOnBlock`, `IsValidBlockIndex`,
-  `BlockIsFull`, `StoreIsFull`. The cost (one extra named function) is the
+  `BlockSequence_IsAboveThreshold`, `FileBlockDevice_IsHandleAlreadyOpenOnBlock`,
+  `FileBlockDevice_IsValidBlockIndex`, `BlockSequence_BlockIsFull`,
+  `BlockSequence_StoreIsFull`. The cost (one extra named function) is the
   benefit (the reader doesn't have to decode the boolean).
 - **One thing at one level of abstraction.** Functions read top-down.
   `_Create` first, `_Destroy` second, public functions in API order, helpers

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -9,12 +9,12 @@ enum
     SEQUENCE_MODULUS = 100
 };
 
-static inline uint8_t NextSequence(uint8_t current)
+static inline uint8_t BlockSequence_NextSequence(uint8_t current)
 {
     return (uint8_t) ((current + 1) % SEQUENCE_MODULUS);
 }
 
-static inline size_t BlockCount(const struct BlockSequence* blockSequence)
+static inline size_t BlockSequence_BlockCount(const struct BlockSequence* blockSequence)
 {
     return (size_t) ((blockSequence->writeSequence - blockSequence->oldestSequence + SEQUENCE_MODULUS) %
                      SEQUENCE_MODULUS) +
@@ -22,7 +22,7 @@ static inline size_t BlockCount(const struct BlockSequence* blockSequence)
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- value, min, max have distinct semantics
-static inline size_t ClampToRange(size_t value, size_t min, size_t max)
+static inline size_t BlockSequence_ClampToRange(size_t value, size_t min, size_t max)
 {
     size_t result = value;
 
@@ -43,7 +43,7 @@ void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockS
 {
     blockSequence->blockDevice = config->blockDevice;
     blockSequence->maxBlockSize = config->maxBlockSize;
-    blockSequence->maxBlocks = ClampToRange(config->maxBlocks, MIN_MAX_BLOCKS, MAX_MAX_BLOCKS);
+    blockSequence->maxBlocks = BlockSequence_ClampToRange(config->maxBlocks, MIN_MAX_BLOCKS, MAX_MAX_BLOCKS);
     blockSequence->discardPolicy = config->discardPolicy;
     blockSequence->onStoreFull = config->onStoreFull;
     blockSequence->storeFullContext = config->storeFullContext;
@@ -61,12 +61,12 @@ void BlockSequence_Init(struct BlockSequence* blockSequence, const struct BlockS
     blockSequence->writeBlockCorrupt = false;
 }
 
-static bool ScanForExistingBlocks(struct BlockSequence* blockSequence);
-static inline void NotifyThresholdCrossed(struct BlockSequence* blockSequence);
+static bool BlockSequence_ScanForExistingBlocks(struct BlockSequence* blockSequence);
+static inline void BlockSequence_NotifyThresholdCrossed(struct BlockSequence* blockSequence);
 
 bool BlockSequence_Open(struct BlockSequence* blockSequence)
 {
-    bool foundExistingBlocks = ScanForExistingBlocks(blockSequence);
+    bool foundExistingBlocks = BlockSequence_ScanForExistingBlocks(blockSequence);
     bool ready = false;
 
     if (foundExistingBlocks)
@@ -82,7 +82,7 @@ bool BlockSequence_Open(struct BlockSequence* blockSequence)
 
     if (ready)
     {
-        NotifyThresholdCrossed(blockSequence); /* fire on resume if usage already at-or-above threshold */
+        BlockSequence_NotifyThresholdCrossed(blockSequence); /* fire on resume if usage already at-or-above threshold */
     }
 
     return ready;
@@ -101,11 +101,11 @@ struct BlockPresence
     int firstAbsent;
 };
 
-static inline int CircularPrev(int index);
-static inline int CircularNext(int index);
-static void ScanForBlockPresence(struct BlockSequence* blockSequence, struct BlockPresence* presence);
+static inline int BlockSequence_CircularPrev(int index);
+static inline int BlockSequence_CircularNext(int index);
+static void BlockSequence_ScanForBlockPresence(struct BlockSequence* blockSequence, struct BlockPresence* presence);
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- oldest / newest are positional run endpoints; distinct semantics
-static void LocateRunBoundaries(const struct BlockPresence* presence, int* oldest, int* newest);
+static void BlockSequence_LocateRunBoundaries(const struct BlockPresence* presence, int* oldest, int* newest);
 
 /* The on-disk block set is a single contiguous run in the circular sequence
  * space [0, MAX_SEQUENCE). After enough rotations the run straddles the
@@ -113,16 +113,16 @@ static void LocateRunBoundaries(const struct BlockPresence* presence, int* oldes
  * highest=write mis-classifies wrapped runs, so locate the gap (the absent
  * blocks) and read the run as the complement: oldest sits one past the gap
  * end, write sits one before the gap start. */
-static bool ScanForExistingBlocks(struct BlockSequence* blockSequence)
+static bool BlockSequence_ScanForExistingBlocks(struct BlockSequence* blockSequence)
 {
     struct BlockPresence presence;
-    ScanForBlockPresence(blockSequence, &presence);
+    BlockSequence_ScanForBlockPresence(blockSequence, &presence);
 
     if (presence.foundAny)
     {
         int oldest = 0;
         int newest = MAX_SEQUENCE - 1;
-        LocateRunBoundaries(&presence, &oldest, &newest);
+        BlockSequence_LocateRunBoundaries(&presence, &oldest, &newest);
 
         blockSequence->oldestSequence = (uint8_t) oldest;
         blockSequence->readSequence = (uint8_t) oldest;
@@ -132,7 +132,7 @@ static bool ScanForExistingBlocks(struct BlockSequence* blockSequence)
     return presence.foundAny;
 }
 
-static void ScanForBlockPresence(struct BlockSequence* blockSequence, struct BlockPresence* presence)
+static void BlockSequence_ScanForBlockPresence(struct BlockSequence* blockSequence, struct BlockPresence* presence)
 {
     presence->foundAny = false;
     presence->foundAbsent = false;
@@ -155,20 +155,20 @@ static void ScanForBlockPresence(struct BlockSequence* blockSequence, struct Blo
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- oldest / newest are positional run endpoints; distinct semantics
-static void LocateRunBoundaries(const struct BlockPresence* presence, int* oldest, int* newest)
+static void BlockSequence_LocateRunBoundaries(const struct BlockPresence* presence, int* oldest, int* newest)
 {
     if (presence->foundAbsent)
     {
-        *oldest = CircularNext(presence->firstAbsent);
+        *oldest = BlockSequence_CircularNext(presence->firstAbsent);
         while (!presence->present[*oldest])
         {
-            *oldest = CircularNext(*oldest);
+            *oldest = BlockSequence_CircularNext(*oldest);
         }
 
-        *newest = CircularPrev(presence->firstAbsent);
+        *newest = BlockSequence_CircularPrev(presence->firstAbsent);
         while (!presence->present[*newest])
         {
-            *newest = CircularPrev(*newest);
+            *newest = BlockSequence_CircularPrev(*newest);
         }
     }
     /* else: every block is present — maxBlocks is clamped to MAX_SEQUENCE - 1
@@ -176,55 +176,55 @@ static void LocateRunBoundaries(const struct BlockPresence* presence, int* oldes
      * for oldest=0, newest=MAX_SEQUENCE-1 stand. */
 }
 
-static inline int CircularNext(int index)
+static inline int BlockSequence_CircularNext(int index)
 {
     return (index + 1) % MAX_SEQUENCE;
 }
 
-static inline int CircularPrev(int index)
+static inline int BlockSequence_CircularPrev(int index)
 {
     return (index + MAX_SEQUENCE - 1) % MAX_SEQUENCE;
 }
 
-static inline bool BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize);
-static inline bool StoreIsFull(const struct BlockSequence* blockSequence);
-static inline void NotifyStoreFull(struct BlockSequence* blockSequence);
-static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged);
+static inline bool BlockSequence_BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize);
+static inline bool BlockSequence_StoreIsFull(const struct BlockSequence* blockSequence);
+static inline void BlockSequence_NotifyStoreFull(struct BlockSequence* blockSequence);
+static bool BlockSequence_RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged);
 
 bool BlockSequence_PrepareForWrite(struct BlockSequence* blockSequence, size_t recordSize, bool* readBlockChanged)
 {
-    bool blockFull = BlockIsFull(blockSequence, recordSize);
+    bool blockFull = BlockSequence_BlockIsFull(blockSequence, recordSize);
     bool spaceAvailable = true;
     *readBlockChanged = false;
 
-    if (blockFull && StoreIsFull(blockSequence))
+    if (blockFull && BlockSequence_StoreIsFull(blockSequence))
     {
         blockSequence->atCapacity = true; /* sticky 100% — fixes UsedBytes at total */
-        NotifyThresholdCrossed(blockSequence); /* threshold first per S05.09 ordering */
-        NotifyStoreFull(blockSequence);
+        BlockSequence_NotifyThresholdCrossed(blockSequence); /* threshold first per S05.09 ordering */
+        BlockSequence_NotifyStoreFull(blockSequence);
         spaceAvailable = false;
     }
     else if (blockFull)
     {
-        spaceAvailable = RotateToNextBlock(blockSequence, readBlockChanged);
+        spaceAvailable = BlockSequence_RotateToNextBlock(blockSequence, readBlockChanged);
     }
 
     return spaceAvailable;
 }
 
-static inline bool BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize)
+static inline bool BlockSequence_BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize)
 {
     return (blockSequence->writeBlockCorrupt) ||
            ((blockSequence->writePosition + recordSize) > blockSequence->maxBlockSize);
 }
 
-static inline bool StoreIsFull(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_StoreIsFull(const struct BlockSequence* blockSequence)
 {
-    return (BlockCount(blockSequence) >= blockSequence->maxBlocks) &&
+    return (BlockSequence_BlockCount(blockSequence) >= blockSequence->maxBlocks) &&
            (blockSequence->discardPolicy != SolidSyslogDiscardPolicy_Oldest);
 }
 
-static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
+static inline void BlockSequence_NotifyStoreFull(struct BlockSequence* blockSequence)
 {
     if ((blockSequence->discardPolicy == SolidSyslogDiscardPolicy_Halt) && !blockSequence->halted)
     {
@@ -237,32 +237,32 @@ static inline void NotifyStoreFull(struct BlockSequence* blockSequence)
     }
 }
 
-static bool DiscardOldestBlock(struct BlockSequence* blockSequence);
-static void ResetReadToOldest(struct BlockSequence* blockSequence);
+static bool BlockSequence_DiscardOldestBlock(struct BlockSequence* blockSequence);
+static void BlockSequence_ResetReadToOldest(struct BlockSequence* blockSequence);
 
-static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence);
-static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence);
-static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex);
+static inline void BlockSequence_AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence);
+static inline bool BlockSequence_ExceedsMaxBlocks(const struct BlockSequence* blockSequence);
+static inline bool BlockSequence_AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex);
 
-static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged)
+static bool BlockSequence_RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlockChanged)
 {
-    uint8_t nextSequence = NextSequence(blockSequence->writeSequence);
-    bool acquired = AcquireEmptyBlock(blockSequence->blockDevice, nextSequence);
+    uint8_t nextSequence = BlockSequence_NextSequence(blockSequence->writeSequence);
+    bool acquired = BlockSequence_AcquireEmptyBlock(blockSequence->blockDevice, nextSequence);
 
     *readBlockChanged = false;
 
     if (acquired)
     {
-        AdvanceWriteToNewBlock(blockSequence, nextSequence);
+        BlockSequence_AdvanceWriteToNewBlock(blockSequence, nextSequence);
 
-        if (ExceedsMaxBlocks(blockSequence))
+        if (BlockSequence_ExceedsMaxBlocks(blockSequence))
         {
-            *readBlockChanged = DiscardOldestBlock(blockSequence);
+            *readBlockChanged = BlockSequence_DiscardOldestBlock(blockSequence);
         }
 
         /* Sealing the prior write block can re-arm dispose-on-empty: drain that
          * fully MarkSent the block before rotation could not fire here because
-         * IsReadBlockActiveWrite was true at MarkSent time. Re-evaluate now. */
+         * BlockSequence_IsReadBlockActiveWrite was true at MarkSent time. Re-evaluate now. */
         bool disposedAfterRotate = false;
         BlockSequence_DisposeReadBlockIfDrained(blockSequence, &disposedAfterRotate);
         *readBlockChanged = *readBlockChanged || disposedAfterRotate;
@@ -281,7 +281,7 @@ static bool RotateToNextBlock(struct BlockSequence* blockSequence, bool* readBlo
  * a "verify-and-use" flash driver (S18.04 design notes) would Acquire-fail on
  * the still-stale block anyway, and skipping the wasted Acquire keeps callers'
  * retry path (slice 3) symmetric with the dispose-failure path. */
-static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex)
+static inline bool BlockSequence_AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size_t blockIndex)
 {
     bool ready = true;
 
@@ -298,30 +298,30 @@ static inline bool AcquireEmptyBlock(struct SolidSyslogBlockDevice* device, size
     return ready;
 }
 
-static inline void AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence)
+static inline void BlockSequence_AdvanceWriteToNewBlock(struct BlockSequence* blockSequence, uint8_t nextSequence)
 {
     blockSequence->writeSequence = nextSequence;
     blockSequence->writePosition = 0;
     blockSequence->writeBlockCorrupt = false;
 }
 
-static inline bool ExceedsMaxBlocks(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_ExceedsMaxBlocks(const struct BlockSequence* blockSequence)
 {
-    return BlockCount(blockSequence) > blockSequence->maxBlocks;
+    return BlockSequence_BlockCount(blockSequence) > blockSequence->maxBlocks;
 }
 
-static bool DiscardOldestBlock(struct BlockSequence* blockSequence)
+static bool BlockSequence_DiscardOldestBlock(struct BlockSequence* blockSequence)
 {
     bool readBlockChanged = false;
 
     if (SolidSyslogBlockDevice_Dispose(blockSequence->blockDevice, blockSequence->oldestSequence))
     {
         bool readingOldestBlock = (blockSequence->readSequence == blockSequence->oldestSequence);
-        blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
+        blockSequence->oldestSequence = BlockSequence_NextSequence(blockSequence->oldestSequence);
 
         if (readingOldestBlock)
         {
-            ResetReadToOldest(blockSequence);
+            BlockSequence_ResetReadToOldest(blockSequence);
             readBlockChanged = true;
         }
     }
@@ -329,7 +329,7 @@ static bool DiscardOldestBlock(struct BlockSequence* blockSequence)
     return readBlockChanged;
 }
 
-static void ResetReadToOldest(struct BlockSequence* blockSequence)
+static void BlockSequence_ResetReadToOldest(struct BlockSequence* blockSequence)
 {
     blockSequence->readSequence = blockSequence->oldestSequence;
     blockSequence->readCursor = 0;
@@ -348,19 +348,19 @@ size_t BlockSequence_WriteSequence(const struct BlockSequence* blockSequence)
 void BlockSequence_NoteRecordWritten(struct BlockSequence* blockSequence, size_t recordSize)
 {
     blockSequence->writePosition += recordSize;
-    NotifyThresholdCrossed(blockSequence);
+    BlockSequence_NotifyThresholdCrossed(blockSequence);
 }
 
-static inline bool ThresholdEnabled(const struct BlockSequence* blockSequence);
-static inline bool IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold);
+static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence);
+static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold);
 
-static inline void NotifyThresholdCrossed(struct BlockSequence* blockSequence)
+static inline void BlockSequence_NotifyThresholdCrossed(struct BlockSequence* blockSequence)
 {
-    if (ThresholdEnabled(blockSequence))
+    if (BlockSequence_ThresholdEnabled(blockSequence))
     {
         size_t threshold = blockSequence->getCapacityThreshold(blockSequence->thresholdContext);
 
-        if (!IsAboveThreshold(blockSequence, threshold))
+        if (!BlockSequence_IsAboveThreshold(blockSequence, threshold))
         {
             blockSequence->thresholdCrossed = false;
         }
@@ -372,12 +372,12 @@ static inline void NotifyThresholdCrossed(struct BlockSequence* blockSequence)
     }
 }
 
-static inline bool ThresholdEnabled(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence)
 {
     return (blockSequence->onThresholdCrossed != NULL) && (blockSequence->getCapacityThreshold != NULL);
 }
 
-static inline bool IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold)
+static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold)
 {
     return (threshold != 0) && (BlockSequence_UsedBytes(blockSequence) >= threshold);
 }
@@ -402,53 +402,53 @@ void BlockSequence_SetReadCursor(struct BlockSequence* blockSequence, size_t cur
     blockSequence->readCursor = cursor;
 }
 
-static inline bool IsReadBlockActiveWrite(const struct BlockSequence* blockSequence);
-static inline bool IsReadBlockOldest(const struct BlockSequence* blockSequence);
-static inline bool IsReadBlockFullyDrained(const struct BlockSequence* blockSequence);
-static inline void AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence);
+static inline bool BlockSequence_IsReadBlockActiveWrite(const struct BlockSequence* blockSequence);
+static inline bool BlockSequence_IsReadBlockOldest(const struct BlockSequence* blockSequence);
+static inline bool BlockSequence_IsReadBlockFullyDrained(const struct BlockSequence* blockSequence);
+static inline void BlockSequence_AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence);
 
 void BlockSequence_DisposeReadBlockIfDrained(struct BlockSequence* blockSequence, bool* readBlockChanged)
 {
     *readBlockChanged = false;
 
-    if (!IsReadBlockActiveWrite(blockSequence) && IsReadBlockOldest(blockSequence) &&
-        IsReadBlockFullyDrained(blockSequence))
+    if (!BlockSequence_IsReadBlockActiveWrite(blockSequence) && BlockSequence_IsReadBlockOldest(blockSequence) &&
+        BlockSequence_IsReadBlockFullyDrained(blockSequence))
     {
         if (SolidSyslogBlockDevice_Dispose(blockSequence->blockDevice, blockSequence->readSequence))
         {
-            AdvancePastDrainedReadBlock(blockSequence);
+            BlockSequence_AdvancePastDrainedReadBlock(blockSequence);
             *readBlockChanged = true;
         }
     }
 }
 
-static inline bool IsReadBlockActiveWrite(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_IsReadBlockActiveWrite(const struct BlockSequence* blockSequence)
 {
     return blockSequence->readSequence == blockSequence->writeSequence;
 }
 
-static inline bool IsReadBlockOldest(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_IsReadBlockOldest(const struct BlockSequence* blockSequence)
 {
     return blockSequence->readSequence == blockSequence->oldestSequence;
 }
 
-static inline bool IsReadBlockFullyDrained(const struct BlockSequence* blockSequence)
+static inline bool BlockSequence_IsReadBlockFullyDrained(const struct BlockSequence* blockSequence)
 {
     return blockSequence->readCursor >=
            SolidSyslogBlockDevice_Size(blockSequence->blockDevice, blockSequence->readSequence);
 }
 
-static inline void AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence)
+static inline void BlockSequence_AdvancePastDrainedReadBlock(struct BlockSequence* blockSequence)
 {
-    blockSequence->oldestSequence = NextSequence(blockSequence->oldestSequence);
+    blockSequence->oldestSequence = BlockSequence_NextSequence(blockSequence->oldestSequence);
     blockSequence->readSequence = blockSequence->oldestSequence;
     blockSequence->readCursor = 0;
-    NotifyThresholdCrossed(blockSequence);
+    BlockSequence_NotifyThresholdCrossed(blockSequence);
 }
 
 void BlockSequence_AdvanceToNextReadBlock(struct BlockSequence* blockSequence)
 {
-    blockSequence->readSequence = NextSequence(blockSequence->readSequence);
+    blockSequence->readSequence = BlockSequence_NextSequence(blockSequence->readSequence);
     blockSequence->readCursor = 0;
 }
 
@@ -482,7 +482,7 @@ size_t BlockSequence_UsedBytes(const struct BlockSequence* blockSequence)
     }
     else
     {
-        size_t closedBlocks = BlockCount(blockSequence) - 1;
+        size_t closedBlocks = BlockSequence_BlockCount(blockSequence) - 1;
         used = (closedBlocks * blockSequence->maxBlockSize) + blockSequence->writePosition;
     }
 

--- a/Core/Source/RecordStore.c
+++ b/Core/Source/RecordStore.c
@@ -22,49 +22,49 @@ enum
  * field offsets are stated in one place each. The same chaining shapes
  * the block-offset helpers below. */
 
-static inline uint8_t* MagicAddress(struct RecordStore* recordStore)
+static inline uint8_t* RecordStore_MagicAddress(struct RecordStore* recordStore)
 {
     return recordStore->buffer;
 }
 
-static inline uint8_t* LengthAddress(struct RecordStore* recordStore)
+static inline uint8_t* RecordStore_LengthAddress(struct RecordStore* recordStore)
 {
-    return MagicAddress(recordStore) + MAGIC_SIZE;
+    return RecordStore_MagicAddress(recordStore) + MAGIC_SIZE;
 }
 
-static inline uint8_t* MessageAddress(struct RecordStore* recordStore)
+static inline uint8_t* RecordStore_MessageAddress(struct RecordStore* recordStore)
 {
-    return LengthAddress(recordStore) + RECORD_LENGTH_SIZE;
+    return RecordStore_LengthAddress(recordStore) + RECORD_LENGTH_SIZE;
 }
 
-static inline uint8_t* IntegrityChecksumAddress(struct RecordStore* recordStore, size_t dataSize)
+static inline uint8_t* RecordStore_IntegrityChecksumAddress(struct RecordStore* recordStore, size_t dataSize)
 {
-    return MessageAddress(recordStore) + dataSize;
+    return RecordStore_MessageAddress(recordStore) + dataSize;
 }
 
-static inline uint8_t* SentFlagAddress(struct RecordStore* recordStore, size_t dataSize)
+static inline uint8_t* RecordStore_SentFlagAddress(struct RecordStore* recordStore, size_t dataSize)
 {
-    return IntegrityChecksumAddress(recordStore, dataSize) + recordStore->securityPolicy->integritySize;
+    return RecordStore_IntegrityChecksumAddress(recordStore, dataSize) + recordStore->securityPolicy->integritySize;
 }
 
-static inline uint8_t* IntegrityRegionAddress(struct RecordStore* recordStore)
+static inline uint8_t* RecordStore_IntegrityRegionAddress(struct RecordStore* recordStore)
 {
-    return MagicAddress(recordStore);
+    return RecordStore_MagicAddress(recordStore);
 }
 
-static inline uint16_t IntegrityRegionSize(size_t dataSize)
+static inline uint16_t RecordStore_IntegrityRegionSize(size_t dataSize)
 {
     return (uint16_t) (MAGIC_SIZE + RECORD_LENGTH_SIZE + dataSize);
 }
 
-static inline size_t IntegrityChecksumOffset(size_t recordStart, uint16_t dataLength)
+static inline size_t RecordStore_IntegrityChecksumOffset(size_t recordStart, uint16_t dataLength)
 {
     return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
 }
 
-static inline size_t SentFlagOffset(const struct RecordStore* recordStore, size_t recordStart, uint16_t dataLength)
+static inline size_t RecordStore_SentFlagOffset(const struct RecordStore* recordStore, size_t recordStart, uint16_t dataLength)
 {
-    return IntegrityChecksumOffset(recordStart, dataLength) + recordStore->securityPolicy->integritySize;
+    return RecordStore_IntegrityChecksumOffset(recordStart, dataLength) + recordStore->securityPolicy->integritySize;
 }
 
 void RecordStore_Init(struct RecordStore* recordStore, struct SolidSyslogSecurityPolicy* securityPolicy)
@@ -81,7 +81,7 @@ size_t RecordStore_RecordSize(const struct RecordStore* recordStore, uint16_t da
            SENT_FLAG_SIZE;
 }
 
-static inline void AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size);
+static inline void RecordStore_AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size);
 
 bool RecordStore_Append(
     struct RecordStore* recordStore,
@@ -91,7 +91,7 @@ bool RecordStore_Append(
     size_t dataSize
 )
 {
-    AssembleRecord(recordStore, data, dataSize);
+    RecordStore_AssembleRecord(recordStore, data, dataSize);
     return SolidSyslogBlockDevice_Append(
         blockDevice,
         blockIndex,
@@ -100,32 +100,32 @@ bool RecordStore_Append(
     );
 }
 
-static inline void AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size)
+static inline void RecordStore_AssembleRecord(struct RecordStore* recordStore, const void* data, size_t size)
 {
-    MagicAddress(recordStore)[0] = MAGIC_BYTE_0;
-    MagicAddress(recordStore)[1] = MAGIC_BYTE_1;
+    RecordStore_MagicAddress(recordStore)[0] = MAGIC_BYTE_0;
+    RecordStore_MagicAddress(recordStore)[1] = MAGIC_BYTE_1;
 
     uint16_t length = (uint16_t) size;
-    memcpy(LengthAddress(recordStore), &length, RECORD_LENGTH_SIZE);
-    memcpy(MessageAddress(recordStore), data, size);
+    memcpy(RecordStore_LengthAddress(recordStore), &length, RECORD_LENGTH_SIZE);
+    memcpy(RecordStore_MessageAddress(recordStore), data, size);
 
     recordStore->securityPolicy->ComputeIntegrity(
-        IntegrityRegionAddress(recordStore),
-        IntegrityRegionSize(size),
-        IntegrityChecksumAddress(recordStore, size)
+        RecordStore_IntegrityRegionAddress(recordStore),
+        RecordStore_IntegrityRegionSize(size),
+        RecordStore_IntegrityChecksumAddress(recordStore, size)
     );
 
-    *SentFlagAddress(recordStore, size) = SENT_FLAG_UNSENT;
+    *RecordStore_SentFlagAddress(recordStore, size) = SENT_FLAG_UNSENT;
 }
 
-static bool ReadAndValidateRecord(
+static bool RecordStore_ReadAndValidateRecord(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
     size_t offset,
     uint16_t* length
 );
-static inline void CopyRecordData(
+static inline void RecordStore_CopyRecordData(
     struct RecordStore* recordStore,
     uint16_t length,
     void* dst,
@@ -133,7 +133,7 @@ static inline void CopyRecordData(
     size_t* bytesRead
 );
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- blockIndex / offset are positional fields of the just-read record; distinct semantics
-static inline void RememberCurrentRecord(
+static inline void RecordStore_RememberCurrentRecord(
     struct RecordStore* recordStore,
     size_t blockIndex,
     size_t offset,
@@ -157,40 +157,40 @@ bool RecordStore_Read(
 
     *bytesRead = 0;
 
-    if (ReadAndValidateRecord(recordStore, blockDevice, blockIndex, offset, &length))
+    if (RecordStore_ReadAndValidateRecord(recordStore, blockDevice, blockIndex, offset, &length))
     {
-        CopyRecordData(recordStore, length, dst, maxSize, bytesRead);
-        RememberCurrentRecord(recordStore, blockIndex, offset, length);
+        RecordStore_CopyRecordData(recordStore, length, dst, maxSize, bytesRead);
+        RecordStore_RememberCurrentRecord(recordStore, blockIndex, offset, length);
         read = *bytesRead > 0;
     }
 
     return read;
 }
 
-static inline bool ReadRecordHeader(
+static inline bool RecordStore_ReadRecordHeader(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
     size_t offset
 );
-static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* length);
-static inline bool ReadRecordBody(
+static inline bool RecordStore_ValidateHeader(struct RecordStore* recordStore, uint16_t* length);
+static inline bool RecordStore_ReadRecordBody(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
     size_t offset,
     uint16_t length
 );
-static inline bool ReadIntegrityChecksum(
+static inline bool RecordStore_ReadIntegrityChecksum(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
     size_t recordStart,
     uint16_t dataLength
 );
-static inline bool VerifyIntegrity(struct RecordStore* recordStore, uint16_t length);
+static inline bool RecordStore_VerifyIntegrity(struct RecordStore* recordStore, uint16_t length);
 
-static bool ReadAndValidateRecord(
+static bool RecordStore_ReadAndValidateRecord(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -198,13 +198,13 @@ static bool ReadAndValidateRecord(
     uint16_t* length
 )
 {
-    return ReadRecordHeader(recordStore, blockDevice, blockIndex, offset) && ValidateHeader(recordStore, length) &&
-           ReadRecordBody(recordStore, blockDevice, blockIndex, offset, *length) &&
-           ReadIntegrityChecksum(recordStore, blockDevice, blockIndex, offset, *length) &&
-           VerifyIntegrity(recordStore, *length);
+    return RecordStore_ReadRecordHeader(recordStore, blockDevice, blockIndex, offset) && RecordStore_ValidateHeader(recordStore, length) &&
+           RecordStore_ReadRecordBody(recordStore, blockDevice, blockIndex, offset, *length) &&
+           RecordStore_ReadIntegrityChecksum(recordStore, blockDevice, blockIndex, offset, *length) &&
+           RecordStore_VerifyIntegrity(recordStore, *length);
 }
 
-static inline bool ReadRecordHeader(
+static inline bool RecordStore_ReadRecordHeader(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -215,43 +215,43 @@ static inline bool ReadRecordHeader(
         blockDevice,
         blockIndex,
         offset,
-        IntegrityRegionAddress(recordStore),
+        RecordStore_IntegrityRegionAddress(recordStore),
         MAGIC_SIZE + RECORD_LENGTH_SIZE
     );
 }
 
-static inline bool IsMagicValid(struct RecordStore* recordStore)
+static inline bool RecordStore_IsMagicValid(struct RecordStore* recordStore)
 {
-    return (MagicAddress(recordStore)[0] == MAGIC_BYTE_0) && (MagicAddress(recordStore)[1] == MAGIC_BYTE_1);
+    return (RecordStore_MagicAddress(recordStore)[0] == MAGIC_BYTE_0) && (RecordStore_MagicAddress(recordStore)[1] == MAGIC_BYTE_1);
 }
 
-static inline uint16_t RecordLength(struct RecordStore* recordStore)
+static inline uint16_t RecordStore_RecordLength(struct RecordStore* recordStore)
 {
     uint16_t length = 0;
-    memcpy(&length, LengthAddress(recordStore), RECORD_LENGTH_SIZE);
+    memcpy(&length, RecordStore_LengthAddress(recordStore), RECORD_LENGTH_SIZE);
     return length;
 }
 
-static inline bool IsValidLength(uint16_t length)
+static inline bool RecordStore_IsValidLength(uint16_t length)
 {
     return length <= SOLIDSYSLOG_MAX_MESSAGE_SIZE;
 }
 
-static inline bool ValidateHeader(struct RecordStore* recordStore, uint16_t* length)
+static inline bool RecordStore_ValidateHeader(struct RecordStore* recordStore, uint16_t* length)
 {
-    bool valid = IsMagicValid(recordStore);
+    bool valid = RecordStore_IsMagicValid(recordStore);
 
     if (valid)
     {
-        *length = RecordLength(recordStore);
-        valid = IsValidLength(*length);
+        *length = RecordStore_RecordLength(recordStore);
+        valid = RecordStore_IsValidLength(*length);
     }
 
     return valid;
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- offset is a block position, length is a data size; distinct semantics
-static inline bool ReadRecordBody(
+static inline bool RecordStore_ReadRecordBody(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -263,14 +263,14 @@ static inline bool ReadRecordBody(
         blockDevice,
         blockIndex,
         offset + MAGIC_SIZE + RECORD_LENGTH_SIZE,
-        MessageAddress(recordStore),
+        RecordStore_MessageAddress(recordStore),
         length
     );
 }
 
 // NOLINTEND(bugprone-easily-swappable-parameters)
 
-static inline bool ReadIntegrityChecksum(
+static inline bool RecordStore_ReadIntegrityChecksum(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -281,27 +281,27 @@ static inline bool ReadIntegrityChecksum(
     return SolidSyslogBlockDevice_Read(
         blockDevice,
         blockIndex,
-        IntegrityChecksumOffset(recordStart, dataLength),
-        IntegrityChecksumAddress(recordStore, dataLength),
+        RecordStore_IntegrityChecksumOffset(recordStart, dataLength),
+        RecordStore_IntegrityChecksumAddress(recordStore, dataLength),
         recordStore->securityPolicy->integritySize
     );
 }
 
-static inline bool VerifyIntegrity(struct RecordStore* recordStore, uint16_t length)
+static inline bool RecordStore_VerifyIntegrity(struct RecordStore* recordStore, uint16_t length)
 {
     return recordStore->securityPolicy->VerifyIntegrity(
-        IntegrityRegionAddress(recordStore),
-        IntegrityRegionSize(length),
-        IntegrityChecksumAddress(recordStore, length)
+        RecordStore_IntegrityRegionAddress(recordStore),
+        RecordStore_IntegrityRegionSize(length),
+        RecordStore_IntegrityChecksumAddress(recordStore, length)
     );
 }
 
-static inline size_t BoundedSize(uint16_t length, size_t maxSize)
+static inline size_t RecordStore_BoundedSize(uint16_t length, size_t maxSize)
 {
     return (length < maxSize) ? length : maxSize;
 }
 
-static inline void CopyRecordData(
+static inline void RecordStore_CopyRecordData(
     struct RecordStore* recordStore,
     uint16_t length,
     void* dst,
@@ -309,13 +309,13 @@ static inline void CopyRecordData(
     size_t* bytesRead
 )
 {
-    size_t copySize = BoundedSize(length, maxSize);
-    memcpy(dst, MessageAddress(recordStore), copySize);
+    size_t copySize = RecordStore_BoundedSize(length, maxSize);
+    memcpy(dst, RecordStore_MessageAddress(recordStore), copySize);
     *bytesRead = copySize;
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- blockIndex / offset are positional fields of the just-read record; distinct semantics
-static inline void RememberCurrentRecord(
+static inline void RecordStore_RememberCurrentRecord(
     struct RecordStore* recordStore,
     size_t blockIndex,
     size_t offset,
@@ -323,13 +323,13 @@ static inline void RememberCurrentRecord(
 )
 {
     recordStore->lastReadBlockIndex = blockIndex;
-    recordStore->lastSentFlagOffset = SentFlagOffset(recordStore, offset, length);
+    recordStore->lastSentFlagOffset = RecordStore_SentFlagOffset(recordStore, offset, length);
     recordStore->hasReadRecord = true;
 }
 
 // NOLINTEND(bugprone-easily-swappable-parameters)
 
-static inline bool WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice);
+static inline bool RecordStore_WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice);
 
 bool RecordStore_MarkLastReadAsSent(
     struct RecordStore* recordStore,
@@ -339,7 +339,7 @@ bool RecordStore_MarkLastReadAsSent(
 {
     bool marked = false;
 
-    if (recordStore->hasReadRecord && WriteSentFlag(recordStore, blockDevice))
+    if (recordStore->hasReadRecord && RecordStore_WriteSentFlag(recordStore, blockDevice))
     {
         *nextCursor = recordStore->lastSentFlagOffset + SENT_FLAG_SIZE;
         recordStore->hasReadRecord = false;
@@ -349,7 +349,7 @@ bool RecordStore_MarkLastReadAsSent(
     return marked;
 }
 
-static inline bool WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice)
+static inline bool RecordStore_WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice)
 {
     uint8_t flag = SENT_FLAG_SENT;
     return SolidSyslogBlockDevice_WriteAt(
@@ -366,7 +366,7 @@ void RecordStore_ForgetLastRead(struct RecordStore* recordStore)
     recordStore->hasReadRecord = false;
 }
 
-static bool AdvancePastSentRecord(
+static bool RecordStore_AdvancePastSentRecord(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -374,14 +374,14 @@ static bool AdvancePastSentRecord(
     size_t blockSize,
     bool* corrupt
 );
-static inline bool IsRecordSent(
+static inline bool RecordStore_IsRecordSent(
     const struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
     size_t recordStart,
     uint16_t length
 );
-static inline void SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length);
+static inline void RecordStore_SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length);
 
 size_t RecordStore_FindFirstUnsent(
     struct RecordStore* recordStore,
@@ -397,13 +397,13 @@ size_t RecordStore_FindFirstUnsent(
 
     while (scanning && (cursor < blockSize))
     {
-        scanning = AdvancePastSentRecord(recordStore, blockDevice, blockIndex, &cursor, blockSize, corrupt);
+        scanning = RecordStore_AdvancePastSentRecord(recordStore, blockDevice, blockIndex, &cursor, blockSize, corrupt);
     }
 
     return cursor;
 }
 
-static bool AdvancePastSentRecord(
+static bool RecordStore_AdvancePastSentRecord(
     struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -415,11 +415,11 @@ static bool AdvancePastSentRecord(
     uint16_t length = 0;
     bool advanced = false;
 
-    if (ReadAndValidateRecord(recordStore, blockDevice, blockIndex, *cursor, &length))
+    if (RecordStore_ReadAndValidateRecord(recordStore, blockDevice, blockIndex, *cursor, &length))
     {
-        if (IsRecordSent(recordStore, blockDevice, blockIndex, *cursor, length))
+        if (RecordStore_IsRecordSent(recordStore, blockDevice, blockIndex, *cursor, length))
         {
-            SkipRecord(recordStore, cursor, length);
+            RecordStore_SkipRecord(recordStore, cursor, length);
             advanced = true;
         }
     }
@@ -440,7 +440,7 @@ static bool AdvancePastSentRecord(
  * downstream as a sequenceId gap (RFC 5424 §6.3.1), which the receiver
  * can detect; an integrator-supplied error reporter will surface
  * persistent media errors directly when that path lands. */
-static inline bool IsRecordSent(
+static inline bool RecordStore_IsRecordSent(
     const struct RecordStore* recordStore,
     struct SolidSyslogBlockDevice* blockDevice,
     size_t blockIndex,
@@ -452,14 +452,14 @@ static inline bool IsRecordSent(
     SolidSyslogBlockDevice_Read(
         blockDevice,
         blockIndex,
-        SentFlagOffset(recordStore, recordStart, length),
+        RecordStore_SentFlagOffset(recordStore, recordStart, length),
         &flag,
         SENT_FLAG_SIZE
     );
     return flag == SENT_FLAG_SENT;
 }
 
-static inline void SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length)
+static inline void RecordStore_SkipRecord(const struct RecordStore* recordStore, size_t* cursor, uint16_t length)
 {
     *cursor += RecordStore_RecordSize(recordStore, length);
 }

--- a/Core/Source/RecordStore.c
+++ b/Core/Source/RecordStore.c
@@ -62,7 +62,11 @@ static inline size_t RecordStore_IntegrityChecksumOffset(size_t recordStart, uin
     return recordStart + MAGIC_SIZE + RECORD_LENGTH_SIZE + dataLength;
 }
 
-static inline size_t RecordStore_SentFlagOffset(const struct RecordStore* recordStore, size_t recordStart, uint16_t dataLength)
+static inline size_t RecordStore_SentFlagOffset(
+    const struct RecordStore* recordStore,
+    size_t recordStart,
+    uint16_t dataLength
+)
 {
     return RecordStore_IntegrityChecksumOffset(recordStart, dataLength) + recordStore->securityPolicy->integritySize;
 }
@@ -198,7 +202,8 @@ static bool RecordStore_ReadAndValidateRecord(
     uint16_t* length
 )
 {
-    return RecordStore_ReadRecordHeader(recordStore, blockDevice, blockIndex, offset) && RecordStore_ValidateHeader(recordStore, length) &&
+    return RecordStore_ReadRecordHeader(recordStore, blockDevice, blockIndex, offset) &&
+           RecordStore_ValidateHeader(recordStore, length) &&
            RecordStore_ReadRecordBody(recordStore, blockDevice, blockIndex, offset, *length) &&
            RecordStore_ReadIntegrityChecksum(recordStore, blockDevice, blockIndex, offset, *length) &&
            RecordStore_VerifyIntegrity(recordStore, *length);
@@ -222,7 +227,8 @@ static inline bool RecordStore_ReadRecordHeader(
 
 static inline bool RecordStore_IsMagicValid(struct RecordStore* recordStore)
 {
-    return (RecordStore_MagicAddress(recordStore)[0] == MAGIC_BYTE_0) && (RecordStore_MagicAddress(recordStore)[1] == MAGIC_BYTE_1);
+    return (RecordStore_MagicAddress(recordStore)[0] == MAGIC_BYTE_0) &&
+           (RecordStore_MagicAddress(recordStore)[1] == MAGIC_BYTE_1);
 }
 
 static inline uint16_t RecordStore_RecordLength(struct RecordStore* recordStore)
@@ -329,7 +335,10 @@ static inline void RecordStore_RememberCurrentRecord(
 
 // NOLINTEND(bugprone-easily-swappable-parameters)
 
-static inline bool RecordStore_WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice);
+static inline bool RecordStore_WriteSentFlag(
+    struct RecordStore* recordStore,
+    struct SolidSyslogBlockDevice* blockDevice
+);
 
 bool RecordStore_MarkLastReadAsSent(
     struct RecordStore* recordStore,
@@ -349,7 +358,10 @@ bool RecordStore_MarkLastReadAsSent(
     return marked;
 }
 
-static inline bool RecordStore_WriteSentFlag(struct RecordStore* recordStore, struct SolidSyslogBlockDevice* blockDevice)
+static inline bool RecordStore_WriteSentFlag(
+    struct RecordStore* recordStore,
+    struct SolidSyslogBlockDevice* blockDevice
+)
 {
     uint8_t flag = SENT_FLAG_SENT;
     return SolidSyslogBlockDevice_WriteAt(

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -91,14 +91,21 @@ static inline uint8_t SolidSyslog_CombineFacilityAndSeverity(uint8_t facility, u
 static inline bool SolidSyslog_FacilityIsValid(uint8_t facility);
 static inline void SolidSyslog_DrainBufferIntoStore(void);
 static inline void SolidSyslog_SendOneFromStore(void);
-static inline void SolidSyslog_FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts);
+static inline void SolidSyslog_FormatCapturedTimestamp(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogTimestamp* ts
+);
 static inline void SolidSyslog_FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message);
 static inline void SolidSyslog_FormatMsg(struct SolidSyslogFormatter* f, const char* msg);
 static inline void SolidSyslog_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId);
 static inline void SolidSyslog_FormatNilvalue(struct SolidSyslogFormatter* f);
 static inline void SolidSyslog_FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
 static inline void SolidSyslog_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival);
-static inline void SolidSyslog_FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize);
+static inline void SolidSyslog_FormatStringField(
+    struct SolidSyslogFormatter* f,
+    SolidSyslogStringFunction fn,
+    size_t maxSize
+);
 static inline void SolidSyslog_FormatStructuredData(
     struct SolidSyslogFormatter* f,
     struct SolidSyslogStructuredData** sd,
@@ -405,7 +412,10 @@ static inline bool SolidSyslog_TimestampIsValid(const struct SolidSyslogTimestam
     return valid;
 }
 
-static inline void SolidSyslog_FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts)
+static inline void SolidSyslog_FormatCapturedTimestamp(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogTimestamp* ts
+)
 {
     SolidSyslogFormatter_FourDigit(f, ts->year);
     SolidSyslogFormatter_AsciiCharacter(f, '-');
@@ -457,7 +467,11 @@ static inline int16_t SolidSyslog_AbsoluteInt16(int16_t value)
     return result;
 }
 
-static inline void SolidSyslog_FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize)
+static inline void SolidSyslog_FormatStringField(
+    struct SolidSyslogFormatter* f,
+    SolidSyslogStringFunction fn,
+    size_t maxSize
+)
 {
     SolidSyslogFormatterStorage fieldStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOSTNAME_SIZE)];
     struct SolidSyslogFormatter* field = SolidSyslogFormatter_Create(fieldStorage, maxSize);
@@ -636,7 +650,12 @@ static bool SolidSyslog_NilStoreWrite(struct SolidSyslogStore* self, const void*
     return false;
 }
 
-static bool SolidSyslog_NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool SolidSyslog_NilStoreReadNextUnsent(
+    struct SolidSyslogStore* self,
+    void* data,
+    size_t maxSize,
+    size_t* bytesRead
+)
 {
     (void) self;
     (void) data;

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -49,8 +49,8 @@ struct SolidSyslog
  * the NilInstance template both reference these by address. The Nil
  * implementations live below SolidSyslog so this file reads as two cooperating
  * "classes" — SolidSyslog first, then the Nil collaborators it depends on. */
-static void NilClock(struct SolidSyslogTimestamp* ts);
-static void NilStringFunction(struct SolidSyslogFormatter* formatter);
+static void SolidSyslog_NilClock(struct SolidSyslogTimestamp* ts);
+static void SolidSyslog_NilStringFunction(struct SolidSyslogFormatter* formatter);
 static struct SolidSyslogBuffer NilBuffer;
 static struct SolidSyslogSender NilSender;
 static struct SolidSyslogStore NilStore;
@@ -61,10 +61,10 @@ static bool instanceInitialised;
 static struct SolidSyslog instance = {
     .buffer = &NilBuffer,
     .sender = &NilSender,
-    .clock = NilClock,
-    .getHostname = NilStringFunction,
-    .getAppName = NilStringFunction,
-    .getProcessId = NilStringFunction,
+    .clock = SolidSyslog_NilClock,
+    .getHostname = SolidSyslog_NilStringFunction,
+    .getAppName = SolidSyslog_NilStringFunction,
+    .getProcessId = SolidSyslog_NilStringFunction,
     .store = &NilStore,
 };
 
@@ -75,54 +75,54 @@ static struct SolidSyslog instance = {
 static const struct SolidSyslog NilInstance = {
     .buffer = &NilBuffer,
     .sender = &NilSender,
-    .clock = NilClock,
-    .getHostname = NilStringFunction,
-    .getAppName = NilStringFunction,
-    .getProcessId = NilStringFunction,
+    .clock = SolidSyslog_NilClock,
+    .getHostname = SolidSyslog_NilStringFunction,
+    .getAppName = SolidSyslog_NilStringFunction,
+    .getProcessId = SolidSyslog_NilStringFunction,
     .store = &NilStore,
 };
 
 /* SolidSyslog helpers forward-declared so the public functions and
  * _Create/_Destroy can call them; each is defined immediately beneath its
  * first caller below. */
-static inline int16_t AbsoluteInt16(int16_t value);
-static inline bool CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock);
-static inline uint8_t CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
-static inline bool FacilityIsValid(uint8_t facility);
-static inline void DrainBufferIntoStore(void);
-static inline void SendOneFromStore(void);
-static inline void FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts);
-static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message);
-static inline void FormatMsg(struct SolidSyslogFormatter* f, const char* msg);
-static inline void FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId);
-static inline void FormatNilvalue(struct SolidSyslogFormatter* f);
-static inline void FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
-static inline void FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival);
-static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize);
-static inline void FormatStructuredData(
+static inline int16_t SolidSyslog_AbsoluteInt16(int16_t value);
+static inline bool SolidSyslog_CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock);
+static inline uint8_t SolidSyslog_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
+static inline bool SolidSyslog_FacilityIsValid(uint8_t facility);
+static inline void SolidSyslog_DrainBufferIntoStore(void);
+static inline void SolidSyslog_SendOneFromStore(void);
+static inline void SolidSyslog_FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts);
+static inline void SolidSyslog_FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message);
+static inline void SolidSyslog_FormatMsg(struct SolidSyslogFormatter* f, const char* msg);
+static inline void SolidSyslog_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId);
+static inline void SolidSyslog_FormatNilvalue(struct SolidSyslogFormatter* f);
+static inline void SolidSyslog_FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
+static inline void SolidSyslog_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival);
+static inline void SolidSyslog_FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize);
+static inline void SolidSyslog_FormatStructuredData(
     struct SolidSyslogFormatter* f,
     struct SolidSyslogStructuredData** sd,
     size_t sdCount
 );
-static inline void FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock);
-static inline void FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
-static void InstallAppName(SolidSyslogStringFunction configured);
-static void InstallBuffer(struct SolidSyslogBuffer* configured);
-static void InstallClock(SolidSyslogClockFunction configured);
-static void InstallConfig(const struct SolidSyslogConfig* config);
-static void InstallHostname(SolidSyslogStringFunction configured);
-static void InstallProcessId(SolidSyslogStringFunction configured);
-static void InstallSender(struct SolidSyslogSender* configured);
-static void InstallStore(struct SolidSyslogStore* configured);
-static void InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count);
-static inline bool IsServiceEnabled(void);
-static inline uint8_t MakePrival(const struct SolidSyslogMessage* message);
-static inline bool PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
-static void ProcessMessages(void);
-static inline bool SeverityIsValid(uint8_t severity);
-static inline const char* SkipLeadingBom(const char* msg);
-static inline bool StringIsValid(const char* value);
-static inline bool TimestampIsValid(const struct SolidSyslogTimestamp* ts);
+static inline void SolidSyslog_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock);
+static inline void SolidSyslog_FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes);
+static void SolidSyslog_InstallAppName(SolidSyslogStringFunction configured);
+static void SolidSyslog_InstallBuffer(struct SolidSyslogBuffer* configured);
+static void SolidSyslog_InstallClock(SolidSyslogClockFunction configured);
+static void SolidSyslog_InstallConfig(const struct SolidSyslogConfig* config);
+static void SolidSyslog_InstallHostname(SolidSyslogStringFunction configured);
+static void SolidSyslog_InstallProcessId(SolidSyslogStringFunction configured);
+static void SolidSyslog_InstallSender(struct SolidSyslogSender* configured);
+static void SolidSyslog_InstallStore(struct SolidSyslogStore* configured);
+static void SolidSyslog_InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count);
+static inline bool SolidSyslog_IsServiceEnabled(void);
+static inline uint8_t SolidSyslog_MakePrival(const struct SolidSyslogMessage* message);
+static inline bool SolidSyslog_PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
+static void SolidSyslog_ProcessMessages(void);
+static inline bool SolidSyslog_SeverityIsValid(uint8_t severity);
+static inline const char* SolidSyslog_SkipLeadingBom(const char* msg);
+static inline bool SolidSyslog_StringIsValid(const char* value);
+static inline bool SolidSyslog_TimestampIsValid(const struct SolidSyslogTimestamp* ts);
 
 void SolidSyslog_Create(const struct SolidSyslogConfig* config)
 {
@@ -136,25 +136,25 @@ void SolidSyslog_Create(const struct SolidSyslogConfig* config)
     }
     else
     {
-        InstallConfig(config);
+        SolidSyslog_InstallConfig(config);
         instanceInitialised = true;
     }
 }
 
-static void InstallConfig(const struct SolidSyslogConfig* config)
+static void SolidSyslog_InstallConfig(const struct SolidSyslogConfig* config)
 {
     instance = NilInstance;
-    InstallBuffer(config->buffer);
-    InstallSender(config->sender);
-    InstallStore(config->store);
-    InstallClock(config->clock);
-    InstallHostname(config->getHostname);
-    InstallAppName(config->getAppName);
-    InstallProcessId(config->getProcessId);
-    InstallStructuredData(config->sd, config->sdCount);
+    SolidSyslog_InstallBuffer(config->buffer);
+    SolidSyslog_InstallSender(config->sender);
+    SolidSyslog_InstallStore(config->store);
+    SolidSyslog_InstallClock(config->clock);
+    SolidSyslog_InstallHostname(config->getHostname);
+    SolidSyslog_InstallAppName(config->getAppName);
+    SolidSyslog_InstallProcessId(config->getProcessId);
+    SolidSyslog_InstallStructuredData(config->sd, config->sdCount);
 }
 
-static void InstallBuffer(struct SolidSyslogBuffer* configured)
+static void SolidSyslog_InstallBuffer(struct SolidSyslogBuffer* configured)
 {
     if (configured == NULL)
     {
@@ -166,7 +166,7 @@ static void InstallBuffer(struct SolidSyslogBuffer* configured)
     }
 }
 
-static void InstallSender(struct SolidSyslogSender* configured)
+static void SolidSyslog_InstallSender(struct SolidSyslogSender* configured)
 {
     if (configured == NULL)
     {
@@ -178,7 +178,7 @@ static void InstallSender(struct SolidSyslogSender* configured)
     }
 }
 
-static void InstallStore(struct SolidSyslogStore* configured)
+static void SolidSyslog_InstallStore(struct SolidSyslogStore* configured)
 {
     if (configured == NULL)
     {
@@ -190,7 +190,7 @@ static void InstallStore(struct SolidSyslogStore* configured)
     }
 }
 
-static void InstallClock(SolidSyslogClockFunction configured)
+static void SolidSyslog_InstallClock(SolidSyslogClockFunction configured)
 {
     if (configured != NULL)
     {
@@ -198,7 +198,7 @@ static void InstallClock(SolidSyslogClockFunction configured)
     }
 }
 
-static void InstallHostname(SolidSyslogStringFunction configured)
+static void SolidSyslog_InstallHostname(SolidSyslogStringFunction configured)
 {
     if (configured != NULL)
     {
@@ -206,7 +206,7 @@ static void InstallHostname(SolidSyslogStringFunction configured)
     }
 }
 
-static void InstallAppName(SolidSyslogStringFunction configured)
+static void SolidSyslog_InstallAppName(SolidSyslogStringFunction configured)
 {
     if (configured != NULL)
     {
@@ -214,7 +214,7 @@ static void InstallAppName(SolidSyslogStringFunction configured)
     }
 }
 
-static void InstallProcessId(SolidSyslogStringFunction configured)
+static void SolidSyslog_InstallProcessId(SolidSyslogStringFunction configured)
 {
     if (configured != NULL)
     {
@@ -222,7 +222,7 @@ static void InstallProcessId(SolidSyslogStringFunction configured)
     }
 }
 
-static void InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count)
+static void SolidSyslog_InstallStructuredData(struct SolidSyslogStructuredData** configured, size_t count)
 {
     instance.sd = configured;
     instance.sdCount = count;
@@ -238,21 +238,21 @@ void SolidSyslog_Destroy(void)
 
 void SolidSyslog_Service(void)
 {
-    if (IsServiceEnabled())
+    if (SolidSyslog_IsServiceEnabled())
     {
-        ProcessMessages();
+        SolidSyslog_ProcessMessages();
     }
 }
 
-static inline bool IsServiceEnabled(void)
+static inline bool SolidSyslog_IsServiceEnabled(void)
 {
     return !SolidSyslogStore_IsHalted(instance.store);
 }
 
-static void ProcessMessages(void)
+static void SolidSyslog_ProcessMessages(void)
 {
-    DrainBufferIntoStore();
-    SendOneFromStore();
+    SolidSyslog_DrainBufferIntoStore();
+    SolidSyslog_SendOneFromStore();
 }
 
 /* Eagerly drain the buffer so the producer-side shock absorber stays small while
@@ -264,7 +264,7 @@ static void ProcessMessages(void)
  * discard policy speaking — letting that message escape via direct send would
  * break the discard-newest contract (a newer message would bypass older stored
  * ones once the sender recovered). */
-static inline void DrainBufferIntoStore(void)
+static inline void SolidSyslog_DrainBufferIntoStore(void)
 {
     char buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     size_t len = 0;
@@ -278,7 +278,7 @@ static inline void DrainBufferIntoStore(void)
     }
 }
 
-static inline void SendOneFromStore(void)
+static inline void SolidSyslog_SendOneFromStore(void)
 {
     char buf[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
     size_t len = 0;
@@ -301,7 +301,7 @@ void SolidSyslog_Log(const struct SolidSyslogMessage* message)
         SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
         struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
-        FormatMessage(f, message);
+        SolidSyslog_FormatMessage(f, message);
         SolidSyslogBuffer_Write(
             instance.buffer,
             SolidSyslogFormatter_AsFormattedBuffer(f),
@@ -310,87 +310,87 @@ void SolidSyslog_Log(const struct SolidSyslogMessage* message)
     }
 }
 
-static inline void FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)
+static inline void SolidSyslog_FormatMessage(struct SolidSyslogFormatter* f, const struct SolidSyslogMessage* message)
 {
-    FormatPrival(f, MakePrival(message));
+    SolidSyslog_FormatPrival(f, SolidSyslog_MakePrival(message));
     SolidSyslogFormatter_AsciiCharacter(f, '1');
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatTimestamp(f, instance.clock);
+    SolidSyslog_FormatTimestamp(f, instance.clock);
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatStringField(f, instance.getHostname, SOLIDSYSLOG_MAX_HOSTNAME_SIZE);
+    SolidSyslog_FormatStringField(f, instance.getHostname, SOLIDSYSLOG_MAX_HOSTNAME_SIZE);
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatStringField(f, instance.getAppName, SOLIDSYSLOG_MAX_APP_NAME_SIZE);
+    SolidSyslog_FormatStringField(f, instance.getAppName, SOLIDSYSLOG_MAX_APP_NAME_SIZE);
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatStringField(f, instance.getProcessId, SOLIDSYSLOG_MAX_PROCESS_ID_SIZE);
+    SolidSyslog_FormatStringField(f, instance.getProcessId, SOLIDSYSLOG_MAX_PROCESS_ID_SIZE);
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatMsgId(f, message->messageId);
+    SolidSyslog_FormatMsgId(f, message->messageId);
     SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    FormatStructuredData(f, instance.sd, instance.sdCount);
-    FormatMsg(f, message->msg);
+    SolidSyslog_FormatStructuredData(f, instance.sd, instance.sdCount);
+    SolidSyslog_FormatMsg(f, message->msg);
 }
 
-static inline void FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival)
+static inline void SolidSyslog_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival)
 {
     SolidSyslogFormatter_AsciiCharacter(f, '<');
     SolidSyslogFormatter_Uint32(f, prival);
     SolidSyslogFormatter_AsciiCharacter(f, '>');
 }
 
-static inline uint8_t MakePrival(const struct SolidSyslogMessage* message)
+static inline uint8_t SolidSyslog_MakePrival(const struct SolidSyslogMessage* message)
 {
     uint8_t f = (uint8_t) message->facility;
     uint8_t s = (uint8_t) message->severity;
-    uint8_t prival = CombineFacilityAndSeverity(SolidSyslogFacility_Syslog, SolidSyslogSeverity_Error);
+    uint8_t prival = SolidSyslog_CombineFacilityAndSeverity(SolidSyslogFacility_Syslog, SolidSyslogSeverity_Error);
 
-    if (PrivalComponentsAreValid(f, s))
+    if (SolidSyslog_PrivalComponentsAreValid(f, s))
     {
-        prival = CombineFacilityAndSeverity(f, s);
+        prival = SolidSyslog_CombineFacilityAndSeverity(f, s);
     }
 
     return prival;
 }
 
-static inline uint8_t CombineFacilityAndSeverity(uint8_t facility, uint8_t severity)
+static inline uint8_t SolidSyslog_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity)
 {
     return (uint8_t) ((facility * UINT8_C(8)) + severity);
 }
 
-static inline bool PrivalComponentsAreValid(uint8_t facility, uint8_t severity)
+static inline bool SolidSyslog_PrivalComponentsAreValid(uint8_t facility, uint8_t severity)
 {
-    return FacilityIsValid(facility) && SeverityIsValid(severity);
+    return SolidSyslog_FacilityIsValid(facility) && SolidSyslog_SeverityIsValid(severity);
 }
 
-static inline bool FacilityIsValid(uint8_t facility)
+static inline bool SolidSyslog_FacilityIsValid(uint8_t facility)
 {
     return facility <= SolidSyslogFacility_Local7;
 }
 
-static inline bool SeverityIsValid(uint8_t severity)
+static inline bool SolidSyslog_SeverityIsValid(uint8_t severity)
 {
     return severity <= SolidSyslogSeverity_Debug;
 }
 
-static inline void FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock)
+static inline void SolidSyslog_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock)
 {
     struct SolidSyslogTimestamp ts = {0};
 
-    if (CaptureTimestamp(&ts, clock))
+    if (SolidSyslog_CaptureTimestamp(&ts, clock))
     {
-        FormatCapturedTimestamp(f, &ts);
+        SolidSyslog_FormatCapturedTimestamp(f, &ts);
     }
     else
     {
-        FormatNilvalue(f);
+        SolidSyslog_FormatNilvalue(f);
     }
 }
 
-static inline bool CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock)
+static inline bool SolidSyslog_CaptureTimestamp(struct SolidSyslogTimestamp* ts, SolidSyslogClockFunction clock)
 {
     clock(ts);
-    return TimestampIsValid(ts);
+    return SolidSyslog_TimestampIsValid(ts);
 }
 
-static inline bool TimestampIsValid(const struct SolidSyslogTimestamp* ts)
+static inline bool SolidSyslog_TimestampIsValid(const struct SolidSyslogTimestamp* ts)
 {
     bool valid = true;
 
@@ -405,7 +405,7 @@ static inline bool TimestampIsValid(const struct SolidSyslogTimestamp* ts)
     return valid;
 }
 
-static inline void FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts)
+static inline void SolidSyslog_FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const struct SolidSyslogTimestamp* ts)
 {
     SolidSyslogFormatter_FourDigit(f, ts->year);
     SolidSyslogFormatter_AsciiCharacter(f, '-');
@@ -420,10 +420,10 @@ static inline void FormatCapturedTimestamp(struct SolidSyslogFormatter* f, const
     SolidSyslogFormatter_TwoDigit(f, ts->second);
     SolidSyslogFormatter_AsciiCharacter(f, '.');
     SolidSyslogFormatter_SixDigit(f, ts->microsecond);
-    FormatUtcOffset(f, ts->utcOffsetMinutes);
+    SolidSyslog_FormatUtcOffset(f, ts->utcOffsetMinutes);
 }
 
-static inline void FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes)
+static inline void SolidSyslog_FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes)
 {
     if (offsetMinutes == 0)
     {
@@ -431,13 +431,13 @@ static inline void FormatUtcOffset(struct SolidSyslogFormatter* f, int16_t offse
     }
     else
     {
-        FormatNonZeroUtcOffset(f, offsetMinutes);
+        SolidSyslog_FormatNonZeroUtcOffset(f, offsetMinutes);
     }
 }
 
-static inline void FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes)
+static inline void SolidSyslog_FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_t offsetMinutes)
 {
-    int16_t absoluteMinutes = AbsoluteInt16(offsetMinutes);
+    int16_t absoluteMinutes = SolidSyslog_AbsoluteInt16(offsetMinutes);
 
     SolidSyslogFormatter_AsciiCharacter(f, (offsetMinutes > 0) ? '+' : '-');
     SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes / 60));
@@ -445,7 +445,7 @@ static inline void FormatNonZeroUtcOffset(struct SolidSyslogFormatter* f, int16_
     SolidSyslogFormatter_TwoDigit(f, (uint32_t) (absoluteMinutes % 60));
 }
 
-static inline int16_t AbsoluteInt16(int16_t value)
+static inline int16_t SolidSyslog_AbsoluteInt16(int16_t value)
 {
     int16_t result = value;
 
@@ -457,7 +457,7 @@ static inline int16_t AbsoluteInt16(int16_t value)
     return result;
 }
 
-static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize)
+static inline void SolidSyslog_FormatStringField(struct SolidSyslogFormatter* f, SolidSyslogStringFunction fn, size_t maxSize)
 {
     SolidSyslogFormatterStorage fieldStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOSTNAME_SIZE)];
     struct SolidSyslogFormatter* field = SolidSyslogFormatter_Create(fieldStorage, maxSize);
@@ -472,31 +472,31 @@ static inline void FormatStringField(struct SolidSyslogFormatter* f, SolidSyslog
     }
     else
     {
-        FormatNilvalue(f);
+        SolidSyslog_FormatNilvalue(f);
     }
 }
 
-static inline void FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId)
+static inline void SolidSyslog_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId)
 {
     size_t lengthBefore = SolidSyslogFormatter_Length(f);
 
-    if (StringIsValid(messageId))
+    if (SolidSyslog_StringIsValid(messageId))
     {
         SolidSyslogFormatter_PrintUsAsciiString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
     }
 
     if (SolidSyslogFormatter_Length(f) == lengthBefore)
     {
-        FormatNilvalue(f);
+        SolidSyslog_FormatNilvalue(f);
     }
 }
 
-static inline bool StringIsValid(const char* value)
+static inline bool SolidSyslog_StringIsValid(const char* value)
 {
     return (value != NULL) && (value[0] != '\0');
 }
 
-static inline void FormatStructuredData(
+static inline void SolidSyslog_FormatStructuredData(
     struct SolidSyslogFormatter* f,
     struct SolidSyslogStructuredData** sd,
     size_t sdCount
@@ -511,24 +511,24 @@ static inline void FormatStructuredData(
 
     if (SolidSyslogFormatter_Length(f) == lengthBefore)
     {
-        FormatNilvalue(f);
+        SolidSyslog_FormatNilvalue(f);
     }
 }
 
-static inline void FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
+static inline void SolidSyslog_FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
 {
-    if (StringIsValid(msg))
+    if (SolidSyslog_StringIsValid(msg))
     {
         SolidSyslogFormatter_AsciiCharacter(f, ' ');
         SolidSyslogFormatter_Bom(f);
-        SolidSyslogFormatter_BoundedString(f, SkipLeadingBom(msg), SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+        SolidSyslogFormatter_BoundedString(f, SolidSyslog_SkipLeadingBom(msg), SOLIDSYSLOG_MAX_MESSAGE_SIZE);
     }
 }
 
 /* MSG body MUST start with the UTF-8 BOM per RFC 5424 §6.4. We always
  * emit the BOM ourselves; if the caller already prefixed one, strip it
  * so the wire frame contains exactly one. */
-static inline const char* SkipLeadingBom(const char* msg)
+static inline const char* SolidSyslog_SkipLeadingBom(const char* msg)
 {
     if ((msg[0] == '\xEF') && (msg[1] == '\xBB') && (msg[2] == '\xBF'))
     {
@@ -537,7 +537,7 @@ static inline const char* SkipLeadingBom(const char* msg)
     return msg;
 }
 
-static inline void FormatNilvalue(struct SolidSyslogFormatter* f)
+static inline void SolidSyslog_FormatNilvalue(struct SolidSyslogFormatter* f)
 {
     SolidSyslogFormatter_AsciiCharacter(f, '-');
 }
@@ -563,19 +563,19 @@ static inline void FormatNilvalue(struct SolidSyslogFormatter* f)
 static bool nilBufferReportArmed = true;
 static bool nilSenderReportArmed = true;
 
-static void NilClock(struct SolidSyslogTimestamp* ts)
+static void SolidSyslog_NilClock(struct SolidSyslogTimestamp* ts)
 {
     (void) ts;
 }
 
-static void NilStringFunction(struct SolidSyslogFormatter* formatter)
+static void SolidSyslog_NilStringFunction(struct SolidSyslogFormatter* formatter)
 {
     (void) formatter;
 }
 
 /* NilBuffer */
 
-static void NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, size_t size)
+static void SolidSyslog_NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     (void) self;
     (void) data;
@@ -587,7 +587,7 @@ static void NilBufferWrite(struct SolidSyslogBuffer* self, const void* data, siz
     }
 }
 
-static bool NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool SolidSyslog_NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     (void) self;
     (void) data;
@@ -597,13 +597,13 @@ static bool NilBufferRead(struct SolidSyslogBuffer* self, void* data, size_t max
 }
 
 static struct SolidSyslogBuffer NilBuffer = {
-    .Write = NilBufferWrite,
-    .Read = NilBufferRead,
+    .Write = SolidSyslog_NilBufferWrite,
+    .Read = SolidSyslog_NilBufferRead,
 };
 
 /* NilSender */
 
-static bool NilSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+static bool SolidSyslog_NilSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     (void) self;
     (void) buffer;
@@ -616,19 +616,19 @@ static bool NilSenderSend(struct SolidSyslogSender* self, const void* buffer, si
     return true;
 }
 
-static void NilSenderDisconnect(struct SolidSyslogSender* self)
+static void SolidSyslog_NilSenderDisconnect(struct SolidSyslogSender* self)
 {
     (void) self;
 }
 
 static struct SolidSyslogSender NilSender = {
-    .Send = NilSenderSend,
-    .Disconnect = NilSenderDisconnect,
+    .Send = SolidSyslog_NilSenderSend,
+    .Disconnect = SolidSyslog_NilSenderDisconnect,
 };
 
 /* NilStore */
 
-static bool NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_t size)
+static bool SolidSyslog_NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_t size)
 {
     (void) self;
     (void) data;
@@ -636,7 +636,7 @@ static bool NilStoreWrite(struct SolidSyslogStore* self, const void* data, size_
     return false;
 }
 
-static bool NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool SolidSyslog_NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     (void) self;
     (void) data;
@@ -645,30 +645,30 @@ static bool NilStoreReadNextUnsent(struct SolidSyslogStore* self, void* data, si
     return false;
 }
 
-static void NilStoreMarkSent(struct SolidSyslogStore* self)
+static void SolidSyslog_NilStoreMarkSent(struct SolidSyslogStore* self)
 {
     (void) self;
 }
 
-static bool NilStoreHasUnsent(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return false;
-}
-
-static bool NilStoreIsHalted(struct SolidSyslogStore* self)
+static bool SolidSyslog_NilStoreHasUnsent(struct SolidSyslogStore* self)
 {
     (void) self;
     return false;
 }
 
-static size_t NilStoreGetTotalBytes(struct SolidSyslogStore* self)
+static bool SolidSyslog_NilStoreIsHalted(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static size_t SolidSyslog_NilStoreGetTotalBytes(struct SolidSyslogStore* self)
 {
     (void) self;
     return 0;
 }
 
-static size_t NilStoreGetUsedBytes(struct SolidSyslogStore* self)
+static size_t SolidSyslog_NilStoreGetUsedBytes(struct SolidSyslogStore* self)
 {
     (void) self;
     return 0;
@@ -677,19 +677,19 @@ static size_t NilStoreGetUsedBytes(struct SolidSyslogStore* self)
 /* NilStore stands in when the integrator passes config.store = NULL —
  * "no store, just try to send." Same transient semantics as NullStore:
  * Service falls through to the sender on Write rejection. */
-static bool NilStoreIsTransient(struct SolidSyslogStore* self)
+static bool SolidSyslog_NilStoreIsTransient(struct SolidSyslogStore* self)
 {
     (void) self;
     return true;
 }
 
 static struct SolidSyslogStore NilStore = {
-    .Write = NilStoreWrite,
-    .ReadNextUnsent = NilStoreReadNextUnsent,
-    .MarkSent = NilStoreMarkSent,
-    .HasUnsent = NilStoreHasUnsent,
-    .IsHalted = NilStoreIsHalted,
-    .GetTotalBytes = NilStoreGetTotalBytes,
-    .GetUsedBytes = NilStoreGetUsedBytes,
-    .IsTransient = NilStoreIsTransient,
+    .Write = SolidSyslog_NilStoreWrite,
+    .ReadNextUnsent = SolidSyslog_NilStoreReadNextUnsent,
+    .MarkSent = SolidSyslog_NilStoreMarkSent,
+    .HasUnsent = SolidSyslog_NilStoreHasUnsent,
+    .IsHalted = SolidSyslog_NilStoreIsHalted,
+    .GetTotalBytes = SolidSyslog_NilStoreGetTotalBytes,
+    .GetUsedBytes = SolidSyslog_NilStoreGetUsedBytes,
+    .IsTransient = SolidSyslog_NilStoreIsTransient,
 };

--- a/Core/Source/SolidSyslogBlockStore.c
+++ b/Core/Source/SolidSyslogBlockStore.c
@@ -10,15 +10,15 @@
 #include "SolidSyslogNullSecurityPolicy.h"
 #include "SolidSyslogStoreDefinition.h"
 
-/* vtable — forward-declared because InitialiseVtable references them before their definitions */
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
-static void MarkSent(struct SolidSyslogStore* self);
-static bool HasUnsent(struct SolidSyslogStore* self);
-static bool IsHalted(struct SolidSyslogStore* self);
-static size_t GetTotalBytes(struct SolidSyslogStore* self);
-static size_t GetUsedBytes(struct SolidSyslogStore* self);
-static bool IsTransient(struct SolidSyslogStore* self);
+/* vtable — forward-declared because BlockStore_InitialiseVtable references them before their definitions */
+static bool BlockStore_Write(struct SolidSyslogStore* self, const void* data, size_t size);
+static bool BlockStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
+static void BlockStore_MarkSent(struct SolidSyslogStore* self);
+static bool BlockStore_HasUnsent(struct SolidSyslogStore* self);
+static bool BlockStore_IsHalted(struct SolidSyslogStore* self);
+static size_t BlockStore_GetTotalBytes(struct SolidSyslogStore* self);
+static size_t BlockStore_GetUsedBytes(struct SolidSyslogStore* self);
+static bool BlockStore_IsTransient(struct SolidSyslogStore* self);
 
 /* ------------------------------------------------------------------
  * Instance
@@ -38,14 +38,14 @@ SOLIDSYSLOG_STATIC_ASSERT(
 
 static const struct SolidSyslogBlockStore DEFAULT_INSTANCE = {0};
 
-static inline struct SolidSyslogBlockStore* AsBlockStore(struct SolidSyslogStore* store);
-static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
-static inline struct BlockSequenceConfig BuildBlockSequenceConfig(
+static inline struct SolidSyslogBlockStore* BlockStore_AsBlockStore(struct SolidSyslogStore* store);
+static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
+static inline struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
     const struct SolidSyslogBlockStoreConfig* config,
     const struct RecordStore* recordStore
 );
-static inline void InitialiseVtable(struct SolidSyslogBlockStore* blockStore);
-static void ResumeFromExistingBlock(struct SolidSyslogBlockStore* blockStore);
+static inline void BlockStore_InitialiseVtable(struct SolidSyslogBlockStore* blockStore);
+static void BlockStore_ResumeFromExistingBlock(struct SolidSyslogBlockStore* blockStore);
 
 /* ------------------------------------------------------------------
  * Create
@@ -59,27 +59,27 @@ struct SolidSyslogStore* SolidSyslogBlockStore_Create(
     struct SolidSyslogBlockStore* blockStore = (struct SolidSyslogBlockStore*) storage;
     *blockStore = DEFAULT_INSTANCE;
 
-    RecordStore_Init(&blockStore->recordStore, ResolveSecurityPolicy(config->securityPolicy));
+    RecordStore_Init(&blockStore->recordStore, BlockStore_ResolveSecurityPolicy(config->securityPolicy));
 
-    struct BlockSequenceConfig blockConfig = BuildBlockSequenceConfig(config, &blockStore->recordStore);
+    struct BlockSequenceConfig blockConfig = BlockStore_BuildBlockSequenceConfig(config, &blockStore->recordStore);
     BlockSequence_Init(&blockStore->blockSequence, &blockConfig);
 
-    InitialiseVtable(blockStore);
+    BlockStore_InitialiseVtable(blockStore);
 
     if (BlockSequence_Open(&blockStore->blockSequence))
     {
-        ResumeFromExistingBlock(blockStore);
+        BlockStore_ResumeFromExistingBlock(blockStore);
     }
 
     return &blockStore->base;
 }
 
-static inline struct SolidSyslogBlockStore* AsBlockStore(struct SolidSyslogStore* store)
+static inline struct SolidSyslogBlockStore* BlockStore_AsBlockStore(struct SolidSyslogStore* store)
 {
     return (struct SolidSyslogBlockStore*) store;
 }
 
-static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
+static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
 {
     struct SolidSyslogSecurityPolicy* resolved = configured;
 
@@ -91,7 +91,7 @@ static inline struct SolidSyslogSecurityPolicy* ResolveSecurityPolicy(struct Sol
     return resolved;
 }
 
-static inline struct BlockSequenceConfig BuildBlockSequenceConfig(
+static inline struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
     const struct SolidSyslogBlockStoreConfig* config,
     const struct RecordStore* recordStore
 )
@@ -113,19 +113,19 @@ static inline struct BlockSequenceConfig BuildBlockSequenceConfig(
     return blockConfig;
 }
 
-static inline void InitialiseVtable(struct SolidSyslogBlockStore* blockStore)
+static inline void BlockStore_InitialiseVtable(struct SolidSyslogBlockStore* blockStore)
 {
-    blockStore->base.Write = Write;
-    blockStore->base.ReadNextUnsent = ReadNextUnsent;
-    blockStore->base.MarkSent = MarkSent;
-    blockStore->base.HasUnsent = HasUnsent;
-    blockStore->base.IsHalted = IsHalted;
-    blockStore->base.GetTotalBytes = GetTotalBytes;
-    blockStore->base.GetUsedBytes = GetUsedBytes;
-    blockStore->base.IsTransient = IsTransient;
+    blockStore->base.Write = BlockStore_Write;
+    blockStore->base.ReadNextUnsent = BlockStore_ReadNextUnsent;
+    blockStore->base.MarkSent = BlockStore_MarkSent;
+    blockStore->base.HasUnsent = BlockStore_HasUnsent;
+    blockStore->base.IsHalted = BlockStore_IsHalted;
+    blockStore->base.GetTotalBytes = BlockStore_GetTotalBytes;
+    blockStore->base.GetUsedBytes = BlockStore_GetUsedBytes;
+    blockStore->base.IsTransient = BlockStore_IsTransient;
 }
 
-static void ResumeFromExistingBlock(struct SolidSyslogBlockStore* blockStore)
+static void BlockStore_ResumeFromExistingBlock(struct SolidSyslogBlockStore* blockStore)
 {
     struct SolidSyslogBlockDevice* device = BlockSequence_BlockDevice(&blockStore->blockSequence);
     size_t readSequence = BlockSequence_ReadSequence(&blockStore->blockSequence);
@@ -152,22 +152,22 @@ static void ResumeFromExistingBlock(struct SolidSyslogBlockStore* blockStore)
 
 void SolidSyslogBlockStore_Destroy(struct SolidSyslogStore* store)
 {
-    struct SolidSyslogBlockStore* blockStore = AsBlockStore(store);
+    struct SolidSyslogBlockStore* blockStore = BlockStore_AsBlockStore(store);
     *blockStore = DEFAULT_INSTANCE;
 }
 
 /* ------------------------------------------------------------------
- * Write
+ * BlockStore_Write
  * ----------------------------------------------------------------*/
 
-static bool StoreRecord(struct SolidSyslogBlockStore* blockStore, const void* data, size_t size);
+static bool BlockStore_StoreRecord(struct SolidSyslogBlockStore* blockStore, const void* data, size_t size);
 
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
+static bool BlockStore_Write(struct SolidSyslogStore* self, const void* data, size_t size)
 {
-    return StoreRecord(AsBlockStore(self), data, size);
+    return BlockStore_StoreRecord(BlockStore_AsBlockStore(self), data, size);
 }
 
-static bool StoreRecord(struct SolidSyslogBlockStore* blockStore, const void* data, size_t size)
+static bool BlockStore_StoreRecord(struct SolidSyslogBlockStore* blockStore, const void* data, size_t size)
 {
     size_t recordSize = RecordStore_RecordSize(&blockStore->recordStore, (uint16_t) size);
     bool readBlockChanged = false;
@@ -197,66 +197,66 @@ static bool StoreRecord(struct SolidSyslogBlockStore* blockStore, const void* da
 }
 
 /* ------------------------------------------------------------------
- * HasUnsent / IsHalted / GetTotalBytes / GetUsedBytes
+ * BlockStore_HasUnsent / BlockStore_IsHalted / BlockStore_GetTotalBytes / BlockStore_GetUsedBytes
  * ----------------------------------------------------------------*/
 
-static bool HasUnsent(struct SolidSyslogStore* self)
+static bool BlockStore_HasUnsent(struct SolidSyslogStore* self)
 {
-    return BlockSequence_HasUnsent(&AsBlockStore(self)->blockSequence);
+    return BlockSequence_HasUnsent(&BlockStore_AsBlockStore(self)->blockSequence);
 }
 
-static bool IsHalted(struct SolidSyslogStore* self)
+static bool BlockStore_IsHalted(struct SolidSyslogStore* self)
 {
-    return BlockSequence_IsHalted(&AsBlockStore(self)->blockSequence);
+    return BlockSequence_IsHalted(&BlockStore_AsBlockStore(self)->blockSequence);
 }
 
-static size_t GetTotalBytes(struct SolidSyslogStore* self)
+static size_t BlockStore_GetTotalBytes(struct SolidSyslogStore* self)
 {
-    return BlockSequence_TotalBytes(&AsBlockStore(self)->blockSequence);
+    return BlockSequence_TotalBytes(&BlockStore_AsBlockStore(self)->blockSequence);
 }
 
-static size_t GetUsedBytes(struct SolidSyslogStore* self)
+static size_t BlockStore_GetUsedBytes(struct SolidSyslogStore* self)
 {
-    return BlockSequence_UsedBytes(&AsBlockStore(self)->blockSequence);
+    return BlockSequence_UsedBytes(&BlockStore_AsBlockStore(self)->blockSequence);
 }
 
-/* BlockStore retains records — a Write rejection here is the discard
+/* BlockStore retains records — a BlockStore_Write rejection here is the discard
  * policy speaking (DISCARD_NEWEST or HALT), and the message must NOT
  * bypass older stored records via a Service direct-send fallback. */
-static bool IsTransient(struct SolidSyslogStore* self)
+static bool BlockStore_IsTransient(struct SolidSyslogStore* self)
 {
     (void) self;
     return false;
 }
 
 /* ------------------------------------------------------------------
- * ReadNextUnsent
+ * BlockStore_ReadNextUnsent
  * ----------------------------------------------------------------*/
 
-static bool ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead);
+static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead);
 
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool BlockStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
-    struct SolidSyslogBlockStore* blockStore = AsBlockStore(self);
+    struct SolidSyslogBlockStore* blockStore = BlockStore_AsBlockStore(self);
     bool read = false;
     *bytesRead = 0;
 
     if (BlockSequence_HasUnsent(&blockStore->blockSequence))
     {
-        read = ReadCurrent(blockStore, data, maxSize, bytesRead);
+        read = BlockStore_ReadCurrent(blockStore, data, maxSize, bytesRead);
 
         while (!read && BlockSequence_ReadIsBehindWrite(&blockStore->blockSequence))
         {
             BlockSequence_AdvanceToNextReadBlock(&blockStore->blockSequence);
             RecordStore_ForgetLastRead(&blockStore->recordStore);
-            read = ReadCurrent(blockStore, data, maxSize, bytesRead);
+            read = BlockStore_ReadCurrent(blockStore, data, maxSize, bytesRead);
         }
     }
 
     return read;
 }
 
-static bool ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead)
+static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead)
 {
     return RecordStore_Read(
         &blockStore->recordStore,
@@ -270,12 +270,12 @@ static bool ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, si
 }
 
 /* ------------------------------------------------------------------
- * MarkSent
+ * BlockStore_MarkSent
  * ----------------------------------------------------------------*/
 
-static void MarkSent(struct SolidSyslogStore* self)
+static void BlockStore_MarkSent(struct SolidSyslogStore* self)
 {
-    struct SolidSyslogBlockStore* blockStore = AsBlockStore(self);
+    struct SolidSyslogBlockStore* blockStore = BlockStore_AsBlockStore(self);
     size_t nextCursor = 0;
 
     if (RecordStore_MarkLastReadAsSent(

--- a/Core/Source/SolidSyslogBlockStore.c
+++ b/Core/Source/SolidSyslogBlockStore.c
@@ -39,7 +39,9 @@ SOLIDSYSLOG_STATIC_ASSERT(
 static const struct SolidSyslogBlockStore DEFAULT_INSTANCE = {0};
 
 static inline struct SolidSyslogBlockStore* BlockStore_AsBlockStore(struct SolidSyslogStore* store);
-static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
+static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(
+    struct SolidSyslogSecurityPolicy* configured
+);
 static inline struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
     const struct SolidSyslogBlockStoreConfig* config,
     const struct RecordStore* recordStore
@@ -79,7 +81,9 @@ static inline struct SolidSyslogBlockStore* BlockStore_AsBlockStore(struct Solid
     return (struct SolidSyslogBlockStore*) store;
 }
 
-static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
+static inline struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(
+    struct SolidSyslogSecurityPolicy* configured
+)
 {
     struct SolidSyslogSecurityPolicy* resolved = configured;
 
@@ -233,7 +237,12 @@ static bool BlockStore_IsTransient(struct SolidSyslogStore* self)
  * BlockStore_ReadNextUnsent
  * ----------------------------------------------------------------*/
 
-static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead);
+static bool BlockStore_ReadCurrent(
+    struct SolidSyslogBlockStore* blockStore,
+    void* data,
+    size_t maxSize,
+    size_t* bytesRead
+);
 
 static bool BlockStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
@@ -256,7 +265,12 @@ static bool BlockStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data,
     return read;
 }
 
-static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* blockStore, void* data, size_t maxSize, size_t* bytesRead)
+static bool BlockStore_ReadCurrent(
+    struct SolidSyslogBlockStore* blockStore,
+    void* data,
+    size_t maxSize,
+    size_t* bytesRead
+)
 {
     return RecordStore_Read(
         &blockStore->recordStore,

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -38,12 +38,22 @@ static void CircularBuffer_Write(struct SolidSyslogBuffer* self, const void* dat
 static inline bool CircularBuffer_IsEmpty(const struct SolidSyslogCircularBuffer* circular);
 static inline bool CircularBuffer_IsWrapped(const struct SolidSyslogCircularBuffer* circular);
 static inline bool CircularBuffer_HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
-static inline bool CircularBuffer_RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
-static inline bool CircularBuffer_RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline bool CircularBuffer_RecordFitsAtTail(
+    const struct SolidSyslogCircularBuffer* circular,
+    size_t recordBytes
+);
+static inline bool CircularBuffer_RecordFitsAfterWrap(
+    const struct SolidSyslogCircularBuffer* circular,
+    size_t recordBytes
+);
 static inline void CircularBuffer_ResetToStart(struct SolidSyslogCircularBuffer* circular);
 static inline void CircularBuffer_WrapTail(struct SolidSyslogCircularBuffer* circular);
 static inline void CircularBuffer_ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
-static inline void CircularBuffer_StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
+static inline void CircularBuffer_StoreRecord(
+    struct SolidSyslogCircularBuffer* circular,
+    const void* data,
+    size_t size
+);
 static inline void CircularBuffer_LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
 static inline size_t CircularBuffer_PeekRecordSize(const struct SolidSyslogCircularBuffer* circular);
 
@@ -169,7 +179,10 @@ static inline bool CircularBuffer_RecordFitsAtTail(const struct SolidSyslogCircu
     return circular->tail + recordBytes <= circular->capacity;
 }
 
-static inline bool CircularBuffer_RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
+static inline bool CircularBuffer_RecordFitsAfterWrap(
+    const struct SolidSyslogCircularBuffer* circular,
+    size_t recordBytes
+)
 {
     return (!CircularBuffer_IsWrapped(circular)) && recordBytes < circular->head;
 }

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -32,20 +32,20 @@ SOLIDSYSLOG_STATIC_ASSERT(
     "SOLIDSYSLOG_CIRCULARBUFFER_OVERHEAD does not match struct layout"
 );
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
+static bool CircularBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
+static void CircularBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
-static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular);
-static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular);
-static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
-static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
-static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
-static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular);
-static inline void WrapTail(struct SolidSyslogCircularBuffer* circular);
-static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
-static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
-static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
-static inline size_t PeekRecordSize(const struct SolidSyslogCircularBuffer* circular);
+static inline bool CircularBuffer_IsEmpty(const struct SolidSyslogCircularBuffer* circular);
+static inline bool CircularBuffer_IsWrapped(const struct SolidSyslogCircularBuffer* circular);
+static inline bool CircularBuffer_HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular);
+static inline bool CircularBuffer_RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline bool CircularBuffer_RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes);
+static inline void CircularBuffer_ResetToStart(struct SolidSyslogCircularBuffer* circular);
+static inline void CircularBuffer_WrapTail(struct SolidSyslogCircularBuffer* circular);
+static inline void CircularBuffer_ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular);
+static inline void CircularBuffer_StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size);
+static inline void CircularBuffer_LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead);
+static inline size_t CircularBuffer_PeekRecordSize(const struct SolidSyslogCircularBuffer* circular);
 
 struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(
     SolidSyslogCircularBufferStorage* storage,
@@ -54,11 +54,11 @@ struct SolidSyslogBuffer* SolidSyslogCircularBuffer_Create(
 )
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) storage;
-    circular->base.Read = Read;
-    circular->base.Write = Write;
+    circular->base.Read = CircularBuffer_Read;
+    circular->base.Write = CircularBuffer_Write;
     circular->mutex = mutex;
     circular->capacity = storageBytes - sizeof(struct SolidSyslogCircularBuffer);
-    ResetToStart(circular);
+    CircularBuffer_ResetToStart(circular);
     return &circular->base;
 }
 
@@ -74,21 +74,21 @@ void SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer* buffer)
     circular->wrapPoint = 0;
 }
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool CircularBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
     SolidSyslogMutex_Lock(circular->mutex);
     *bytesRead = 0;
-    bool delivered = !IsEmpty(circular);
+    bool delivered = !CircularBuffer_IsEmpty(circular);
     if (delivered)
     {
-        if (HeadAtWrapPoint(circular))
+        if (CircularBuffer_HeadAtWrapPoint(circular))
         {
-            ConsumeWrapMarker(circular);
+            CircularBuffer_ConsumeWrapMarker(circular);
         }
-        if (PeekRecordSize(circular) <= maxSize)
+        if (CircularBuffer_PeekRecordSize(circular) <= maxSize)
         {
-            LoadRecord(circular, data, bytesRead);
+            CircularBuffer_LoadRecord(circular, data, bytesRead);
         }
         else
         {
@@ -99,95 +99,95 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
     return delivered;
 }
 
-static inline bool IsEmpty(const struct SolidSyslogCircularBuffer* circular)
+static inline bool CircularBuffer_IsEmpty(const struct SolidSyslogCircularBuffer* circular)
 {
     return circular->head == circular->tail;
 }
 
-static inline bool HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular)
+static inline bool CircularBuffer_HeadAtWrapPoint(const struct SolidSyslogCircularBuffer* circular)
 {
     return circular->head >= circular->wrapPoint;
 }
 
-static inline void ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
+static inline void CircularBuffer_ConsumeWrapMarker(struct SolidSyslogCircularBuffer* circular)
 {
     circular->head = 0;
     circular->wrapPoint = circular->capacity;
 }
 
-static inline size_t PeekRecordSize(const struct SolidSyslogCircularBuffer* circular)
+static inline size_t CircularBuffer_PeekRecordSize(const struct SolidSyslogCircularBuffer* circular)
 {
     uint16_t header = 0;
     memcpy(&header, &circular->storage[circular->head], HEADER_BYTES);
     return header;
 }
 
-static inline void LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
+static inline void CircularBuffer_LoadRecord(struct SolidSyslogCircularBuffer* circular, void* data, size_t* bytesRead)
 {
-    size_t recordSize = PeekRecordSize(circular);
+    size_t recordSize = CircularBuffer_PeekRecordSize(circular);
     memcpy(data, &circular->storage[circular->head + HEADER_BYTES], recordSize);
     circular->head += HEADER_BYTES + recordSize;
     *bytesRead = recordSize;
 }
 
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
+static void CircularBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogCircularBuffer* circular = (struct SolidSyslogCircularBuffer*) self;
     if (size <= SOLIDSYSLOG_MAX_MESSAGE_SIZE)
     {
         SolidSyslogMutex_Lock(circular->mutex);
-        if (IsEmpty(circular))
+        if (CircularBuffer_IsEmpty(circular))
         {
-            ResetToStart(circular);
+            CircularBuffer_ResetToStart(circular);
         }
         size_t recordBytes = HEADER_BYTES + size;
-        bool fitsAtTail = RecordFitsAtTail(circular, recordBytes);
-        bool shouldWrite = fitsAtTail || RecordFitsAfterWrap(circular, recordBytes);
+        bool fitsAtTail = CircularBuffer_RecordFitsAtTail(circular, recordBytes);
+        bool shouldWrite = fitsAtTail || CircularBuffer_RecordFitsAfterWrap(circular, recordBytes);
         if (shouldWrite)
         {
             if (!fitsAtTail)
             {
-                WrapTail(circular);
+                CircularBuffer_WrapTail(circular);
             }
-            StoreRecord(circular, data, size);
+            CircularBuffer_StoreRecord(circular, data, size);
         }
         SolidSyslogMutex_Unlock(circular->mutex);
     }
 }
 
-static inline bool IsWrapped(const struct SolidSyslogCircularBuffer* circular)
+static inline bool CircularBuffer_IsWrapped(const struct SolidSyslogCircularBuffer* circular)
 {
     return circular->head > circular->tail;
 }
 
-static inline bool RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
+static inline bool CircularBuffer_RecordFitsAtTail(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
 {
-    if (IsWrapped(circular))
+    if (CircularBuffer_IsWrapped(circular))
     {
         return circular->tail + recordBytes < circular->head;
     }
     return circular->tail + recordBytes <= circular->capacity;
 }
 
-static inline bool RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
+static inline bool CircularBuffer_RecordFitsAfterWrap(const struct SolidSyslogCircularBuffer* circular, size_t recordBytes)
 {
-    return (!IsWrapped(circular)) && recordBytes < circular->head;
+    return (!CircularBuffer_IsWrapped(circular)) && recordBytes < circular->head;
 }
 
-static inline void ResetToStart(struct SolidSyslogCircularBuffer* circular)
+static inline void CircularBuffer_ResetToStart(struct SolidSyslogCircularBuffer* circular)
 {
     circular->head = 0;
     circular->tail = 0;
     circular->wrapPoint = circular->capacity;
 }
 
-static inline void WrapTail(struct SolidSyslogCircularBuffer* circular)
+static inline void CircularBuffer_WrapTail(struct SolidSyslogCircularBuffer* circular)
 {
     circular->wrapPoint = circular->tail;
     circular->tail = 0;
 }
 
-static inline void StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size)
+static inline void CircularBuffer_StoreRecord(struct SolidSyslogCircularBuffer* circular, const void* data, size_t size)
 {
     uint16_t header = (uint16_t) size;
     memcpy(&circular->storage[circular->tail], &header, HEADER_BYTES);

--- a/Core/Source/SolidSyslogCrc16Policy.c
+++ b/Core/Source/SolidSyslogCrc16Policy.c
@@ -11,13 +11,13 @@ enum
     CRC16_SIZE = 2
 };
 
-static void Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
-static bool Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
+static void Crc16Policy_Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
+static bool Crc16Policy_Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
 
 static struct SolidSyslogSecurityPolicy instance = {
     CRC16_SIZE,
-    Crc16ComputeIntegrity,
-    Crc16VerifyIntegrity,
+    Crc16Policy_Crc16ComputeIntegrity,
+    Crc16Policy_Crc16VerifyIntegrity,
 };
 
 struct SolidSyslogSecurityPolicy* SolidSyslogCrc16Policy_Create(void)
@@ -29,14 +29,14 @@ void SolidSyslogCrc16Policy_Destroy(void)
 {
 }
 
-static void Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
+static void Crc16Policy_Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
 {
     uint16_t crc = SolidSyslogCrc16_Compute(data, length);
     integrityOut[0] = (uint8_t) (crc >> 8U);
     integrityOut[1] = (uint8_t) (crc & 0xFFU);
 }
 
-static bool Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
+static bool Crc16Policy_Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
 {
     uint16_t crc = SolidSyslogCrc16_Compute(data, length);
     uint16_t expected = (uint16_t) ((uint16_t) (integrityIn[0] << 8U) | integrityIn[1]);

--- a/Core/Source/SolidSyslogError.c
+++ b/Core/Source/SolidSyslogError.c
@@ -2,21 +2,21 @@
 
 #include <stddef.h>
 
-static void NoOpErrorHandler(void* context, enum SolidSyslogSeverity severity, const char* message)
+static void Error_NoOpErrorHandler(void* context, enum SolidSyslogSeverity severity, const char* message)
 {
     (void) context;
     (void) severity;
     (void) message;
 }
 
-static SolidSyslogErrorHandler currentHandler = NoOpErrorHandler;
+static SolidSyslogErrorHandler currentHandler = Error_NoOpErrorHandler;
 static void* currentContext = NULL;
 
 void SolidSyslog_SetErrorHandler(SolidSyslogErrorHandler handler, void* context)
 {
     if (handler == NULL)
     {
-        handler = NoOpErrorHandler;
+        handler = Error_NoOpErrorHandler;
     }
     currentHandler = handler;
     currentContext = context;

--- a/Core/Source/SolidSyslogFileBlockDevice.c
+++ b/Core/Source/SolidSyslogFileBlockDevice.c
@@ -28,7 +28,7 @@ enum
     MAX_BLOCK_INDEX = 99
 };
 
-static inline bool IsValidBlockIndex(size_t blockIndex)
+static inline bool FileBlockDevice_IsValidBlockIndex(size_t blockIndex)
 {
     return blockIndex <= MAX_BLOCK_INDEX;
 }
@@ -57,14 +57,14 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 /* vtable — forward-declared because Create wires them before their definitions */
-static bool Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex);
-static bool Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex);
-static bool Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex);
+static bool FileBlockDevice_Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex);
+static bool FileBlockDevice_Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex);
+static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count);
-static bool Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count);
+static bool FileBlockDevice_Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count);
+static bool FileBlockDevice_Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count);
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool WriteAt(
+static bool FileBlockDevice_WriteAt(
     struct SolidSyslogBlockDevice* self,
     size_t blockIndex,
     size_t offset,
@@ -72,10 +72,10 @@ static bool WriteAt(
     size_t count
 );
 // NOLINTEND(bugprone-easily-swappable-parameters)
-static size_t Size(struct SolidSyslogBlockDevice* self, size_t blockIndex);
+static size_t FileBlockDevice_Size(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 
-static inline struct SolidSyslogFileBlockDevice* AsFileBlockDevice(struct SolidSyslogBlockDevice* device);
-static inline void InitialiseVtable(struct SolidSyslogFileBlockDevice* device);
+static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device);
+static inline void FileBlockDevice_InitialiseVtable(struct SolidSyslogFileBlockDevice* device);
 
 /* ------------------------------------------------------------------
  * Create
@@ -89,42 +89,42 @@ struct SolidSyslogBlockDevice* SolidSyslogFileBlockDevice_Create(
 {
     struct SolidSyslogFileBlockDevice* device = (struct SolidSyslogFileBlockDevice*) storage;
 
-    InitialiseVtable(device);
+    FileBlockDevice_InitialiseVtable(device);
     device->handle = (struct OpenHandle) {.file = file, .blockIndex = 0, .isOpen = false};
     device->pathPrefix = pathPrefix;
 
     return &device->base;
 }
 
-static inline struct SolidSyslogFileBlockDevice* AsFileBlockDevice(struct SolidSyslogBlockDevice* device)
+static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device)
 {
     return (struct SolidSyslogFileBlockDevice*) device;
 }
 
-static inline void InitialiseVtable(struct SolidSyslogFileBlockDevice* device)
+static inline void FileBlockDevice_InitialiseVtable(struct SolidSyslogFileBlockDevice* device)
 {
-    device->base.Acquire = Acquire;
-    device->base.Dispose = Dispose;
-    device->base.Exists = Exists;
-    device->base.Read = Read;
-    device->base.Append = Append;
-    device->base.WriteAt = WriteAt;
-    device->base.Size = Size;
+    device->base.Acquire = FileBlockDevice_Acquire;
+    device->base.Dispose = FileBlockDevice_Dispose;
+    device->base.Exists = FileBlockDevice_Exists;
+    device->base.Read = FileBlockDevice_Read;
+    device->base.Append = FileBlockDevice_Append;
+    device->base.WriteAt = FileBlockDevice_WriteAt;
+    device->base.Size = FileBlockDevice_Size;
 }
 
 /* ------------------------------------------------------------------
  * Destroy
  * ----------------------------------------------------------------*/
 
-static inline void CloseIfOpen(struct OpenHandle* handle);
+static inline void FileBlockDevice_CloseIfOpen(struct OpenHandle* handle);
 
 void SolidSyslogFileBlockDevice_Destroy(struct SolidSyslogBlockDevice* device)
 {
-    struct SolidSyslogFileBlockDevice* fileDevice = AsFileBlockDevice(device);
-    CloseIfOpen(&fileDevice->handle);
+    struct SolidSyslogFileBlockDevice* fileDevice = FileBlockDevice_AsFileBlockDevice(device);
+    FileBlockDevice_CloseIfOpen(&fileDevice->handle);
 }
 
-static inline void CloseIfOpen(struct OpenHandle* handle)
+static inline void FileBlockDevice_CloseIfOpen(struct OpenHandle* handle)
 {
     if (handle->isOpen)
     {
@@ -134,33 +134,33 @@ static inline void CloseIfOpen(struct OpenHandle* handle)
 }
 
 /* ------------------------------------------------------------------
- * Acquire
+ * FileBlockDevice_Acquire
  * ----------------------------------------------------------------*/
 
-static bool EnsureHandleOpenOnBlock(
+static bool FileBlockDevice_EnsureHandleOpenOnBlock(
     struct OpenHandle* handle,
     const struct SolidSyslogFileBlockDevice* device,
     size_t blockIndex
 );
-static bool OpenHandleOnBlock(
+static bool FileBlockDevice_OpenHandleOnBlock(
     struct OpenHandle* handle,
     const struct SolidSyslogFileBlockDevice* device,
     size_t blockIndex
 );
-static inline const char* FormatBlockFilename(
+static inline const char* FileBlockDevice_FormatBlockFilename(
     const struct SolidSyslogFileBlockDevice* device,
     SolidSyslogFormatterStorage* storage,
     size_t blockIndex
 );
 
-static bool Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex)
+static bool FileBlockDevice_Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
     bool ready = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
-        ready = EnsureHandleOpenOnBlock(&device->handle, device, blockIndex);
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
+        ready = FileBlockDevice_EnsureHandleOpenOnBlock(&device->handle, device, blockIndex);
 
         if (ready)
         {
@@ -171,7 +171,7 @@ static bool Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex)
     return ready;
 }
 
-static inline bool IsHandleAlreadyOpenOnBlock(
+static inline bool FileBlockDevice_IsHandleAlreadyOpenOnBlock(
     const struct OpenHandle* handle,
     bool underlyingFileIsOpen,
     size_t blockIndex
@@ -180,24 +180,24 @@ static inline bool IsHandleAlreadyOpenOnBlock(
     return handle->isOpen && underlyingFileIsOpen && (handle->blockIndex == blockIndex);
 }
 
-static bool EnsureHandleOpenOnBlock(
+static bool FileBlockDevice_EnsureHandleOpenOnBlock(
     struct OpenHandle* handle,
     const struct SolidSyslogFileBlockDevice* device,
     size_t blockIndex
 )
 {
     bool underlyingFileIsOpen = SolidSyslogFile_IsOpen(handle->file);
-    bool ready = IsHandleAlreadyOpenOnBlock(handle, underlyingFileIsOpen, blockIndex);
+    bool ready = FileBlockDevice_IsHandleAlreadyOpenOnBlock(handle, underlyingFileIsOpen, blockIndex);
 
     if (!ready)
     {
-        ready = OpenHandleOnBlock(handle, device, blockIndex);
+        ready = FileBlockDevice_OpenHandleOnBlock(handle, device, blockIndex);
     }
 
     return ready;
 }
 
-static bool OpenHandleOnBlock(
+static bool FileBlockDevice_OpenHandleOnBlock(
     struct OpenHandle* handle,
     const struct SolidSyslogFileBlockDevice* device,
     size_t blockIndex
@@ -210,7 +210,7 @@ static bool OpenHandleOnBlock(
     handle->isOpen = false;
 
     SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-    const char* name = FormatBlockFilename(device, nameStorage, blockIndex);
+    const char* name = FileBlockDevice_FormatBlockFilename(device, nameStorage, blockIndex);
 
     bool opened = SolidSyslogFile_Open(handle->file, name);
 
@@ -223,7 +223,7 @@ static bool OpenHandleOnBlock(
     return opened;
 }
 
-static inline const char* FormatBlockFilename(
+static inline const char* FileBlockDevice_FormatBlockFilename(
     const struct SolidSyslogFileBlockDevice* device,
     SolidSyslogFormatterStorage* storage,
     size_t blockIndex
@@ -239,30 +239,30 @@ static inline const char* FormatBlockFilename(
 }
 
 /* ------------------------------------------------------------------
- * Dispose
+ * FileBlockDevice_Dispose
  * ----------------------------------------------------------------*/
 
-static inline void CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIndex);
+static inline void FileBlockDevice_CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIndex);
 
-static bool Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex)
+static bool FileBlockDevice_Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
     bool disposed = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
 
-        CloseIfHoldingBlock(&device->handle, blockIndex);
+        FileBlockDevice_CloseIfHoldingBlock(&device->handle, blockIndex);
 
         SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-        const char* name = FormatBlockFilename(device, nameStorage, blockIndex);
+        const char* name = FileBlockDevice_FormatBlockFilename(device, nameStorage, blockIndex);
         disposed = SolidSyslogFile_Delete(device->handle.file, name);
     }
 
     return disposed;
 }
 
-static inline void CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIndex)
+static inline void FileBlockDevice_CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIndex)
 {
     if (handle->isOpen && (handle->blockIndex == blockIndex))
     {
@@ -272,18 +272,18 @@ static inline void CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIn
 }
 
 /* ------------------------------------------------------------------
- * Exists
+ * FileBlockDevice_Exists
  * ----------------------------------------------------------------*/
 
-static bool Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex)
+static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
     bool exists = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
         SolidSyslogFormatterStorage nameStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(MAX_PATH_SIZE)];
-        const char* name = FormatBlockFilename(device, nameStorage, blockIndex);
+        const char* name = FileBlockDevice_FormatBlockFilename(device, nameStorage, blockIndex);
         exists = SolidSyslogFile_Exists(device->handle.file, name);
     }
 
@@ -291,18 +291,18 @@ static bool Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 }
 
 /* ------------------------------------------------------------------
- * Read / Append / WriteAt / Size
+ * FileBlockDevice_Read / FileBlockDevice_Append / FileBlockDevice_WriteAt / FileBlockDevice_Size
  * ----------------------------------------------------------------*/
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count)
+static bool FileBlockDevice_Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count)
 {
     bool read = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
-        if (EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
+        if (FileBlockDevice_EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
         {
             SolidSyslogFile_SeekTo(device->handle.file, offset);
             read = SolidSyslogFile_Read(device->handle.file, buf, count);
@@ -312,14 +312,14 @@ static bool Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t 
     return read;
 }
 
-static bool Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count)
+static bool FileBlockDevice_Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count)
 {
     bool written = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
-        if (EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
+        if (FileBlockDevice_EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
         {
             SolidSyslogFile_SeekTo(device->handle.file, SolidSyslogFile_Size(device->handle.file));
             written = SolidSyslogFile_Write(device->handle.file, buf, count);
@@ -330,7 +330,7 @@ static bool Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const
 }
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool WriteAt(
+static bool FileBlockDevice_WriteAt(
     struct SolidSyslogBlockDevice* self,
     size_t blockIndex,
     size_t offset,
@@ -340,10 +340,10 @@ static bool WriteAt(
 {
     bool written = false;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
-        if (EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
+        if (FileBlockDevice_EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
         {
             SolidSyslogFile_SeekTo(device->handle.file, offset);
             written = SolidSyslogFile_Write(device->handle.file, buf, count);
@@ -355,14 +355,14 @@ static bool WriteAt(
 
 // NOLINTEND(bugprone-easily-swappable-parameters)
 
-static size_t Size(struct SolidSyslogBlockDevice* self, size_t blockIndex)
+static size_t FileBlockDevice_Size(struct SolidSyslogBlockDevice* self, size_t blockIndex)
 {
     size_t size = 0;
 
-    if (IsValidBlockIndex(blockIndex))
+    if (FileBlockDevice_IsValidBlockIndex(blockIndex))
     {
-        struct SolidSyslogFileBlockDevice* device = AsFileBlockDevice(self);
-        if (EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
+        struct SolidSyslogFileBlockDevice* device = FileBlockDevice_AsFileBlockDevice(self);
+        if (FileBlockDevice_EnsureHandleOpenOnBlock(&device->handle, device, blockIndex))
         {
             size = SolidSyslogFile_Size(device->handle.file);
         }

--- a/Core/Source/SolidSyslogFileBlockDevice.c
+++ b/Core/Source/SolidSyslogFileBlockDevice.c
@@ -61,8 +61,19 @@ static bool FileBlockDevice_Acquire(struct SolidSyslogBlockDevice* self, size_t 
 static bool FileBlockDevice_Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool FileBlockDevice_Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count);
-static bool FileBlockDevice_Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count);
+static bool FileBlockDevice_Read(
+    struct SolidSyslogBlockDevice* self,
+    size_t blockIndex,
+    size_t offset,
+    void* buf,
+    size_t count
+);
+static bool FileBlockDevice_Append(
+    struct SolidSyslogBlockDevice* self,
+    size_t blockIndex,
+    const void* buf,
+    size_t count
+);
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
 static bool FileBlockDevice_WriteAt(
     struct SolidSyslogBlockDevice* self,
@@ -74,7 +85,8 @@ static bool FileBlockDevice_WriteAt(
 // NOLINTEND(bugprone-easily-swappable-parameters)
 static size_t FileBlockDevice_Size(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 
-static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device);
+static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device
+);
 static inline void FileBlockDevice_InitialiseVtable(struct SolidSyslogFileBlockDevice* device);
 
 /* ------------------------------------------------------------------
@@ -96,7 +108,8 @@ struct SolidSyslogBlockDevice* SolidSyslogFileBlockDevice_Create(
     return &device->base;
 }
 
-static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device)
+static inline struct SolidSyslogFileBlockDevice* FileBlockDevice_AsFileBlockDevice(struct SolidSyslogBlockDevice* device
+)
 {
     return (struct SolidSyslogFileBlockDevice*) device;
 }
@@ -295,7 +308,13 @@ static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t b
  * ----------------------------------------------------------------*/
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
-static bool FileBlockDevice_Read(struct SolidSyslogBlockDevice* self, size_t blockIndex, size_t offset, void* buf, size_t count)
+static bool FileBlockDevice_Read(
+    struct SolidSyslogBlockDevice* self,
+    size_t blockIndex,
+    size_t offset,
+    void* buf,
+    size_t count
+)
 {
     bool read = false;
 
@@ -312,7 +331,12 @@ static bool FileBlockDevice_Read(struct SolidSyslogBlockDevice* self, size_t blo
     return read;
 }
 
-static bool FileBlockDevice_Append(struct SolidSyslogBlockDevice* self, size_t blockIndex, const void* buf, size_t count)
+static bool FileBlockDevice_Append(
+    struct SolidSyslogBlockDevice* self,
+    size_t blockIndex,
+    const void* buf,
+    size_t count
+)
 {
     bool written = false;
 

--- a/Core/Source/SolidSyslogFileBlockDevice.c
+++ b/Core/Source/SolidSyslogFileBlockDevice.c
@@ -60,7 +60,7 @@ SOLIDSYSLOG_STATIC_ASSERT(
 static bool FileBlockDevice_Acquire(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 static bool FileBlockDevice_Dispose(struct SolidSyslogBlockDevice* self, size_t blockIndex);
 static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t blockIndex);
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
+// NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
 static bool FileBlockDevice_Read(
     struct SolidSyslogBlockDevice* self,
     size_t blockIndex,
@@ -68,6 +68,7 @@ static bool FileBlockDevice_Read(
     void* buf,
     size_t count
 );
+// NOLINTEND(bugprone-easily-swappable-parameters)
 static bool FileBlockDevice_Append(
     struct SolidSyslogBlockDevice* self,
     size_t blockIndex,
@@ -307,7 +308,7 @@ static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* self, size_t b
  * FileBlockDevice_Read / FileBlockDevice_Append / FileBlockDevice_WriteAt / FileBlockDevice_Size
  * ----------------------------------------------------------------*/
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
+// NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
 static bool FileBlockDevice_Read(
     struct SolidSyslogBlockDevice* self,
     size_t blockIndex,
@@ -330,6 +331,8 @@ static bool FileBlockDevice_Read(
 
     return read;
 }
+
+// NOLINTEND(bugprone-easily-swappable-parameters)
 
 static bool FileBlockDevice_Append(
     struct SolidSyslogBlockDevice* self,

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -197,7 +197,8 @@ static inline size_t Formatter_Utf8CodepointLength(const char* source)
     {
         length = 2;
     }
-    else if ((source[1] != '\0') && (source[2] != '\0') && Formatter_IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    else if ((source[1] != '\0') && (source[2] != '\0') &&
+             Formatter_IsValidUtf8ThreeByte(source[0], source[1], source[2]))
     {
         length = 3;
     }
@@ -224,7 +225,8 @@ static inline bool Formatter_IsOverlongTwoByteLead(char byte)
 static inline bool Formatter_IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
 {
     return SolidSyslogUtf8_IsThreeByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) &&
-           SolidSyslogUtf8_IsContinuationByte(continuation2) && !Formatter_IsOverlongThreeByteEncoding(lead, continuation1) &&
+           SolidSyslogUtf8_IsContinuationByte(continuation2) &&
+           !Formatter_IsOverlongThreeByteEncoding(lead, continuation1) &&
            !Formatter_IsUtf16SurrogateEncoding(lead, continuation1);
 }
 
@@ -242,7 +244,8 @@ static inline bool Formatter_IsValidUtf8FourByte(char lead, char continuation1, 
 {
     return SolidSyslogUtf8_IsFourByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) &&
            SolidSyslogUtf8_IsContinuationByte(continuation2) && SolidSyslogUtf8_IsContinuationByte(continuation3) &&
-           !Formatter_IsOverlongFourByteEncoding(lead, continuation1) && !Formatter_IsAboveUnicodeMaxEncoding(lead, continuation1);
+           !Formatter_IsOverlongFourByteEncoding(lead, continuation1) &&
+           !Formatter_IsAboveUnicodeMaxEncoding(lead, continuation1);
 }
 
 static inline bool Formatter_IsOverlongFourByteEncoding(char lead, char continuation1)
@@ -350,7 +353,13 @@ static inline void Formatter_WriteCodepoint(struct EscapedContext* context)
     size_t codepointLength = Formatter_Utf8CodepointLength(&context->source[context->sourcePos]);
     if (Formatter_Fits(context, codepointLength))
     {
-        Formatter_WriteContext(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
+        Formatter_WriteContext(
+            context,
+            &context->source[context->sourcePos],
+            codepointLength,
+            codepointLength,
+            codepointLength
+        );
         return;
     }
     Formatter_WriteReplacement(context);
@@ -360,7 +369,13 @@ static inline void Formatter_WriteReplacement(struct EscapedContext* context)
 {
     if (Formatter_Fits(context, sizeof(REPLACEMENT_CHARACTER)))
     {
-        Formatter_WriteContext(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
+        Formatter_WriteContext(
+            context,
+            REPLACEMENT_CHARACTER,
+            sizeof(REPLACEMENT_CHARACTER),
+            1,
+            sizeof(REPLACEMENT_CHARACTER)
+        );
         return;
     }
     Formatter_Exhaust(context);

--- a/Core/Source/SolidSyslogFormatter.c
+++ b/Core/Source/SolidSyslogFormatter.c
@@ -51,32 +51,32 @@ struct EscapedContext
     bool exhausted;
 };
 
-static inline bool CodepointFits(size_t codepointLength, size_t remainingDecodedLength);
-static inline bool Fits(const struct EscapedContext* context, size_t decodedAdvance);
-static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter);
-static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1);
-static inline bool IsOverlongFourByteEncoding(char lead, char continuation1);
-static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1);
-static inline bool IsOverlongTwoByteLead(char byte);
-static inline bool IsAsciiCharacter(char value);
-static inline bool IsExhausted(const struct EscapedContext* context);
-static inline bool IsPrintableUsAscii(char value);
-static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1);
-static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
-static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
-static inline bool IsValidUtf8TwoByte(char lead, char continuation1);
-static inline bool NeedsEscape(char value);
-static inline char DigitToChar(uint32_t value);
-static size_t CountDigits(uint32_t value);
-static inline size_t Utf8CodepointLength(const char* source);
-static inline void Exhaust(struct EscapedContext* context);
-static inline void NullTerminate(struct SolidSyslogFormatter* formatter);
-static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
-static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
-static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void WriteCodepoint(struct EscapedContext* context);
+static inline bool Formatter_CodepointFits(size_t codepointLength, size_t remainingDecodedLength);
+static inline bool Formatter_Fits(const struct EscapedContext* context, size_t decodedAdvance);
+static inline bool Formatter_HasCapacity(const struct SolidSyslogFormatter* formatter);
+static inline bool Formatter_IsAboveUnicodeMaxEncoding(char lead, char continuation1);
+static inline bool Formatter_IsOverlongFourByteEncoding(char lead, char continuation1);
+static inline bool Formatter_IsOverlongThreeByteEncoding(char lead, char continuation1);
+static inline bool Formatter_IsOverlongTwoByteLead(char byte);
+static inline bool Formatter_IsAsciiCharacter(char value);
+static inline bool Formatter_IsExhausted(const struct EscapedContext* context);
+static inline bool Formatter_IsPrintableUsAscii(char value);
+static inline bool Formatter_IsUtf16SurrogateEncoding(char lead, char continuation1);
+static inline bool Formatter_IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3);
+static inline bool Formatter_IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2);
+static inline bool Formatter_IsValidUtf8TwoByte(char lead, char continuation1);
+static inline bool Formatter_NeedsEscape(char value);
+static inline char Formatter_DigitToChar(uint32_t value);
+static size_t Formatter_CountDigits(uint32_t value);
+static inline size_t Formatter_Utf8CodepointLength(const char* source);
+static inline void Formatter_Exhaust(struct EscapedContext* context);
+static inline void Formatter_NullTerminate(struct SolidSyslogFormatter* formatter);
+static inline void Formatter_TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter);
+static inline void Formatter_WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count);
+static inline void Formatter_WriteChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void Formatter_WriteCodepoint(struct EscapedContext* context);
 /* NOLINTBEGIN(bugprone-easily-swappable-parameters) -- 3 callers in this file pass compile-time constants or codepointLength; param names disambiguate */
-static inline void WriteContext(
+static inline void Formatter_WriteContext(
     struct EscapedContext* context,
     const char* bytes,
     size_t byteCount,
@@ -84,20 +84,20 @@ static inline void WriteContext(
     size_t decodedAdvance
 );
 /* NOLINTEND(bugprone-easily-swappable-parameters) */
-static inline void WriteEscaped(struct EscapedContext* context);
-static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
-static inline void WriteReplacement(struct EscapedContext* context);
+static inline void Formatter_WriteEscaped(struct EscapedContext* context);
+static inline void Formatter_WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value);
+static inline void Formatter_WriteReplacement(struct EscapedContext* context);
 
 struct SolidSyslogFormatter* SolidSyslogFormatter_Create(SolidSyslogFormatterStorage* storage, size_t bufferSize)
 {
     struct SolidSyslogFormatter* formatter = (struct SolidSyslogFormatter*) storage;
     formatter->size = bufferSize;
     formatter->position = 0;
-    NullTerminate(formatter);
+    Formatter_NullTerminate(formatter);
     return formatter;
 }
 
-static inline void NullTerminate(struct SolidSyslogFormatter* formatter)
+static inline void Formatter_NullTerminate(struct SolidSyslogFormatter* formatter)
 {
     if (formatter->size > 0)
     {
@@ -107,35 +107,35 @@ static inline void NullTerminate(struct SolidSyslogFormatter* formatter)
 
 void SolidSyslogFormatter_AsciiCharacter(struct SolidSyslogFormatter* formatter, char value)
 {
-    if (!IsAsciiCharacter(value))
+    if (!Formatter_IsAsciiCharacter(value))
     {
         value = NON_PRINTABLE_SUBSTITUTE;
     }
-    WriteChar(formatter, value);
-    NullTerminate(formatter);
+    Formatter_WriteChar(formatter, value);
+    Formatter_NullTerminate(formatter);
 }
 
 void SolidSyslogFormatter_Bom(struct SolidSyslogFormatter* formatter)
 {
-    WriteBytes(formatter, UTF8_BOM, sizeof(UTF8_BOM));
-    NullTerminate(formatter);
+    Formatter_WriteBytes(formatter, UTF8_BOM, sizeof(UTF8_BOM));
+    Formatter_NullTerminate(formatter);
 }
 
-static inline bool IsAsciiCharacter(char value)
+static inline bool Formatter_IsAsciiCharacter(char value)
 {
-    return (value == ' ') || IsPrintableUsAscii(value);
+    return (value == ' ') || Formatter_IsPrintableUsAscii(value);
 }
 
-static inline void WriteChar(struct SolidSyslogFormatter* formatter, char value)
+static inline void Formatter_WriteChar(struct SolidSyslogFormatter* formatter, char value)
 {
-    if (HasCapacity(formatter))
+    if (Formatter_HasCapacity(formatter))
     {
         formatter->buffer[formatter->position] = value;
         formatter->position++;
     }
 }
 
-static inline bool HasCapacity(const struct SolidSyslogFormatter* formatter)
+static inline bool Formatter_HasCapacity(const struct SolidSyslogFormatter* formatter)
 {
     return (formatter->size > 0) && (formatter->position < formatter->size - 1);
 }
@@ -164,28 +164,28 @@ void SolidSyslogFormatter_BoundedString(struct SolidSyslogFormatter* formatter, 
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        size_t codepointLength = Utf8CodepointLength(&source[len]);
+        size_t codepointLength = Formatter_Utf8CodepointLength(&source[len]);
 
-        if (CodepointFits(codepointLength, maxLength - len))
+        if (Formatter_CodepointFits(codepointLength, maxLength - len))
         {
-            WriteBytes(formatter, &source[len], codepointLength);
+            Formatter_WriteBytes(formatter, &source[len], codepointLength);
             len += codepointLength;
         }
         else
         {
-            WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
+            Formatter_WriteBytes(formatter, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER));
             len += 1;
         }
     }
-    NullTerminate(formatter);
+    Formatter_NullTerminate(formatter);
 }
 
-static inline bool CodepointFits(size_t codepointLength, size_t remainingDecodedLength)
+static inline bool Formatter_CodepointFits(size_t codepointLength, size_t remainingDecodedLength)
 {
     return (codepointLength > 0) && (codepointLength <= remainingDecodedLength);
 }
 
-static inline size_t Utf8CodepointLength(const char* source)
+static inline size_t Formatter_Utf8CodepointLength(const char* source)
 {
     size_t length = 0;
 
@@ -193,16 +193,16 @@ static inline size_t Utf8CodepointLength(const char* source)
     {
         length = 1;
     }
-    else if ((source[1] != '\0') && IsValidUtf8TwoByte(source[0], source[1]))
+    else if ((source[1] != '\0') && Formatter_IsValidUtf8TwoByte(source[0], source[1]))
     {
         length = 2;
     }
-    else if ((source[1] != '\0') && (source[2] != '\0') && IsValidUtf8ThreeByte(source[0], source[1], source[2]))
+    else if ((source[1] != '\0') && (source[2] != '\0') && Formatter_IsValidUtf8ThreeByte(source[0], source[1], source[2]))
     {
         length = 3;
     }
     else if ((source[1] != '\0') && (source[2] != '\0') && (source[3] != '\0') &&
-             IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
+             Formatter_IsValidUtf8FourByte(source[0], source[1], source[2], source[3]))
     {
         length = 4;
     }
@@ -210,58 +210,58 @@ static inline size_t Utf8CodepointLength(const char* source)
     return length;
 }
 
-static inline bool IsValidUtf8TwoByte(char lead, char continuation1)
+static inline bool Formatter_IsValidUtf8TwoByte(char lead, char continuation1)
 {
-    return SolidSyslogUtf8_IsTwoByteLead(lead) && !IsOverlongTwoByteLead(lead) &&
+    return SolidSyslogUtf8_IsTwoByteLead(lead) && !Formatter_IsOverlongTwoByteLead(lead) &&
            SolidSyslogUtf8_IsContinuationByte(continuation1);
 }
 
-static inline bool IsOverlongTwoByteLead(char byte)
+static inline bool Formatter_IsOverlongTwoByteLead(char byte)
 {
     return (byte & 0xFE) == 0xC0;
 }
 
-static inline bool IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
+static inline bool Formatter_IsValidUtf8ThreeByte(char lead, char continuation1, char continuation2)
 {
     return SolidSyslogUtf8_IsThreeByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) &&
-           SolidSyslogUtf8_IsContinuationByte(continuation2) && !IsOverlongThreeByteEncoding(lead, continuation1) &&
-           !IsUtf16SurrogateEncoding(lead, continuation1);
+           SolidSyslogUtf8_IsContinuationByte(continuation2) && !Formatter_IsOverlongThreeByteEncoding(lead, continuation1) &&
+           !Formatter_IsUtf16SurrogateEncoding(lead, continuation1);
 }
 
-static inline bool IsOverlongThreeByteEncoding(char lead, char continuation1)
+static inline bool Formatter_IsOverlongThreeByteEncoding(char lead, char continuation1)
 {
     return (lead == '\xE0') && ((continuation1 & 0xE0) == 0x80);
 }
 
-static inline bool IsUtf16SurrogateEncoding(char lead, char continuation1)
+static inline bool Formatter_IsUtf16SurrogateEncoding(char lead, char continuation1)
 {
     return (lead == '\xED') && ((continuation1 & 0xE0) == 0xA0);
 }
 
-static inline bool IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
+static inline bool Formatter_IsValidUtf8FourByte(char lead, char continuation1, char continuation2, char continuation3)
 {
     return SolidSyslogUtf8_IsFourByteLead(lead) && SolidSyslogUtf8_IsContinuationByte(continuation1) &&
            SolidSyslogUtf8_IsContinuationByte(continuation2) && SolidSyslogUtf8_IsContinuationByte(continuation3) &&
-           !IsOverlongFourByteEncoding(lead, continuation1) && !IsAboveUnicodeMaxEncoding(lead, continuation1);
+           !Formatter_IsOverlongFourByteEncoding(lead, continuation1) && !Formatter_IsAboveUnicodeMaxEncoding(lead, continuation1);
 }
 
-static inline bool IsOverlongFourByteEncoding(char lead, char continuation1)
+static inline bool Formatter_IsOverlongFourByteEncoding(char lead, char continuation1)
 {
     return (lead == '\xF0') && ((continuation1 & 0xF0) == 0x80);
 }
 
-static inline bool IsAboveUnicodeMaxEncoding(char lead, char continuation1)
+static inline bool Formatter_IsAboveUnicodeMaxEncoding(char lead, char continuation1)
 {
     bool f4WithCont1Above8F = (lead == '\xF4') && ((continuation1 & 0xF0) != 0x80);
     bool f5OrHigherLead = (lead == '\xF5') || (lead == '\xF6') || (lead == '\xF7');
     return f4WithCont1Above8F || f5OrHigherLead;
 }
 
-static inline void WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
+static inline void Formatter_WriteBytes(struct SolidSyslogFormatter* formatter, const char* bytes, size_t count)
 {
     for (size_t i = 0; i < count; i++)
     {
-        WriteChar(formatter, bytes[i]);
+        Formatter_WriteChar(formatter, bytes[i]);
     }
 }
 
@@ -280,48 +280,48 @@ void SolidSyslogFormatter_EscapedString(
         .exhausted = false,
     };
 
-    while (!IsExhausted(&context))
+    while (!Formatter_IsExhausted(&context))
     {
-        if (NeedsEscape(source[context.sourcePos]))
+        if (Formatter_NeedsEscape(source[context.sourcePos]))
         {
-            WriteEscaped(&context);
+            Formatter_WriteEscaped(&context);
         }
         else
         {
-            WriteCodepoint(&context);
+            Formatter_WriteCodepoint(&context);
         }
     }
-    NullTerminate(formatter);
+    Formatter_NullTerminate(formatter);
 }
 
-static inline bool NeedsEscape(char value)
+static inline bool Formatter_NeedsEscape(char value)
 {
     return (value == QUOTE) || (value == BACKSLASH) || (value == CLOSE_BRACKET);
 }
 
-static inline bool IsExhausted(const struct EscapedContext* context)
+static inline bool Formatter_IsExhausted(const struct EscapedContext* context)
 {
     return context->exhausted || (context->source[context->sourcePos] == '\0');
 }
 
-static inline void WriteEscaped(struct EscapedContext* context)
+static inline void Formatter_WriteEscaped(struct EscapedContext* context)
 {
-    if (Fits(context, ESCAPED_CHARACTER_DECODED_LENGTH))
+    if (Formatter_Fits(context, ESCAPED_CHARACTER_DECODED_LENGTH))
     {
         char escaped[] = {ESCAPE_PREFIX, context->source[context->sourcePos]};
-        WriteContext(context, escaped, sizeof(escaped), 1, ESCAPED_CHARACTER_DECODED_LENGTH);
+        Formatter_WriteContext(context, escaped, sizeof(escaped), 1, ESCAPED_CHARACTER_DECODED_LENGTH);
         return;
     }
-    Exhaust(context);
+    Formatter_Exhaust(context);
 }
 
-static inline bool Fits(const struct EscapedContext* context, size_t decodedAdvance)
+static inline bool Formatter_Fits(const struct EscapedContext* context, size_t decodedAdvance)
 {
     return (decodedAdvance > 0) && (decodedAdvance <= context->maxDecodedLength - context->decodedLength);
 }
 
 /* NOLINTBEGIN(bugprone-easily-swappable-parameters) -- see forward declaration */
-static inline void WriteContext(
+static inline void Formatter_WriteContext(
     struct EscapedContext* context,
     const char* bytes,
     size_t byteCount,
@@ -329,41 +329,41 @@ static inline void WriteContext(
     size_t decodedAdvance
 )
 {
-    WriteBytes(context->formatter, bytes, byteCount);
+    Formatter_WriteBytes(context->formatter, bytes, byteCount);
     context->sourcePos += sourceAdvance;
     context->decodedLength += decodedAdvance;
 }
 
 /* NOLINTEND(bugprone-easily-swappable-parameters) */
 
-static inline void Exhaust(struct EscapedContext* context)
+static inline void Formatter_Exhaust(struct EscapedContext* context)
 {
     context->exhausted = true;
 }
 
 /* Writes the source codepoint at sourcePos if it fits the decoded budget;
- * otherwise falls back to WriteReplacement (which emits U+FFFD or marks
- * the context exhausted). Fits also rejects invalid UTF-8 because
- * Utf8CodepointLength returns 0 for ill-formed sequences. */
-static inline void WriteCodepoint(struct EscapedContext* context)
+ * otherwise falls back to Formatter_WriteReplacement (which emits U+FFFD or marks
+ * the context exhausted). Formatter_Fits also rejects invalid UTF-8 because
+ * Formatter_Utf8CodepointLength returns 0 for ill-formed sequences. */
+static inline void Formatter_WriteCodepoint(struct EscapedContext* context)
 {
-    size_t codepointLength = Utf8CodepointLength(&context->source[context->sourcePos]);
-    if (Fits(context, codepointLength))
+    size_t codepointLength = Formatter_Utf8CodepointLength(&context->source[context->sourcePos]);
+    if (Formatter_Fits(context, codepointLength))
     {
-        WriteContext(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
+        Formatter_WriteContext(context, &context->source[context->sourcePos], codepointLength, codepointLength, codepointLength);
         return;
     }
-    WriteReplacement(context);
+    Formatter_WriteReplacement(context);
 }
 
-static inline void WriteReplacement(struct EscapedContext* context)
+static inline void Formatter_WriteReplacement(struct EscapedContext* context)
 {
-    if (Fits(context, sizeof(REPLACEMENT_CHARACTER)))
+    if (Formatter_Fits(context, sizeof(REPLACEMENT_CHARACTER)))
     {
-        WriteContext(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
+        Formatter_WriteContext(context, REPLACEMENT_CHARACTER, sizeof(REPLACEMENT_CHARACTER), 1, sizeof(REPLACEMENT_CHARACTER));
         return;
     }
-    Exhaust(context);
+    Formatter_Exhaust(context);
 }
 
 void SolidSyslogFormatter_PrintUsAsciiString(
@@ -376,32 +376,32 @@ void SolidSyslogFormatter_PrintUsAsciiString(
 
     while ((len < maxLength) && (source[len] != '\0'))
     {
-        WritePrintableUsAsciiChar(formatter, source[len]);
+        Formatter_WritePrintableUsAsciiChar(formatter, source[len]);
         len++;
     }
-    NullTerminate(formatter);
+    Formatter_NullTerminate(formatter);
 }
 
-static inline void WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
+static inline void Formatter_WritePrintableUsAsciiChar(struct SolidSyslogFormatter* formatter, char value)
 {
-    if (IsPrintableUsAscii(value))
+    if (Formatter_IsPrintableUsAscii(value))
     {
-        WriteChar(formatter, value);
+        Formatter_WriteChar(formatter, value);
     }
     else
     {
-        WriteChar(formatter, NON_PRINTABLE_SUBSTITUTE);
+        Formatter_WriteChar(formatter, NON_PRINTABLE_SUBSTITUTE);
     }
 }
 
-static inline bool IsPrintableUsAscii(char value)
+static inline bool Formatter_IsPrintableUsAscii(char value)
 {
     return (value >= LOWEST_PRINTABLE_US_ASCII) && (value <= HIGHEST_PRINTABLE_US_ASCII);
 }
 
 void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    size_t digits = CountDigits(value);
+    size_t digits = Formatter_CountDigits(value);
     uint32_t divisor = 1;
 
     for (size_t i = 1; i < digits; i++)
@@ -411,14 +411,14 @@ void SolidSyslogFormatter_Uint32(struct SolidSyslogFormatter* formatter, uint32_
 
     for (size_t i = 0; i < digits; i++)
     {
-        WriteChar(formatter, DigitToChar(value / divisor));
+        Formatter_WriteChar(formatter, Formatter_DigitToChar(value / divisor));
         value %= divisor;
         divisor /= 10U;
     }
-    NullTerminate(formatter);
+    Formatter_NullTerminate(formatter);
 }
 
-static size_t CountDigits(uint32_t value)
+static size_t Formatter_CountDigits(uint32_t value)
 {
     size_t count = 1;
 
@@ -431,45 +431,45 @@ static size_t CountDigits(uint32_t value)
     return count;
 }
 
-static inline char DigitToChar(uint32_t value)
+static inline char Formatter_DigitToChar(uint32_t value)
 {
     return (char) ('0' + (value % 10U));
 }
 
 void SolidSyslogFormatter_TwoDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    WriteChar(formatter, DigitToChar(value / 10U));
-    WriteChar(formatter, DigitToChar(value));
-    NullTerminate(formatter);
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 10U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value));
+    Formatter_NullTerminate(formatter);
 }
 
 void SolidSyslogFormatter_FourDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    WriteChar(formatter, DigitToChar(value / 1000U));
-    WriteChar(formatter, DigitToChar(value / 100U));
-    WriteChar(formatter, DigitToChar(value / 10U));
-    WriteChar(formatter, DigitToChar(value));
-    NullTerminate(formatter);
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 1000U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 100U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 10U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value));
+    Formatter_NullTerminate(formatter);
 }
 
 void SolidSyslogFormatter_SixDigit(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
-    WriteChar(formatter, DigitToChar(value / 100000U));
-    WriteChar(formatter, DigitToChar(value / 10000U));
-    WriteChar(formatter, DigitToChar(value / 1000U));
-    WriteChar(formatter, DigitToChar(value / 100U));
-    WriteChar(formatter, DigitToChar(value / 10U));
-    WriteChar(formatter, DigitToChar(value));
-    NullTerminate(formatter);
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 100000U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 10000U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 1000U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 100U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value / 10U));
+    Formatter_WriteChar(formatter, Formatter_DigitToChar(value));
+    Formatter_NullTerminate(formatter);
 }
 
 const char* SolidSyslogFormatter_AsFormattedBuffer(struct SolidSyslogFormatter* formatter)
 {
-    TrimTruncatedMultiByteTail(formatter);
+    Formatter_TrimTruncatedMultiByteTail(formatter);
     return formatter->buffer;
 }
 
-static inline void TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter)
+static inline void Formatter_TrimTruncatedMultiByteTail(struct SolidSyslogFormatter* formatter)
 {
     char* buffer = formatter->buffer;
     size_t p = formatter->position;

--- a/Core/Source/SolidSyslogMetaSd.c
+++ b/Core/Source/SolidSyslogMetaSd.c
@@ -19,14 +19,14 @@ struct SolidSyslogMetaSd
     SolidSyslogStringFunction getLanguage;
 };
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static void NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
-static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
-static inline void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static void MetaSd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static void MetaSd_NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static inline void MetaSd_EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static inline void MetaSd_EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
+static inline void MetaSd_EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter);
 
 static struct SolidSyslogMetaSd instance;
-static struct SolidSyslogStructuredData NilMetaSd = {.Format = NilMetaSdFormat};
+static struct SolidSyslogStructuredData NilMetaSd = {.Format = MetaSd_NilMetaSdFormat};
 
 struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(const struct SolidSyslogMetaSdConfig* config)
 {
@@ -41,7 +41,7 @@ struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(const struct SolidSys
     }
     else
     {
-        instance.base.Format = Format;
+        instance.base.Format = MetaSd_Format;
         instance.counter = config->counter;
         instance.getSysUpTime = config->getSysUpTime;
         instance.getLanguage = config->getLanguage;
@@ -58,7 +58,7 @@ void SolidSyslogMetaSd_Destroy(void)
     instance.getLanguage = NULL;
 }
 
-static void NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
+static void MetaSd_NilMetaSdFormat(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
 {
     (void) self;
     (void) formatter;
@@ -69,25 +69,25 @@ static const char SEQUENCE_ID_SD[] = " sequenceId=\"";
 static const char SYS_UP_TIME_SD[] = " sysUpTime=\"";
 static const char LANGUAGE_SD[] = " language=\"";
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
+static void MetaSd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
 {
     struct SolidSyslogMetaSd* meta = (struct SolidSyslogMetaSd*) self;
 
     SolidSyslogFormatter_BoundedString(formatter, SD_PREFIX, sizeof(SD_PREFIX) - 1);
-    EmitSequenceId(meta, formatter);
-    EmitSysUpTime(meta, formatter);
-    EmitLanguage(meta, formatter);
+    MetaSd_EmitSequenceId(meta, formatter);
+    MetaSd_EmitSysUpTime(meta, formatter);
+    MetaSd_EmitLanguage(meta, formatter);
     SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
-static inline void EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void MetaSd_EmitSequenceId(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
     SolidSyslogFormatter_BoundedString(formatter, SEQUENCE_ID_SD, sizeof(SEQUENCE_ID_SD) - 1);
     SolidSyslogFormatter_Uint32(formatter, SolidSyslogAtomicCounter_Increment(meta->counter));
     SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
-static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void MetaSd_EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
     if (meta->getSysUpTime != NULL)
     {
@@ -97,7 +97,7 @@ static inline void EmitSysUpTime(struct SolidSyslogMetaSd* meta, struct SolidSys
     }
 }
 
-static inline void EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
+static inline void MetaSd_EmitLanguage(struct SolidSyslogMetaSd* meta, struct SolidSyslogFormatter* formatter)
 {
     if (meta->getLanguage != NULL)
     {

--- a/Core/Source/SolidSyslogNullBuffer.c
+++ b/Core/Source/SolidSyslogNullBuffer.c
@@ -6,8 +6,8 @@
 #include "SolidSyslogBufferDefinition.h"
 #include "SolidSyslogSender.h"
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
+static bool NullBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
+static void NullBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
 struct SolidSyslogNullBuffer
 {
@@ -19,8 +19,8 @@ static struct SolidSyslogNullBuffer instance;
 
 struct SolidSyslogBuffer* SolidSyslogNullBuffer_Create(struct SolidSyslogSender* sender)
 {
-    instance.base.Write = Write;
-    instance.base.Read = Read;
+    instance.base.Write = NullBuffer_Write;
+    instance.base.Read = NullBuffer_Read;
     instance.sender = sender;
     return &instance.base;
 }
@@ -32,7 +32,7 @@ void SolidSyslogNullBuffer_Destroy(void)
     instance.sender = NULL;
 }
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool NullBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     (void) self;
     (void) data;
@@ -41,7 +41,7 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
     return false;
 }
 
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
+static void NullBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogNullBuffer* nullBuffer = (struct SolidSyslogNullBuffer*) self;
     SolidSyslogSender_Send(nullBuffer->sender, data, size);

--- a/Core/Source/SolidSyslogNullMutex.c
+++ b/Core/Source/SolidSyslogNullMutex.c
@@ -4,15 +4,15 @@
 
 #include "SolidSyslogMutexDefinition.h"
 
-static void Lock(struct SolidSyslogMutex* self);
-static void Unlock(struct SolidSyslogMutex* self);
+static void NullMutex_Lock(struct SolidSyslogMutex* self);
+static void NullMutex_Unlock(struct SolidSyslogMutex* self);
 
 static struct SolidSyslogMutex instance;
 
 struct SolidSyslogMutex* SolidSyslogNullMutex_Create(void)
 {
-    instance.Lock = Lock;
-    instance.Unlock = Unlock;
+    instance.Lock = NullMutex_Lock;
+    instance.Unlock = NullMutex_Unlock;
     return &instance;
 }
 
@@ -22,12 +22,12 @@ void SolidSyslogNullMutex_Destroy(void)
     instance.Unlock = NULL;
 }
 
-static void Lock(struct SolidSyslogMutex* self)
+static void NullMutex_Lock(struct SolidSyslogMutex* self)
 {
     (void) self;
 }
 
-static void Unlock(struct SolidSyslogMutex* self)
+static void NullMutex_Unlock(struct SolidSyslogMutex* self)
 {
     (void) self;
 }

--- a/Core/Source/SolidSyslogNullSecurityPolicy.c
+++ b/Core/Source/SolidSyslogNullSecurityPolicy.c
@@ -6,14 +6,14 @@
 #include "SolidSyslogSecurityPolicyDefinition.h"
 
 // NOLINTNEXTLINE(readability-non-const-parameter) -- matches SecurityPolicy vtable signature
-static void NullComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
+static void NullSecurityPolicy_NullComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut)
 {
     (void) data;
     (void) length;
     (void) integrityOut;
 }
 
-static bool NullVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
+static bool NullSecurityPolicy_NullVerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn)
 {
     (void) data;
     (void) length;
@@ -23,8 +23,8 @@ static bool NullVerifyIntegrity(const uint8_t* data, uint16_t length, const uint
 
 static struct SolidSyslogSecurityPolicy instance = {
     0,
-    NullComputeIntegrity,
-    NullVerifyIntegrity,
+    NullSecurityPolicy_NullComputeIntegrity,
+    NullSecurityPolicy_NullVerifyIntegrity,
 };
 
 struct SolidSyslogSecurityPolicy* SolidSyslogNullSecurityPolicy_Create(void)

--- a/Core/Source/SolidSyslogNullStore.c
+++ b/Core/Source/SolidSyslogNullStore.c
@@ -5,14 +5,14 @@
 
 #include "SolidSyslogStoreDefinition.h"
 
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size);
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
-static void MarkSent(struct SolidSyslogStore* self);
-static bool HasUnsent(struct SolidSyslogStore* self);
-static bool IsHalted(struct SolidSyslogStore* self);
-static size_t GetTotalBytes(struct SolidSyslogStore* self);
-static size_t GetUsedBytes(struct SolidSyslogStore* self);
-static bool IsTransient(struct SolidSyslogStore* self);
+static bool NullStore_Write(struct SolidSyslogStore* self, const void* data, size_t size);
+static bool NullStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead);
+static void NullStore_MarkSent(struct SolidSyslogStore* self);
+static bool NullStore_HasUnsent(struct SolidSyslogStore* self);
+static bool NullStore_IsHalted(struct SolidSyslogStore* self);
+static size_t NullStore_GetTotalBytes(struct SolidSyslogStore* self);
+static size_t NullStore_GetUsedBytes(struct SolidSyslogStore* self);
+static bool NullStore_IsTransient(struct SolidSyslogStore* self);
 
 struct SolidSyslogNullStore
 {
@@ -23,14 +23,14 @@ static struct SolidSyslogNullStore instance;
 
 struct SolidSyslogStore* SolidSyslogNullStore_Create(void)
 {
-    instance.base.Write = Write;
-    instance.base.ReadNextUnsent = ReadNextUnsent;
-    instance.base.MarkSent = MarkSent;
-    instance.base.HasUnsent = HasUnsent;
-    instance.base.IsHalted = IsHalted;
-    instance.base.GetTotalBytes = GetTotalBytes;
-    instance.base.GetUsedBytes = GetUsedBytes;
-    instance.base.IsTransient = IsTransient;
+    instance.base.Write = NullStore_Write;
+    instance.base.ReadNextUnsent = NullStore_ReadNextUnsent;
+    instance.base.MarkSent = NullStore_MarkSent;
+    instance.base.HasUnsent = NullStore_HasUnsent;
+    instance.base.IsHalted = NullStore_IsHalted;
+    instance.base.GetTotalBytes = NullStore_GetTotalBytes;
+    instance.base.GetUsedBytes = NullStore_GetUsedBytes;
+    instance.base.IsTransient = NullStore_IsTransient;
     return &instance.base;
 }
 
@@ -50,7 +50,7 @@ void SolidSyslogNullStore_Destroy(void)
  * so the eager-drain loop in ProcessMessages takes the direct-send path —
  * NullStore + real-buffer + UDP is the constrained-system "one attempt per
  * message, no buffering" configuration. */
-static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
+static bool NullStore_Write(struct SolidSyslogStore* self, const void* data, size_t size)
 {
     (void) self;
     (void) data;
@@ -58,7 +58,7 @@ static bool Write(struct SolidSyslogStore* self, const void* data, size_t size)
     return false;
 }
 
-static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool NullStore_ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     (void) self;
     (void) data;
@@ -67,39 +67,39 @@ static bool ReadNextUnsent(struct SolidSyslogStore* self, void* data, size_t max
     return false;
 }
 
-static void MarkSent(struct SolidSyslogStore* self)
+static void NullStore_MarkSent(struct SolidSyslogStore* self)
 {
     (void) self;
 }
 
-static bool HasUnsent(struct SolidSyslogStore* self)
-{
-    (void) self;
-    return false;
-}
-
-static bool IsHalted(struct SolidSyslogStore* self)
+static bool NullStore_HasUnsent(struct SolidSyslogStore* self)
 {
     (void) self;
     return false;
 }
 
-static size_t GetTotalBytes(struct SolidSyslogStore* self)
+static bool NullStore_IsHalted(struct SolidSyslogStore* self)
+{
+    (void) self;
+    return false;
+}
+
+static size_t NullStore_GetTotalBytes(struct SolidSyslogStore* self)
 {
     (void) self;
     return 0;
 }
 
-static size_t GetUsedBytes(struct SolidSyslogStore* self)
+static size_t NullStore_GetUsedBytes(struct SolidSyslogStore* self)
 {
     (void) self;
     return 0;
 }
 
-/* NullStore retains nothing — a Write rejection means "I never had it,
+/* NullStore retains nothing — a NullStore_Write rejection means "I never had it,
  * please try the sender." Service's DrainBufferIntoStore consults this
  * to know it's safe to fall through to direct-send. */
-static bool IsTransient(struct SolidSyslogStore* self)
+static bool NullStore_IsTransient(struct SolidSyslogStore* self)
 {
     (void) self;
     return true;

--- a/Core/Source/SolidSyslogOriginSd.c
+++ b/Core/Source/SolidSyslogOriginSd.c
@@ -32,9 +32,18 @@ static const char SD_IP_SD[] = " ip=\"";
 
 static void OriginSd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
 static inline void OriginSd_PreFormatStaticPrefix(const struct SolidSyslogOriginSdConfig* config);
-static inline void OriginSd_EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
-static inline void OriginSd_EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
-static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
+static inline void OriginSd_EmitSoftware(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogOriginSdConfig* config
+);
+static inline void OriginSd_EmitSwVersion(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogOriginSdConfig* config
+);
+static inline void OriginSd_EmitEnterpriseId(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogOriginSdConfig* config
+);
 static inline void OriginSd_EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* origin);
 static inline void OriginSd_EmitIp(
     struct SolidSyslogFormatter* formatter,
@@ -95,7 +104,10 @@ static inline void OriginSd_EmitSoftware(struct SolidSyslogFormatter* f, const s
     }
 }
 
-static inline void OriginSd_EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_EmitSwVersion(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogOriginSdConfig* config
+)
 {
     if (config->swVersion != NULL)
     {
@@ -105,7 +117,10 @@ static inline void OriginSd_EmitSwVersion(struct SolidSyslogFormatter* f, const 
     }
 }
 
-static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_EmitEnterpriseId(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogOriginSdConfig* config
+)
 {
     if (config->enterpriseId != NULL)
     {

--- a/Core/Source/SolidSyslogOriginSd.c
+++ b/Core/Source/SolidSyslogOriginSd.c
@@ -9,7 +9,7 @@ enum
     ORIGIN_ENTERPRISE_ID_MAX = 64,
     ORIGIN_IP_MAX = 64,
     ORIGIN_LITERAL_BYTES =
-        48, /* [origin software="" swVersion="" enterpriseId="" — closing ']' deferred to per-message Format */
+        48, /* [origin software="" swVersion="" enterpriseId="" — closing ']' deferred to per-message OriginSd_Format */
     ORIGIN_CONTENT_MAX = ORIGIN_LITERAL_BYTES + SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SOFTWARE_MAX) +
                          SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SWVERSION_MAX) +
                          SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_ENTERPRISE_ID_MAX),
@@ -30,13 +30,13 @@ static const char SD_VERSION_SD[] = " swVersion=\"";
 static const char SD_ENTERPRISE_ID_SD[] = " enterpriseId=\"";
 static const char SD_IP_SD[] = " ip=\"";
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static inline void PreFormatStaticPrefix(const struct SolidSyslogOriginSdConfig* config);
-static inline void EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
-static inline void EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
-static inline void EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
-static inline void EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* origin);
-static inline void EmitIp(
+static void OriginSd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static inline void OriginSd_PreFormatStaticPrefix(const struct SolidSyslogOriginSdConfig* config);
+static inline void OriginSd_EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
+static inline void OriginSd_EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
+static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config);
+static inline void OriginSd_EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* origin);
+static inline void OriginSd_EmitIp(
     struct SolidSyslogFormatter* formatter,
     const struct SolidSyslogOriginSd* origin,
     size_t index
@@ -46,10 +46,10 @@ static struct SolidSyslogOriginSd instance;
 
 struct SolidSyslogStructuredData* SolidSyslogOriginSd_Create(const struct SolidSyslogOriginSdConfig* config)
 {
-    instance.base.Format = Format;
+    instance.base.Format = OriginSd_Format;
     instance.getIpCount = config->getIpCount;
     instance.getIpAt = config->getIpAt;
-    PreFormatStaticPrefix(config);
+    OriginSd_PreFormatStaticPrefix(config);
     return &instance.base;
 }
 
@@ -60,7 +60,7 @@ void SolidSyslogOriginSd_Destroy(void)
     instance.getIpAt = NULL;
 }
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
+static void OriginSd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
 {
     struct SolidSyslogOriginSd* origin = (struct SolidSyslogOriginSd*) self;
     struct SolidSyslogFormatter* preformat = SolidSyslogFormatter_FromStorage(origin->formattedStorage);
@@ -70,22 +70,22 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
         SolidSyslogFormatter_AsFormattedBuffer(preformat),
         SolidSyslogFormatter_Length(preformat)
     );
-    EmitIps(formatter, origin);
+    OriginSd_EmitIps(formatter, origin);
     SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
-static inline void PreFormatStaticPrefix(const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_PreFormatStaticPrefix(const struct SolidSyslogOriginSdConfig* config)
 {
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(instance.formattedStorage, ORIGIN_FORMATTED_MAX);
 
     SolidSyslogFormatter_BoundedString(f, SD_PREFIX, sizeof(SD_PREFIX) - 1);
-    EmitSoftware(f, config);
-    EmitSwVersion(f, config);
-    EmitEnterpriseId(f, config);
-    /* closing ']' deferred to Format() so per-message ip params can be spliced in */
+    OriginSd_EmitSoftware(f, config);
+    OriginSd_EmitSwVersion(f, config);
+    OriginSd_EmitEnterpriseId(f, config);
+    /* closing ']' deferred to OriginSd_Format() so per-message ip params can be spliced in */
 }
 
-static inline void EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
 {
     if (config->software != NULL)
     {
@@ -95,7 +95,7 @@ static inline void EmitSoftware(struct SolidSyslogFormatter* f, const struct Sol
     }
 }
 
-static inline void EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_EmitSwVersion(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
 {
     if (config->swVersion != NULL)
     {
@@ -105,7 +105,7 @@ static inline void EmitSwVersion(struct SolidSyslogFormatter* f, const struct So
     }
 }
 
-static inline void EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
+static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
 {
     if (config->enterpriseId != NULL)
     {
@@ -115,19 +115,19 @@ static inline void EmitEnterpriseId(struct SolidSyslogFormatter* f, const struct
     }
 }
 
-static inline void EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* origin)
+static inline void OriginSd_EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* origin)
 {
     if ((origin->getIpCount != NULL) && (origin->getIpAt != NULL))
     {
         size_t count = origin->getIpCount();
         for (size_t i = 0; i < count; i++)
         {
-            EmitIp(formatter, origin, i);
+            OriginSd_EmitIp(formatter, origin, i);
         }
     }
 }
 
-static inline void EmitIp(
+static inline void OriginSd_EmitIp(
     struct SolidSyslogFormatter* formatter,
     const struct SolidSyslogOriginSd* origin,
     size_t index

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -42,7 +42,10 @@ static bool StreamSender_ResolveDestination(struct SolidSyslogStreamSender* send
 static void StreamSender_Disconnect(struct SolidSyslogSender* self);
 static inline void StreamSender_CloseStream(struct SolidSyslogStreamSender* sender);
 static bool StreamSender_TransmitFramed(struct SolidSyslogStreamSender* sender, const void* buffer, size_t size);
-static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
+static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(
+    SolidSyslogFormatterStorage* storage,
+    size_t messageSize
+);
 static bool StreamSender_SendBytes(struct SolidSyslogStreamSender* sender, const void* data, size_t len);
 static void StreamSender_NilEndpoint(struct SolidSyslogEndpoint* endpoint);
 static uint32_t StreamSender_NilEndpointVersion(void);
@@ -177,11 +180,18 @@ static bool StreamSender_TransmitFramed(struct SolidSyslogStreamSender* sender, 
     SolidSyslogFormatterStorage prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
     struct SolidSyslogFormatter* prefix = StreamSender_FormatOctetCountingPrefix(prefixStorage, size);
 
-    return StreamSender_SendBytes(sender, SolidSyslogFormatter_AsFormattedBuffer(prefix), SolidSyslogFormatter_Length(prefix)) &&
+    return StreamSender_SendBytes(
+               sender,
+               SolidSyslogFormatter_AsFormattedBuffer(prefix),
+               SolidSyslogFormatter_Length(prefix)
+           ) &&
            StreamSender_SendBytes(sender, buffer, size);
 }
 
-static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)
+static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(
+    SolidSyslogFormatterStorage* storage,
+    size_t messageSize
+)
 {
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, OCTET_COUNTING_PREFIX_CAPACITY);
     SolidSyslogFormatter_Uint32(f, (uint32_t) messageSize);

--- a/Core/Source/SolidSyslogStreamSender.c
+++ b/Core/Source/SolidSyslogStreamSender.c
@@ -32,20 +32,20 @@ enum
         UINT32_MAX_DECIMAL_DIGITS + OCTET_COUNTING_SEPARATOR + OCTET_COUNTING_NULL_TERMINATOR
 };
 
-static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
-static inline bool Reconcile(struct SolidSyslogStreamSender* sender);
-static inline void DisconnectIfStale(struct SolidSyslogStreamSender* sender);
-static inline bool EnsureConnected(struct SolidSyslogStreamSender* sender);
-static inline bool Connected(struct SolidSyslogStreamSender* sender);
-static bool Connect(struct SolidSyslogStreamSender* sender);
-static bool ResolveDestination(struct SolidSyslogStreamSender* sender, struct SolidSyslogAddress* addr);
-static void Disconnect(struct SolidSyslogSender* self);
-static inline void CloseStream(struct SolidSyslogStreamSender* sender);
-static bool TransmitFramed(struct SolidSyslogStreamSender* sender, const void* buffer, size_t size);
-static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
-static bool SendBytes(struct SolidSyslogStreamSender* sender, const void* data, size_t len);
-static void NilEndpoint(struct SolidSyslogEndpoint* endpoint);
-static uint32_t NilEndpointVersion(void);
+static bool StreamSender_Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static inline bool StreamSender_Reconcile(struct SolidSyslogStreamSender* sender);
+static inline void StreamSender_DisconnectIfStale(struct SolidSyslogStreamSender* sender);
+static inline bool StreamSender_EnsureConnected(struct SolidSyslogStreamSender* sender);
+static inline bool StreamSender_Connected(struct SolidSyslogStreamSender* sender);
+static bool StreamSender_Connect(struct SolidSyslogStreamSender* sender);
+static bool StreamSender_ResolveDestination(struct SolidSyslogStreamSender* sender, struct SolidSyslogAddress* addr);
+static void StreamSender_Disconnect(struct SolidSyslogSender* self);
+static inline void StreamSender_CloseStream(struct SolidSyslogStreamSender* sender);
+static bool StreamSender_TransmitFramed(struct SolidSyslogStreamSender* sender, const void* buffer, size_t size);
+static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize);
+static bool StreamSender_SendBytes(struct SolidSyslogStreamSender* sender, const void* data, size_t len);
+static void StreamSender_NilEndpoint(struct SolidSyslogEndpoint* endpoint);
+static uint32_t StreamSender_NilEndpointVersion(void);
 
 SOLIDSYSLOG_STATIC_ASSERT(
     sizeof(struct SolidSyslogStreamSender) <= sizeof(SolidSyslogStreamSenderStorage),
@@ -53,15 +53,15 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogStreamSender DEFAULT_INSTANCE = {
-    {Send, Disconnect},
-    {NULL, NULL, NilEndpoint, NilEndpointVersion},
+    {StreamSender_Send, StreamSender_Disconnect},
+    {NULL, NULL, StreamSender_NilEndpoint, StreamSender_NilEndpointVersion},
     false,
     0,
 };
 
 static const struct SolidSyslogStreamSender DESTROYED_INSTANCE = {
     {NULL, NULL},
-    {NULL, NULL, NilEndpoint, NilEndpointVersion},
+    {NULL, NULL, StreamSender_NilEndpoint, StreamSender_NilEndpointVersion},
     false,
     0,
 };
@@ -89,57 +89,57 @@ struct SolidSyslogSender* SolidSyslogStreamSender_Create(
 void SolidSyslogStreamSender_Destroy(struct SolidSyslogSender* sender)
 {
     struct SolidSyslogStreamSender* self = (struct SolidSyslogStreamSender*) sender;
-    Disconnect(sender);
+    StreamSender_Disconnect(sender);
     *self = DESTROYED_INSTANCE;
 }
 
-static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
+static bool StreamSender_Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     struct SolidSyslogStreamSender* sender = (struct SolidSyslogStreamSender*) self;
-    return Reconcile(sender) && TransmitFramed(sender, buffer, size);
+    return StreamSender_Reconcile(sender) && StreamSender_TransmitFramed(sender, buffer, size);
 }
 
-static inline bool Reconcile(struct SolidSyslogStreamSender* sender)
+static inline bool StreamSender_Reconcile(struct SolidSyslogStreamSender* sender)
 {
-    DisconnectIfStale(sender);
-    return EnsureConnected(sender);
+    StreamSender_DisconnectIfStale(sender);
+    return StreamSender_EnsureConnected(sender);
 }
 
-static inline void DisconnectIfStale(struct SolidSyslogStreamSender* sender)
+static inline void StreamSender_DisconnectIfStale(struct SolidSyslogStreamSender* sender)
 {
     uint32_t version = sender->config.endpointVersion();
 
     if (version != sender->lastEndpointVersion)
     {
-        Disconnect(&sender->base);
+        StreamSender_Disconnect(&sender->base);
         sender->lastEndpointVersion = version;
     }
 }
 
-static inline bool EnsureConnected(struct SolidSyslogStreamSender* sender)
+static inline bool StreamSender_EnsureConnected(struct SolidSyslogStreamSender* sender)
 {
-    return Connected(sender) || Connect(sender);
+    return StreamSender_Connected(sender) || StreamSender_Connect(sender);
 }
 
-static inline bool Connected(struct SolidSyslogStreamSender* sender)
+static inline bool StreamSender_Connected(struct SolidSyslogStreamSender* sender)
 {
     return sender->connected;
 }
 
-static bool Connect(struct SolidSyslogStreamSender* sender)
+static bool StreamSender_Connect(struct SolidSyslogStreamSender* sender)
 {
     SolidSyslogAddressStorage addrStorage = {0};
     struct SolidSyslogAddress* addr = SolidSyslogAddress_FromStorage(&addrStorage);
 
-    if (ResolveDestination(sender, addr))
+    if (StreamSender_ResolveDestination(sender, addr))
     {
         sender->connected = SolidSyslogStream_Open(sender->config.stream, addr);
     }
 
-    return Connected(sender);
+    return StreamSender_Connected(sender);
 }
 
-static bool ResolveDestination(struct SolidSyslogStreamSender* sender, struct SolidSyslogAddress* addr)
+static bool StreamSender_ResolveDestination(struct SolidSyslogStreamSender* sender, struct SolidSyslogAddress* addr)
 {
     SolidSyslogFormatterStorage hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
@@ -156,32 +156,32 @@ static bool ResolveDestination(struct SolidSyslogStreamSender* sender, struct So
     );
 }
 
-static void Disconnect(struct SolidSyslogSender* self)
+static void StreamSender_Disconnect(struct SolidSyslogSender* self)
 {
     struct SolidSyslogStreamSender* sender = (struct SolidSyslogStreamSender*) self;
 
-    if (Connected(sender))
+    if (StreamSender_Connected(sender))
     {
-        CloseStream(sender);
+        StreamSender_CloseStream(sender);
     }
 }
 
-static inline void CloseStream(struct SolidSyslogStreamSender* sender)
+static inline void StreamSender_CloseStream(struct SolidSyslogStreamSender* sender)
 {
     SolidSyslogStream_Close(sender->config.stream);
     sender->connected = false;
 }
 
-static bool TransmitFramed(struct SolidSyslogStreamSender* sender, const void* buffer, size_t size)
+static bool StreamSender_TransmitFramed(struct SolidSyslogStreamSender* sender, const void* buffer, size_t size)
 {
     SolidSyslogFormatterStorage prefixStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(OCTET_COUNTING_PREFIX_CAPACITY)];
-    struct SolidSyslogFormatter* prefix = FormatOctetCountingPrefix(prefixStorage, size);
+    struct SolidSyslogFormatter* prefix = StreamSender_FormatOctetCountingPrefix(prefixStorage, size);
 
-    return SendBytes(sender, SolidSyslogFormatter_AsFormattedBuffer(prefix), SolidSyslogFormatter_Length(prefix)) &&
-           SendBytes(sender, buffer, size);
+    return StreamSender_SendBytes(sender, SolidSyslogFormatter_AsFormattedBuffer(prefix), SolidSyslogFormatter_Length(prefix)) &&
+           StreamSender_SendBytes(sender, buffer, size);
 }
 
-static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)
+static struct SolidSyslogFormatter* StreamSender_FormatOctetCountingPrefix(SolidSyslogFormatterStorage* storage, size_t messageSize)
 {
     struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, OCTET_COUNTING_PREFIX_CAPACITY);
     SolidSyslogFormatter_Uint32(f, (uint32_t) messageSize);
@@ -189,25 +189,25 @@ static struct SolidSyslogFormatter* FormatOctetCountingPrefix(SolidSyslogFormatt
     return f;
 }
 
-static bool SendBytes(struct SolidSyslogStreamSender* sender, const void* data, size_t len)
+static bool StreamSender_SendBytes(struct SolidSyslogStreamSender* sender, const void* data, size_t len)
 {
     bool sent = SolidSyslogStream_Send(sender->config.stream, data, len);
 
     if (!sent)
     {
-        CloseStream(sender);
+        StreamSender_CloseStream(sender);
     }
 
     return sent;
 }
 
-static void NilEndpoint(struct SolidSyslogEndpoint* endpoint)
+static void StreamSender_NilEndpoint(struct SolidSyslogEndpoint* endpoint)
 {
     SolidSyslogFormatter_BoundedString(endpoint->host, "", 0);
     endpoint->port = 0;
 }
 
-static uint32_t NilEndpointVersion(void)
+static uint32_t StreamSender_NilEndpointVersion(void)
 {
     return 0;
 }

--- a/Core/Source/SolidSyslogSwitchingSender.c
+++ b/Core/Source/SolidSyslogSwitchingSender.c
@@ -20,7 +20,10 @@ static inline bool SwitchingSender_SenderChanged(
     const struct SolidSyslogSwitchingSender* self,
     const struct SolidSyslogSender* requestedSender
 );
-static inline void SwitchingSender_SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent);
+static inline void SwitchingSender_SwitchTo(
+    struct SolidSyslogSwitchingSender* self,
+    struct SolidSyslogSender* newCurrent
+);
 static inline struct SolidSyslogSender* SwitchingSender_RequestedSender(const struct SolidSyslogSwitchingSender* self);
 static bool SwitchingSender_NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size);
 static void SwitchingSender_NilDisconnect(struct SolidSyslogSender* sender);
@@ -74,7 +77,10 @@ static inline bool SwitchingSender_SenderChanged(
     return requestedSender != self->currentSender;
 }
 
-static inline void SwitchingSender_SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent)
+static inline void SwitchingSender_SwitchTo(
+    struct SolidSyslogSwitchingSender* self,
+    struct SolidSyslogSender* newCurrent
+)
 {
     SolidSyslogSender_Disconnect(self->currentSender);
     self->currentSender = newCurrent;

--- a/Core/Source/SolidSyslogSwitchingSender.c
+++ b/Core/Source/SolidSyslogSwitchingSender.c
@@ -13,19 +13,19 @@ struct SolidSyslogSwitchingSender
     struct SolidSyslogSender* currentSender;
 };
 
-static bool Send(struct SolidSyslogSender* sender, const void* buffer, size_t size);
-static void Disconnect(struct SolidSyslogSender* sender);
-static inline void SelectSender(struct SolidSyslogSwitchingSender* self);
-static inline bool SenderChanged(
+static bool SwitchingSender_Send(struct SolidSyslogSender* sender, const void* buffer, size_t size);
+static void SwitchingSender_Disconnect(struct SolidSyslogSender* sender);
+static inline void SwitchingSender_SelectSender(struct SolidSyslogSwitchingSender* self);
+static inline bool SwitchingSender_SenderChanged(
     const struct SolidSyslogSwitchingSender* self,
     const struct SolidSyslogSender* requestedSender
 );
-static inline void SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent);
-static inline struct SolidSyslogSender* RequestedSender(const struct SolidSyslogSwitchingSender* self);
-static bool NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size);
-static void NilDisconnect(struct SolidSyslogSender* sender);
+static inline void SwitchingSender_SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent);
+static inline struct SolidSyslogSender* SwitchingSender_RequestedSender(const struct SolidSyslogSwitchingSender* self);
+static bool SwitchingSender_NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size);
+static void SwitchingSender_NilDisconnect(struct SolidSyslogSender* sender);
 
-static struct SolidSyslogSender NIL_SENDER = {NilSend, NilDisconnect};
+static struct SolidSyslogSender NIL_SENDER = {SwitchingSender_NilSend, SwitchingSender_NilDisconnect};
 static const struct SolidSyslogSwitchingSender DEFAULT_INSTANCE = {.currentSender = &NIL_SENDER};
 static struct SolidSyslogSwitchingSender instance;
 
@@ -33,8 +33,8 @@ struct SolidSyslogSender* SolidSyslogSwitchingSender_Create(const struct SolidSy
 {
     instance = DEFAULT_INSTANCE;
     instance.config = *config;
-    instance.base.Send = Send;
-    instance.base.Disconnect = Disconnect;
+    instance.base.Send = SwitchingSender_Send;
+    instance.base.Disconnect = SwitchingSender_Disconnect;
     return &instance.base;
 }
 
@@ -43,30 +43,30 @@ void SolidSyslogSwitchingSender_Destroy(void)
     instance = DEFAULT_INSTANCE;
 }
 
-static bool Send(struct SolidSyslogSender* sender, const void* buffer, size_t size)
+static bool SwitchingSender_Send(struct SolidSyslogSender* sender, const void* buffer, size_t size)
 {
     struct SolidSyslogSwitchingSender* self = (struct SolidSyslogSwitchingSender*) sender;
-    SelectSender(self);
+    SwitchingSender_SelectSender(self);
     return SolidSyslogSender_Send(self->currentSender, buffer, size);
 }
 
-static void Disconnect(struct SolidSyslogSender* sender)
+static void SwitchingSender_Disconnect(struct SolidSyslogSender* sender)
 {
     struct SolidSyslogSwitchingSender* self = (struct SolidSyslogSwitchingSender*) sender;
     SolidSyslogSender_Disconnect(self->currentSender);
 }
 
-static inline void SelectSender(struct SolidSyslogSwitchingSender* self)
+static inline void SwitchingSender_SelectSender(struct SolidSyslogSwitchingSender* self)
 {
-    struct SolidSyslogSender* requestedSender = RequestedSender(self);
+    struct SolidSyslogSender* requestedSender = SwitchingSender_RequestedSender(self);
 
-    if (SenderChanged(self, requestedSender))
+    if (SwitchingSender_SenderChanged(self, requestedSender))
     {
-        SwitchTo(self, requestedSender);
+        SwitchingSender_SwitchTo(self, requestedSender);
     }
 }
 
-static inline bool SenderChanged(
+static inline bool SwitchingSender_SenderChanged(
     const struct SolidSyslogSwitchingSender* self,
     const struct SolidSyslogSender* requestedSender
 )
@@ -74,7 +74,7 @@ static inline bool SenderChanged(
     return requestedSender != self->currentSender;
 }
 
-static inline void SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent)
+static inline void SwitchingSender_SwitchTo(struct SolidSyslogSwitchingSender* self, struct SolidSyslogSender* newCurrent)
 {
     SolidSyslogSender_Disconnect(self->currentSender);
     self->currentSender = newCurrent;
@@ -83,7 +83,7 @@ static inline void SwitchTo(struct SolidSyslogSwitchingSender* self, struct Soli
 /* Falls back to the nil sender when the selector returns an out-of-range
  * index (including the empty-array case). Contains the application contract
  * violation of an invalid selector without corrupting memory or crashing. */
-static inline struct SolidSyslogSender* RequestedSender(const struct SolidSyslogSwitchingSender* self)
+static inline struct SolidSyslogSender* SwitchingSender_RequestedSender(const struct SolidSyslogSwitchingSender* self)
 {
     uint8_t index = self->config.selector();
     struct SolidSyslogSender* result = &NIL_SENDER;
@@ -96,7 +96,7 @@ static inline struct SolidSyslogSender* RequestedSender(const struct SolidSyslog
     return result;
 }
 
-static bool NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size)
+static bool SwitchingSender_NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t size)
 {
     (void) sender;
     (void) buffer;
@@ -104,7 +104,7 @@ static bool NilSend(struct SolidSyslogSender* sender, const void* buffer, size_t
     return false;
 }
 
-static void NilDisconnect(struct SolidSyslogSender* sender)
+static void SwitchingSender_NilDisconnect(struct SolidSyslogSender* sender)
 {
     (void) sender;
 }

--- a/Core/Source/SolidSyslogTimeQualitySd.c
+++ b/Core/Source/SolidSyslogTimeQualitySd.c
@@ -15,20 +15,20 @@ struct SolidSyslogTimeQualitySd
     SolidSyslogTimeQualityFunction getTimeQuality;
 };
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
-static inline void FormatBoolParam(
+static void TimeQualitySd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter);
+static inline void TimeQualitySd_FormatBoolParam(
     struct SolidSyslogFormatter* formatter,
     const char* name,
     size_t nameLength,
     bool value
 );
-static inline void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value);
+static inline void TimeQualitySd_FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value);
 
 static struct SolidSyslogTimeQualitySd instance;
 
 struct SolidSyslogStructuredData* SolidSyslogTimeQualitySd_Create(SolidSyslogTimeQualityFunction getTimeQuality)
 {
-    instance.base.Format = Format;
+    instance.base.Format = TimeQualitySd_Format;
     instance.getTimeQuality = getTimeQuality;
     return &instance.base;
 }
@@ -44,7 +44,7 @@ static const char PARAM_TZ_KNOWN[] = " tzKnown";
 static const char PARAM_IS_SYNCED[] = " isSynced";
 static const char PARAM_SYNC_ACCURACY[] = " syncAccuracy=\"";
 
-static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
+static void TimeQualitySd_Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFormatter* formatter)
 {
     struct SolidSyslogTimeQualitySd* tq = (struct SolidSyslogTimeQualitySd*) self;
     struct SolidSyslogTimeQuality q = {0};
@@ -52,13 +52,13 @@ static void Format(struct SolidSyslogStructuredData* self, struct SolidSyslogFor
     tq->getTimeQuality(&q);
 
     SolidSyslogFormatter_BoundedString(formatter, SD_PREFIX, sizeof(SD_PREFIX) - 1);
-    FormatBoolParam(formatter, PARAM_TZ_KNOWN, sizeof(PARAM_TZ_KNOWN) - 1, q.tzKnown);
-    FormatBoolParam(formatter, PARAM_IS_SYNCED, sizeof(PARAM_IS_SYNCED) - 1, q.isSynced);
-    FormatSyncAccuracy(formatter, q.syncAccuracyMicroseconds);
+    TimeQualitySd_FormatBoolParam(formatter, PARAM_TZ_KNOWN, sizeof(PARAM_TZ_KNOWN) - 1, q.tzKnown);
+    TimeQualitySd_FormatBoolParam(formatter, PARAM_IS_SYNCED, sizeof(PARAM_IS_SYNCED) - 1, q.isSynced);
+    TimeQualitySd_FormatSyncAccuracy(formatter, q.syncAccuracyMicroseconds);
     SolidSyslogFormatter_AsciiCharacter(formatter, ']');
 }
 
-static inline void FormatBoolParam(
+static inline void TimeQualitySd_FormatBoolParam(
     struct SolidSyslogFormatter* formatter,
     const char* name,
     size_t nameLength,
@@ -72,7 +72,7 @@ static inline void FormatBoolParam(
     SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }
 
-static inline void FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
+static inline void TimeQualitySd_FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
 {
     if (value != SOLIDSYSLOG_SYNC_ACCURACY_OMIT)
     {

--- a/Core/Source/SolidSyslogUdpPayload.c
+++ b/Core/Source/SolidSyslogUdpPayload.c
@@ -8,9 +8,9 @@ enum
     UDP_HEADER_BYTES = 8
 };
 
-static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length);
-static inline bool LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
-static inline size_t ExpectedSequenceLength(uint8_t startByte);
+static inline size_t UdpPayload_FindLastCodepointStart(const uint8_t* buffer, size_t length);
+static inline bool UdpPayload_LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
+static inline size_t UdpPayload_ExpectedSequenceLength(uint8_t startByte);
 
 size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6)
 {
@@ -22,8 +22,8 @@ size_t SolidSyslogUdpPayload_TrimToCodepointBoundary(const uint8_t* buffer, size
 {
     if (length > 0)
     {
-        size_t lastCodepointStart = FindLastCodepointStart(buffer, length);
-        if (LastCodepointExtendsPastCut(buffer, length, lastCodepointStart))
+        size_t lastCodepointStart = UdpPayload_FindLastCodepointStart(buffer, length);
+        if (UdpPayload_LastCodepointExtendsPastCut(buffer, length, lastCodepointStart))
         {
             length = lastCodepointStart;
         }
@@ -31,7 +31,7 @@ size_t SolidSyslogUdpPayload_TrimToCodepointBoundary(const uint8_t* buffer, size
     return length;
 }
 
-static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length)
+static inline size_t UdpPayload_FindLastCodepointStart(const uint8_t* buffer, size_t length)
 {
     size_t startIndex = length - 1;
     while (startIndex > 0 && SolidSyslogUtf8_IsContinuationByte((char) buffer[startIndex]))
@@ -41,14 +41,14 @@ static inline size_t FindLastCodepointStart(const uint8_t* buffer, size_t length
     return startIndex;
 }
 
-static inline bool LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart)
+static inline bool UdpPayload_LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart)
 {
-    return (lastCodepointStart + ExpectedSequenceLength(buffer[lastCodepointStart])) > length;
+    return (lastCodepointStart + UdpPayload_ExpectedSequenceLength(buffer[lastCodepointStart])) > length;
 }
 
 /* 11110xxx is the only remaining pattern — invalid bytes never reach here
  * because the formatter (S12.10) guarantees valid UTF-8 upstream. */
-static inline size_t ExpectedSequenceLength(uint8_t startByte)
+static inline size_t UdpPayload_ExpectedSequenceLength(uint8_t startByte)
 {
     char b = (char) startByte;
     size_t length = 0;

--- a/Core/Source/SolidSyslogUdpPayload.c
+++ b/Core/Source/SolidSyslogUdpPayload.c
@@ -9,7 +9,11 @@ enum
 };
 
 static inline size_t UdpPayload_FindLastCodepointStart(const uint8_t* buffer, size_t length);
-static inline bool UdpPayload_LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart);
+static inline bool UdpPayload_LastCodepointExtendsPastCut(
+    const uint8_t* buffer,
+    size_t length,
+    size_t lastCodepointStart
+);
 static inline size_t UdpPayload_ExpectedSequenceLength(uint8_t startByte);
 
 size_t SolidSyslogUdpPayload_FromMtu(size_t mtu, bool isIpv6)
@@ -41,7 +45,11 @@ static inline size_t UdpPayload_FindLastCodepointStart(const uint8_t* buffer, si
     return startIndex;
 }
 
-static inline bool UdpPayload_LastCodepointExtendsPastCut(const uint8_t* buffer, size_t length, size_t lastCodepointStart)
+static inline bool UdpPayload_LastCodepointExtendsPastCut(
+    const uint8_t* buffer,
+    size_t length,
+    size_t lastCodepointStart
+)
 {
     return (lastCodepointStart + UdpPayload_ExpectedSequenceLength(buffer[lastCodepointStart])) > length;
 }

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -35,7 +35,10 @@ static inline void UdpSender_DisconnectIfStale(struct SolidSyslogUdpSender* udp)
 static inline bool UdpSender_EnsureConnected(struct SolidSyslogUdpSender* udp);
 static inline bool UdpSender_Connected(struct SolidSyslogUdpSender* udp);
 static bool UdpSender_Connect(struct SolidSyslogUdpSender* udp);
-static inline uint16_t UdpSender_QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter);
+static inline uint16_t UdpSender_QueryEndpointPort(
+    struct SolidSyslogUdpSender* udp,
+    struct SolidSyslogFormatter* hostFormatter
+);
 static inline bool UdpSender_OpenSocket(struct SolidSyslogUdpSender* udp);
 static bool UdpSender_ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
 static inline struct SolidSyslogAddress* UdpSender_Address(struct SolidSyslogUdpSender* udp);
@@ -50,9 +53,14 @@ static uint32_t UdpSender_NilEndpointVersion(void);
 static bool UdpSender_NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size);
 static void UdpSender_NilUdpSenderDisconnect(struct SolidSyslogSender* self);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpointVersion = UdpSender_NilEndpointVersion}};
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {
+    .config = {.endpointVersion = UdpSender_NilEndpointVersion}
+};
 static struct SolidSyslogUdpSender instance;
-static struct SolidSyslogSender NilUdpSender = {.Send = UdpSender_NilUdpSenderSend, .Disconnect = UdpSender_NilUdpSenderDisconnect};
+static struct SolidSyslogSender NilUdpSender = {
+    .Send = UdpSender_NilUdpSenderSend,
+    .Disconnect = UdpSender_NilUdpSenderDisconnect
+};
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
@@ -179,7 +187,10 @@ static bool UdpSender_Connect(struct SolidSyslogUdpSender* udp)
     return UdpSender_Connected(udp);
 }
 
-static inline uint16_t UdpSender_QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter)
+static inline uint16_t UdpSender_QueryEndpointPort(
+    struct SolidSyslogUdpSender* udp,
+    struct SolidSyslogFormatter* hostFormatter
+)
 {
     struct SolidSyslogEndpoint endpoint = {.host = hostFormatter, .port = 0};
     udp->config.endpoint(&endpoint);
@@ -193,7 +204,13 @@ static inline bool UdpSender_OpenSocket(struct SolidSyslogUdpSender* udp)
 
 static bool UdpSender_ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port)
 {
-    return SolidSyslogResolver_Resolve(udp->config.resolver, SolidSyslogTransport_Udp, host, port, UdpSender_Address(udp));
+    return SolidSyslogResolver_Resolve(
+        udp->config.resolver,
+        SolidSyslogTransport_Udp,
+        host,
+        port,
+        UdpSender_Address(udp)
+    );
 }
 
 static inline struct SolidSyslogAddress* UdpSender_Address(struct SolidSyslogUdpSender* udp)

--- a/Core/Source/SolidSyslogUdpSender.c
+++ b/Core/Source/SolidSyslogUdpSender.c
@@ -26,46 +26,46 @@ struct SolidSyslogUdpSender
     uint32_t lastEndpointVersion;
 };
 
-static bool IsValidConfig(const struct SolidSyslogUdpSenderConfig* config);
-static void InstallConfig(const struct SolidSyslogUdpSenderConfig* config);
-static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
-static void Disconnect(struct SolidSyslogSender* self);
-static inline bool Reconcile(struct SolidSyslogUdpSender* udp);
-static inline void DisconnectIfStale(struct SolidSyslogUdpSender* udp);
-static inline bool EnsureConnected(struct SolidSyslogUdpSender* udp);
-static inline bool Connected(struct SolidSyslogUdpSender* udp);
-static bool Connect(struct SolidSyslogUdpSender* udp);
-static inline uint16_t QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter);
-static inline bool OpenSocket(struct SolidSyslogUdpSender* udp);
-static bool ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
-static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp);
-static inline void CloseSocket(struct SolidSyslogUdpSender* udp);
-static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
-static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(
+static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* config);
+static void UdpSender_InstallConfig(const struct SolidSyslogUdpSenderConfig* config);
+static bool UdpSender_Send(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static void UdpSender_Disconnect(struct SolidSyslogSender* self);
+static inline bool UdpSender_Reconcile(struct SolidSyslogUdpSender* udp);
+static inline void UdpSender_DisconnectIfStale(struct SolidSyslogUdpSender* udp);
+static inline bool UdpSender_EnsureConnected(struct SolidSyslogUdpSender* udp);
+static inline bool UdpSender_Connected(struct SolidSyslogUdpSender* udp);
+static bool UdpSender_Connect(struct SolidSyslogUdpSender* udp);
+static inline uint16_t UdpSender_QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter);
+static inline bool UdpSender_OpenSocket(struct SolidSyslogUdpSender* udp);
+static bool UdpSender_ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port);
+static inline struct SolidSyslogAddress* UdpSender_Address(struct SolidSyslogUdpSender* udp);
+static inline void UdpSender_CloseSocket(struct SolidSyslogUdpSender* udp);
+static inline bool UdpSender_TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size);
+static inline enum SolidSyslogDatagramSendResult UdpSender_RetryAfterOversize(
     struct SolidSyslogUdpSender* udp,
     const void* buffer,
     size_t size
 );
-static uint32_t NilEndpointVersion(void);
-static bool NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size);
-static void NilUdpSenderDisconnect(struct SolidSyslogSender* self);
+static uint32_t UdpSender_NilEndpointVersion(void);
+static bool UdpSender_NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size);
+static void UdpSender_NilUdpSenderDisconnect(struct SolidSyslogSender* self);
 
-static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpointVersion = NilEndpointVersion}};
+static const struct SolidSyslogUdpSender DEFAULT_INSTANCE = {.config = {.endpointVersion = UdpSender_NilEndpointVersion}};
 static struct SolidSyslogUdpSender instance;
-static struct SolidSyslogSender NilUdpSender = {.Send = NilUdpSenderSend, .Disconnect = NilUdpSenderDisconnect};
+static struct SolidSyslogSender NilUdpSender = {.Send = UdpSender_NilUdpSenderSend, .Disconnect = UdpSender_NilUdpSenderDisconnect};
 
 struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUdpSenderConfig* config)
 {
     struct SolidSyslogSender* result = &NilUdpSender;
-    if (IsValidConfig(config))
+    if (UdpSender_IsValidConfig(config))
     {
-        InstallConfig(config);
+        UdpSender_InstallConfig(config);
         result = &instance.base;
     }
     return result;
 }
 
-static bool IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
+static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
     bool valid = false;
     if (config == NULL)
@@ -91,25 +91,25 @@ static bool IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
     return valid;
 }
 
-static void InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
+static void UdpSender_InstallConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
     instance = DEFAULT_INSTANCE;
     instance.config = *config;
     if (instance.config.endpointVersion == NULL)
     {
-        instance.config.endpointVersion = NilEndpointVersion;
+        instance.config.endpointVersion = UdpSender_NilEndpointVersion;
     }
-    instance.base.Send = Send;
-    instance.base.Disconnect = Disconnect;
+    instance.base.Send = UdpSender_Send;
+    instance.base.Disconnect = UdpSender_Disconnect;
 }
 
 void SolidSyslogUdpSender_Destroy(void)
 {
-    Disconnect(&instance.base);
+    UdpSender_Disconnect(&instance.base);
     instance = DEFAULT_INSTANCE;
 }
 
-static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
+static bool UdpSender_Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     bool result = false;
     if (buffer == NULL)
@@ -119,106 +119,106 @@ static bool Send(struct SolidSyslogSender* self, const void* buffer, size_t size
     else
     {
         struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
-        result = Reconcile(udp) && TransmitDatagram(udp, buffer, size);
+        result = UdpSender_Reconcile(udp) && UdpSender_TransmitDatagram(udp, buffer, size);
     }
     return result;
 }
 
-static void Disconnect(struct SolidSyslogSender* self)
+static void UdpSender_Disconnect(struct SolidSyslogSender* self)
 {
     struct SolidSyslogUdpSender* udp = (struct SolidSyslogUdpSender*) self;
 
-    if (Connected(udp))
+    if (UdpSender_Connected(udp))
     {
-        CloseSocket(udp);
+        UdpSender_CloseSocket(udp);
     }
 }
 
-static inline bool Reconcile(struct SolidSyslogUdpSender* udp)
+static inline bool UdpSender_Reconcile(struct SolidSyslogUdpSender* udp)
 {
-    DisconnectIfStale(udp);
-    return EnsureConnected(udp);
+    UdpSender_DisconnectIfStale(udp);
+    return UdpSender_EnsureConnected(udp);
 }
 
-static inline void DisconnectIfStale(struct SolidSyslogUdpSender* udp)
+static inline void UdpSender_DisconnectIfStale(struct SolidSyslogUdpSender* udp)
 {
     uint32_t version = udp->config.endpointVersion();
 
     if (version != udp->lastEndpointVersion)
     {
-        Disconnect(&udp->base);
+        UdpSender_Disconnect(&udp->base);
         udp->lastEndpointVersion = version;
     }
 }
 
-static inline bool EnsureConnected(struct SolidSyslogUdpSender* udp)
+static inline bool UdpSender_EnsureConnected(struct SolidSyslogUdpSender* udp)
 {
-    return Connected(udp) || Connect(udp);
+    return UdpSender_Connected(udp) || UdpSender_Connect(udp);
 }
 
-static inline bool Connected(struct SolidSyslogUdpSender* udp)
+static inline bool UdpSender_Connected(struct SolidSyslogUdpSender* udp)
 {
     return udp->connected;
 }
 
-static bool Connect(struct SolidSyslogUdpSender* udp)
+static bool UdpSender_Connect(struct SolidSyslogUdpSender* udp)
 {
     SolidSyslogFormatterStorage hostStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOST_SIZE)];
     struct SolidSyslogFormatter* hostFormatter = SolidSyslogFormatter_Create(hostStorage, SOLIDSYSLOG_MAX_HOST_SIZE);
-    uint16_t port = QueryEndpointPort(udp, hostFormatter);
+    uint16_t port = UdpSender_QueryEndpointPort(udp, hostFormatter);
     const char* host = SolidSyslogFormatter_AsFormattedBuffer(hostFormatter);
 
-    if (OpenSocket(udp) && ResolveDestination(udp, host, port))
+    if (UdpSender_OpenSocket(udp) && UdpSender_ResolveDestination(udp, host, port))
     {
         udp->connected = true;
     }
     else
     {
-        CloseSocket(udp);
+        UdpSender_CloseSocket(udp);
     }
-    return Connected(udp);
+    return UdpSender_Connected(udp);
 }
 
-static inline uint16_t QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter)
+static inline uint16_t UdpSender_QueryEndpointPort(struct SolidSyslogUdpSender* udp, struct SolidSyslogFormatter* hostFormatter)
 {
     struct SolidSyslogEndpoint endpoint = {.host = hostFormatter, .port = 0};
     udp->config.endpoint(&endpoint);
     return endpoint.port;
 }
 
-static inline bool OpenSocket(struct SolidSyslogUdpSender* udp)
+static inline bool UdpSender_OpenSocket(struct SolidSyslogUdpSender* udp)
 {
     return SolidSyslogDatagram_Open(udp->config.datagram);
 }
 
-static bool ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port)
+static bool UdpSender_ResolveDestination(struct SolidSyslogUdpSender* udp, const char* host, uint16_t port)
 {
-    return SolidSyslogResolver_Resolve(udp->config.resolver, SolidSyslogTransport_Udp, host, port, Address(udp));
+    return SolidSyslogResolver_Resolve(udp->config.resolver, SolidSyslogTransport_Udp, host, port, UdpSender_Address(udp));
 }
 
-static inline struct SolidSyslogAddress* Address(struct SolidSyslogUdpSender* udp)
+static inline struct SolidSyslogAddress* UdpSender_Address(struct SolidSyslogUdpSender* udp)
 {
     return SolidSyslogAddress_FromStorage(&udp->addrStorage);
 }
 
-static inline void CloseSocket(struct SolidSyslogUdpSender* udp)
+static inline void UdpSender_CloseSocket(struct SolidSyslogUdpSender* udp)
 {
     SolidSyslogDatagram_Close(udp->config.datagram);
     udp->connected = false;
 }
 
-static inline bool TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
+static inline bool UdpSender_TransmitDatagram(struct SolidSyslogUdpSender* udp, const void* buffer, size_t size)
 {
     enum SolidSyslogDatagramSendResult result =
-        SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, Address(udp));
+        SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, size, UdpSender_Address(udp));
     if (result == SolidSyslogDatagramSendResult_Oversize)
     {
-        result = RetryAfterOversize(udp, buffer, size);
+        result = UdpSender_RetryAfterOversize(udp, buffer, size);
     }
     return result == SolidSyslogDatagramSendResult_Sent;
 }
 
-static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(
+static inline enum SolidSyslogDatagramSendResult UdpSender_RetryAfterOversize(
     struct SolidSyslogUdpSender* udp,
     const void* buffer,
     size_t size
@@ -232,7 +232,7 @@ static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagramSendResult_Sent;
     if (trimmed > 0)
     {
-        result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, trimmed, Address(udp));
+        result = SolidSyslogDatagram_SendTo(udp->config.datagram, buffer, trimmed, UdpSender_Address(udp));
         if (result == SolidSyslogDatagramSendResult_Oversize)
         {
             /* Retry still OVERSIZE means the kernel disagrees with its own
@@ -243,12 +243,12 @@ static inline enum SolidSyslogDatagramSendResult RetryAfterOversize(
     return result;
 }
 
-static uint32_t NilEndpointVersion(void)
+static uint32_t UdpSender_NilEndpointVersion(void)
 {
     return 0;
 }
 
-static bool NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
+static bool UdpSender_NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
     (void) self;
     (void) buffer;
@@ -256,7 +256,7 @@ static bool NilUdpSenderSend(struct SolidSyslogSender* self, const void* buffer,
     return true;
 }
 
-static void NilUdpSenderDisconnect(struct SolidSyslogSender* self)
+static void UdpSender_NilUdpSenderDisconnect(struct SolidSyslogSender* self)
 {
     (void) self;
 }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -49,7 +49,7 @@ across `Core/Source/` + `Platform/*/Source/`. Cleared all 168 MISRA
   - Pass 1: per-file extract static-function names, then
     `s/\b<name>\b/<Prefix>_<name>/g` for each.
   - Pass 2: un-mangle vtable-member accesses that Pass 1 also
-    renamed — `s/\.<X>_<Y>\b/.<Y>/g` and `s/->.<X>_<Y>\b/->\<Y>/g`.
+    renamed — `s/\.<X>_<Y>\b/.<Y>/g` and `s/-><X>_<Y>\b/-><Y>/g`.
   - Designated-initialiser pattern `.Open = Open` lands correctly:
     Pass 1 renames both sides; Pass 2 un-renames the left.
   - Positional vtable init `{Open, Send, Read, Close}` also lands

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,91 @@
 # Dev Log
 
+## 2026-05-15 — S10.08 static-function `Class_` prefix sweep (#371)
+
+Resolved the static-function-prefix question that had been deferred
+since S08.03 (`feedback_static_name_prefix.md` /
+`project_naming_sweep_deferred.md`). Wide sweep — applied
+NAMING.md Tier 2 `Class_Function` form to all ~811 static functions
+across `Core/Source/` + `Platform/*/Source/`. Cleared all 168 MISRA
+5.9 collisions as a structural consequence.
+
+### Decisions
+
+- **Wide scope over narrow.** The audit's 168 figure counts only
+  the MISRA-5.9 colliders, but applying the prefix uniformly is
+  what NAMING.md Tier 2 actually says. Renaming only the
+  colliders would leave the rest of the tree as "MISRA-clean by
+  accident, prefix-inconsistent on purpose" — invites drift as
+  new files are added. Wide sweep is the only end state where
+  the rule is also the convention.
+
+- **Strip-only-`SolidSyslog` prefix-form rule.** `SolidSyslog<X>.c`
+  → `<X>_*`. So `SolidSyslogWinsockTcpStream.c` →
+  `WinsockTcpStream_*`, `SolidSyslogFreeRtosTcpStream.c` →
+  `FreeRtosTcpStream_*` (long, but unambiguous and mechanical).
+  Files whose basename already drops the library prefix
+  (`BlockSequence.c`, `RecordStore.c`) use the basename as-is.
+  Short-shorthand alternatives (`Tls_`, `FrTcp_`, `WinTcp_`)
+  rejected — every file would need a hand-picked prefix and the
+  choice would be unpredictable at the call site.
+
+- **`SolidSyslog.c` exception.** Strip rule yields an empty
+  prefix for the library-namespace file. Uses
+  `SolidSyslog_<Function>` for statics — same shape as Tier 1
+  whole-library API entry points (`SolidSyslog_Log`, etc.),
+  distinguished by `static` linkage. Zero collision risk since
+  only one file can have this name. Pre-rename audit verified
+  none of the 48 static names in `SolidSyslog.c` collide with
+  the 6 Tier 1 names (`Create`/`Destroy`/`Log`/`Service`/`Error`/
+  `SetErrorHandler`).
+
+- **Files already conformant left untouched as-is.** `TlsStream`
+  (50/52 already prefixed — fixed 2 stragglers
+  `IsRetryableSslError` + `IsHandshakeBudgetExhausted`),
+  `FreeRtosTcpStream` (38/38), `FatFsFile` (24/24),
+  `AtomicCounter` (2/2). Already-prefixed names not re-renamed.
+
+- **Two-pass sed methodology.**
+  - Pass 1: per-file extract static-function names, then
+    `s/\b<name>\b/<Prefix>_<name>/g` for each.
+  - Pass 2: un-mangle vtable-member accesses that Pass 1 also
+    renamed — `s/\.<X>_<Y>\b/.<Y>/g` and `s/->.<X>_<Y>\b/->\<Y>/g`.
+  - Designated-initialiser pattern `.Open = Open` lands correctly:
+    Pass 1 renames both sides; Pass 2 un-renames the left.
+  - Positional vtable init `{Open, Send, Read, Close}` also lands
+    correctly: Pass 1 renames every token (all are static-fn
+    names → prefixed RHS); Pass 2 doesn't match (no leading
+    `.`/`->`).
+
+- **Slice ordering.** Phase A (collision-heavy files) first — five
+  slices covering TcpStream / Datagram / Sender / Buffer / Store
+  layers — then Phase B (convention sweep over the rest). After
+  Phase A, MISRA 5.9 was already at 0; Phase B is pure Tier 2
+  conformance with no MISRA delta. The PR splits into 11 commits
+  for review tractability; collapses to one on squash.
+
+### Deferred
+
+- **Type-name consistency** (`SolidSyslog_FreeRtosDatagram` vs
+  `SolidSyslogFreeRtosDatagram` etc.) — still deferred per
+  `project_naming_sweep_deferred.md`. S10.08 only resolved the
+  static-function piece of that memory.
+
+- **File-scope `static` variables and constants.** Tier 2 says
+  `Class_Variable` / `CLASS_SCREAMING_SNAKE` for these; S10.08
+  scoped to functions only. The handful of file-scope statics
+  (`DEFAULT_INSTANCE`, `DESTROYED_INSTANCE`, `INSTANCE`, etc.)
+  in the renamed files were left as-is because they're already
+  SCREAMING_SNAKE constants — consistent with the `CLASS_` macro
+  convention applied at file scope. If a future sweep wants
+  `Class_DefaultInstance` instead, it slots in cleanly.
+
+### Open questions
+
+- None. The static-prefix piece of the deferred naming-sweep
+  question is resolved; memory `feedback_static_name_prefix.md`
+  + `project_naming_sweep_deferred.md` both updated to reflect.
+
 ## 2026-05-15 — S10.07 enum constants SCREAMING_SNAKE → Class_PascalCase (#369)
 
 First cross-cutting sweep of E10's S10.07+ block. Executes the **enum

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -31,23 +31,23 @@ SOLIDSYSLOG_STATIC_ASSERT(
  * 50 ms is generous against typical sub-millisecond LAN ARP RTT but short
  * enough that the first send latency stays tolerable. If the reply hasn't
  * arrived in time the sendto is allowed to fail or be dropped — UDP semantics. */
-static const TickType_t ARP_RESOLUTION_WAIT_TICKS = pdMS_TO_TICKS(50);
+static const TickType_t ARP_RESOLUTION_WAIT_TICKS = FreeRtosDatagram_pdMS_TO_TICKS(50);
 
-static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
+static bool FreeRtosDatagram_FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_FreeRtosDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 );
-static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self);
-static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
-static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
-static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
-static inline void PrimeArpIfMissing(uint32_t ip);
+static size_t FreeRtosDatagram_FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self);
+static void FreeRtosDatagram_FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
+static inline FreeRtosDatagram* FreeRtosDatagram_FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
+static inline bool FreeRtosDatagram_FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
+static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip);
 
 static const FreeRtosDatagram DEFAULT_INSTANCE = {
-    {FreeRtosDatagram_Open, FreeRtosDatagram_SendTo, FreeRtosDatagram_MaxPayload, FreeRtosDatagram_Close},
+    {FreeRtosDatagram_FreeRtosDatagram_Open, FreeRtosDatagram_FreeRtosDatagram_SendTo, FreeRtosDatagram_FreeRtosDatagram_MaxPayload, FreeRtosDatagram_FreeRtosDatagram_Close},
     FREERTOS_INVALID_SOCKET,
 };
 
@@ -65,39 +65,39 @@ struct SolidSyslogDatagram* SolidSyslogFreeRtosDatagram_Create(SolidSyslogFreeRt
 
 void SolidSyslogFreeRtosDatagram_Destroy(struct SolidSyslogDatagram* datagram)
 {
-    FreeRtosDatagram* self = FreeRtosDatagram_From(datagram);
-    FreeRtosDatagram_Close(datagram);
+    FreeRtosDatagram* self = FreeRtosDatagram_FreeRtosDatagram_From(datagram);
+    FreeRtosDatagram_FreeRtosDatagram_Close(datagram);
     *self = DESTROYED_INSTANCE;
 }
 
-static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram* self)
+static inline FreeRtosDatagram* FreeRtosDatagram_FreeRtosDatagram_From(struct SolidSyslogDatagram* self)
 {
     return (FreeRtosDatagram*) self;
 }
 
-static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
+static bool FreeRtosDatagram_FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
-    if (!FreeRtosDatagram_IsOpen(datagram))
+    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
+    if (!FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
     {
         datagram->socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
     }
-    return FreeRtosDatagram_IsOpen(datagram);
+    return FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram);
 }
 
-static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_FreeRtosDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 )
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
+    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagramSendResult_Failed;
-    if (FreeRtosDatagram_IsOpen(datagram))
+    if (FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
     {
         const struct freertos_sockaddr* dest = SolidSyslogAddress_AsConstFreertosSockaddr(addr);
-        PrimeArpIfMissing(dest->sin_address.ulIP_IPv4);
+        FreeRtosDatagram_PrimeArpIfMissing(dest->sin_address.ulIP_IPv4);
         int32_t sent = FreeRTOS_sendto(datagram->socket, buffer, size, 0, dest, sizeof(*dest));
         if (sent > 0)
         {
@@ -113,7 +113,7 @@ static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
  * probe and yield once for the reply to land. If the reply hasn't arrived in
  * time the sendto is allowed to fail or be dropped — UDP is best-effort and
  * retry belongs in the store-and-forward layer above, not here. */
-static inline void PrimeArpIfMissing(uint32_t ip)
+static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip)
 {
     if (xIsIPInARPCache(ip) == pdFALSE)
     {
@@ -122,21 +122,21 @@ static inline void PrimeArpIfMissing(uint32_t ip)
     }
 }
 
-static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)
+static inline bool FreeRtosDatagram_FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)
 {
     return datagram->socket != FREERTOS_INVALID_SOCKET;
 }
 
-static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self)
+static size_t FreeRtosDatagram_FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self)
 {
     (void) self;
     return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
 }
 
-static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
+static void FreeRtosDatagram_FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
-    if (FreeRtosDatagram_IsOpen(datagram))
+    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
+    if (FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
     {
         (void) FreeRTOS_closesocket(datagram->socket);
         datagram->socket = FREERTOS_INVALID_SOCKET;

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -47,7 +47,10 @@ static inline bool FreeRtosDatagram_FreeRtosDatagram_IsOpen(const FreeRtosDatagr
 static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip);
 
 static const FreeRtosDatagram DEFAULT_INSTANCE = {
-    {FreeRtosDatagram_FreeRtosDatagram_Open, FreeRtosDatagram_FreeRtosDatagram_SendTo, FreeRtosDatagram_FreeRtosDatagram_MaxPayload, FreeRtosDatagram_FreeRtosDatagram_Close},
+    {FreeRtosDatagram_FreeRtosDatagram_Open,
+     FreeRtosDatagram_FreeRtosDatagram_SendTo,
+     FreeRtosDatagram_FreeRtosDatagram_MaxPayload,
+     FreeRtosDatagram_FreeRtosDatagram_Close},
     FREERTOS_INVALID_SOCKET,
 };
 

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -31,26 +31,23 @@ SOLIDSYSLOG_STATIC_ASSERT(
  * 50 ms is generous against typical sub-millisecond LAN ARP RTT but short
  * enough that the first send latency stays tolerable. If the reply hasn't
  * arrived in time the sendto is allowed to fail or be dropped — UDP semantics. */
-static const TickType_t ARP_RESOLUTION_WAIT_TICKS = FreeRtosDatagram_pdMS_TO_TICKS(50);
+static const TickType_t ARP_RESOLUTION_WAIT_TICKS = pdMS_TO_TICKS(50);
 
-static bool FreeRtosDatagram_FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult FreeRtosDatagram_FreeRtosDatagram_SendTo(
+static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 );
-static size_t FreeRtosDatagram_FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self);
-static void FreeRtosDatagram_FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
-static inline FreeRtosDatagram* FreeRtosDatagram_FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
-static inline bool FreeRtosDatagram_FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
+static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self);
+static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self);
+static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram* self);
+static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram);
 static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip);
 
 static const FreeRtosDatagram DEFAULT_INSTANCE = {
-    {FreeRtosDatagram_FreeRtosDatagram_Open,
-     FreeRtosDatagram_FreeRtosDatagram_SendTo,
-     FreeRtosDatagram_FreeRtosDatagram_MaxPayload,
-     FreeRtosDatagram_FreeRtosDatagram_Close},
+    {FreeRtosDatagram_Open, FreeRtosDatagram_SendTo, FreeRtosDatagram_MaxPayload, FreeRtosDatagram_Close},
     FREERTOS_INVALID_SOCKET,
 };
 
@@ -68,36 +65,36 @@ struct SolidSyslogDatagram* SolidSyslogFreeRtosDatagram_Create(SolidSyslogFreeRt
 
 void SolidSyslogFreeRtosDatagram_Destroy(struct SolidSyslogDatagram* datagram)
 {
-    FreeRtosDatagram* self = FreeRtosDatagram_FreeRtosDatagram_From(datagram);
-    FreeRtosDatagram_FreeRtosDatagram_Close(datagram);
+    FreeRtosDatagram* self = FreeRtosDatagram_From(datagram);
+    FreeRtosDatagram_Close(datagram);
     *self = DESTROYED_INSTANCE;
 }
 
-static inline FreeRtosDatagram* FreeRtosDatagram_FreeRtosDatagram_From(struct SolidSyslogDatagram* self)
+static inline FreeRtosDatagram* FreeRtosDatagram_From(struct SolidSyslogDatagram* self)
 {
     return (FreeRtosDatagram*) self;
 }
 
-static bool FreeRtosDatagram_FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
+static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* self)
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
-    if (!FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
+    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
+    if (!FreeRtosDatagram_IsOpen(datagram))
     {
         datagram->socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
     }
-    return FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram);
+    return FreeRtosDatagram_IsOpen(datagram);
 }
 
-static enum SolidSyslogDatagramSendResult FreeRtosDatagram_FreeRtosDatagram_SendTo(
+static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 )
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
+    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagramSendResult_Failed;
-    if (FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
+    if (FreeRtosDatagram_IsOpen(datagram))
     {
         const struct freertos_sockaddr* dest = SolidSyslogAddress_AsConstFreertosSockaddr(addr);
         FreeRtosDatagram_PrimeArpIfMissing(dest->sin_address.ulIP_IPv4);
@@ -125,21 +122,21 @@ static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip)
     }
 }
 
-static inline bool FreeRtosDatagram_FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)
+static inline bool FreeRtosDatagram_IsOpen(const FreeRtosDatagram* datagram)
 {
     return datagram->socket != FREERTOS_INVALID_SOCKET;
 }
 
-static size_t FreeRtosDatagram_FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self)
+static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* self)
 {
     (void) self;
     return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
 }
 
-static void FreeRtosDatagram_FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
+static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* self)
 {
-    FreeRtosDatagram* datagram = FreeRtosDatagram_FreeRtosDatagram_From(self);
-    if (FreeRtosDatagram_FreeRtosDatagram_IsOpen(datagram))
+    FreeRtosDatagram* datagram = FreeRtosDatagram_From(self);
+    if (FreeRtosDatagram_IsOpen(datagram))
     {
         (void) FreeRTOS_closesocket(datagram->socket);
         datagram->socket = FREERTOS_INVALID_SOCKET;

--- a/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
+++ b/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
@@ -339,12 +339,12 @@ static inline bool TlsStream_ConfigureExpectedHostname(struct SolidSyslogTlsStre
     return ok;
 }
 
-static inline bool IsRetryableSslError(int err)
+static inline bool TlsStream_IsRetryableSslError(int err)
 {
     return (err == SSL_ERROR_WANT_READ) || (err == SSL_ERROR_WANT_WRITE);
 }
 
-static inline bool IsHandshakeBudgetExhausted(int totalSleptMs)
+static inline bool TlsStream_IsHandshakeBudgetExhausted(int totalSleptMs)
 {
     return totalSleptMs >= HANDSHAKE_TIMEOUT_MILLISECONDS;
 }
@@ -371,7 +371,7 @@ static inline bool TlsStream_PerformHandshake(struct SolidSyslogTlsStream* strea
         else
         {
             int err = SSL_get_error(stream->ssl, rc);
-            if (!IsRetryableSslError(err) || IsHandshakeBudgetExhausted(totalSleptMs))
+            if (!TlsStream_IsRetryableSslError(err) || TlsStream_IsHandshakeBudgetExhausted(totalSleptMs))
             {
                 done = true;
             }

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c
@@ -19,14 +19,14 @@ enum
     GETADDRINFO_SUCCESS = 0
 };
 
-static bool Resolve(
+static bool GetAddrInfoResolver_Resolve(
     struct SolidSyslogResolver* self,
     enum SolidSyslogTransport transport,
     const char* host,
     uint16_t port,
     struct SolidSyslogAddress* result
 );
-static int MapTransport(enum SolidSyslogTransport transport);
+static int GetAddrInfoResolver_MapTransport(enum SolidSyslogTransport transport);
 
 struct SolidSyslogGetAddrInfoResolver
 {
@@ -37,7 +37,7 @@ static struct SolidSyslogGetAddrInfoResolver instance;
 
 struct SolidSyslogResolver* SolidSyslogGetAddrInfoResolver_Create(void)
 {
-    instance.base.Resolve = Resolve;
+    instance.base.Resolve = GetAddrInfoResolver_Resolve;
     return &instance.base;
 }
 
@@ -46,7 +46,7 @@ void SolidSyslogGetAddrInfoResolver_Destroy(void)
     instance.base.Resolve = NULL;
 }
 
-static bool Resolve(
+static bool GetAddrInfoResolver_Resolve(
     struct SolidSyslogResolver* self,
     enum SolidSyslogTransport transport,
     const char* host,
@@ -58,7 +58,7 @@ static bool Resolve(
 
     struct addrinfo hints = {0};
     hints.ai_family = AF_INET;
-    hints.ai_socktype = MapTransport(transport);
+    hints.ai_socktype = GetAddrInfoResolver_MapTransport(transport);
 
     struct addrinfo* info = NULL;
     bool resolved = false;
@@ -75,7 +75,7 @@ static bool Resolve(
     return resolved;
 }
 
-static int MapTransport(enum SolidSyslogTransport transport)
+static int GetAddrInfoResolver_MapTransport(enum SolidSyslogTransport transport)
 {
     int socktype = SOCK_DGRAM;
 

--- a/Platform/Posix/Source/SolidSyslogPosixClock.c
+++ b/Platform/Posix/Source/SolidSyslogPosixClock.c
@@ -9,8 +9,8 @@
 struct timespec;
 struct tm;
 
-static inline bool GetBrokenDownTime(struct timespec* now, struct tm* breakdown);
-static inline void PopulateTimestamp(
+static inline bool PosixClock_GetBrokenDownTime(struct timespec* now, struct tm* breakdown);
+static inline void PosixClock_PopulateTimestamp(
     struct SolidSyslogTimestamp* timestamp,
     const struct timespec* now,
     const struct tm* breakdown
@@ -23,18 +23,18 @@ void SolidSyslogPosixClock_GetTimestamp(struct SolidSyslogTimestamp* timestamp)
 
     *timestamp = (struct SolidSyslogTimestamp) {0};
 
-    if (GetBrokenDownTime(&now, &breakdown))
+    if (PosixClock_GetBrokenDownTime(&now, &breakdown))
     {
-        PopulateTimestamp(timestamp, &now, &breakdown);
+        PosixClock_PopulateTimestamp(timestamp, &now, &breakdown);
     }
 }
 
-static inline bool GetBrokenDownTime(struct timespec* now, struct tm* breakdown)
+static inline bool PosixClock_GetBrokenDownTime(struct timespec* now, struct tm* breakdown)
 {
     return (clock_gettime(CLOCK_REALTIME, now) == 0) && (gmtime_r(&now->tv_sec, breakdown) != NULL);
 }
 
-static inline void PopulateTimestamp(
+static inline void PosixClock_PopulateTimestamp(
     struct SolidSyslogTimestamp* timestamp,
     const struct timespec* now,
     const struct tm* breakdown

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -27,26 +27,26 @@ struct SolidSyslogPosixDatagram
     bool connected;
 };
 
-static bool Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult SendTo(
+static bool PosixDatagram_Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult PosixDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 );
-static size_t MaxPayload(struct SolidSyslogDatagram* self);
-static void Close(struct SolidSyslogDatagram* self);
-static inline bool ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr);
-static inline bool IsFileDescriptorValid(int fd);
+static size_t PosixDatagram_MaxPayload(struct SolidSyslogDatagram* self);
+static void PosixDatagram_Close(struct SolidSyslogDatagram* self);
+static inline bool PosixDatagram_ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool PosixDatagram_IsFileDescriptorValid(int fd);
 
 static struct SolidSyslogPosixDatagram instance = {.fd = INVALID_FD};
 
 struct SolidSyslogDatagram* SolidSyslogPosixDatagram_Create(void)
 {
-    instance.base.Open = Open;
-    instance.base.SendTo = SendTo;
-    instance.base.MaxPayload = MaxPayload;
-    instance.base.Close = Close;
+    instance.base.Open = PosixDatagram_Open;
+    instance.base.SendTo = PosixDatagram_SendTo;
+    instance.base.MaxPayload = PosixDatagram_MaxPayload;
+    instance.base.Close = PosixDatagram_Close;
     return &instance.base;
 }
 
@@ -58,20 +58,20 @@ void SolidSyslogPosixDatagram_Destroy(void)
     instance.base.Close = NULL;
 }
 
-static bool Open(struct SolidSyslogDatagram* self)
+static bool PosixDatagram_Open(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     datagram->fd = socket(AF_INET, SOCK_DGRAM, 0);
     datagram->connected = false;
-    return IsFileDescriptorValid(datagram->fd);
+    return PosixDatagram_IsFileDescriptorValid(datagram->fd);
 }
 
-static inline bool IsFileDescriptorValid(int fd)
+static inline bool PosixDatagram_IsFileDescriptorValid(int fd)
 {
     return fd >= 0;
 }
 
-static enum SolidSyslogDatagramSendResult SendTo(
+static enum SolidSyslogDatagramSendResult PosixDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
@@ -80,7 +80,7 @@ static enum SolidSyslogDatagramSendResult SendTo(
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagramSendResult_Failed;
-    if (ConnectIfNeeded(datagram, addr))
+    if (PosixDatagram_ConnectIfNeeded(datagram, addr))
     {
         const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
         ssize_t sent = sendto(datagram->fd, buffer, size, 0, (const struct sockaddr*) sin, sizeof(*sin));
@@ -96,7 +96,7 @@ static enum SolidSyslogDatagramSendResult SendTo(
     return result;
 }
 
-static inline bool ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr)
+static inline bool PosixDatagram_ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr)
 {
     if (!datagram->connected)
     {
@@ -111,7 +111,7 @@ static inline bool ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, co
     return datagram->connected;
 }
 
-static size_t MaxPayload(struct SolidSyslogDatagram* self)
+static size_t PosixDatagram_MaxPayload(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
     size_t result = SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
@@ -127,10 +127,10 @@ static size_t MaxPayload(struct SolidSyslogDatagram* self)
     return result;
 }
 
-static void Close(struct SolidSyslogDatagram* self)
+static void PosixDatagram_Close(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogPosixDatagram* datagram = (struct SolidSyslogPosixDatagram*) self;
-    if (IsFileDescriptorValid(datagram->fd))
+    if (PosixDatagram_IsFileDescriptorValid(datagram->fd))
     {
         close(datagram->fd);
         datagram->fd = INVALID_FD;

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -36,7 +36,10 @@ static enum SolidSyslogDatagramSendResult PosixDatagram_SendTo(
 );
 static size_t PosixDatagram_MaxPayload(struct SolidSyslogDatagram* self);
 static void PosixDatagram_Close(struct SolidSyslogDatagram* self);
-static inline bool PosixDatagram_ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool PosixDatagram_ConnectIfNeeded(
+    struct SolidSyslogPosixDatagram* datagram,
+    const struct SolidSyslogAddress* addr
+);
 static inline bool PosixDatagram_IsFileDescriptorValid(int fd);
 
 static struct SolidSyslogPosixDatagram instance = {.fd = INVALID_FD};
@@ -96,7 +99,10 @@ static enum SolidSyslogDatagramSendResult PosixDatagram_SendTo(
     return result;
 }
 
-static inline bool PosixDatagram_ConnectIfNeeded(struct SolidSyslogPosixDatagram* datagram, const struct SolidSyslogAddress* addr)
+static inline bool PosixDatagram_ConnectIfNeeded(
+    struct SolidSyslogPosixDatagram* datagram,
+    const struct SolidSyslogAddress* addr
+)
 {
     if (!datagram->connected)
     {

--- a/Platform/Posix/Source/SolidSyslogPosixFile.c
+++ b/Platform/Posix/Source/SolidSyslogPosixFile.c
@@ -41,7 +41,16 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogPosixFile DEFAULT_INSTANCE = {
-    {PosixFile_Open, PosixFile_Close, PosixFile_IsOpen, PosixFile_Read, PosixFile_Write, PosixFile_SeekTo, PosixFile_Size, PosixFile_Truncate, PosixFile_Exists, PosixFile_Delete},
+    {PosixFile_Open,
+     PosixFile_Close,
+     PosixFile_IsOpen,
+     PosixFile_Read,
+     PosixFile_Write,
+     PosixFile_SeekTo,
+     PosixFile_Size,
+     PosixFile_Truncate,
+     PosixFile_Exists,
+     PosixFile_Delete},
     INVALID_FD,
 };
 

--- a/Platform/Posix/Source/SolidSyslogPosixFile.c
+++ b/Platform/Posix/Source/SolidSyslogPosixFile.c
@@ -18,16 +18,16 @@ enum
     INVALID_FD = -1
 };
 
-static bool Open(struct SolidSyslogFile* self, const char* path);
-static void Close(struct SolidSyslogFile* self);
-static bool IsOpen(struct SolidSyslogFile* self);
-static bool Read(struct SolidSyslogFile* self, void* buf, size_t count);
-static bool Write(struct SolidSyslogFile* self, const void* buf, size_t count);
-static void SeekTo(struct SolidSyslogFile* self, size_t offset);
-static size_t Size(struct SolidSyslogFile* self);
-static void Truncate(struct SolidSyslogFile* self);
-static bool Exists(struct SolidSyslogFile* self, const char* path);
-static bool Delete(struct SolidSyslogFile* self, const char* path);
+static bool PosixFile_Open(struct SolidSyslogFile* self, const char* path);
+static void PosixFile_Close(struct SolidSyslogFile* self);
+static bool PosixFile_IsOpen(struct SolidSyslogFile* self);
+static bool PosixFile_Read(struct SolidSyslogFile* self, void* buf, size_t count);
+static bool PosixFile_Write(struct SolidSyslogFile* self, const void* buf, size_t count);
+static void PosixFile_SeekTo(struct SolidSyslogFile* self, size_t offset);
+static size_t PosixFile_Size(struct SolidSyslogFile* self);
+static void PosixFile_Truncate(struct SolidSyslogFile* self);
+static bool PosixFile_Exists(struct SolidSyslogFile* self, const char* path);
+static bool PosixFile_Delete(struct SolidSyslogFile* self, const char* path);
 
 struct SolidSyslogPosixFile
 {
@@ -41,7 +41,7 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogPosixFile DEFAULT_INSTANCE = {
-    {Open, Close, IsOpen, Read, Write, SeekTo, Size, Truncate, Exists, Delete},
+    {PosixFile_Open, PosixFile_Close, PosixFile_IsOpen, PosixFile_Read, PosixFile_Write, PosixFile_SeekTo, PosixFile_Size, PosixFile_Truncate, PosixFile_Exists, PosixFile_Delete},
     INVALID_FD,
 };
 
@@ -69,14 +69,14 @@ void SolidSyslogPosixFile_Destroy(struct SolidSyslogFile* file)
     *posix = DESTROYED_INSTANCE;
 }
 
-static bool Open(struct SolidSyslogFile* self, const char* path)
+static bool PosixFile_Open(struct SolidSyslogFile* self, const char* path)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     posix->fd = open(path, O_RDWR | O_CREAT, DEFAULT_FILE_PERMISSIONS);
     return posix->fd != INVALID_FD;
 }
 
-static void Close(struct SolidSyslogFile* self)
+static void PosixFile_Close(struct SolidSyslogFile* self)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
 
@@ -87,50 +87,50 @@ static void Close(struct SolidSyslogFile* self)
     }
 }
 
-static bool IsOpen(struct SolidSyslogFile* self)
+static bool PosixFile_IsOpen(struct SolidSyslogFile* self)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     return posix->fd != INVALID_FD;
 }
 
-static bool Read(struct SolidSyslogFile* self, void* buf, size_t count)
+static bool PosixFile_Read(struct SolidSyslogFile* self, void* buf, size_t count)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     return read(posix->fd, buf, count) == (ssize_t) count;
 }
 
-static bool Write(struct SolidSyslogFile* self, const void* buf, size_t count)
+static bool PosixFile_Write(struct SolidSyslogFile* self, const void* buf, size_t count)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     return write(posix->fd, buf, count) == (ssize_t) count;
 }
 
-static void SeekTo(struct SolidSyslogFile* self, size_t offset)
+static void PosixFile_SeekTo(struct SolidSyslogFile* self, size_t offset)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     lseek(posix->fd, (off_t) offset, SEEK_SET);
 }
 
-static size_t Size(struct SolidSyslogFile* self)
+static size_t PosixFile_Size(struct SolidSyslogFile* self)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     off_t size = lseek(posix->fd, 0, SEEK_END);
     return (size >= 0) ? (size_t) size : 0;
 }
 
-static void Truncate(struct SolidSyslogFile* self)
+static void PosixFile_Truncate(struct SolidSyslogFile* self)
 {
     struct SolidSyslogPosixFile* posix = (struct SolidSyslogPosixFile*) self;
     ftruncate(posix->fd, 0);
 }
 
-static bool Exists(struct SolidSyslogFile* self, const char* path)
+static bool PosixFile_Exists(struct SolidSyslogFile* self, const char* path)
 {
     (void) self;
     return access(path, F_OK) == 0;
 }
 
-static bool Delete(struct SolidSyslogFile* self, const char* path)
+static bool PosixFile_Delete(struct SolidSyslogFile* self, const char* path)
 {
     (void) self;
     return unlink(path) == 0;

--- a/Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c
@@ -16,8 +16,8 @@ enum
 
 static const char QUEUE_NAME_PREFIX[] = "/solidsyslog_";
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
+static bool PosixMessageQueueBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead);
+static void PosixMessageQueueBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size);
 
 struct SolidSyslogPosixMessageQueueBuffer
 {
@@ -29,7 +29,7 @@ struct SolidSyslogPosixMessageQueueBuffer
 
 static struct SolidSyslogPosixMessageQueueBuffer instance;
 
-static inline const char* QueueName(void)
+static inline const char* PosixMessageQueueBuffer_QueueName(void)
 {
     return SolidSyslogFormatter_AsFormattedBuffer(SolidSyslogFormatter_FromStorage(instance.nameStorage));
 }
@@ -47,10 +47,10 @@ struct SolidSyslogBuffer* SolidSyslogPosixMessageQueueBuffer_Create(size_t maxMe
     attr.mq_maxmsg = maxMessages;
     attr.mq_msgsize = (long) maxMessageSize;
 
-    instance.mq = mq_open(QueueName(), O_CREAT | O_RDWR | O_NONBLOCK, 0600, &attr);
+    instance.mq = mq_open(PosixMessageQueueBuffer_QueueName(), O_CREAT | O_RDWR | O_NONBLOCK, 0600, &attr);
     instance.maxMessageSize = maxMessageSize;
-    instance.base.Write = Write;
-    instance.base.Read = Read;
+    instance.base.Write = PosixMessageQueueBuffer_Write;
+    instance.base.Read = PosixMessageQueueBuffer_Read;
 
     return &instance.base;
 }
@@ -58,11 +58,11 @@ struct SolidSyslogBuffer* SolidSyslogPosixMessageQueueBuffer_Create(size_t maxMe
 void SolidSyslogPosixMessageQueueBuffer_Destroy(void)
 {
     mq_close(instance.mq);
-    mq_unlink(QueueName());
+    mq_unlink(PosixMessageQueueBuffer_QueueName());
     instance = (struct SolidSyslogPosixMessageQueueBuffer) {0};
 }
 
-static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
+static bool PosixMessageQueueBuffer_Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, size_t* bytesRead)
 {
     struct SolidSyslogPosixMessageQueueBuffer* mqBuffer = (struct SolidSyslogPosixMessageQueueBuffer*) self;
     ssize_t received = mq_receive(mqBuffer->mq, data, maxSize, NULL);
@@ -73,7 +73,7 @@ static bool Read(struct SolidSyslogBuffer* self, void* data, size_t maxSize, siz
     return success;
 }
 
-static void Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
+static void PosixMessageQueueBuffer_Write(struct SolidSyslogBuffer* self, const void* data, size_t size)
 {
     struct SolidSyslogPosixMessageQueueBuffer* mqBuffer = (struct SolidSyslogPosixMessageQueueBuffer*) self;
     mq_send(mqBuffer->mq, data, size, 0);

--- a/Platform/Posix/Source/SolidSyslogPosixMutex.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMutex.c
@@ -17,14 +17,14 @@ SOLIDSYSLOG_STATIC_ASSERT(
     "SOLIDSYSLOG_POSIXMUTEX_SIZE is too small for SolidSyslogPosixMutex layout"
 );
 
-static void Lock(struct SolidSyslogMutex* self);
-static void Unlock(struct SolidSyslogMutex* self);
+static void PosixMutex_Lock(struct SolidSyslogMutex* self);
+static void PosixMutex_Unlock(struct SolidSyslogMutex* self);
 
 struct SolidSyslogMutex* SolidSyslogPosixMutex_Create(SolidSyslogPosixMutexStorage* storage)
 {
     struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) storage;
-    posix->base.Lock = Lock;
-    posix->base.Unlock = Unlock;
+    posix->base.Lock = PosixMutex_Lock;
+    posix->base.Unlock = PosixMutex_Unlock;
     pthread_mutex_init(&posix->mutex, NULL);
     return &posix->base;
 }
@@ -37,13 +37,13 @@ void SolidSyslogPosixMutex_Destroy(struct SolidSyslogMutex* mutex)
     posix->base.Unlock = NULL;
 }
 
-static void Lock(struct SolidSyslogMutex* self)
+static void PosixMutex_Lock(struct SolidSyslogMutex* self)
 {
     struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) self;
     pthread_mutex_lock(&posix->mutex);
 }
 
-static void Unlock(struct SolidSyslogMutex* self)
+static void PosixMutex_Unlock(struct SolidSyslogMutex* self)
 {
     struct SolidSyslogPosixMutex* posix = (struct SolidSyslogPosixMutex*) self;
     pthread_mutex_unlock(&posix->mutex);

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -42,23 +42,23 @@ struct SolidSyslogPosixTcpStream
     int fd;
 };
 
-static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
-static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
-static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size);
-static void Close(struct SolidSyslogStream* self);
+static bool PosixTcpStream_Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
+static bool PosixTcpStream_Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
+static SolidSyslogSsize PosixTcpStream_Read(struct SolidSyslogStream* self, void* buffer, size_t size);
+static void PosixTcpStream_Close(struct SolidSyslogStream* self);
 
-static int OpenAndConfigureSocket(void);
-static bool ConfigureSocket(int fd);
-static void EnableTcpNoDelay(int fd);
-static void EnableKeepalive(int fd);
-static bool SetNonBlocking(int fd);
-static inline bool IsFileDescriptorValid(int fd);
-static bool ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin);
-static bool Connect(int fd, const struct sockaddr_in* sin);
-static bool WaitForConnectCompletion(int fd);
-static bool ReadDeferredConnectError(int fd);
-static bool WroteAllBytes(ssize_t sent, size_t expected);
-static inline bool WouldBlock(void);
+static int PosixTcpStream_OpenAndConfigureSocket(void);
+static bool PosixTcpStream_ConfigureSocket(int fd);
+static void PosixTcpStream_EnableTcpNoDelay(int fd);
+static void PosixTcpStream_EnableKeepalive(int fd);
+static bool PosixTcpStream_SetNonBlocking(int fd);
+static inline bool PosixTcpStream_IsFileDescriptorValid(int fd);
+static bool PosixTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin);
+static bool PosixTcpStream_Connect(int fd, const struct sockaddr_in* sin);
+static bool PosixTcpStream_WaitForConnectCompletion(int fd);
+static bool PosixTcpStream_ReadDeferredConnectError(int fd);
+static bool PosixTcpStream_WroteAllBytes(ssize_t sent, size_t expected);
+static inline bool PosixTcpStream_WouldBlock(void);
 
 SOLIDSYSLOG_STATIC_ASSERT(
     sizeof(struct SolidSyslogPosixTcpStream) <= SOLIDSYSLOG_POSIX_TCP_STREAM_SIZE,
@@ -66,7 +66,7 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogPosixTcpStream DEFAULT_INSTANCE = {
-    {Open, Send, Read, Close},
+    {PosixTcpStream_Open, PosixTcpStream_Send, PosixTcpStream_Read, PosixTcpStream_Close},
     INVALID_FD,
 };
 
@@ -85,31 +85,31 @@ struct SolidSyslogStream* SolidSyslogPosixTcpStream_Create(SolidSyslogPosixTcpSt
 void SolidSyslogPosixTcpStream_Destroy(struct SolidSyslogStream* stream)
 {
     struct SolidSyslogPosixTcpStream* self = (struct SolidSyslogPosixTcpStream*) stream;
-    Close(stream);
+    PosixTcpStream_Close(stream);
     *self = DESTROYED_INSTANCE;
 }
 
-static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
+static bool PosixTcpStream_Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
     const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
     bool connected = false;
 
-    stream->fd = OpenAndConfigureSocket();
-    if (IsFileDescriptorValid(stream->fd))
+    stream->fd = PosixTcpStream_OpenAndConfigureSocket();
+    if (PosixTcpStream_IsFileDescriptorValid(stream->fd))
     {
-        connected = ConnectOrCloseOnFailure(stream, sin);
+        connected = PosixTcpStream_ConnectOrCloseOnFailure(stream, sin);
     }
     return connected;
 }
 
 /* Non-blocking from the start: connect() reports EINPROGRESS, the wait is
- * bounded by select(), and Send/Read never block the service thread on a
+ * bounded by select(), and PosixTcpStream_Send/PosixTcpStream_Read never block the service thread on a
  * wedged peer or a full kernel send buffer. */
-static int OpenAndConfigureSocket(void)
+static int PosixTcpStream_OpenAndConfigureSocket(void)
 {
     int fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (IsFileDescriptorValid(fd) && !ConfigureSocket(fd))
+    if (PosixTcpStream_IsFileDescriptorValid(fd) && !PosixTcpStream_ConfigureSocket(fd))
     {
         close(fd);
         fd = INVALID_FD;
@@ -117,25 +117,25 @@ static int OpenAndConfigureSocket(void)
     return fd;
 }
 
-static bool ConfigureSocket(int fd)
+static bool PosixTcpStream_ConfigureSocket(int fd)
 {
-    EnableTcpNoDelay(fd);
-    EnableKeepalive(fd);
-    return SetNonBlocking(fd);
+    PosixTcpStream_EnableTcpNoDelay(fd);
+    PosixTcpStream_EnableKeepalive(fd);
+    return PosixTcpStream_SetNonBlocking(fd);
 }
 
-static void EnableTcpNoDelay(int fd)
+static void PosixTcpStream_EnableTcpNoDelay(int fd)
 {
     int enable = 1;
     setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
 }
 
 /* Enable kernel TCP keepalive so a dead peer is surfaced as ETIMEDOUT during
- * idle periods, not on the next Send. TCP_USER_TIMEOUT covers the orthogonal
+ * idle periods, not on the next PosixTcpStream_Send. TCP_USER_TIMEOUT covers the orthogonal
  * pending-write case (keepalive only fires on a fully idle socket). Linux is
  * the POSIX target — TCP_KEEP* and TCP_USER_TIMEOUT are all available there;
  * other POSIX targets are out of scope until we actually port to one. */
-static void EnableKeepalive(int fd)
+static void PosixTcpStream_EnableKeepalive(int fd)
 {
     int enable = 1;
     int idle = KEEPALIVE_IDLE_SECONDS;
@@ -150,20 +150,20 @@ static void EnableKeepalive(int fd)
     setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &userTimeout, sizeof(userTimeout));
 }
 
-static bool SetNonBlocking(int fd)
+static bool PosixTcpStream_SetNonBlocking(int fd)
 {
     int flags = fcntl(fd, F_GETFL, 0);
     return (flags >= 0) && (fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1);
 }
 
-static inline bool IsFileDescriptorValid(int fd)
+static inline bool PosixTcpStream_IsFileDescriptorValid(int fd)
 {
     return (fd >= 0);
 }
 
-static bool ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin)
+static bool PosixTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin)
 {
-    bool connected = Connect(stream->fd, sin);
+    bool connected = PosixTcpStream_Connect(stream->fd, sin);
     if (!connected)
     {
         close(stream->fd);
@@ -178,7 +178,7 @@ static bool ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, co
  *                    CONNECT_TIMEOUT_MICROSECONDS, then read SO_ERROR to
  *                    distinguish completed-success from deferred-failure.
  *   -1 other    — immediate fail-fast (refused, unreachable, etc.). */
-static bool Connect(int fd, const struct sockaddr_in* sin)
+static bool PosixTcpStream_Connect(int fd, const struct sockaddr_in* sin)
 {
     bool connected = false;
     int rc = connect(fd, (const struct sockaddr*) sin, sizeof(*sin));
@@ -189,12 +189,12 @@ static bool Connect(int fd, const struct sockaddr_in* sin)
     }
     else if (errno == EINPROGRESS)
     {
-        connected = WaitForConnectCompletion(fd) && ReadDeferredConnectError(fd);
+        connected = PosixTcpStream_WaitForConnectCompletion(fd) && PosixTcpStream_ReadDeferredConnectError(fd);
     }
     return connected;
 }
 
-static bool WaitForConnectCompletion(int fd)
+static bool PosixTcpStream_WaitForConnectCompletion(int fd)
 {
     fd_set writeSet;
     FD_ZERO(&writeSet);
@@ -210,7 +210,7 @@ static bool WaitForConnectCompletion(int fd)
     return (rc > 0) && FD_ISSET(fd, &writeSet) && !FD_ISSET(fd, &errorSet);
 }
 
-static bool ReadDeferredConnectError(int fd)
+static bool PosixTcpStream_ReadDeferredConnectError(int fd)
 {
     int err = 0;
     socklen_t errlen = (socklen_t) sizeof(err);
@@ -218,27 +218,27 @@ static bool ReadDeferredConnectError(int fd)
     return (rc == 0) && (err == 0);
 }
 
-static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
+static bool PosixTcpStream_Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
     ssize_t sent = send(stream->fd, buffer, size, MSG_NOSIGNAL);
-    bool ok = WroteAllBytes(sent, size);
+    bool ok = PosixTcpStream_WroteAllBytes(sent, size);
 
     if (!ok)
     {
-        Close(self);
+        PosixTcpStream_Close(self);
     }
     return ok;
 }
 
 /* Non-blocking single-call contract: short write or any error means the
  * connection is gone; the caller closes and reconnects on the next attempt. */
-static bool WroteAllBytes(ssize_t sent, size_t expected)
+static bool PosixTcpStream_WroteAllBytes(ssize_t sent, size_t expected)
 {
     return (sent >= 0) && ((size_t) sent == expected);
 }
 
-static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size)
+static SolidSyslogSsize PosixTcpStream_Read(struct SolidSyslogStream* self, void* buffer, size_t size)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
     ssize_t n = recv(stream->fd, buffer, size, 0);
@@ -248,26 +248,26 @@ static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_
     {
         result = (SolidSyslogSsize) n;
     }
-    else if ((n < 0) && WouldBlock())
+    else if ((n < 0) && PosixTcpStream_WouldBlock())
     {
         result = 0;
     }
     else
     {
-        Close(self);
+        PosixTcpStream_Close(self);
     }
     return result;
 }
 
-static inline bool WouldBlock(void)
+static inline bool PosixTcpStream_WouldBlock(void)
 {
     return (errno == EAGAIN) || (errno == EWOULDBLOCK);
 }
 
-static void Close(struct SolidSyslogStream* self)
+static void PosixTcpStream_Close(struct SolidSyslogStream* self)
 {
     struct SolidSyslogPosixTcpStream* stream = (struct SolidSyslogPosixTcpStream*) self;
-    if (IsFileDescriptorValid(stream->fd))
+    if (PosixTcpStream_IsFileDescriptorValid(stream->fd))
     {
         close(stream->fd);
         stream->fd = INVALID_FD;

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -53,7 +53,10 @@ static void PosixTcpStream_EnableTcpNoDelay(int fd);
 static void PosixTcpStream_EnableKeepalive(int fd);
 static bool PosixTcpStream_SetNonBlocking(int fd);
 static inline bool PosixTcpStream_IsFileDescriptorValid(int fd);
-static bool PosixTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin);
+static bool PosixTcpStream_ConnectOrCloseOnFailure(
+    struct SolidSyslogPosixTcpStream* stream,
+    const struct sockaddr_in* sin
+);
 static bool PosixTcpStream_Connect(int fd, const struct sockaddr_in* sin);
 static bool PosixTcpStream_WaitForConnectCompletion(int fd);
 static bool PosixTcpStream_ReadDeferredConnectError(int fd);
@@ -161,7 +164,10 @@ static inline bool PosixTcpStream_IsFileDescriptorValid(int fd)
     return (fd >= 0);
 }
 
-static bool PosixTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogPosixTcpStream* stream, const struct sockaddr_in* sin)
+static bool PosixTcpStream_ConnectOrCloseOnFailure(
+    struct SolidSyslogPosixTcpStream* stream,
+    const struct sockaddr_in* sin
+)
 {
     bool connected = PosixTcpStream_Connect(stream->fd, sin);
     if (!connected)

--- a/Platform/Windows/Source/SolidSyslogWindowsClock.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsClock.c
@@ -8,11 +8,11 @@
    for static initialisation may trigger MSVC C4232 in some configurations;
    forwarding through a static function whose address IS a compile-time
    constant avoids the warning without a suppression. */
-static void WINAPI CallGetSystemTimeAsFileTime(LPFILETIME fileTime);
+static void WINAPI WindowsClock_CallGetSystemTimeAsFileTime(LPFILETIME fileTime);
 
-WindowsGetSystemTimeAsFileTimeFn WindowsClock_GetSystemTimeAsFileTime = CallGetSystemTimeAsFileTime;
+WindowsGetSystemTimeAsFileTimeFn WindowsClock_GetSystemTimeAsFileTime = WindowsClock_CallGetSystemTimeAsFileTime;
 
-static void WINAPI CallGetSystemTimeAsFileTime(LPFILETIME fileTime)
+static void WINAPI WindowsClock_CallGetSystemTimeAsFileTime(LPFILETIME fileTime)
 {
     GetSystemTimeAsFileTime(fileTime);
 }
@@ -23,9 +23,9 @@ enum
     HUNDRED_NS_PER_SECOND = 10000000
 };
 
-static inline bool BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown);
-static inline uint32_t MicrosecondsFromFileTime(const FILETIME* fileTime);
-static inline void PopulateTimestamp(
+static inline bool WindowsClock_BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown);
+static inline uint32_t WindowsClock_MicrosecondsFromFileTime(const FILETIME* fileTime);
+static inline void WindowsClock_PopulateTimestamp(
     struct SolidSyslogTimestamp* timestamp,
     const SYSTEMTIME* breakdown,
     uint32_t microseconds
@@ -40,24 +40,24 @@ void SolidSyslogWindowsClock_GetTimestamp(struct SolidSyslogTimestamp* timestamp
 
     WindowsClock_GetSystemTimeAsFileTime(&fileTime);
 
-    if (BreakDownFileTime(&fileTime, &breakdown))
+    if (WindowsClock_BreakDownFileTime(&fileTime, &breakdown))
     {
-        PopulateTimestamp(timestamp, &breakdown, MicrosecondsFromFileTime(&fileTime));
+        WindowsClock_PopulateTimestamp(timestamp, &breakdown, WindowsClock_MicrosecondsFromFileTime(&fileTime));
     }
 }
 
-static inline bool BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown)
+static inline bool WindowsClock_BreakDownFileTime(const FILETIME* fileTime, SYSTEMTIME* breakdown)
 {
     return FileTimeToSystemTime(fileTime, breakdown) != 0;
 }
 
-static inline uint32_t MicrosecondsFromFileTime(const FILETIME* fileTime)
+static inline uint32_t WindowsClock_MicrosecondsFromFileTime(const FILETIME* fileTime)
 {
     uint64_t hundredNs = ((uint64_t) fileTime->dwHighDateTime << 32) | (uint64_t) fileTime->dwLowDateTime;
     return (uint32_t) ((hundredNs % HUNDRED_NS_PER_SECOND) / HUNDRED_NS_PER_MICROSECOND);
 }
 
-static inline void PopulateTimestamp(
+static inline void WindowsClock_PopulateTimestamp(
     struct SolidSyslogTimestamp* timestamp,
     const SYSTEMTIME* breakdown,
     uint32_t microseconds

--- a/Platform/Windows/Source/SolidSyslogWindowsFile.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsFile.c
@@ -45,7 +45,16 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogWindowsFile DEFAULT_INSTANCE = {
-    {WindowsFile_Open, WindowsFile_Close, WindowsFile_IsOpen, WindowsFile_Read, WindowsFile_Write, WindowsFile_SeekTo, WindowsFile_Size, WindowsFile_Truncate, WindowsFile_Exists, WindowsFile_Delete},
+    {WindowsFile_Open,
+     WindowsFile_Close,
+     WindowsFile_IsOpen,
+     WindowsFile_Read,
+     WindowsFile_Write,
+     WindowsFile_SeekTo,
+     WindowsFile_Size,
+     WindowsFile_Truncate,
+     WindowsFile_Exists,
+     WindowsFile_Delete},
     INVALID_FD,
 };
 

--- a/Platform/Windows/Source/SolidSyslogWindowsFile.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsFile.c
@@ -22,16 +22,16 @@ enum
     ACCESS_EXISTENCE_CHECK = 0 /* equivalent to POSIX F_OK; <io.h> does not define an alias */
 };
 
-static bool Open(struct SolidSyslogFile* self, const char* path);
-static void Close(struct SolidSyslogFile* self);
-static bool IsOpen(struct SolidSyslogFile* self);
-static bool Read(struct SolidSyslogFile* self, void* buf, size_t count);
-static bool Write(struct SolidSyslogFile* self, const void* buf, size_t count);
-static void SeekTo(struct SolidSyslogFile* self, size_t offset);
-static size_t Size(struct SolidSyslogFile* self);
-static void Truncate(struct SolidSyslogFile* self);
-static bool Exists(struct SolidSyslogFile* self, const char* path);
-static bool Delete(struct SolidSyslogFile* self, const char* path);
+static bool WindowsFile_Open(struct SolidSyslogFile* self, const char* path);
+static void WindowsFile_Close(struct SolidSyslogFile* self);
+static bool WindowsFile_IsOpen(struct SolidSyslogFile* self);
+static bool WindowsFile_Read(struct SolidSyslogFile* self, void* buf, size_t count);
+static bool WindowsFile_Write(struct SolidSyslogFile* self, const void* buf, size_t count);
+static void WindowsFile_SeekTo(struct SolidSyslogFile* self, size_t offset);
+static size_t WindowsFile_Size(struct SolidSyslogFile* self);
+static void WindowsFile_Truncate(struct SolidSyslogFile* self);
+static bool WindowsFile_Exists(struct SolidSyslogFile* self, const char* path);
+static bool WindowsFile_Delete(struct SolidSyslogFile* self, const char* path);
 
 struct SolidSyslogWindowsFile
 {
@@ -45,7 +45,7 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogWindowsFile DEFAULT_INSTANCE = {
-    {Open, Close, IsOpen, Read, Write, SeekTo, Size, Truncate, Exists, Delete},
+    {WindowsFile_Open, WindowsFile_Close, WindowsFile_IsOpen, WindowsFile_Read, WindowsFile_Write, WindowsFile_SeekTo, WindowsFile_Size, WindowsFile_Truncate, WindowsFile_Exists, WindowsFile_Delete},
     INVALID_FD,
 };
 
@@ -73,7 +73,7 @@ void SolidSyslogWindowsFile_Destroy(struct SolidSyslogFile* file)
     *windows = DESTROYED_INSTANCE;
 }
 
-static bool Open(struct SolidSyslogFile* self, const char* path)
+static bool WindowsFile_Open(struct SolidSyslogFile* self, const char* path)
 {
     /* _sopen_s is the non-deprecated MSVC equivalent of POSIX open(): the
      * plain _open triggers C4996 (Microsoft's safe-CRT preference) and
@@ -88,7 +88,7 @@ static bool Open(struct SolidSyslogFile* self, const char* path)
     return windows->fd != INVALID_FD;
 }
 
-static void Close(struct SolidSyslogFile* self)
+static void WindowsFile_Close(struct SolidSyslogFile* self)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
 
@@ -99,50 +99,50 @@ static void Close(struct SolidSyslogFile* self)
     }
 }
 
-static bool IsOpen(struct SolidSyslogFile* self)
+static bool WindowsFile_IsOpen(struct SolidSyslogFile* self)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     return windows->fd != INVALID_FD;
 }
 
-static bool Read(struct SolidSyslogFile* self, void* buf, size_t count)
+static bool WindowsFile_Read(struct SolidSyslogFile* self, void* buf, size_t count)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     return _read(windows->fd, buf, (unsigned int) count) == (int) count;
 }
 
-static bool Write(struct SolidSyslogFile* self, const void* buf, size_t count)
+static bool WindowsFile_Write(struct SolidSyslogFile* self, const void* buf, size_t count)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     return _write(windows->fd, buf, (unsigned int) count) == (int) count;
 }
 
-static void SeekTo(struct SolidSyslogFile* self, size_t offset)
+static void WindowsFile_SeekTo(struct SolidSyslogFile* self, size_t offset)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     _lseeki64(windows->fd, (__int64) offset, SEEK_SET);
 }
 
-static size_t Size(struct SolidSyslogFile* self)
+static size_t WindowsFile_Size(struct SolidSyslogFile* self)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     __int64 size = _lseeki64(windows->fd, 0, SEEK_END);
     return (size >= 0) ? (size_t) size : 0;
 }
 
-static void Truncate(struct SolidSyslogFile* self)
+static void WindowsFile_Truncate(struct SolidSyslogFile* self)
 {
     struct SolidSyslogWindowsFile* windows = (struct SolidSyslogWindowsFile*) self;
     _chsize_s(windows->fd, 0);
 }
 
-static bool Exists(struct SolidSyslogFile* self, const char* path)
+static bool WindowsFile_Exists(struct SolidSyslogFile* self, const char* path)
 {
     (void) self;
     return _access(path, ACCESS_EXISTENCE_CHECK) == 0;
 }
 
-static bool Delete(struct SolidSyslogFile* self, const char* path)
+static bool WindowsFile_Delete(struct SolidSyslogFile* self, const char* path)
 {
     (void) self;
     return _unlink(path) == 0;

--- a/Platform/Windows/Source/SolidSyslogWindowsHostname.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsHostname.c
@@ -6,11 +6,11 @@
    for static initialisation may trigger MSVC C4232 in some configurations;
    forwarding through a static function whose address IS a compile-time
    constant avoids the warning without a suppression. */
-static BOOL WINAPI CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size);
+static BOOL WINAPI WindowsHostname_CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size);
 
-WindowsGetComputerNameExAFn WindowsHostname_GetComputerNameExA = CallGetComputerNameExA;
+WindowsGetComputerNameExAFn WindowsHostname_GetComputerNameExA = WindowsHostname_CallGetComputerNameExA;
 
-static BOOL WINAPI CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size)
+static BOOL WINAPI WindowsHostname_CallGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR buffer, LPDWORD size)
 {
     return GetComputerNameExA(nameType, buffer, size);
 }

--- a/Platform/Windows/Source/SolidSyslogWindowsMutex.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsMutex.c
@@ -17,14 +17,14 @@ SOLIDSYSLOG_STATIC_ASSERT(
     "SOLIDSYSLOG_WINDOWSMUTEX_SIZE is too small for SolidSyslogWindowsMutex layout"
 );
 
-static void Lock(struct SolidSyslogMutex* self);
-static void Unlock(struct SolidSyslogMutex* self);
+static void WindowsMutex_Lock(struct SolidSyslogMutex* self);
+static void WindowsMutex_Unlock(struct SolidSyslogMutex* self);
 
 struct SolidSyslogMutex* SolidSyslogWindowsMutex_Create(SolidSyslogWindowsMutexStorage* storage)
 {
     struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) storage;
-    windows->base.Lock = Lock;
-    windows->base.Unlock = Unlock;
+    windows->base.Lock = WindowsMutex_Lock;
+    windows->base.Unlock = WindowsMutex_Unlock;
     InitializeCriticalSection(&windows->section);
     return &windows->base;
 }
@@ -37,13 +37,13 @@ void SolidSyslogWindowsMutex_Destroy(struct SolidSyslogMutex* mutex)
     windows->base.Unlock = NULL;
 }
 
-static void Lock(struct SolidSyslogMutex* self)
+static void WindowsMutex_Lock(struct SolidSyslogMutex* self)
 {
     struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) self;
     EnterCriticalSection(&windows->section);
 }
 
-static void Unlock(struct SolidSyslogMutex* self)
+static void WindowsMutex_Unlock(struct SolidSyslogMutex* self)
 {
     struct SolidSyslogWindowsMutex* windows = (struct SolidSyslogWindowsMutex*) self;
     LeaveCriticalSection(&windows->section);

--- a/Platform/Windows/Source/SolidSyslogWindowsProcessId.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsProcessId.c
@@ -8,11 +8,11 @@
    for static initialisation may trigger MSVC C4232 in some configurations;
    forwarding through a static function whose address IS a compile-time
    constant avoids the warning without a suppression. */
-static DWORD WINAPI CallGetCurrentProcessId(void);
+static DWORD WINAPI WindowsProcessId_CallGetCurrentProcessId(void);
 
-WindowsGetCurrentProcessIdFn WindowsProcessId_GetCurrentProcessId = CallGetCurrentProcessId;
+WindowsGetCurrentProcessIdFn WindowsProcessId_GetCurrentProcessId = WindowsProcessId_CallGetCurrentProcessId;
 
-static DWORD WINAPI CallGetCurrentProcessId(void)
+static DWORD WINAPI WindowsProcessId_CallGetCurrentProcessId(void)
 {
     return GetCurrentProcessId();
 }

--- a/Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c
@@ -5,11 +5,11 @@
    for static initialisation may trigger MSVC C4232 in some configurations;
    forwarding through a static function whose address IS a compile-time
    constant avoids the warning without a suppression. */
-static ULONGLONG WINAPI CallGetTickCount64(void);
+static ULONGLONG WINAPI WindowsSysUpTime_CallGetTickCount64(void);
 
-WindowsGetTickCount64Fn WindowsSysUpTime_GetTickCount64 = CallGetTickCount64;
+WindowsGetTickCount64Fn WindowsSysUpTime_GetTickCount64 = WindowsSysUpTime_CallGetTickCount64;
 
-static ULONGLONG WINAPI CallGetTickCount64(void)
+static ULONGLONG WINAPI WindowsSysUpTime_CallGetTickCount64(void)
 {
     return GetTickCount64();
 }

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -13,7 +13,8 @@
    isn't a compile-time constant); forwarding through a static function whose
    address IS a compile-time constant avoids the warning without a suppression. */
 static SOCKET WSAAPI WinsockDatagram_CallSocket(int af, int type, int protocol);
-static int WSAAPI WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
+static int WSAAPI
+WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
 static int WSAAPI WinsockDatagram_CallCloseSocket(SOCKET s);
 static int WSAAPI WinsockDatagram_CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
 static int WSAAPI WinsockDatagram_CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
@@ -31,7 +32,8 @@ static SOCKET WSAAPI WinsockDatagram_CallSocket(int af, int type, int protocol)
     return socket(af, type, protocol);
 }
 
-static int WSAAPI WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
+static int WSAAPI
+WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
 {
     return sendto(s, buf, len, flags, to, tolen);
 }
@@ -72,7 +74,10 @@ static enum SolidSyslogDatagramSendResult WinsockDatagram_SendTo(
 );
 static size_t WinsockDatagram_MaxPayload(struct SolidSyslogDatagram* self);
 static void WinsockDatagram_Close(struct SolidSyslogDatagram* self);
-static inline bool WinsockDatagram_ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool WinsockDatagram_ConnectIfNeeded(
+    struct SolidSyslogWinsockDatagram* datagram,
+    const struct SolidSyslogAddress* addr
+);
 static inline bool WinsockDatagram_IsSocketValid(SOCKET fd);
 
 static struct SolidSyslogWinsockDatagram instance = {.fd = INVALID_SOCKET};
@@ -139,7 +144,10 @@ static enum SolidSyslogDatagramSendResult WinsockDatagram_SendTo(
     return result;
 }
 
-static inline bool WinsockDatagram_ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr)
+static inline bool WinsockDatagram_ConnectIfNeeded(
+    struct SolidSyslogWinsockDatagram* datagram,
+    const struct SolidSyslogAddress* addr
+)
 {
     if (!datagram->connected)
     {

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -12,46 +12,46 @@
    Winsock function for static initialisation triggers MSVC C4232 (the address
    isn't a compile-time constant); forwarding through a static function whose
    address IS a compile-time constant avoids the warning without a suppression. */
-static SOCKET WSAAPI CallSocket(int af, int type, int protocol);
-static int WSAAPI CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
-static int WSAAPI CallCloseSocket(SOCKET s);
-static int WSAAPI CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
-static int WSAAPI CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
-static int WSAAPI CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen);
+static SOCKET WSAAPI WinsockDatagram_CallSocket(int af, int type, int protocol);
+static int WSAAPI WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen);
+static int WSAAPI WinsockDatagram_CallCloseSocket(SOCKET s);
+static int WSAAPI WinsockDatagram_CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
+static int WSAAPI WinsockDatagram_CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
+static int WSAAPI WinsockDatagram_CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen);
 
-WinsockSocketFn Winsock_socket = CallSocket;
-WinsockSendToFn Winsock_sendto = CallSendTo;
-WinsockCloseSocketFn Winsock_closesocket = CallCloseSocket;
-WinsockConnectFn Winsock_connect = CallConnect;
-WinsockSetSockOptFn Winsock_setsockopt = CallSetSockOpt;
-WinsockGetSockOptFn Winsock_getsockopt = CallGetSockOpt;
+WinsockSocketFn Winsock_socket = WinsockDatagram_CallSocket;
+WinsockSendToFn Winsock_sendto = WinsockDatagram_CallSendTo;
+WinsockCloseSocketFn Winsock_closesocket = WinsockDatagram_CallCloseSocket;
+WinsockConnectFn Winsock_connect = WinsockDatagram_CallConnect;
+WinsockSetSockOptFn Winsock_setsockopt = WinsockDatagram_CallSetSockOpt;
+WinsockGetSockOptFn Winsock_getsockopt = WinsockDatagram_CallGetSockOpt;
 
-static SOCKET WSAAPI CallSocket(int af, int type, int protocol)
+static SOCKET WSAAPI WinsockDatagram_CallSocket(int af, int type, int protocol)
 {
     return socket(af, type, protocol);
 }
 
-static int WSAAPI CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
+static int WSAAPI WinsockDatagram_CallSendTo(SOCKET s, const char* buf, int len, int flags, const struct sockaddr* to, int tolen)
 {
     return sendto(s, buf, len, flags, to, tolen);
 }
 
-static int WSAAPI CallCloseSocket(SOCKET s)
+static int WSAAPI WinsockDatagram_CallCloseSocket(SOCKET s)
 {
     return closesocket(s);
 }
 
-static int WSAAPI CallConnect(SOCKET s, const struct sockaddr* name, int namelen)
+static int WSAAPI WinsockDatagram_CallConnect(SOCKET s, const struct sockaddr* name, int namelen)
 {
     return connect(s, name, namelen);
 }
 
-static int WSAAPI CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen)
+static int WSAAPI WinsockDatagram_CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen)
 {
     return setsockopt(s, level, optname, optval, optlen);
 }
 
-static int WSAAPI CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen)
+static int WSAAPI WinsockDatagram_CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen)
 {
     return getsockopt(s, level, optname, optval, optlen);
 }
@@ -63,26 +63,26 @@ struct SolidSyslogWinsockDatagram
     bool connected;
 };
 
-static bool Open(struct SolidSyslogDatagram* self);
-static enum SolidSyslogDatagramSendResult SendTo(
+static bool WinsockDatagram_Open(struct SolidSyslogDatagram* self);
+static enum SolidSyslogDatagramSendResult WinsockDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
     const struct SolidSyslogAddress* addr
 );
-static size_t MaxPayload(struct SolidSyslogDatagram* self);
-static void Close(struct SolidSyslogDatagram* self);
-static inline bool ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr);
-static inline bool IsSocketValid(SOCKET fd);
+static size_t WinsockDatagram_MaxPayload(struct SolidSyslogDatagram* self);
+static void WinsockDatagram_Close(struct SolidSyslogDatagram* self);
+static inline bool WinsockDatagram_ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr);
+static inline bool WinsockDatagram_IsSocketValid(SOCKET fd);
 
 static struct SolidSyslogWinsockDatagram instance = {.fd = INVALID_SOCKET};
 
 struct SolidSyslogDatagram* SolidSyslogWinsockDatagram_Create(void)
 {
-    instance.base.Open = Open;
-    instance.base.SendTo = SendTo;
-    instance.base.MaxPayload = MaxPayload;
-    instance.base.Close = Close;
+    instance.base.Open = WinsockDatagram_Open;
+    instance.base.SendTo = WinsockDatagram_SendTo;
+    instance.base.MaxPayload = WinsockDatagram_MaxPayload;
+    instance.base.Close = WinsockDatagram_Close;
     return &instance.base;
 }
 
@@ -94,20 +94,20 @@ void SolidSyslogWinsockDatagram_Destroy(void)
     instance.base.Close = NULL;
 }
 
-static bool Open(struct SolidSyslogDatagram* self)
+static bool WinsockDatagram_Open(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
     datagram->fd = Winsock_socket(AF_INET, SOCK_DGRAM, 0);
     datagram->connected = false;
-    return IsSocketValid(datagram->fd);
+    return WinsockDatagram_IsSocketValid(datagram->fd);
 }
 
-static inline bool IsSocketValid(SOCKET fd)
+static inline bool WinsockDatagram_IsSocketValid(SOCKET fd)
 {
     return fd != INVALID_SOCKET;
 }
 
-static enum SolidSyslogDatagramSendResult SendTo(
+static enum SolidSyslogDatagramSendResult WinsockDatagram_SendTo(
     struct SolidSyslogDatagram* self,
     const void* buffer,
     size_t size,
@@ -116,7 +116,7 @@ static enum SolidSyslogDatagramSendResult SendTo(
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
     enum SolidSyslogDatagramSendResult result = SolidSyslogDatagramSendResult_Failed;
-    if (ConnectIfNeeded(datagram, addr))
+    if (WinsockDatagram_ConnectIfNeeded(datagram, addr))
     {
         const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
         int sent = Winsock_sendto(
@@ -139,7 +139,7 @@ static enum SolidSyslogDatagramSendResult SendTo(
     return result;
 }
 
-static inline bool ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr)
+static inline bool WinsockDatagram_ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, const struct SolidSyslogAddress* addr)
 {
     if (!datagram->connected)
     {
@@ -155,7 +155,7 @@ static inline bool ConnectIfNeeded(struct SolidSyslogWinsockDatagram* datagram, 
     return datagram->connected;
 }
 
-static size_t MaxPayload(struct SolidSyslogDatagram* self)
+static size_t WinsockDatagram_MaxPayload(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
     size_t result = SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
@@ -171,10 +171,10 @@ static size_t MaxPayload(struct SolidSyslogDatagram* self)
     return result;
 }
 
-static void Close(struct SolidSyslogDatagram* self)
+static void WinsockDatagram_Close(struct SolidSyslogDatagram* self)
 {
     struct SolidSyslogWinsockDatagram* datagram = (struct SolidSyslogWinsockDatagram*) self;
-    if (IsSocketValid(datagram->fd))
+    if (WinsockDatagram_IsSocketValid(datagram->fd))
     {
         Winsock_closesocket(datagram->fd);
         datagram->fd = INVALID_SOCKET;

--- a/Platform/Windows/Source/SolidSyslogWinsockResolver.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolver.c
@@ -13,10 +13,10 @@
    address IS a compile-time constant avoids the warning without a suppression. */
 static int WSAAPI
 CallGetAddrInfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res);
-static void WSAAPI CallFreeAddrInfo(struct addrinfo* res);
+static void WSAAPI WinsockResolver_CallFreeAddrInfo(struct addrinfo* res);
 
 WinsockGetAddrInfoFn Winsock_getaddrinfo = CallGetAddrInfo;
-WinsockFreeAddrInfoFn Winsock_freeaddrinfo = CallFreeAddrInfo;
+WinsockFreeAddrInfoFn Winsock_freeaddrinfo = WinsockResolver_CallFreeAddrInfo;
 
 static int WSAAPI
 CallGetAddrInfo(const char* node, const char* service, const struct addrinfo* hints, struct addrinfo** res)
@@ -24,7 +24,7 @@ CallGetAddrInfo(const char* node, const char* service, const struct addrinfo* hi
     return getaddrinfo(node, service, hints, res);
 }
 
-static void WSAAPI CallFreeAddrInfo(struct addrinfo* res)
+static void WSAAPI WinsockResolver_CallFreeAddrInfo(struct addrinfo* res)
 {
     freeaddrinfo(res);
 }
@@ -34,14 +34,14 @@ enum
     GETADDRINFO_SUCCESS = 0
 };
 
-static bool Resolve(
+static bool WinsockResolver_Resolve(
     struct SolidSyslogResolver* self,
     enum SolidSyslogTransport transport,
     const char* host,
     uint16_t port,
     struct SolidSyslogAddress* result
 );
-static int MapTransport(enum SolidSyslogTransport transport);
+static int WinsockResolver_MapTransport(enum SolidSyslogTransport transport);
 
 struct SolidSyslogWinsockResolver
 {
@@ -52,7 +52,7 @@ static struct SolidSyslogWinsockResolver instance;
 
 struct SolidSyslogResolver* SolidSyslogWinsockResolver_Create(void)
 {
-    instance.base.Resolve = Resolve;
+    instance.base.Resolve = WinsockResolver_Resolve;
     return &instance.base;
 }
 
@@ -61,7 +61,7 @@ void SolidSyslogWinsockResolver_Destroy(void)
     instance.base.Resolve = NULL;
 }
 
-static bool Resolve(
+static bool WinsockResolver_Resolve(
     struct SolidSyslogResolver* self,
     enum SolidSyslogTransport transport,
     const char* host,
@@ -73,7 +73,7 @@ static bool Resolve(
 
     struct addrinfo hints = {0};
     hints.ai_family = AF_INET;
-    hints.ai_socktype = MapTransport(transport);
+    hints.ai_socktype = WinsockResolver_MapTransport(transport);
 
     struct addrinfo* info = NULL;
     bool resolved = false;
@@ -90,7 +90,7 @@ static bool Resolve(
     return resolved;
 }
 
-static int MapTransport(enum SolidSyslogTransport transport)
+static int WinsockResolver_MapTransport(enum SolidSyslogTransport transport)
 {
     int socktype = SOCK_DGRAM;
 

--- a/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
@@ -129,7 +129,10 @@ static bool WinsockTcpStream_ConfigureSocket(SOCKET fd);
 static void WinsockTcpStream_EnableTcpNoDelay(SOCKET fd);
 static void WinsockTcpStream_EnableKeepalive(SOCKET fd);
 static inline bool WinsockTcpStream_IsSocketValid(SOCKET fd);
-static bool WinsockTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin);
+static bool WinsockTcpStream_ConnectOrCloseOnFailure(
+    struct SolidSyslogWinsockTcpStream* stream,
+    const struct sockaddr_in* sin
+);
 static bool WinsockTcpStream_Connect(SOCKET fd, const struct sockaddr_in* sin);
 static bool WinsockTcpStream_SetNonBlocking(SOCKET fd);
 static bool WinsockTcpStream_WaitForConnectCompletion(SOCKET fd);
@@ -228,7 +231,10 @@ static inline bool WinsockTcpStream_IsSocketValid(SOCKET fd)
     return fd != INVALID_SOCKET;
 }
 
-static bool WinsockTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin)
+static bool WinsockTcpStream_ConnectOrCloseOnFailure(
+    struct SolidSyslogWinsockTcpStream* stream,
+    const struct sockaddr_in* sin
+)
 {
     bool connected = WinsockTcpStream_Connect(stream->fd, sin);
     if (!connected)

--- a/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
@@ -11,65 +11,65 @@
    Winsock function for static initialisation triggers MSVC C4232 (the address
    isn't a compile-time constant); forwarding through a static function whose
    address IS a compile-time constant avoids the warning without a suppression. */
-static SOCKET WSAAPI CallSocket(int af, int type, int protocol);
-static int WSAAPI CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
-static int WSAAPI CallSend(SOCKET s, const char* buf, int len, int flags);
-static int WSAAPI CallRecv(SOCKET s, char* buf, int len, int flags);
-static int WSAAPI CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
-static int WSAAPI CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen);
-static int WSAAPI CallCloseSocket(SOCKET s);
-static int WSAAPI CallIoctlSocket(SOCKET s, long cmd, u_long* argp);
+static SOCKET WSAAPI WinsockTcpStream_CallSocket(int af, int type, int protocol);
+static int WSAAPI WinsockTcpStream_CallConnect(SOCKET s, const struct sockaddr* name, int namelen);
+static int WSAAPI WinsockTcpStream_CallSend(SOCKET s, const char* buf, int len, int flags);
+static int WSAAPI WinsockTcpStream_CallRecv(SOCKET s, char* buf, int len, int flags);
+static int WSAAPI WinsockTcpStream_CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen);
+static int WSAAPI WinsockTcpStream_CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen);
+static int WSAAPI WinsockTcpStream_CallCloseSocket(SOCKET s);
+static int WSAAPI WinsockTcpStream_CallIoctlSocket(SOCKET s, long cmd, u_long* argp);
 static int WSAAPI
 CallSelect(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, const struct timeval* timeout);
-static int WSAAPI CallWSAGetLastError(void);
+static int WSAAPI WinsockTcpStream_CallWSAGetLastError(void);
 
-WinsockTcpStreamSocketFn WinsockTcpStream_socket = CallSocket;
-WinsockTcpStreamConnectFn WinsockTcpStream_connect = CallConnect;
-WinsockTcpStreamSendFn WinsockTcpStream_send = CallSend;
-WinsockTcpStreamRecvFn WinsockTcpStream_recv = CallRecv;
-WinsockTcpStreamSetSockOptFn WinsockTcpStream_setsockopt = CallSetSockOpt;
-WinsockTcpStreamGetSockOptFn WinsockTcpStream_getsockopt = CallGetSockOpt;
-WinsockTcpStreamCloseSocketFn WinsockTcpStream_closesocket = CallCloseSocket;
-WinsockTcpStreamIoctlSocketFn WinsockTcpStream_ioctlsocket = CallIoctlSocket;
+WinsockTcpStreamSocketFn WinsockTcpStream_socket = WinsockTcpStream_CallSocket;
+WinsockTcpStreamConnectFn WinsockTcpStream_connect = WinsockTcpStream_CallConnect;
+WinsockTcpStreamSendFn WinsockTcpStream_send = WinsockTcpStream_CallSend;
+WinsockTcpStreamRecvFn WinsockTcpStream_recv = WinsockTcpStream_CallRecv;
+WinsockTcpStreamSetSockOptFn WinsockTcpStream_setsockopt = WinsockTcpStream_CallSetSockOpt;
+WinsockTcpStreamGetSockOptFn WinsockTcpStream_getsockopt = WinsockTcpStream_CallGetSockOpt;
+WinsockTcpStreamCloseSocketFn WinsockTcpStream_closesocket = WinsockTcpStream_CallCloseSocket;
+WinsockTcpStreamIoctlSocketFn WinsockTcpStream_ioctlsocket = WinsockTcpStream_CallIoctlSocket;
 WinsockTcpStreamSelectFn WinsockTcpStream_select = CallSelect;
-WinsockTcpStreamWSAGetLastErrorFn WinsockTcpStream_WSAGetLastError = CallWSAGetLastError;
+WinsockTcpStreamWSAGetLastErrorFn WinsockTcpStream_WSAGetLastError = WinsockTcpStream_CallWSAGetLastError;
 
-static SOCKET WSAAPI CallSocket(int af, int type, int protocol)
+static SOCKET WSAAPI WinsockTcpStream_CallSocket(int af, int type, int protocol)
 {
     return socket(af, type, protocol);
 }
 
-static int WSAAPI CallConnect(SOCKET s, const struct sockaddr* name, int namelen)
+static int WSAAPI WinsockTcpStream_CallConnect(SOCKET s, const struct sockaddr* name, int namelen)
 {
     return connect(s, name, namelen);
 }
 
-static int WSAAPI CallSend(SOCKET s, const char* buf, int len, int flags)
+static int WSAAPI WinsockTcpStream_CallSend(SOCKET s, const char* buf, int len, int flags)
 {
     return send(s, buf, len, flags);
 }
 
-static int WSAAPI CallRecv(SOCKET s, char* buf, int len, int flags)
+static int WSAAPI WinsockTcpStream_CallRecv(SOCKET s, char* buf, int len, int flags)
 {
     return recv(s, buf, len, flags);
 }
 
-static int WSAAPI CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen)
+static int WSAAPI WinsockTcpStream_CallSetSockOpt(SOCKET s, int level, int optname, const char* optval, int optlen)
 {
     return setsockopt(s, level, optname, optval, optlen);
 }
 
-static int WSAAPI CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen)
+static int WSAAPI WinsockTcpStream_CallGetSockOpt(SOCKET s, int level, int optname, char* optval, int* optlen)
 {
     return getsockopt(s, level, optname, optval, optlen);
 }
 
-static int WSAAPI CallCloseSocket(SOCKET s)
+static int WSAAPI WinsockTcpStream_CallCloseSocket(SOCKET s)
 {
     return closesocket(s);
 }
 
-static int WSAAPI CallIoctlSocket(SOCKET s, long cmd, u_long* argp)
+static int WSAAPI WinsockTcpStream_CallIoctlSocket(SOCKET s, long cmd, u_long* argp)
 {
     return ioctlsocket(s, cmd, argp);
 }
@@ -82,7 +82,7 @@ CallSelect(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, const
     return select(nfds, readfds, writefds, exceptfds, (struct timeval*) timeout);
 }
 
-static int WSAAPI CallWSAGetLastError(void)
+static int WSAAPI WinsockTcpStream_CallWSAGetLastError(void)
 {
     return WSAGetLastError();
 }
@@ -119,23 +119,23 @@ struct SolidSyslogWinsockTcpStream
     SOCKET fd;
 };
 
-static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
-static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
-static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size);
-static void Close(struct SolidSyslogStream* self);
+static bool WinsockTcpStream_Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr);
+static bool WinsockTcpStream_Send(struct SolidSyslogStream* self, const void* buffer, size_t size);
+static SolidSyslogSsize WinsockTcpStream_Read(struct SolidSyslogStream* self, void* buffer, size_t size);
+static void WinsockTcpStream_Close(struct SolidSyslogStream* self);
 
-static SOCKET OpenAndConfigureSocket(void);
-static bool ConfigureSocket(SOCKET fd);
-static void EnableTcpNoDelay(SOCKET fd);
-static void EnableKeepalive(SOCKET fd);
-static inline bool IsSocketValid(SOCKET fd);
-static bool ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin);
-static bool Connect(SOCKET fd, const struct sockaddr_in* sin);
-static bool SetNonBlocking(SOCKET fd);
-static bool WaitForConnectCompletion(SOCKET fd);
-static bool ReadDeferredConnectError(SOCKET fd);
-static bool WroteAllBytes(int sent, size_t expected);
-static inline bool WouldBlock(int wsaError);
+static SOCKET WinsockTcpStream_OpenAndConfigureSocket(void);
+static bool WinsockTcpStream_ConfigureSocket(SOCKET fd);
+static void WinsockTcpStream_EnableTcpNoDelay(SOCKET fd);
+static void WinsockTcpStream_EnableKeepalive(SOCKET fd);
+static inline bool WinsockTcpStream_IsSocketValid(SOCKET fd);
+static bool WinsockTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin);
+static bool WinsockTcpStream_Connect(SOCKET fd, const struct sockaddr_in* sin);
+static bool WinsockTcpStream_SetNonBlocking(SOCKET fd);
+static bool WinsockTcpStream_WaitForConnectCompletion(SOCKET fd);
+static bool WinsockTcpStream_ReadDeferredConnectError(SOCKET fd);
+static bool WinsockTcpStream_WroteAllBytes(int sent, size_t expected);
+static inline bool WinsockTcpStream_WouldBlock(int wsaError);
 
 SOLIDSYSLOG_STATIC_ASSERT(
     sizeof(struct SolidSyslogWinsockTcpStream) <= SOLIDSYSLOG_WINSOCK_TCP_STREAM_SIZE,
@@ -143,7 +143,7 @@ SOLIDSYSLOG_STATIC_ASSERT(
 );
 
 static const struct SolidSyslogWinsockTcpStream DEFAULT_INSTANCE = {
-    {Open, Send, Read, Close},
+    {WinsockTcpStream_Open, WinsockTcpStream_Send, WinsockTcpStream_Read, WinsockTcpStream_Close},
     INVALID_SOCKET,
 };
 
@@ -162,31 +162,31 @@ struct SolidSyslogStream* SolidSyslogWinsockTcpStream_Create(SolidSyslogWinsockT
 void SolidSyslogWinsockTcpStream_Destroy(struct SolidSyslogStream* stream)
 {
     struct SolidSyslogWinsockTcpStream* self = (struct SolidSyslogWinsockTcpStream*) stream;
-    Close(stream);
+    WinsockTcpStream_Close(stream);
     *self = DESTROYED_INSTANCE;
 }
 
-static bool Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
+static bool WinsockTcpStream_Open(struct SolidSyslogStream* self, const struct SolidSyslogAddress* addr)
 {
     struct SolidSyslogWinsockTcpStream* stream = (struct SolidSyslogWinsockTcpStream*) self;
     const struct sockaddr_in* sin = SolidSyslogAddress_AsConstSockaddrIn(addr);
     bool connected = false;
 
-    stream->fd = OpenAndConfigureSocket();
-    if (IsSocketValid(stream->fd))
+    stream->fd = WinsockTcpStream_OpenAndConfigureSocket();
+    if (WinsockTcpStream_IsSocketValid(stream->fd))
     {
-        connected = ConnectOrCloseOnFailure(stream, sin);
+        connected = WinsockTcpStream_ConnectOrCloseOnFailure(stream, sin);
     }
     return connected;
 }
 
 /* Non-blocking from the start: connect() returns WSAEWOULDBLOCK and the wait
- * is bounded via select(); Send/Read never block the service thread on a
+ * is bounded via select(); WinsockTcpStream_Send/WinsockTcpStream_Read never block the service thread on a
  * wedged peer or a full kernel send buffer. */
-static SOCKET OpenAndConfigureSocket(void)
+static SOCKET WinsockTcpStream_OpenAndConfigureSocket(void)
 {
     SOCKET fd = WinsockTcpStream_socket(AF_INET, SOCK_STREAM, 0);
-    if (IsSocketValid(fd) && !ConfigureSocket(fd))
+    if (WinsockTcpStream_IsSocketValid(fd) && !WinsockTcpStream_ConfigureSocket(fd))
     {
         WinsockTcpStream_closesocket(fd);
         fd = INVALID_SOCKET;
@@ -194,23 +194,23 @@ static SOCKET OpenAndConfigureSocket(void)
     return fd;
 }
 
-static bool ConfigureSocket(SOCKET fd)
+static bool WinsockTcpStream_ConfigureSocket(SOCKET fd)
 {
-    EnableTcpNoDelay(fd);
-    EnableKeepalive(fd);
-    return SetNonBlocking(fd);
+    WinsockTcpStream_EnableTcpNoDelay(fd);
+    WinsockTcpStream_EnableKeepalive(fd);
+    return WinsockTcpStream_SetNonBlocking(fd);
 }
 
-static void EnableTcpNoDelay(SOCKET fd)
+static void WinsockTcpStream_EnableTcpNoDelay(SOCKET fd)
 {
     int enable = 1;
     WinsockTcpStream_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (const char*) &enable, (int) sizeof(enable));
 }
 
-/* Mirrors the POSIX EnableKeepalive — Windows 10 1709+ exposes TCP_KEEPIDLE /
+/* Mirrors the POSIX WinsockTcpStream_EnableKeepalive — Windows 10 1709+ exposes TCP_KEEPIDLE /
  * TCP_KEEPINTVL / TCP_KEEPCNT via setsockopt (declared in <mstcpip.h>), so the
  * shape matches the POSIX path one-for-one. No TCP_USER_TIMEOUT analogue. */
-static void EnableKeepalive(SOCKET fd)
+static void WinsockTcpStream_EnableKeepalive(SOCKET fd)
 {
     int enable = 1;
     int idle = KEEPALIVE_IDLE_SECONDS;
@@ -223,14 +223,14 @@ static void EnableKeepalive(SOCKET fd)
     WinsockTcpStream_setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (const char*) &count, (int) sizeof(count));
 }
 
-static inline bool IsSocketValid(SOCKET fd)
+static inline bool WinsockTcpStream_IsSocketValid(SOCKET fd)
 {
     return fd != INVALID_SOCKET;
 }
 
-static bool ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin)
+static bool WinsockTcpStream_ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, const struct sockaddr_in* sin)
 {
-    bool connected = Connect(stream->fd, sin);
+    bool connected = WinsockTcpStream_Connect(stream->fd, sin);
     if (!connected)
     {
         WinsockTcpStream_closesocket(stream->fd);
@@ -245,8 +245,8 @@ static bool ConnectOrCloseOnFailure(struct SolidSyslogWinsockTcpStream* stream, 
  * rate during an outage is throttled to ~0.5 records/s, preventing the
  * discard policy from firing in BDD outage scenarios. The non-blocking path
  * bounds each connect attempt to CONNECT_TIMEOUT_MILLISECONDS; the socket
- * stays non-blocking thereafter so Send/Read are also fail-fast. */
-static bool Connect(SOCKET fd, const struct sockaddr_in* sin)
+ * stays non-blocking thereafter so WinsockTcpStream_Send/WinsockTcpStream_Read are also fail-fast. */
+static bool WinsockTcpStream_Connect(SOCKET fd, const struct sockaddr_in* sin)
 {
     bool connected = false;
     int rc = WinsockTcpStream_connect(fd, (const struct sockaddr*) sin, (int) sizeof(*sin));
@@ -257,18 +257,18 @@ static bool Connect(SOCKET fd, const struct sockaddr_in* sin)
     }
     else if (WinsockTcpStream_WSAGetLastError() == WSAEWOULDBLOCK)
     {
-        connected = WaitForConnectCompletion(fd) && ReadDeferredConnectError(fd);
+        connected = WinsockTcpStream_WaitForConnectCompletion(fd) && WinsockTcpStream_ReadDeferredConnectError(fd);
     }
     return connected;
 }
 
-static bool SetNonBlocking(SOCKET fd)
+static bool WinsockTcpStream_SetNonBlocking(SOCKET fd)
 {
     u_long mode = 1;
     return WinsockTcpStream_ioctlsocket(fd, (long) FIONBIO, &mode) != SOCKET_ERROR;
 }
 
-static bool WaitForConnectCompletion(SOCKET fd)
+static bool WinsockTcpStream_WaitForConnectCompletion(SOCKET fd)
 {
     fd_set writeSet;
     FD_ZERO(&writeSet);
@@ -288,7 +288,7 @@ static bool WaitForConnectCompletion(SOCKET fd)
     return (rc > 0) && FD_ISSET(fd, &writeSet) && !FD_ISSET(fd, &errorSet);
 }
 
-static bool ReadDeferredConnectError(SOCKET fd)
+static bool WinsockTcpStream_ReadDeferredConnectError(SOCKET fd)
 {
     int err = 0;
     int errlen = (int) sizeof(err);
@@ -297,27 +297,27 @@ static bool ReadDeferredConnectError(SOCKET fd)
     return (rc != SOCKET_ERROR) && (err == 0);
 }
 
-static bool Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
+static bool WinsockTcpStream_Send(struct SolidSyslogStream* self, const void* buffer, size_t size)
 {
     struct SolidSyslogWinsockTcpStream* stream = (struct SolidSyslogWinsockTcpStream*) self;
     int sent = WinsockTcpStream_send(stream->fd, (const char*) buffer, (int) size, 0);
-    bool ok = WroteAllBytes(sent, size);
+    bool ok = WinsockTcpStream_WroteAllBytes(sent, size);
 
     if (!ok)
     {
-        Close(self);
+        WinsockTcpStream_Close(self);
     }
     return ok;
 }
 
 /* Non-blocking single-call contract: short write or any error means the
  * connection is gone; the caller closes and reconnects on the next attempt. */
-static bool WroteAllBytes(int sent, size_t expected)
+static bool WinsockTcpStream_WroteAllBytes(int sent, size_t expected)
 {
     return (sent >= 0) && ((size_t) sent == expected);
 }
 
-static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_t size)
+static SolidSyslogSsize WinsockTcpStream_Read(struct SolidSyslogStream* self, void* buffer, size_t size)
 {
     struct SolidSyslogWinsockTcpStream* stream = (struct SolidSyslogWinsockTcpStream*) self;
     int n = WinsockTcpStream_recv(stream->fd, (char*) buffer, (int) size, 0);
@@ -327,26 +327,26 @@ static SolidSyslogSsize Read(struct SolidSyslogStream* self, void* buffer, size_
     {
         result = (SolidSyslogSsize) n;
     }
-    else if ((n == SOCKET_ERROR) && WouldBlock(WinsockTcpStream_WSAGetLastError()))
+    else if ((n == SOCKET_ERROR) && WinsockTcpStream_WouldBlock(WinsockTcpStream_WSAGetLastError()))
     {
         result = 0;
     }
     else
     {
-        Close(self);
+        WinsockTcpStream_Close(self);
     }
     return result;
 }
 
-static inline bool WouldBlock(int wsaError)
+static inline bool WinsockTcpStream_WouldBlock(int wsaError)
 {
     return wsaError == WSAEWOULDBLOCK;
 }
 
-static void Close(struct SolidSyslogStream* self)
+static void WinsockTcpStream_Close(struct SolidSyslogStream* self)
 {
     struct SolidSyslogWinsockTcpStream* stream = (struct SolidSyslogWinsockTcpStream*) self;
-    if (IsSocketValid(stream->fd))
+    if (WinsockTcpStream_IsSocketValid(stream->fd))
     {
         WinsockTcpStream_closesocket(stream->fd);
         stream->fd = INVALID_SOCKET;

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -184,6 +184,33 @@ Rationale:
 - One class per translation unit is the norm; if a `.c` file contains
   helpers for two classes, use both prefixes accordingly.
 
+### Picking the `Class_` prefix from the filename
+
+For source files matching `SolidSyslog<X>.c`, the Tier 2 class prefix
+is `<X>_` — the filename with the `SolidSyslog` library namespace
+stripped. So `SolidSyslogTlsStream.c` → `TlsStream_*`,
+`SolidSyslogFreeRtosTcpStream.c` → `FreeRtosTcpStream_*`,
+`SolidSyslogWinsockTcpStream.c` → `WinsockTcpStream_*`. Files whose
+basename already drops the library prefix (e.g. `BlockSequence.c`,
+`RecordStore.c`) use the basename as the class verbatim →
+`BlockSequence_*`, `RecordStore_*`.
+
+The strip-only rule is mechanical and predictable; short-shorthand
+prefixes (e.g. `Tls_`, `FrTcp_`, `WinTcp_`) were considered and
+rejected — every file would need a hand-picked prefix, the choice
+would be hard to predict at a call site, and the convention would
+be harder to enforce going forward.
+
+#### The `SolidSyslog.c` exception
+
+`Core/Source/SolidSyslog.c` is the one file where the strip rule
+yields an empty prefix (the file *is* the library namespace).
+Statics in this file use **`SolidSyslog_<Function>`** — the same
+shape as Tier 1 whole-library API entry points (`SolidSyslog_Log`,
+`SolidSyslog_Service`, etc.). Linkage (`static`) distinguishes them
+at definition; collision risk is zero because only one file can
+ever be named `SolidSyslog.c`.
+
 ### When a Tier 2 tag DOES carry the `SolidSyslog` prefix
 
 The implementation struct that corresponds to a Tier 1 opaque type

--- a/docs/iec62443.md
+++ b/docs/iec62443.md
@@ -110,8 +110,8 @@ No `malloc`, no heap fragmentation, no allocation failure paths. The
 with compile-time sizing.
 
 **Single overflow protection point** — all formatted output flows through a
-single `WriteChar` function with bounds checking. Buffer overflows are
-structurally prevented regardless of input data.
+single `Formatter_WriteChar` function with bounds checking. Buffer overflows
+are structurally prevented regardless of input data.
 
 **Composition over configuration** — optional features are composed at link
 time by selecting concrete implementations. No `#ifdef` feature flags, no

--- a/docs/misra-conformance.md
+++ b/docs/misra-conformance.md
@@ -158,7 +158,7 @@ Recurring themes that recur across many rules — useful for **S10.06** when wri
 
 5. **C11 `<stdatomic.h>` use** drives rule 1.4 (2 findings — Atomics adapters). One deviation.
 
-6. **`Class_Function` static helpers across TUs** drive rule 5.9 (168 findings) — these are simultaneously the planned S10.08 sweep target *and* an instance of the project's MISRA Tier 2 Class-prefix convention. After S10.08 the count drops to whatever vtable-derived statics remain (probably <20), and those become a separate deviation if any.
+6. **`Class_Function` static helpers across TUs** drive rule 5.9 (168 findings) — these were the named S10.08 sweep target *and* an instance of the project's MISRA Tier 2 Class-prefix convention. **S10.08 landed wide** — applied the prefix to all ~811 statics across `Core/Source/` + `Platform/*/Source/` per the strip-only-`SolidSyslog` rule (and the `SolidSyslog_<Function>` exception for `Core/Source/SolidSyslog.c`), clearing 5.9 to **0**. No residual vtable-derived 5.9 findings; no follow-up deviation needed.
 
 These six concentrated buckets together account for **339 of the 575 findings (59%)** — the named S10.08 sweep on rule 5.9 (168), plus the five structural deviations (D.002 covers 11.3/11.2/11.5 = 109, D.003 = 54, D.004 = 4, D.005 = 2, D.006 = 2). The remainder — **236 findings spread across the other 23 rules** — is per-site cleanup, decomposed as: **221 Fix** target (mostly diffuse mechanical: U-suffix on literals, return-value use, trailing-else, explicit precedence parens), **11 Mixed** (rule 11.8 needs per-site split in S10.06), and **4 Investigate** (rules 21.10 / 21.6 likely transitive system-header includes).
 

--- a/docs/misra-conformance.md
+++ b/docs/misra-conformance.md
@@ -97,7 +97,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 
 | Rule | Count | What it asks | Top sites | Verdict | Rationale | Owner |
 |------|------:|--------------|-----------|---------|-----------|-------|
-| **5.9** (advisory) | 168 | Identifiers with internal linkage shall be unique | `SolidSyslogWinsockTcpStream.c` (21), `SolidSyslogPosixTcpStream.c` (16), `SolidSyslogUdpSender.c` (12) | **Fix** | These are `static` helpers reusing common names (`Write`, `Read`, `Open`, etc.) across TUs. Sweep target — rename to `Class_Function` per NAMING.md Tier 2 (Stream_Write, TcpStream_Write, etc.). | **S10.08** (already named: "Static-function `Class_` prefix sweep") |
+| **5.9** (advisory) | 168 → 0 *(landed in S10.08)* | Identifiers with internal linkage shall be unique | `SolidSyslogWinsockTcpStream.c` (21), `SolidSyslogPosixTcpStream.c` (16), `SolidSyslogUdpSender.c` (12) | **Fix — landed in S10.08** | `static` helpers reusing common names (`Write`, `Read`, `Open`, etc.) across TUs were renamed `Class_Function` per NAMING.md Tier 2 using a strip-only-`SolidSyslog` rule (`SolidSyslogWinsockTcpStream.c` → `WinsockTcpStream_*` etc.). `Core/Source/SolidSyslog.c` got `SolidSyslog_<Function>` per the documented exception. Sweep was wide — applied to all ~811 statics across Core/Source + Platform/\*/Source, not just the 168 collisions; 5.9 cleared as a structural consequence. | **S10.08** |
 | **11.3** | 95 | Cast between pointer to object types of different kinds | `SolidSyslogPosixFile.c` (10), `SolidSyslogWindowsFile.c` (10), `SolidSyslogTlsStream.c` (6) | **Deviate** | Vtable + caller-supplied-storage is the project's foundational OO-in-C mechanism: `(struct Impl*) storage` is unavoidable at every `_Create`. Replacing it would require dynamic allocation or copy-by-value, both rejected. Document as project-wide deviation. | **S10.06** (deviation D.002 in `docs/misra-deviations.md`) |
 | **10.4** | 92 | Both operands of operator shall be in same essential type category | `SolidSyslogFormatter.c` (15), `SolidSyslog.c` (6), `SolidSyslogFileBlockDevice.c` (6) | **Fix** | Mostly `size_t + 1` where `1` is `int`. Add `U` suffix to literals; occasional explicit cast for mixed cases. Mechanical sweep. | **New sweep story** (no existing slot in epic — propose S10.09a essential-type cleanups, or roll into S10.09 abbreviation purge / a new dedicated story) |
 | **8.9** (advisory) | 56 | Object referenced in one function should have block scope | `SolidSyslogFormatter.c` (8), `SolidSyslogMetaSd.c` (5), `SolidSyslogOriginSd.c` (5) | **Fix** | File-scope statics that should be locals or `static const` block-scope. Per-site review. | **S10.09** (if "abbreviation purge" widens to "code-shape hygiene") or **new sweep story** |
@@ -131,7 +131,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 
 | Verdict | Count | Rules |
 |---------|------:|-------|
-| **Fix** — rule 5.9 (named sweep target S10.08) | 168 | 5.9 |
+| **Fix — landed in S10.08** — rule 5.9 (static-function `Class_` prefix sweep) | 168 → 0 | 5.9 |
 | **Fix** — other rules (mechanical or per-component sweeps S10.07+) | 220 | 10.4, 8.9, 17.7, 10.1, 15.7, 8.4, 12.1, 17.8, 5.6, 15.5, 10.8, 22.10, 8.6, 2.5, 3.1, 7.1, 14.4 |
 | **Deviate** — landed in S10.06 (D.002–D.010) | 187 | 11.3, 11.2, 11.5 *(D.002)*; 5.7 *(D.003)*; 18.4 *(D.004)*; 18.7 *(D.005)*; 1.4 *(D.006)*; 11.8 *(D.007)*; 21.10 *(D.008)*; 21.6 *(D.009)*; 2.4 *(D.010)* |
 | **Disable** | 0 | — |


### PR DESCRIPTION
## Purpose

Closes #371. Resolves the static-function-prefix question that's
been deferred since S08.03 (memories `feedback_static_name_prefix.md`
and `project_naming_sweep_deferred.md`). Applies NAMING.md Tier 2
`Class_Function` form to all ~811 static functions across
`Core/Source/` + `Platform/*/Source/`. Clears all 168 MISRA 5.9
collisions as a structural consequence.

Second cross-cutting sweep of E10's S10.07+ block.

## Change Description

### Prefix-form rule (locked)

`SolidSyslog<X>.c` → `<X>_*` (strip-only-`SolidSyslog`):

| File pattern | Prefix |
|---|---|
| `SolidSyslogTlsStream.c` | `TlsStream_` (existing, kept) |
| `SolidSyslogWinsockTcpStream.c` | `WinsockTcpStream_` |
| `SolidSyslogPosixTcpStream.c` | `PosixTcpStream_` |
| `SolidSyslogStreamSender.c` | `StreamSender_` |
| `SolidSyslogUdpSender.c` | `UdpSender_` |
| `BlockSequence.c` | `BlockSequence_` (no `SolidSyslog` to strip) |
| `RecordStore.c` | `RecordStore_` |
| `SolidSyslogFormatter.c` | `Formatter_` |
| `Core/Source/SolidSyslog.c` | `SolidSyslog_` (exception — see below) |

Short-shorthand alternatives (`Tls_`, `FrTcp_`, …) considered and
rejected: would require hand-picked prefix per file, harder to
predict at call sites, harder to enforce.

### `SolidSyslog.c` exception

`Core/Source/SolidSyslog.c` is the library-namespace file — the
strip rule yields an empty prefix. Statics use
`SolidSyslog_<Function>`: same shape as Tier 1 whole-library API
entry points (`SolidSyslog_Log`, etc.), distinguished by `static`
linkage. Zero collision risk (only one file has this name).
Pre-rename audit verified the 48 static names in this file do not
collide with any of the 6 Tier 1 names.

### Sweep methodology — two-pass sed

Per file, with prefix `<P>`:

1. Extract every static-function name from the file (lines starting
   with `static`, with an identifier directly before `(`).
2. Pass 1: `s/\b<name>\b/<P>_<name>/g` for each name.
3. Pass 2 (un-mangle vtable member access):
   `s/\.<X>_<Y>\b/.<Y>/g` and `s/->.<X>_<Y>\b/->\<Y>/g`.

Designated initialisers (`.Open = Open`) and positional vtable inits
(`{Open, Send, Read, Close}`) both land correctly.

### Wide vs narrow

Audit named 168 sites (MISRA 5.9 colliders). PR is wider — applies
the prefix to all ~811 statics, not just the 168. Reasoning:
narrow scope leaves "MISRA-clean by accident, prefix-inconsistent
on purpose" — invites drift. NAMING.md Tier 2 requires the prefix
uniformly anyway; doing it now is the only end state where the
rule and the convention are the same thing.

## Test Evidence

- **MISRA 5.9 finding count: 168 → 0** (cppcheck-misra fresh
  rebuild verified).
- All 1122 tests, 2451 checks green on every slice (gcc + clang).
- Coverage 99.5% lines / 98.9% functions — matches pre-rename
  baseline; no drift.
- `analyze-tidy`: clean (no new naming warnings introduced; the 287
  pre-existing ones are the 186 data-member sibling and 101
  anonymous-enum-idiom warnings, both out of scope).
- `analyze-cppcheck`: clean.
- `analyze-format`: clean (one `clang-format -i` pass committed to
  re-wrap lines pushed past 120 cols by the longer prefixed names).

### Slice structure (collapses on squash)

Branch carries 13 commits in two phases:

**Phase A — MISRA 5.9 collision-heavy files (5 slices):**
1. TcpStream impls (WinsockTcpStream + PosixTcpStream)
2. Datagram impls (Posix + Winsock + FreeRtos)
3. Sender impls (Udp + Stream + Switching)
4. Buffer impls (Circular + Null + PosixMessageQueue)
5. Store layer (BlockStore + RecordStore + BlockSequence + FileBlockDevice + NullStore)

After Phase A: cppcheck-misra rule 5.9 count = 0.

**Phase B — NAMING.md Tier 2 conformance sweep (6 slices):**
1. `Core/Source/SolidSyslog.c` (84 statics, `SolidSyslog_` exception)
2. `Core/Source/SolidSyslogFormatter.c`
3. SD + remaining Core helpers
4. Platform helpers (clocks, hostnames, process IDs, sysuptime)
5. File adapters + Resolvers
6. Mutex adapters + TlsStream stragglers (2 leftover unprefixed names)

Plus: docs slice (NAMING.md / misra-conformance.md / DEVLOG) and
format-pass slice.

## Areas Affected

- 30 source files in `Core/Source/` + `Platform/*/Source/` with
  static functions renamed
- `docs/NAMING.md`: new "Picking the Class_ prefix from the
  filename" subsection + "SolidSyslog.c exception" subsection
- `docs/misra-conformance.md`: rule 5.9 row + summary table flipped
  to "landed in S10.08"
- `DEVLOG.md`: session entry appended

Memory `feedback_static_name_prefix.md` and
`project_naming_sweep_deferred.md` will be updated post-merge to
mark the static-function piece resolved.

No production-code behaviour change — pure identifier rename.
Tests/, Bdd/Targets/, and Tests/Bdd/ are unaffected (statics never
cross TU boundaries; tests call public APIs only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and consistency throughout the codebase
* **Documentation**
  * Updated naming conventions documentation
  * MISRA C:2012 rule 5.9 conformance fully resolved (168 violations → 0)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/372)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->