### PR TITLE
docs: S10.21 soften NAMING.md abbreviation rule (domain terms include RFC-spec field names)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -7971,3 +7971,58 @@ MISRA rule — different category, doesn't set precedent.
 
 - None. Sweep landed, all sweep-target rules at 0, full local CI
   battery green.
+
+## 2026-05-16 — S10.21 abbreviation rule softened (docs-only)
+
+### Decisions
+
+- **Raised S10.21** as the descoped successor to the deferred
+  S10.XX abbreviation purge. The original brief (rename
+  `buf` / `len` / `cfg` / `msg` across the tree) didn't survive
+  the ~140-site audit: the bulk of "offenders" are either
+  universally idiomatic in C (`buf`, `len`, `msg`, `err`, `rc`)
+  or third-party-API mirrors (`cmd` in `BIO_ctrl`, `attr` for
+  `struct mq_attr`, `info` for `addrinfo`, `buf`/`len` in
+  `send` / `recv` wrappers). Renaming them would hurt
+  readability against the standard signatures they shadow, not
+  help it.
+- **No `SolidSyslogMessage.Msg` → `.Message` rename.** The
+  original sizing exercise flagged the field as a readability
+  smell (member name `Msg` shadowing the struct name
+  `SolidSyslogMessage`, sitting next to its long-form
+  neighbour `.MessageId`). On closer inspection, `Msg` is
+  taken directly from **RFC 5424's MSG field label** —
+  alongside `MSGID`, `PRIVAL`, `BOM`, `SD`, `PROCID`. The
+  internal helpers `SolidSyslog_FormatMsg` /
+  `SolidSyslog_FormatMsgId` mirror the same spec labels.
+  Renaming the field would have broken the direct C-to-spec
+  mapping and forced an awkward `FormatMessageBody` /
+  `FormatRecord` rename to avoid colliding with the existing
+  `SolidSyslog_FormatMessage` (which formats the whole syslog
+  record).
+- **NAMING.md amendment instead.** Two related edits:
+    - Tier 3 (locals/parameters): the existing one-line
+      "lazy abbreviation vs domain term" bullet grew a
+      categorised list — RFC field names, protocol /
+      technology shorthands, POSIX / Win32 idioms — with a
+      cross-reference to the existing Pragmatic-tier
+      scope-table exemption for adapter-wrapper locals
+      (`buf` / `len` in `send` / `recv`, `attr` for
+      `mq_attr`).
+    - Tier 4 (struct members): one paragraph noting the
+      domain-term exemption applies at Tier 4 too, with
+      `SolidSyslogMessage.MessageId` + `.Msg` as the worked
+      example for full-English and RFC-abbreviation forms
+      legitimately co-existing within one struct.
+- **Issue / epic bodies updated** to reflect the descoped
+  scope (#379 and #12).
+
+### Deferred
+
+- Nothing — the story self-completes in one PR. E10 is now down
+  to S10.20 (enforcement flip) as the remaining cross-cutting
+  story before close.
+
+### Open questions
+
+- None.

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -256,7 +256,16 @@ Constraints:
 - **No lazy abbreviations.** `buffer` not `buf`, `message` not `msg`,
   `configuration` not `cfg`, `pointer` not `ptr`. Distinguish lazy
   abbreviations from domain terms — the latter are the real names of
-  things and should be used unmodified (e.g. `mq`, `crc`, `tls`).
+  things and should be used unmodified. Domain terms include:
+    - RFC field names from specs the library implements (RFC 5424
+      `MSG` / `MSGID` / `PRIVAL` / `BOM` / `SD` / `PROCID`).
+    - Protocol and technology shorthands (`mq`, `crc`, `tls`, `tcp`,
+      `udp`, `ip`, `dns`).
+    - POSIX / Win32 idioms that mirror third-party signatures (`fd`,
+      `errno`, `pid`, `sock`) — see also the Pragmatic-tier exemption
+      in the Scope table for parameter locals in adapter wrappers
+      (`buf` / `len` in `send` / `recv` wrappers, `attr` for
+      `struct mq_attr`, etc.).
 - **No pointer Hungarian.** Never prefix pointer variables with `p`/`P`
   or suffix with `Ptr`. Pointer-ness is visible from the declaration.
 - **Booleans.** Predicates and boolean variables use `isX`, `hasX`,
@@ -372,6 +381,12 @@ the same shape. The boolean and no-Hungarian conventions from Tier 3
 do **not** apply at this tier — PascalCase carries the visual signal that
 "this is a named, persistent piece of state" without needing an `is`/`has`
 prefix to convey "this is a boolean."
+
+The domain-term exemption from Tier 3 applies equally at Tier 4 —
+`struct SolidSyslogMessage`'s members `MessageId` (the full English
+word) and `Msg` (RFC 5424's spec label for the body field) are an
+example of how the two forms legitimately co-exist when one is an
+RFC abbreviation and the other is not.
 
 ```c
 struct SolidSyslogSecurityPolicy


### PR DESCRIPTION
## Purpose

Closes #379. Descopes the cross-cutting abbreviation-purge story originally planned as S10.09 (and bookmarked as `S10.XX (TBD)` in E10). The ~140-site sizing audit on the parent epic surfaced that the bulk of "offenders" are either universally idiomatic in C (`buf`, `len`, `msg`, `err`, `rc`) or third-party-API mirrors (`cmd` in `BIO_ctrl`, `attr` for `struct mq_attr`, `info` for `addrinfo`, `buf`/`len` in `send` / `recv` wrappers). A tree-wide sweep would hurt readability against the standard signatures these locals shadow, not help it.

The original draft also proposed renaming `SolidSyslogMessage.Msg` → `.Message`. Closer inspection showed `Msg` is taken directly from **RFC 5424's MSG field label** — alongside `MSGID`, `PRIVAL`, `BOM`, `SD`, `PROCID` — making it a domain term (like `mq`/`crc`/`tls` already are at Tier 3) rather than a lazy abbreviation. Renaming would have broken the code-to-spec mapping and forced collision-avoidance gymnastics with the existing `SolidSyslog_FormatMessage` (which formats the whole syslog record, not the MSG body). Decision: **no code rename**; amend the doc to make the spec-derived exemption explicit.

## Change Description

Two edits to `docs/NAMING.md`:

1. **Tier 3 (locals/parameters) lazy-abbreviation bullet** — the existing one-line "domain term" exemption (which already covered `mq` / `crc` / `tls`) is broadened into a categorised list:
   - RFC field names from specs the library implements (`MSG` / `MSGID` / `PRIVAL` / `BOM` / `SD` / `PROCID`)
   - Protocol and technology shorthands (`mq` / `crc` / `tls` / `tcp` / `udp` / `ip` / `dns`)
   - POSIX / Win32 idioms that mirror third-party signatures (`fd` / `errno` / `pid` / `sock`) with a cross-reference to the existing Pragmatic-tier exemption in the Scope table for adapter-wrapper locals like `buf` / `len` in `send` / `recv` and `attr` for `struct mq_attr`.

2. **Tier 4 (struct members) cross-reference** — one paragraph noting the domain-term exemption applies at Tier 4 too, using `SolidSyslogMessage`'s `MessageId` (full English) + `Msg` (RFC 5424 MSG label) as the worked example for how the two forms legitimately co-exist within one struct.

Plus a DEVLOG entry recording the audit conclusion, the no-rename decision, and the link from the spec field labels through to the C identifiers.

## Test Evidence

Docs-only. No production-code or test changes. Existing CI gates (build / clang-tidy / cppcheck / format) re-verify the unchanged tree.

## Areas Affected

- `docs/NAMING.md` — Tier 3 bullet expanded, Tier 4 paragraph added.
- `DEVLOG.md` — appended session entry.

No code, no headers, no tests touched. No impact on derived projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)