### PR TITLE
refactor: S10.13 Security policies + CRC + Sync primitives conformance

### DIFF
--- a/Core/Source/SolidSyslogCrc16.c
+++ b/Core/Source/SolidSyslogCrc16.c
@@ -12,7 +12,6 @@ enum
 {
     CRC16_CCITT_INIT = 0xFFFFU,
     CRC16_CCITT_POLY = 0x1021U,
-    BITS_PER_BYTE = 8U,
     MSB_MASK = 0x8000U
 };
 
@@ -24,9 +23,9 @@ uint16_t SolidSyslogCrc16_Compute(const uint8_t* data, uint16_t length)
     {
         crc ^= (uint16_t) ((uint16_t) data[i] << 8U);
 
-        for (int bit = 0; bit < BITS_PER_BYTE; bit++)
+        for (uint_fast8_t bit = 0; bit < 8U; bit++)
         {
-            if ((crc & MSB_MASK) != 0)
+            if ((crc & MSB_MASK) != 0U)
             {
                 crc = (uint16_t) ((crc << 1) ^ CRC16_CCITT_POLY);
             }

--- a/Core/Source/SolidSyslogCrc16Policy.c
+++ b/Core/Source/SolidSyslogCrc16Policy.c
@@ -14,14 +14,13 @@ enum
 static void Crc16Policy_Crc16ComputeIntegrity(const uint8_t* data, uint16_t length, uint8_t* integrityOut);
 static bool Crc16Policy_Crc16VerifyIntegrity(const uint8_t* data, uint16_t length, const uint8_t* integrityIn);
 
-static struct SolidSyslogSecurityPolicy instance = {
-    CRC16_SIZE,
-    Crc16Policy_Crc16ComputeIntegrity,
-    Crc16Policy_Crc16VerifyIntegrity,
-};
-
 struct SolidSyslogSecurityPolicy* SolidSyslogCrc16Policy_Create(void)
 {
+    static struct SolidSyslogSecurityPolicy instance = {
+        CRC16_SIZE,
+        Crc16Policy_Crc16ComputeIntegrity,
+        Crc16Policy_Crc16VerifyIntegrity,
+    };
     return &instance;
 }
 

--- a/Core/Source/SolidSyslogNullMutex.c
+++ b/Core/Source/SolidSyslogNullMutex.c
@@ -7,19 +7,19 @@
 static void NullMutex_Lock(struct SolidSyslogMutex* base);
 static void NullMutex_Unlock(struct SolidSyslogMutex* base);
 
-static struct SolidSyslogMutex instance;
+static struct SolidSyslogMutex NullMutex_Instance;
 
 struct SolidSyslogMutex* SolidSyslogNullMutex_Create(void)
 {
-    instance.Lock = NullMutex_Lock;
-    instance.Unlock = NullMutex_Unlock;
-    return &instance;
+    NullMutex_Instance.Lock = NullMutex_Lock;
+    NullMutex_Instance.Unlock = NullMutex_Unlock;
+    return &NullMutex_Instance;
 }
 
 void SolidSyslogNullMutex_Destroy(void)
 {
-    instance.Lock = NULL;
-    instance.Unlock = NULL;
+    NullMutex_Instance.Lock = NULL;
+    NullMutex_Instance.Unlock = NULL;
 }
 
 static void NullMutex_Lock(struct SolidSyslogMutex* base)

--- a/Core/Source/SolidSyslogNullSecurityPolicy.c
+++ b/Core/Source/SolidSyslogNullSecurityPolicy.c
@@ -21,14 +21,13 @@ static bool NullSecurityPolicy_NullVerifyIntegrity(const uint8_t* data, uint16_t
     return true;
 }
 
-static struct SolidSyslogSecurityPolicy instance = {
-    0,
-    NullSecurityPolicy_NullComputeIntegrity,
-    NullSecurityPolicy_NullVerifyIntegrity,
-};
-
 struct SolidSyslogSecurityPolicy* SolidSyslogNullSecurityPolicy_Create(void)
 {
+    static struct SolidSyslogSecurityPolicy instance = {
+        0,
+        NullSecurityPolicy_NullComputeIntegrity,
+        NullSecurityPolicy_NullVerifyIntegrity,
+    };
     return &instance;
 }
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,113 @@
 # Dev Log
 
+## 2026-05-17 — S10.13 Security policies + CRC + Sync primitives conformance (#383)
+
+Second per-group conformance story in E10, applying the S10.12 pilot
+recipe to the Security policies + CRC + Sync primitives group. Cleared
+all warning-mode findings raised by `analyze-tidy` and
+`analyze-cppcheck` (with the cppcheck-misra addon) against
+`SolidSyslogCrc16.{c,h}`, `SolidSyslogCrc16Policy.{c,h}`,
+`SolidSyslogNullSecurityPolicy.{c,h}`, `SolidSyslogSecurityPolicyDefinition.h`,
+`SolidSyslogMutex.{c,h}`, `SolidSyslogMutexDefinition.h`,
+`SolidSyslogNullMutex.{c,h}` and the three Platform mutex impls
+(`SolidSyslogPosixMutex.{c,h}`, `SolidSyslogWindowsMutex.{c,h}`,
+`SolidSyslogFreeRtosMutex.{c,h}`).
+
+### MISRA fixes — three new findings, each reviewed per-site
+
+- 1× rule 5.9 in `SolidSyslogNullMutex.c` — bare `instance` collided
+  with the same name in `SolidSyslogNullSecurityPolicy.c` and
+  `SolidSyslogCrc16Policy.c`. Renamed to `NullMutex_Instance` per the
+  S10.08 / S10.12 `<Class>_Instance` convention. Couldn't move into
+  `_Create` because `_Destroy` also touches it.
+- 2× rule 8.9 (advisory) in `SolidSyslogNullSecurityPolicy.c` and
+  `SolidSyslogCrc16Policy.c` — file-scope `static instance` only read
+  in `_Create`. Moved into `_Create` as block-scope statics, matching
+  the S10.12 `QUEUE_NAME_PREFIX` recipe.
+
+No new deviations. No new `cppcheck-suppress` comments. No count bumps
+to existing deviations (D.002 / D.003 / D.010) — no new sites accrued
+to those.
+
+### CRC-16 inner-loop review
+
+`SolidSyslogCrc16.c` had zero warning-mode findings, so this was a
+deliberate "walk the loop and decide whether to tighten anything
+anyway" pass. Three small changes landed:
+
+- `int bit` → `uint_fast8_t bit` — match the comparand's unsigned
+  essential type. cppcheck-misra's chosen 10.4 subset doesn't flag
+  the signed/unsigned mix in `for`-loop bounds, but it's still the
+  right type.
+- `!= 0` → `!= 0U` — match the U-suffixed literal style used
+  elsewhere in the file (S10.10 sweep convention).
+- Dropped the `BITS_PER_BYTE = 8U` enum constant; inlined `8U`.
+
+### Decisions
+
+- **Drop `BITS_PER_BYTE`, inline the literal.** Switching the loop
+  variable to `uint_fast8_t` unmasked clang-tidy's
+  `bugprone-too-small-loop-variable`, because anonymous-enum constants
+  in C have essential type `int` regardless of the `U` suffix on
+  their literal. clang-tidy compared the 8-bit `uint_fast8_t`
+  variable against the 32-bit `int` bound and flagged it. Three fixes
+  considered:
+  - (A) inline the literal `8U` (clang-tidy's `MagnitudeBitsUpperLimit`
+    default 16 skips small-literal warnings — 8's magnitude is 3 bits,
+    well below the threshold);
+  - (B) promote `BITS_PER_BYTE` out of the enum to
+    `static const uint8_t` (type-honest but diverges from the
+    tree-wide enum convention for one constant);
+  - (C) widen the loop variable to `unsigned` (keeps the enum form
+    but loses the "explicitly small unsigned" semantic).
+  Went with (A) — `BITS_PER_BYTE` was a one-use named constant whose
+  meaning ("there are 8 bits in a byte") is self-evident from the
+  surrounding CRC code. The other CRC enum constants
+  (`CRC16_CCITT_INIT`, `CRC16_CCITT_POLY`, `MSB_MASK`) carry
+  non-obvious values and retain their names.
+
+- **Anonymous-enum constants in C are `int`, not the literal's type.**
+  Surfaced explicitly during the CRC review: even when the literal is
+  `0x1021U` (essentially unsigned), the enum constant the literal
+  initialises is typed `int` per C99 §6.7.2.2. This is a quirk of
+  the form, not a bug — within cast-wrapped bitwise ops (as in
+  `(uint16_t) ((crc << 1) ^ CRC16_CCITT_POLY)`) the boundary cast
+  normalises the essential type. But it does mean enum constants
+  can't always stand in for typed integer constants without surprise
+  — e.g. as the upper bound of a narrow-typed loop. Worth knowing
+  for future per-group stories.
+
+### Scope rule observation
+
+The scoped cppcheck-misra re-runs we used during fix-verification
+flagged additional 2.4 findings on `Crc16.c` / `Crc16Policy.c` that
+didn't appear in the full-tree run. Re-confirmed the S10.12 scope
+rule: trust the **full-tree** invocation as the source of truth.
+Scoped runs are useful for fast iteration but can produce different
+output because cppcheck-misra's rule subset behaves differently when
+fewer translation units are visible.
+
+### Gates
+
+- `cmake --preset tidy && cmake --build --preset tidy` — clean
+  (0 findings).
+- `cmake --preset debug && cmake --build --preset debug --target junit`
+  — 1122 tests, 0 failures.
+- `cmake --preset clang-debug && cmake --build --preset clang-debug --target junit`
+  — 1122 tests, 0 failures.
+- `cmake --preset sanitize && cmake --build --preset sanitize --target junit`
+  — 1122 tests, 0 failures.
+- `cmake --preset coverage && cmake --build --preset coverage --target coverage`
+  — 100% line coverage on every Linux-buildable file in scope. (Tree
+  overall: 99.6% lines / 99.0% functions, well above the 90% gate.)
+- Standalone non-MISRA `cppcheck Core/Source/` — clean (0 findings).
+- Standalone `cppcheck --addon=misra` full tree — zero findings on
+  S10.13 scope files.
+- `clang-format --dry-run --Werror` on edited files — clean.
+
+Windows / BDD / OpenSSL integration are CI's responsibility per the
+CLAUDE.md workflow note.
+
 ## 2026-05-16 — S10.12 Pilot — Buffer group conformance + anonymous-enum policy (#381)
 
 First per-group conformance story in E10. Cleared all warning-mode


### PR DESCRIPTION
## Purpose

Second per-group conformance story in E10, applying the S10.12 pilot recipe to the Security policies + CRC + Sync primitives group. Resolves all warning-mode findings raised by `analyze-tidy` and `analyze-cppcheck` (with the cppcheck-misra addon) against the files listed under **Areas Affected**.

Closes #383

## Change Description

### MISRA fixes — 3 new findings, each reviewed per-site

| Rule | Site | Fix |
|---|---|---|
| 5.9 | `Core/Source/SolidSyslogNullMutex.c:10` (bare `instance` collided with same name in NullSecurityPolicy and Crc16Policy) | Renamed to `NullMutex_Instance` per the S10.08 / S10.12 `<Class>_Instance` convention. Couldn't move into `_Create` because `_Destroy` also touches it. |
| 8.9 (advisory) | `Core/Source/SolidSyslogNullSecurityPolicy.c:24` (file-scope `static instance` only read in `_Create`) | Moved into `_Create` as a block-scope static, matching the S10.12 `QUEUE_NAME_PREFIX` recipe. |
| 8.9 (advisory) | `Core/Source/SolidSyslogCrc16Policy.c:17` (same pattern) | Same fix — moved into `_Create`. |

No new deviations. No new `cppcheck-suppress` inline comments. No count bumps to existing deviations (D.002 11.3 mutex casts / D.003 5.7 tag-name / D.010 2.4 anonymous-enum) — no new sites accrued.

### CRC-16 inner-loop review

`SolidSyslogCrc16.c` was already MISRA-clean, so this was a deliberate "walk the loop and decide whether to tighten anything anyway" pass. Three small changes:

```c
// before
for (int bit = 0; bit < BITS_PER_BYTE; bit++)
{
    if ((crc & MSB_MASK) != 0)

// after
for (uint_fast8_t bit = 0; bit < 8U; bit++)
{
    if ((crc & MSB_MASK) != 0U)
```

- `int bit` → `uint_fast8_t bit` — match the comparand's unsigned essential type.
- `!= 0` → `!= 0U` — U-suffixed literal style (S10.10 convention).
- Dropped the `BITS_PER_BYTE = 8U` enum constant; inlined the literal.

The last one needed thinking — switching the loop variable to `uint_fast8_t` unmasked clang-tidy's `bugprone-too-small-loop-variable`, because anonymous-enum constants in C have essential type `int` regardless of the `U` suffix. clang-tidy compared the 8-bit loop variable against the 32-bit `int` enum bound and flagged it. Three options weighed (inline the literal; promote the constant to `static const uint8_t`; widen the loop variable to `unsigned`) — chose inline-the-literal because `BITS_PER_BYTE` was a one-use named constant whose meaning is self-evident from the surrounding CRC code. The other CRC enum constants (`CRC16_CCITT_INIT`, `CRC16_CCITT_POLY`, `MSB_MASK`) carry non-obvious values and retain their names.

Full discussion in `DEVLOG.md`.

## Test Evidence

This is MISRA-conformance refactoring with no behaviour change — the bar is "existing tests stay green, gates clean".

Ran locally under the dev container:
- `cmake --preset debug && cmake --build --preset debug --target junit` → **1122 tests, 0 failures**
- `cmake --preset clang-debug && cmake --build --preset clang-debug --target junit` → clean, 1122 ran
- `cmake --preset sanitize && cmake --build --preset sanitize --target junit` → clean, 1122 ran
- `cmake --preset tidy && cmake --build --preset tidy` → **0 findings**
- `cmake --preset coverage && cmake --build --preset coverage --target coverage` → **100% line coverage** on every Linux-buildable file in scope
- Standalone non-MISRA `cppcheck Core/Source/` → clean (0 findings)
- Full-tree `cppcheck --addon=misra` → **zero findings on S10.13 scope files**
- `clang-format --dry-run --Werror` on edited files → clean

Windows / BDD / OpenSSL integration jobs are CI's responsibility per the CLAUDE.md workflow note.

## Areas Affected

**Edited:**
- `Core/Source/SolidSyslogCrc16.c`
- `Core/Source/SolidSyslogCrc16Policy.c`
- `Core/Source/SolidSyslogNullMutex.c`
- `Core/Source/SolidSyslogNullSecurityPolicy.c`
- `DEVLOG.md`

**In scope but already clean (no edits required):**
- `Core/Interface/SolidSyslogSecurityPolicyDefinition.h`
- `Core/Interface/SolidSyslogNullSecurityPolicy.h`
- `Core/Interface/SolidSyslogCrc16.h`
- `Core/Interface/SolidSyslogCrc16Policy.h`
- `Core/Interface/SolidSyslogMutex.h`
- `Core/Interface/SolidSyslogMutexDefinition.h`
- `Core/Interface/SolidSyslogNullMutex.h`
- `Core/Source/SolidSyslogMutex.c`
- `Platform/Posix/Interface/SolidSyslogPosixMutex.h`
- `Platform/Posix/Source/SolidSyslogPosixMutex.c`
- `Platform/Windows/Interface/SolidSyslogWindowsMutex.h`
- `Platform/Windows/Source/SolidSyslogWindowsMutex.c`
- `Platform/FreeRtos/Interface/SolidSyslogFreeRtosMutex.h`
- `Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal implementations across security policy, CRC computation, and synchronization modules for improved code organization and maintainability.

* **Documentation**
  * Added development log entry documenting recent conformance work and code adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->