### PR TITLE
feat: harden BDD target stderr error handler to exit on ERROR severity

### DIFF
--- a/Bdd/Targets/Common/BddTargetStderrErrorHandler.c
+++ b/Bdd/Targets/Common/BddTargetStderrErrorHandler.c
@@ -1,6 +1,7 @@
 #include "BddTargetStderrErrorHandler.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "SolidSyslogError.h"
 #include "SolidSyslogPrival.h"
@@ -8,7 +9,16 @@
 static void StderrErrorHandler(void* context, enum SolidSyslogSeverity severity, const char* message)
 {
     (void) context;
-    (void) fprintf(stderr, "[solidsyslog] severity=%d %s\n", (int) severity, message);
+    if (severity <= SOLIDSYSLOG_SEVERITY_ERROR)
+    {
+        (void) fprintf(stderr, "BDD-TARGET: FATAL: %s\n", message);
+        (void) fflush(stderr);
+        _Exit(3);
+    }
+    else
+    {
+        (void) fprintf(stderr, "[solidsyslog] severity=%d %s\n", (int) severity, message);
+    }
 }
 
 void BddTargetStderrErrorHandler_Install(void)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,61 @@
 # Dev Log
 
+## 2026-05-19 — BDD target stderr handler: fatal exit on ERROR severity
+
+Follow-up from S11.05 part B post-merge. The PR's final CI run took 23m
+instead of the usual 4–5m. Per-step timing showed both
+`build-linux-tunable-override` and `build-freertos-target` spent 16+ minutes
+in the "Initialize containers" step (image pull from ghcr.io) while other
+jobs on the same run using the same image pulled in seconds — runner
+cold-cache, not a project regression.
+
+The genuine concern surfaced by that diagnosis: pool exhaustion in a BDD
+wiring scenario would currently fail silently. `_Create` returns the shared
+null object, the BDD target keeps running on it, the oracle receives
+nothing, the scenario times out — and the captured failure mode is "oracle
+received 0 of 1" rather than "BDD target died on POOL_EXHAUSTED". Same
+failure class as part A's STREAM_SENDER default-1 bust.
+
+This PR hardens `BddTargetStderrErrorHandler` so any severity at or below
+`SOLIDSYSLOG_SEVERITY_ERROR` (EMERGENCY/ALERT/CRITICAL/ERROR) writes
+`BDD-TARGET: FATAL: <message>\n` to stderr, flushes, and `_Exit(3)`.
+WARNING stays as the existing print-only line (UNKNOWN_DESTROY noise).
+
+### Decisions
+
+- **`_Exit` not `_exit`.** C99 `<stdlib.h>`, portable to POSIX/MSVC/
+  FreeRTOS-Posix; POSIX-only `_exit` would break the Windows BDD target.
+  Same no-atexit / no-stdio-flush semantics for our purpose — we
+  `fflush(stderr)` ourselves first so the FATAL marker reaches the wire
+  before the process disappears.
+
+- **`severity <= SOLIDSYSLOG_SEVERITY_ERROR`** rather than `==`. Catches
+  EMERGENCY/ALERT/CRITICAL too. The library only emits ERROR and WARNING
+  in practice today, so the two forms are equivalent now, but `<=` is the
+  defensible semantics — any future EMERGENCY would still mean "BDD target
+  is hosed".
+
+- **No unit test for the handler.** The handler is six production lines; a
+  `_Exit` seam (function-pointer indirection + paired interceptor test) is
+  more abstraction than the change justifies. Validation is the local gate
+  sweep (debug / sanitize / clang-debug / tidy / cppcheck / coverage / iwyu /
+  clang-format — all green) plus future BDD scenarios that deliberately
+  starve a pool, which don't yet exist.
+
+### Deferred
+
+- A pool-starvation BDD scenario that actually fires the new fatal path.
+  Today's scenarios all use healthy wiring, so the new branch is exercised
+  only by static analysis, not at runtime. Worth raising once an E11 sweep
+  story touches BDD wiring.
+
+### Open questions
+
+- The CI slowdown root cause (ghcr.io cold-cache image pull) is left as
+  watch-and-see. If it recurs, ticket the mitigation (slimmer base image,
+  GHCR retention/replication tier, or a small image-pull warm-up job that
+  other jobs gate on).
+
 ## 2026-05-19 — S11.05 part B: BlockStore composition onto PoolAllocator
 
 Closes S11.05. The composition migration that part A deferred — RecordStore


### PR DESCRIPTION
## Purpose

S11.05 part B (#403) finished green but spent 23 minutes in CI vs the usual 4–5. Per-step timing showed both `build-linux-tunable-override` and `build-freertos-target` spent ~16 minutes in the "Initialize containers" step (ghcr.io image pull) — runner cold-cache, not a project regression. Other jobs on the same run using the same image pulled in seconds.

The real concern surfaced by that diagnosis is that pool exhaustion in a BDD wiring scenario would currently fail silently: `_Create` returns the shared null object, the BDD target keeps running on it, the oracle receives nothing, the scenario times out, and the captured failure is "oracle received 0 of 1" rather than "BDD target died on `POOL_EXHAUSTED`". Same failure class as part A's `STREAM_SENDER` default-1 bust (#402).

This PR hardens the BDD-target stderr handler so the silent-drop class becomes a loud, locally-debuggable failure.

## Change Description

`Bdd/Targets/Common/BddTargetStderrErrorHandler.c` now branches on severity:

- `severity <= SOLIDSYSLOG_SEVERITY_ERROR` (EMERGENCY / ALERT / CRITICAL / ERROR) ⇒ `fprintf(stderr, "BDD-TARGET: FATAL: %s\n", message)`, `fflush(stderr)`, `_Exit(3)`.
- Any other severity (WARNING, etc.) ⇒ existing print-only line, unchanged.

Design notes:

- **`_Exit` (C99 `<stdlib.h>`) not `_exit` (POSIX `<unistd.h>`).** The Common/ file is shared by the Windows BDD target as well, so the portable C99 form is required. Same no-atexit / no-stdio-flush semantics — `fflush(stderr)` is called first so the FATAL marker reaches the wire before the process disappears.
- **`<=` rather than `==`** so EMERGENCY / ALERT / CRITICAL also exit. Library code only emits ERROR/WARNING today, so the forms are equivalent in practice, but `<=` is the defensible semantics.
- **No unit test.** The handler is six production lines; a `_Exit` seam (function-pointer indirection + paired interceptor test) is more abstraction than the change justifies. The honest validation is end-to-end via a BDD scenario that deliberately starves a pool — which doesn't yet exist; raised as a Deferred item in DEVLOG. Compile-time gates carry the rest.

## Test Evidence

All local gates green on the branch in the project's dev containers:

- `debug` — 1188 tests pass
- `sanitize` (ASan + UBSan) — 1188 tests pass
- `clang-debug` — 1188 tests pass
- `tidy` — clean (warnings-as-errors)
- `cppcheck` — clean
- `coverage` — clean
- `iwyu` — clean (invoked as `cmake --build --preset iwyu --target iwyu`)
- `clang-format --dry-run --Werror` over `Core/Interface Core/Source Tests Bdd/Targets` — clean

CI will cover Windows MSVC, FreeRTOS cross/QEMU, and the BDD jobs.

## Areas Affected

- `Bdd/Targets/Common/BddTargetStderrErrorHandler.c` — Tier 3 (BDD targets, best-effort). No production-library impact.
- `DEVLOG.md` — session entry.

No public-header or Core/ changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to treat critical error severities as fatal, triggering process termination with a clear status message for improved system robustness.

* **Documentation**
  * Added documentation detailing error handling hardening improvements and related design decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->