### PR TITLE
chore: mark *Static.c pool helpers static inline

### DIFF
--- a/Core/Source/BlockSequenceStatic.c
+++ b/Core/Source/BlockSequenceStatic.c
@@ -5,8 +5,8 @@
 #include "SolidSyslogPoolAllocator.h"
 #include "SolidSyslogTunables.h"
 
-static size_t BlockSequence_IndexFromHandle(const struct BlockSequence* blockSequence);
-static void BlockSequence_CleanupAtIndex(size_t index, void* context);
+static inline size_t BlockSequence_IndexFromHandle(const struct BlockSequence* blockSequence);
+static inline void BlockSequence_CleanupAtIndex(size_t index, void* context);
 
 static bool BlockSequence_InUse[SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE];
 static struct BlockSequence BlockSequence_Pool[SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE];
@@ -39,7 +39,7 @@ void BlockSequence_Destroy(struct BlockSequence* blockSequence)
     }
 }
 
-static size_t BlockSequence_IndexFromHandle(const struct BlockSequence* blockSequence)
+static inline size_t BlockSequence_IndexFromHandle(const struct BlockSequence* blockSequence)
 {
     size_t result = SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE; poolIndex++)
@@ -53,7 +53,7 @@ static size_t BlockSequence_IndexFromHandle(const struct BlockSequence* blockSeq
     return result;
 }
 
-static void BlockSequence_CleanupAtIndex(size_t index, void* context)
+static inline void BlockSequence_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     BlockSequence_Cleanup(&BlockSequence_Pool[index]);

--- a/Core/Source/RecordStoreStatic.c
+++ b/Core/Source/RecordStoreStatic.c
@@ -7,8 +7,8 @@
 
 struct SolidSyslogSecurityPolicy;
 
-static size_t RecordStore_IndexFromHandle(const struct RecordStore* recordStore);
-static void RecordStore_CleanupAtIndex(size_t index, void* context);
+static inline size_t RecordStore_IndexFromHandle(const struct RecordStore* recordStore);
+static inline void RecordStore_CleanupAtIndex(size_t index, void* context);
 
 static bool RecordStore_InUse[SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE];
 static struct RecordStore RecordStore_Pool[SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE];
@@ -38,7 +38,7 @@ void RecordStore_Destroy(struct RecordStore* recordStore)
     }
 }
 
-static size_t RecordStore_IndexFromHandle(const struct RecordStore* recordStore)
+static inline size_t RecordStore_IndexFromHandle(const struct RecordStore* recordStore)
 {
     size_t result = SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE; poolIndex++)
@@ -52,7 +52,7 @@ static size_t RecordStore_IndexFromHandle(const struct RecordStore* recordStore)
     return result;
 }
 
-static void RecordStore_CleanupAtIndex(size_t index, void* context)
+static inline void RecordStore_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     RecordStore_Cleanup(&RecordStore_Pool[index]);

--- a/Core/Source/SolidSyslogBlockStoreStatic.c
+++ b/Core/Source/SolidSyslogBlockStoreStatic.c
@@ -17,8 +17,8 @@
 
 struct SolidSyslogStore;
 
-static size_t BlockStore_IndexFromHandle(const struct SolidSyslogStore* base);
-static void BlockStore_CleanupAtIndex(size_t index, void* context);
+static inline size_t BlockStore_IndexFromHandle(const struct SolidSyslogStore* base);
+static inline void BlockStore_CleanupAtIndex(size_t index, void* context);
 static struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured);
 static struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
     const struct SolidSyslogBlockStoreConfig* config,
@@ -100,7 +100,7 @@ void SolidSyslogBlockStore_Destroy(struct SolidSyslogStore* base)
     }
 }
 
-static size_t BlockStore_IndexFromHandle(const struct SolidSyslogStore* base)
+static inline size_t BlockStore_IndexFromHandle(const struct SolidSyslogStore* base)
 {
     size_t result = SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE; poolIndex++)
@@ -114,7 +114,7 @@ static size_t BlockStore_IndexFromHandle(const struct SolidSyslogStore* base)
     return result;
 }
 
-static void BlockStore_CleanupAtIndex(size_t index, void* context)
+static inline void BlockStore_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     BlockStore_Cleanup(&BlockStore_Pool[index].Base);

--- a/Core/Source/SolidSyslogCircularBufferStatic.c
+++ b/Core/Source/SolidSyslogCircularBufferStatic.c
@@ -15,8 +15,8 @@
 struct SolidSyslogBuffer;
 struct SolidSyslogMutex;
 
-static size_t CircularBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
-static void CircularBuffer_CleanupAtIndex(size_t index, void* context);
+static inline size_t CircularBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
+static inline void CircularBuffer_CleanupAtIndex(size_t index, void* context);
 
 static bool CircularBuffer_InUse[SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE];
 static struct SolidSyslogCircularBuffer CircularBuffer_Pool[SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE];
@@ -57,7 +57,7 @@ void SolidSyslogCircularBuffer_Destroy(struct SolidSyslogBuffer* base)
     }
 }
 
-static size_t CircularBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
+static inline size_t CircularBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
 {
     size_t result = SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE; poolIndex++)
@@ -71,7 +71,7 @@ static size_t CircularBuffer_IndexFromHandle(const struct SolidSyslogBuffer* bas
     return result;
 }
 
-static void CircularBuffer_CleanupAtIndex(size_t index, void* context)
+static inline void CircularBuffer_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     CircularBuffer_Cleanup(&CircularBuffer_Pool[index].Base);

--- a/Core/Source/SolidSyslogFileBlockDeviceStatic.c
+++ b/Core/Source/SolidSyslogFileBlockDeviceStatic.c
@@ -14,8 +14,8 @@
 struct SolidSyslogBlockDevice;
 struct SolidSyslogFile;
 
-static size_t FileBlockDevice_IndexFromHandle(const struct SolidSyslogBlockDevice* base);
-static void FileBlockDevice_CleanupAtIndex(size_t index, void* context);
+static inline size_t FileBlockDevice_IndexFromHandle(const struct SolidSyslogBlockDevice* base);
+static inline void FileBlockDevice_CleanupAtIndex(size_t index, void* context);
 
 static bool FileBlockDevice_InUse[SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE];
 static struct SolidSyslogFileBlockDevice FileBlockDevice_Pool[SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE];
@@ -52,7 +52,7 @@ void SolidSyslogFileBlockDevice_Destroy(struct SolidSyslogBlockDevice* base)
     }
 }
 
-static size_t FileBlockDevice_IndexFromHandle(const struct SolidSyslogBlockDevice* base)
+static inline size_t FileBlockDevice_IndexFromHandle(const struct SolidSyslogBlockDevice* base)
 {
     size_t result = SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE; poolIndex++)
@@ -66,7 +66,7 @@ static size_t FileBlockDevice_IndexFromHandle(const struct SolidSyslogBlockDevic
     return result;
 }
 
-static void FileBlockDevice_CleanupAtIndex(size_t index, void* context)
+static inline void FileBlockDevice_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     FileBlockDevice_Cleanup(&FileBlockDevice_Pool[index].Base);

--- a/Core/Source/SolidSyslogMetaSdStatic.c
+++ b/Core/Source/SolidSyslogMetaSdStatic.c
@@ -14,8 +14,8 @@
 struct SolidSyslogStructuredData;
 
 static bool MetaSd_IsValidConfig(const struct SolidSyslogMetaSdConfig* config);
-static size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
-static void MetaSd_CleanupAtIndex(size_t index, void* context);
+static inline size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
+static inline void MetaSd_CleanupAtIndex(size_t index, void* context);
 
 static bool MetaSd_InUse[SOLIDSYSLOG_META_SD_POOL_SIZE];
 static struct SolidSyslogMetaSd MetaSd_Pool[SOLIDSYSLOG_META_SD_POOL_SIZE];
@@ -69,7 +69,7 @@ static bool MetaSd_IsValidConfig(const struct SolidSyslogMetaSdConfig* config)
     return valid;
 }
 
-static size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
+static inline size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
 {
     size_t result = SOLIDSYSLOG_META_SD_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_META_SD_POOL_SIZE; poolIndex++)
@@ -83,7 +83,7 @@ static size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* bas
     return result;
 }
 
-static void MetaSd_CleanupAtIndex(size_t index, void* context)
+static inline void MetaSd_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     MetaSd_Cleanup(&MetaSd_Pool[index].Base);

--- a/Core/Source/SolidSyslogOriginSdStatic.c
+++ b/Core/Source/SolidSyslogOriginSdStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogStructuredData;
 
-static size_t OriginSd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
-static void OriginSd_CleanupAtIndex(size_t index, void* context);
+static inline size_t OriginSd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
+static inline void OriginSd_CleanupAtIndex(size_t index, void* context);
 
 static bool OriginSd_InUse[SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE];
 static struct SolidSyslogOriginSd OriginSd_Pool[SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE];
@@ -47,7 +47,7 @@ void SolidSyslogOriginSd_Destroy(struct SolidSyslogStructuredData* base)
     }
 }
 
-static size_t OriginSd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
+static inline size_t OriginSd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
 {
     size_t result = SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE; poolIndex++)
@@ -61,7 +61,7 @@ static size_t OriginSd_IndexFromHandle(const struct SolidSyslogStructuredData* b
     return result;
 }
 
-static void OriginSd_CleanupAtIndex(size_t index, void* context)
+static inline void OriginSd_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     OriginSd_Cleanup(&OriginSd_Pool[index].Base);

--- a/Core/Source/SolidSyslogPassthroughBufferStatic.c
+++ b/Core/Source/SolidSyslogPassthroughBufferStatic.c
@@ -14,8 +14,8 @@
 struct SolidSyslogBuffer;
 struct SolidSyslogSender;
 
-static size_t PassthroughBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
-static void PassthroughBuffer_CleanupAtIndex(size_t index, void* context);
+static inline size_t PassthroughBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
+static inline void PassthroughBuffer_CleanupAtIndex(size_t index, void* context);
 
 static bool PassthroughBuffer_InUse[SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE];
 static struct SolidSyslogPassthroughBuffer PassthroughBuffer_Pool[SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE];
@@ -56,7 +56,7 @@ void SolidSyslogPassthroughBuffer_Destroy(struct SolidSyslogBuffer* base)
     }
 }
 
-static size_t PassthroughBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
+static inline size_t PassthroughBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
 {
     size_t result = SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE; poolIndex++)
@@ -70,7 +70,7 @@ static size_t PassthroughBuffer_IndexFromHandle(const struct SolidSyslogBuffer* 
     return result;
 }
 
-static void PassthroughBuffer_CleanupAtIndex(size_t index, void* context)
+static inline void PassthroughBuffer_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PassthroughBuffer_Cleanup(&PassthroughBuffer_Pool[index].Base);

--- a/Core/Source/SolidSyslogStreamSenderStatic.c
+++ b/Core/Source/SolidSyslogStreamSenderStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogSender;
 
-static size_t StreamSender_IndexFromHandle(const struct SolidSyslogSender* base);
-static void StreamSender_CleanupAtIndex(size_t index, void* context);
+static inline size_t StreamSender_IndexFromHandle(const struct SolidSyslogSender* base);
+static inline void StreamSender_CleanupAtIndex(size_t index, void* context);
 
 static bool StreamSender_InUse[SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE];
 static struct SolidSyslogStreamSender StreamSender_Pool[SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogStreamSender_Destroy(struct SolidSyslogSender* base)
     }
 }
 
-static size_t StreamSender_IndexFromHandle(const struct SolidSyslogSender* base)
+static inline size_t StreamSender_IndexFromHandle(const struct SolidSyslogSender* base)
 {
     size_t result = SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t StreamSender_IndexFromHandle(const struct SolidSyslogSender* base)
     return result;
 }
 
-static void StreamSender_CleanupAtIndex(size_t index, void* context)
+static inline void StreamSender_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     StreamSender_Cleanup(&StreamSender_Pool[index].Base);

--- a/Core/Source/SolidSyslogSwitchingSenderStatic.c
+++ b/Core/Source/SolidSyslogSwitchingSenderStatic.c
@@ -14,8 +14,8 @@
 struct SolidSyslogSender;
 
 static bool SwitchingSender_IsValidConfig(const struct SolidSyslogSwitchingSenderConfig* config);
-static size_t SwitchingSender_IndexFromHandle(const struct SolidSyslogSender* base);
-static void SwitchingSender_CleanupAtIndex(size_t index, void* context);
+static inline size_t SwitchingSender_IndexFromHandle(const struct SolidSyslogSender* base);
+static inline void SwitchingSender_CleanupAtIndex(size_t index, void* context);
 
 static bool SwitchingSender_InUse[SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE];
 static struct SolidSyslogSwitchingSender SwitchingSender_Pool[SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE];
@@ -77,7 +77,7 @@ void SolidSyslogSwitchingSender_Destroy(struct SolidSyslogSender* base)
     }
 }
 
-static size_t SwitchingSender_IndexFromHandle(const struct SolidSyslogSender* base)
+static inline size_t SwitchingSender_IndexFromHandle(const struct SolidSyslogSender* base)
 {
     size_t result = SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE; poolIndex++)
@@ -91,7 +91,7 @@ static size_t SwitchingSender_IndexFromHandle(const struct SolidSyslogSender* ba
     return result;
 }
 
-static void SwitchingSender_CleanupAtIndex(size_t index, void* context)
+static inline void SwitchingSender_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     SwitchingSender_Cleanup(&SwitchingSender_Pool[index].Base);

--- a/Core/Source/SolidSyslogTimeQualitySdStatic.c
+++ b/Core/Source/SolidSyslogTimeQualitySdStatic.c
@@ -14,8 +14,8 @@
 
 struct SolidSyslogStructuredData;
 
-static size_t TimeQualitySd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
-static void TimeQualitySd_CleanupAtIndex(size_t index, void* context);
+static inline size_t TimeQualitySd_IndexFromHandle(const struct SolidSyslogStructuredData* base);
+static inline void TimeQualitySd_CleanupAtIndex(size_t index, void* context);
 
 static bool TimeQualitySd_InUse[SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE];
 static struct SolidSyslogTimeQualitySd TimeQualitySd_Pool[SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE];
@@ -59,7 +59,7 @@ void SolidSyslogTimeQualitySd_Destroy(struct SolidSyslogStructuredData* base)
     }
 }
 
-static size_t TimeQualitySd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
+static inline size_t TimeQualitySd_IndexFromHandle(const struct SolidSyslogStructuredData* base)
 {
     size_t result = SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE; poolIndex++)
@@ -73,7 +73,7 @@ static size_t TimeQualitySd_IndexFromHandle(const struct SolidSyslogStructuredDa
     return result;
 }
 
-static void TimeQualitySd_CleanupAtIndex(size_t index, void* context)
+static inline void TimeQualitySd_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     TimeQualitySd_Cleanup(&TimeQualitySd_Pool[index].Base);

--- a/Core/Source/SolidSyslogUdpSenderStatic.c
+++ b/Core/Source/SolidSyslogUdpSenderStatic.c
@@ -14,8 +14,8 @@
 struct SolidSyslogSender;
 
 static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* config);
-static size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base);
-static void UdpSender_CleanupAtIndex(size_t index, void* context);
+static inline size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base);
+static inline void UdpSender_CleanupAtIndex(size_t index, void* context);
 
 static bool UdpSender_InUse[SOLIDSYSLOG_UDP_SENDER_POOL_SIZE];
 static struct SolidSyslogUdpSender UdpSender_Pool[SOLIDSYSLOG_UDP_SENDER_POOL_SIZE];
@@ -77,7 +77,7 @@ static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* con
     return valid;
 }
 
-static size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base)
+static inline size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base)
 {
     size_t result = SOLIDSYSLOG_UDP_SENDER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_UDP_SENDER_POOL_SIZE; poolIndex++)
@@ -91,7 +91,7 @@ static size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base)
     return result;
 }
 
-static void UdpSender_CleanupAtIndex(size_t index, void* context)
+static inline void UdpSender_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     UdpSender_Cleanup(&UdpSender_Pool[index].Base);

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,34 @@
 # Dev Log
 
+## 2026-05-20 — chore: `*Static.c` helper functions to `static inline`
+
+Mechanical sweep over every `*Static.c` file across Core, Posix and Windows
+(23 files) to mark `IndexFromHandle` and `CleanupAtIndex` `static inline`
+rather than plain `static`. Flagged as a CodeRabbit nit on S11.07's
+`SolidSyslogWinsockResolverStatic.c`; the rule applies to the whole family
+and the inconsistency had drifted across S11.01 / S11.04 / S11.05 / S11.06 /
+S11.07.
+
+Scope is narrow on purpose:
+
+- Only the two mechanical pool helpers (`IndexFromHandle`, `CleanupAtIndex`)
+  in each `*Static.c` get `inline`. They're 5- and 3-liners — natural inline
+  candidates. The forward declarations and definitions both gain the
+  `inline` keyword in the same line edit.
+- The handful of larger `*Static.c` helpers — `BlockStore_ResolveSecurityPolicy`,
+  `BlockStore_BuildBlockSequenceConfig`, `MetaSd_IsValidConfig`,
+  `SwitchingSender_IsValidConfig`, `UdpSender_IsValidConfig` — are
+  deliberately *not* touched. They carry real branching logic and are not
+  inline candidates; their placement at file end is a separate concern
+  (CLAUDE.md "defined immediately beneath the function that first calls
+  them") that would expand this chore's scope materially.
+
+Per-class delta: 4 lines changed per file (two forward decls + two
+definitions). No behaviour change. MSVC build + full 1131-test suite green
+locally. Linux smoke + tidy + iwyu skipped by user judgement — the change
+is text-substitution-of-a-keyword on a fixed-format pair of identifiers,
+trusted to CI.
+
 ## 2026-05-20 — S11.07: Windows adapters onto PoolAllocator
 
 Closes S11.07 (#406). The second platform-adapter sweep in E11 — applies the

--- a/Platform/Posix/Source/SolidSyslogGetAddrInfoResolverStatic.c
+++ b/Platform/Posix/Source/SolidSyslogGetAddrInfoResolverStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogResolver;
 
-static size_t GetAddrInfoResolver_IndexFromHandle(const struct SolidSyslogResolver* base);
-static void GetAddrInfoResolver_CleanupAtIndex(size_t index, void* context);
+static inline size_t GetAddrInfoResolver_IndexFromHandle(const struct SolidSyslogResolver* base);
+static inline void GetAddrInfoResolver_CleanupAtIndex(size_t index, void* context);
 
 static bool GetAddrInfoResolver_InUse[SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE];
 static struct SolidSyslogGetAddrInfoResolver GetAddrInfoResolver_Pool[SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE];
@@ -55,7 +55,7 @@ void SolidSyslogGetAddrInfoResolver_Destroy(struct SolidSyslogResolver* base)
     }
 }
 
-static size_t GetAddrInfoResolver_IndexFromHandle(const struct SolidSyslogResolver* base)
+static inline size_t GetAddrInfoResolver_IndexFromHandle(const struct SolidSyslogResolver* base)
 {
     size_t result = SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE; poolIndex++)
@@ -69,7 +69,7 @@ static size_t GetAddrInfoResolver_IndexFromHandle(const struct SolidSyslogResolv
     return result;
 }
 
-static void GetAddrInfoResolver_CleanupAtIndex(size_t index, void* context)
+static inline void GetAddrInfoResolver_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     GetAddrInfoResolver_Cleanup(&GetAddrInfoResolver_Pool[index].Base);

--- a/Platform/Posix/Source/SolidSyslogPosixDatagramStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagramStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogDatagram;
 
-static size_t PosixDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base);
-static void PosixDatagram_CleanupAtIndex(size_t index, void* context);
+static inline size_t PosixDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base);
+static inline void PosixDatagram_CleanupAtIndex(size_t index, void* context);
 
 static bool PosixDatagram_InUse[SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE];
 static struct SolidSyslogPosixDatagram PosixDatagram_Pool[SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogPosixDatagram_Destroy(struct SolidSyslogDatagram* base)
     }
 }
 
-static size_t PosixDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base)
+static inline size_t PosixDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base)
 {
     size_t result = SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t PosixDatagram_IndexFromHandle(const struct SolidSyslogDatagram* ba
     return result;
 }
 
-static void PosixDatagram_CleanupAtIndex(size_t index, void* context)
+static inline void PosixDatagram_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PosixDatagram_Cleanup(&PosixDatagram_Pool[index].Base);

--- a/Platform/Posix/Source/SolidSyslogPosixFileStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixFileStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogFile;
 
-static size_t PosixFile_IndexFromHandle(const struct SolidSyslogFile* base);
-static void PosixFile_CleanupAtIndex(size_t index, void* context);
+static inline size_t PosixFile_IndexFromHandle(const struct SolidSyslogFile* base);
+static inline void PosixFile_CleanupAtIndex(size_t index, void* context);
 
 static bool PosixFile_InUse[SOLIDSYSLOG_POSIX_FILE_POOL_SIZE];
 static struct SolidSyslogPosixFile PosixFile_Pool[SOLIDSYSLOG_POSIX_FILE_POOL_SIZE];
@@ -47,7 +47,7 @@ void SolidSyslogPosixFile_Destroy(struct SolidSyslogFile* base)
     }
 }
 
-static size_t PosixFile_IndexFromHandle(const struct SolidSyslogFile* base)
+static inline size_t PosixFile_IndexFromHandle(const struct SolidSyslogFile* base)
 {
     size_t result = SOLIDSYSLOG_POSIX_FILE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_POSIX_FILE_POOL_SIZE; poolIndex++)
@@ -61,7 +61,7 @@ static size_t PosixFile_IndexFromHandle(const struct SolidSyslogFile* base)
     return result;
 }
 
-static void PosixFile_CleanupAtIndex(size_t index, void* context)
+static inline void PosixFile_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PosixFile_Cleanup(&PosixFile_Pool[index].Base);

--- a/Platform/Posix/Source/SolidSyslogPosixMessageQueueBufferStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMessageQueueBufferStatic.c
@@ -18,8 +18,8 @@ struct SolidSyslogBuffer;
  * in-process pool entries from aliasing onto the same kernel queue
  * object when the pool tunable is bumped above 1. */
 
-static size_t PosixMessageQueueBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
-static void PosixMessageQueueBuffer_CleanupAtIndex(size_t index, void* context);
+static inline size_t PosixMessageQueueBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base);
+static inline void PosixMessageQueueBuffer_CleanupAtIndex(size_t index, void* context);
 
 static bool PosixMessageQueueBuffer_InUse[SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE];
 static struct SolidSyslogPosixMessageQueueBuffer
@@ -67,7 +67,7 @@ void SolidSyslogPosixMessageQueueBuffer_Destroy(struct SolidSyslogBuffer* base)
     }
 }
 
-static size_t PosixMessageQueueBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
+static inline size_t PosixMessageQueueBuffer_IndexFromHandle(const struct SolidSyslogBuffer* base)
 {
     size_t result = SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE; poolIndex++)
@@ -81,7 +81,7 @@ static size_t PosixMessageQueueBuffer_IndexFromHandle(const struct SolidSyslogBu
     return result;
 }
 
-static void PosixMessageQueueBuffer_CleanupAtIndex(size_t index, void* context)
+static inline void PosixMessageQueueBuffer_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PosixMessageQueueBuffer_Cleanup(&PosixMessageQueueBuffer_Pool[index].Base);

--- a/Platform/Posix/Source/SolidSyslogPosixMutexStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixMutexStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogMutex;
 
-static size_t PosixMutex_IndexFromHandle(const struct SolidSyslogMutex* base);
-static void PosixMutex_CleanupAtIndex(size_t index, void* context);
+static inline size_t PosixMutex_IndexFromHandle(const struct SolidSyslogMutex* base);
+static inline void PosixMutex_CleanupAtIndex(size_t index, void* context);
 
 static bool PosixMutex_InUse[SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE];
 static struct SolidSyslogPosixMutex PosixMutex_Pool[SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE];
@@ -47,7 +47,7 @@ void SolidSyslogPosixMutex_Destroy(struct SolidSyslogMutex* base)
     }
 }
 
-static size_t PosixMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
+static inline size_t PosixMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
 {
     size_t result = SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE; poolIndex++)
@@ -61,7 +61,7 @@ static size_t PosixMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
     return result;
 }
 
-static void PosixMutex_CleanupAtIndex(size_t index, void* context)
+static inline void PosixMutex_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PosixMutex_Cleanup(&PosixMutex_Pool[index].Base);

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStreamStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStreamStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogStream;
 
-static size_t PosixTcpStream_IndexFromHandle(const struct SolidSyslogStream* base);
-static void PosixTcpStream_CleanupAtIndex(size_t index, void* context);
+static inline size_t PosixTcpStream_IndexFromHandle(const struct SolidSyslogStream* base);
+static inline void PosixTcpStream_CleanupAtIndex(size_t index, void* context);
 
 static bool PosixTcpStream_InUse[SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE];
 static struct SolidSyslogPosixTcpStream PosixTcpStream_Pool[SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogPosixTcpStream_Destroy(struct SolidSyslogStream* base)
     }
 }
 
-static size_t PosixTcpStream_IndexFromHandle(const struct SolidSyslogStream* base)
+static inline size_t PosixTcpStream_IndexFromHandle(const struct SolidSyslogStream* base)
 {
     size_t result = SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t PosixTcpStream_IndexFromHandle(const struct SolidSyslogStream* bas
     return result;
 }
 
-static void PosixTcpStream_CleanupAtIndex(size_t index, void* context)
+static inline void PosixTcpStream_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     PosixTcpStream_Cleanup(&PosixTcpStream_Pool[index].Base);

--- a/Platform/Windows/Source/SolidSyslogWindowsFileStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsFileStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogFile;
 
-static size_t WindowsFile_IndexFromHandle(const struct SolidSyslogFile* base);
-static void WindowsFile_CleanupAtIndex(size_t index, void* context);
+static inline size_t WindowsFile_IndexFromHandle(const struct SolidSyslogFile* base);
+static inline void WindowsFile_CleanupAtIndex(size_t index, void* context);
 
 static bool WindowsFile_InUse[SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE];
 static struct SolidSyslogWindowsFile WindowsFile_Pool[SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE];
@@ -48,7 +48,7 @@ void SolidSyslogWindowsFile_Destroy(struct SolidSyslogFile* base)
     }
 }
 
-static size_t WindowsFile_IndexFromHandle(const struct SolidSyslogFile* base)
+static inline size_t WindowsFile_IndexFromHandle(const struct SolidSyslogFile* base)
 {
     size_t result = SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE; poolIndex++)
@@ -62,7 +62,7 @@ static size_t WindowsFile_IndexFromHandle(const struct SolidSyslogFile* base)
     return result;
 }
 
-static void WindowsFile_CleanupAtIndex(size_t index, void* context)
+static inline void WindowsFile_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     WindowsFile_Cleanup(&WindowsFile_Pool[index].Base);

--- a/Platform/Windows/Source/SolidSyslogWindowsMutexStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsMutexStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogMutex;
 
-static size_t WindowsMutex_IndexFromHandle(const struct SolidSyslogMutex* base);
-static void WindowsMutex_CleanupAtIndex(size_t index, void* context);
+static inline size_t WindowsMutex_IndexFromHandle(const struct SolidSyslogMutex* base);
+static inline void WindowsMutex_CleanupAtIndex(size_t index, void* context);
 
 static bool WindowsMutex_InUse[SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE];
 static struct SolidSyslogWindowsMutex WindowsMutex_Pool[SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogWindowsMutex_Destroy(struct SolidSyslogMutex* base)
     }
 }
 
-static size_t WindowsMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
+static inline size_t WindowsMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
 {
     size_t result = SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t WindowsMutex_IndexFromHandle(const struct SolidSyslogMutex* base)
     return result;
 }
 
-static void WindowsMutex_CleanupAtIndex(size_t index, void* context)
+static inline void WindowsMutex_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     WindowsMutex_Cleanup(&WindowsMutex_Pool[index].Base);

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagramStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagramStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogDatagram;
 
-static size_t WinsockDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base);
-static void WinsockDatagram_CleanupAtIndex(size_t index, void* context);
+static inline size_t WinsockDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base);
+static inline void WinsockDatagram_CleanupAtIndex(size_t index, void* context);
 
 static bool WinsockDatagram_InUse[SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE];
 static struct SolidSyslogWinsockDatagram WinsockDatagram_Pool[SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogWinsockDatagram_Destroy(struct SolidSyslogDatagram* base)
     }
 }
 
-static size_t WinsockDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base)
+static inline size_t WinsockDatagram_IndexFromHandle(const struct SolidSyslogDatagram* base)
 {
     size_t result = SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t WinsockDatagram_IndexFromHandle(const struct SolidSyslogDatagram* 
     return result;
 }
 
-static void WinsockDatagram_CleanupAtIndex(size_t index, void* context)
+static inline void WinsockDatagram_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     WinsockDatagram_Cleanup(&WinsockDatagram_Pool[index].Base);

--- a/Platform/Windows/Source/SolidSyslogWinsockResolverStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockResolverStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogResolver;
 
-static size_t WinsockResolver_IndexFromHandle(const struct SolidSyslogResolver* base);
-static void WinsockResolver_CleanupAtIndex(size_t index, void* context);
+static inline size_t WinsockResolver_IndexFromHandle(const struct SolidSyslogResolver* base);
+static inline void WinsockResolver_CleanupAtIndex(size_t index, void* context);
 
 static bool WinsockResolver_InUse[SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE];
 static struct SolidSyslogWinsockResolver WinsockResolver_Pool[SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogWinsockResolver_Destroy(struct SolidSyslogResolver* base)
     }
 }
 
-static size_t WinsockResolver_IndexFromHandle(const struct SolidSyslogResolver* base)
+static inline size_t WinsockResolver_IndexFromHandle(const struct SolidSyslogResolver* base)
 {
     size_t result = SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t WinsockResolver_IndexFromHandle(const struct SolidSyslogResolver* 
     return result;
 }
 
-static void WinsockResolver_CleanupAtIndex(size_t index, void* context)
+static inline void WinsockResolver_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     WinsockResolver_Cleanup(&WinsockResolver_Pool[index].Base);

--- a/Platform/Windows/Source/SolidSyslogWinsockTcpStreamStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockTcpStreamStatic.c
@@ -13,8 +13,8 @@
 
 struct SolidSyslogStream;
 
-static size_t WinsockTcpStream_IndexFromHandle(const struct SolidSyslogStream* base);
-static void WinsockTcpStream_CleanupAtIndex(size_t index, void* context);
+static inline size_t WinsockTcpStream_IndexFromHandle(const struct SolidSyslogStream* base);
+static inline void WinsockTcpStream_CleanupAtIndex(size_t index, void* context);
 
 static bool WinsockTcpStream_InUse[SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE];
 static struct SolidSyslogWinsockTcpStream WinsockTcpStream_Pool[SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE];
@@ -51,7 +51,7 @@ void SolidSyslogWinsockTcpStream_Destroy(struct SolidSyslogStream* base)
     }
 }
 
-static size_t WinsockTcpStream_IndexFromHandle(const struct SolidSyslogStream* base)
+static inline size_t WinsockTcpStream_IndexFromHandle(const struct SolidSyslogStream* base)
 {
     size_t result = SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE;
     for (size_t poolIndex = 0; poolIndex < SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE; poolIndex++)
@@ -65,7 +65,7 @@ static size_t WinsockTcpStream_IndexFromHandle(const struct SolidSyslogStream* b
     return result;
 }
 
-static void WinsockTcpStream_CleanupAtIndex(size_t index, void* context)
+static inline void WinsockTcpStream_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     WinsockTcpStream_Cleanup(&WinsockTcpStream_Pool[index].Base);


### PR DESCRIPTION
## Purpose

Mechanical sweep across every `*Static.c` file in the tree (23 files, Core + Posix + Windows) to mark the two pool helpers — `IndexFromHandle` and `CleanupAtIndex` — `static inline` rather than plain `static`. Both forward declaration and definition pick up the `inline` keyword in the same line edit.

The rule comes from [CLAUDE.md](CLAUDE.md):
> Helper functions are forward-declared at the top of the file (after constants/types, before the first definition), usually `static inline`, and defined immediately beneath the function that first calls them.

CodeRabbit flagged the omission on S11.07's `SolidSyslogWinsockResolverStatic.c` ([PR #408 comment](https://github.com/DavidCozens/solid-syslog/pull/408#discussion_r-)) but the inconsistency had drifted across the whole family — S11.01 / S11.04 / S11.05 / S11.06 / S11.07 — so fixing only S11.07 would leave the family lopsided. One-shot sweep across the lot.

## Change Description

Per-file diff is 4 lines (two forward decls + two definitions). 23 files × 4 lines = 92 keyword insertions. No behaviour change.

Both helpers are textbook inline candidates: `IndexFromHandle` is a 5-line `for`-loop reverse lookup; `CleanupAtIndex` is a 3-line bridge that calls the per-class `_Cleanup`. The compiler will still emit an out-of-line copy of `CleanupAtIndex` because its address is taken by `SolidSyslogPoolAllocator_FreeIfInUse` — that's expected and harmless.

## Out of scope

The handful of larger `*Static.c` helpers — `BlockStore_ResolveSecurityPolicy`, `BlockStore_BuildBlockSequenceConfig`, `MetaSd_IsValidConfig`, `SwitchingSender_IsValidConfig`, `UdpSender_IsValidConfig` — carry real branching logic and are not inline candidates. Their placement at file end (rather than immediately beneath `_Create`, their first caller) is a separate placement-rule violation; deferring to a future cleanup so this PR stays narrow.

## Verification

- **MSVC `msvc-debug`** (local): full build clean, all 1131 tests pass.
- **Linux build, tidy, IWYU**: skipped by judgement — the change is a keyword insertion on a fixed-format pair of identifiers, trusted to CI.