### PR TITLE
chore: S11.11 honest MISRA suppressions + E11 close-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,11 +501,10 @@ code should follow them; reviewers should call out drift.
 
 ## Callback Conventions
 
-The library is migrating away from singleton instances toward integrator-injected storage and
-context-pointer callbacks. The migration is **opportunistic per-class** — not a sweep — so older
-context-less callbacks (`SolidSyslogClockFunction`, `SolidSyslogStringFunction`,
-`SolidSyslogStoreFullCallback`, etc.) keep their current shape until the class that owns them is
-next touched.
+The library is migrating callbacks toward a `void* context` parameter. The migration is
+**opportunistic per-class** — not a sweep — so older context-less callbacks
+(`SolidSyslogClockFunction`, `SolidSyslogStringFunction`, `SolidSyslogStoreFullCallback`, etc.)
+keep their current shape until the class that owns them is next touched.
 
 **For new callbacks:**
 
@@ -521,14 +520,37 @@ next touched.
   example, `SolidSyslogStoreFullCallback` migrates inside the FileStore split (S18.01), not in a
   separate sweep PR.
 
-**Storage injection:**
+## Pool Allocation (E11)
 
-- Mirrors the `SolidSyslogFormatterStorage` pattern. The public header exposes an opaque storage
-  type and a `SOLIDSYSLOG_<TYPE>_STORAGE_SIZE` macro; `_Create` takes a pointer to caller-allocated
-  storage of that size. No `malloc` anywhere in the library.
-- Internal sub-components (e.g. RecordStore and BlockSequence inside BlockStore) nest inside the
-  parent's storage blob. Their types stay in `Core/Source/` and never appear in public headers,
-  so integrator and example code physically cannot reach them.
+Every stateful Created class lives in a library-internal static pool of N slots, sized by a
+`SOLIDSYSLOG_<CLASS>_POOL_SIZE` tunable in `Core/Interface/SolidSyslogTunablesDefaults.h`. The
+public `_Create` accepts a config struct and returns an opaque handle (a pointer into the
+pool); `_Destroy` takes the handle and releases the slot. Pool semantics:
+
+- **No `malloc`.** Pools are file-scope `static` arrays. Integrators on bare-metal /
+  FreeRTOS-static-allocation / DO-178C-style targets get the same code path as hosted targets.
+- **Pool exhaustion** falls back to a shared null sibling — `SolidSyslogNullSender`,
+  `SolidSyslogNullBuffer`, `SolidSyslogNullStore`, etc. — whose vtable methods are safe no-ops.
+  Caller code keeps running; the integrator sees `SolidSyslog_Error(ERR, ...)` at the
+  exhaustion site if a handler is installed.
+- **Slot-walk synchronisation.** Every pool's Create / Destroy wraps its slot probe in the
+  `SolidSyslog_LockConfig` / `_UnlockConfig` injection pair. Single-task targets get the
+  no-op default; multi-task targets wire `taskENTER_CRITICAL` (FreeRTOS), `pthread_mutex_lock`
+  (POSIX), `EnterCriticalSection` (Windows), etc.
+- **Shared helper.** `Core/Source/SolidSyslogPoolAllocator.{h,c}` (TU-internal) owns the
+  three-operation contract (`AcquireFirstFree`, `FreeIfInUse`, `IndexIsValid`) every
+  pool class reuses. No class re-implements the slot walk.
+
+**Caller-supplied storage** survives in two places only — both intentionally outside the
+pool pattern. `SolidSyslogFormatter` is a transient stack-built builder whose payload size
+is per-call (`SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(n)`); `SolidSyslogAddress` is a value type
+(`SolidSyslogAddressStorage` + `SOLIDSYSLOG_ADDRESS_SIZE`) with no `_Create`/`_Destroy`
+lifecycle. Both are documented under deviation D.002 in `docs/misra-deviations.md`.
+
+**Internal sub-components** of pool-allocated classes (e.g. `RecordStore` and
+`BlockSequence` inside `BlockStore`) live in sibling pools sized off the parent's
+tunable. Their types stay in `Core/Source/` and never appear in public headers, so
+integrator and example code physically cannot reach them.
 
 ---
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,224 @@
 # Dev Log
 
+## 2026-05-20 — S11.11: Honest MISRA suppressions + E11 close-out
+
+Closes S11.11 (#414) and **closes E11** (#29).
+
+### Suppressions honesty rebuild
+
+Dropped `misra_suppressions.txt` entirely (keeping only the file
+header) and reconstructed it from a fresh cppcheck-misra run with
+no suppressions list. Three-baseline picture:
+
+| Rule | Pre-E11 (#168632b9) | Post-S11.10 (current main) | Post-honesty (this story) |
+|---|---|---|---|
+| 5.7 | 55 | 55 | **40** (-15 stale) |
+| 2.5 | 2 | 1 | **39** (+38 newly captured) |
+| 11.3 | 56 | 53 | **38** (-15 stale) |
+| 11.8 | 11 | 11 | 11 |
+| 11.2 | 10 | 10 | 10 |
+| 18.4 | 4 | 4 | 4 |
+| 11.5 | 4 | 4 | 4 |
+| 21.10 | 3 | 3 | 3 |
+| 21.6 | 1 | 1 | 1 |
+| 20.10 | 1 | 1 | 1 |
+| 18.7 | 2 | 1 | 1 |
+| 2.4 | 8 | 8 | **5** (line drift) |
+| 1.4 | 1 | 1 | **0** (retired) |
+| **Total entries** | **158** | **153** | **157** |
+| File line count | 202 | 197 | 197 |
+
+The line count coincidence (197 → 197) hides a substantial
+reshuffle: 34 stale entries deleted (mostly drifted line numbers
+from the per-class file rewrites under S11.04 – S11.10), 38 new
+entries added (rule 2.5 — every new public macro the sweep added
+had been firing as an unsuppressed CI warning since it landed),
+net +4 entries.
+
+**Why the rule-2.5 explosion is the canonical S11.11 signal.**
+The deviation rationale ("public API macros consumed outside
+cppcheck-misra scope") still applies — these are legitimately
+public macros (`SOLIDSYSLOG_*_POOL_SIZE` tunables, error-message
+macros, handle-API symbols added per class as it migrated). What
+went wrong is that the suppressions file had ONE entry covering
+the original `SOLIDSYSLOG_CIRCULAR_BUFFER_STORAGE_SIZE` macros
+from S10.10 (line 1, line 22) and never expanded as new public
+macros were added. Each E11 sweep silently shipped CI warnings
+on its new macros; nobody noticed because cppcheck-misra is in
+warning mode (`--error-exitcode=0`).
+
+**Convergence took two iterations** of cppcheck. Some findings
+mask each other: when 5.7 fires on a struct tag, rule 2.4 (unused
+tag declaration) at the same site is silently suppressed by
+cppcheck. After applying the iter-1 5.7 suppressions, rule 2.4
+surfaced an additional 5 findings; after applying those, the
+final pass was clean. The mechanism is documented in the original
+`docs/misra-conformance.md` S10.06 entry — same behaviour, just
+caught us with stale assumptions about which rules were live.
+
+### D.006-original (rule 1.4 / C11 `<stdatomic.h>`) retired
+
+Pre-E11 the deviation covered a single site,
+`Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:21`. The
+file still includes `<stdatomic.h>` and still uses C11 atomics —
+nothing changed in the production code. cppcheck 2.10 simply no
+longer flags this as a 1.4 ("emergent language feature") finding;
+plausibly the addon's threshold for "emergent" was relaxed as
+C11 became dominant. Either way: zero findings in the fresh run,
+deviation retired, suppression line gone.
+
+The deviations renumbered down by one — old D.007 – D.012 became
+new D.006 – D.011 — across `docs/misra-deviations.md`,
+`docs/misra-conformance.md`, `docs/NAMING.md`,
+`misra_suppressions.txt`, and the
+`project_per_group_conformance_workflow` memory entry. DEVLOG.md
+is append-only history and stays frozen (D.NNN references in
+earlier entries reflect the numbering at the time of writing).
+This was a safe rewrite because the library is pre-alpha with no
+public consumers.
+
+### D.002 compacted
+
+Pre-E11, D.002 was the big one — covered every storage-cast
+`_Create` in the library (~30 classes) plus every vtable
+downcast. Post-E11, the only surviving sites are the three
+structural buckets:
+
+- **(a) Vtable downcasts** — `SelfFromBase` in every pool class
+  (Buffer / Sender / Stream / Datagram / Store / Mutex / File /
+  BlockDevice / AtomicCounter / Resolver / StructuredData /
+  SecurityPolicy).
+- **(b) `SolidSyslogAddress`** — strict-tier opaque value type;
+  has no `_Create`/`_Destroy` so was deliberately outside the
+  E11 pool migration.
+- **(c) `SolidSyslogFormatter`** — variable-size stack builder;
+  per-call lifecycle, fundamentally not a pool fit.
+
+Dropped the historical alternatives-comparison table (malloc /
+public concrete types / pass-by-value). It read as
+over-justification with only two non-vtable consumers left;
+collapsed to a single sentence. Approval line notes the S11.11
+scope narrowing.
+
+### CLAUDE.md + SKILL.md aligned with pool model
+
+CLAUDE.md "Callback Conventions" section had an obsolete
+"Storage injection:" subsection describing the
+`SOLIDSYSLOG_<TYPE>_STORAGE_SIZE` macro + caller-allocated storage
+as the canonical pattern. Replaced with a "Pool Allocation (E11)"
+section covering: tunable per-class pool size, handle-returning
+Create, null-sibling pool-exhaustion fallback, ConfigLock-guarded
+slot walks, shared PoolAllocator helper, and the two non-pool
+exceptions (Formatter, Address).
+
+SKILL.md dropped "allocator" from the dependency-injection list
+and rewrote the "No dynamic memory allocation required" line to
+name the pool-size tunable mechanism explicitly.
+
+### Memory cleanup
+
+`feedback_storage_pattern` retired — the pattern described
+(single Address-style `intptr_t slots` + `_SIZE` enum +
+`DEFAULT/DESTROYED_INSTANCE` template) was the canonical shape
+for the pre-E11 caller-supplied-storage classes; with every such
+class now on the pool, the pattern only survives for Address and
+Formatter and doesn't need its own memory pointer.
+
+### E11 epic retrospective
+
+**Eleven stories landed across three weeks** (2026-04-30 → 2026-05-20):
+
+- **S11.01** (#392) — Pilot: CircularBuffer pool migration.
+  Established the canonical 3-TU split (`Class.c` /
+  `ClassPrivate.h` / `ClassStatic.c`) and the ConfigLock
+  injection point.
+- **S11.02** (#395) — Extracted `SolidSyslogPoolAllocator` helper
+  (TU-internal). Set the per-class delta target at ≈3 file-scope
+  functions + bridge + vtable entries.
+- **S11.03** (#397) — Cross-tree rename `NullBuffer` →
+  `PassthroughBuffer`. Pure mechanical rename, separate review
+  surface.
+- **S11.04** (#399) — Core singleton stateful classes:
+  PassthroughBuffer, UdpSender, SwitchingSender, MetaSd,
+  TimeQualitySd, OriginSd. Introduced two new public Null
+  siblings (`SolidSyslogNullSd`, `SolidSyslogNullSender`).
+- **S11.05** (#401) — Core storage-cast classes: BlockStore,
+  FileBlockDevice, StreamSender. Removed
+  `SOLIDSYSLOG_<*>_STORAGE_SIZE` public macros for these.
+- **S11.06** (#405) — POSIX adapters: PosixMutex,
+  PosixMessageQueueBuffer, PosixTcpStream, PosixFile,
+  PosixDatagram, GetAddrInfoResolver.
+- **S11.07** (#406) — Windows adapters: WindowsMutex,
+  WinsockTcpStream, WindowsFile, WinsockDatagram,
+  WinsockResolver.
+- **S11.08** (#410) — FreeRTOS adapters: FreeRtosMutex,
+  FreeRtosTcpStream, FreeRtosDatagram, FreeRtosStaticResolver.
+- **S11.09** (#412) — AtomicCounter family (Std + Windows) + TLS
+  (OpenSSL) + FatFs.
+- **S11.10** (#413/#416) — SolidSyslog core retrofit. Public API
+  break: handle-taking `_Log` / `_Service`; new tunable
+  `SOLIDSYSLOG_POOL_SIZE` (default 1).
+- **S11.11** (#414) — this story.
+
+**Public API surface change.** Counting only what integrators
+see in their setup code:
+
+- `SolidSyslog_Create` returns a handle (was `void`); `_Destroy`,
+  `_Log`, `_Service` take that handle (S11.10 — `feat!`).
+- Every Created class gained a `SOLIDSYSLOG_<CLASS>_POOL_SIZE`
+  tunable in `Core/Interface/SolidSyslogTunablesDefaults.h`,
+  default 1 (sender / buffer / store / mutex / file / atomic
+  counter / SD / resolver / stream / datagram / block device)
+  or 2 (TcpStream variants — they need to support the
+  TLS-via-mbedTLS + plain-TCP pair).
+- `SolidSyslog_SetConfigLock(lockFn, unlockFn)` injection added
+  in S11.01 — lets integrators wrap pool slot walks in
+  `taskENTER_CRITICAL` / `pthread_mutex_lock` / etc.
+- `SOLIDSYSLOG_CIRCULAR_BUFFER_STORAGE_SIZE` and
+  `SOLIDSYSLOG_CIRCULAR_BUFFER_STORAGE_SIZE_BYTES` removed (just
+  the ring memory parameter stays — the instance struct lives
+  in the pool).
+- `SOLIDSYSLOG_<*>_STORAGE_SIZE` removed for BlockStore,
+  FileBlockDevice, StreamSender, every Mutex / File / Stream /
+  Datagram / TcpStream / TlsStream / FatFsFile / AtomicCounter
+  / Address-not-touched / Formatter-not-touched class.
+
+**MISRA conformance.** The pattern itself is MISRA-clean by
+construction: every pool class lands at the per-class delta
+target (3 file-scope functions plus the `CleanupAtIndex`
+bridge), `SelfFromBase` is the only remaining 11.3 firing site
+per class. No suppression was added that wasn't matched 1-for-1
+by an old caller-storage suppression deleted.
+
+**Deferred follow-ups.**
+
+- **Dynamic-allocation epic.** The 3-TU split anticipates a
+  sibling `ClassDynamic.c` TU per class on a `malloc`/`free`
+  strategy; CMake's `SOLIDSYSLOG_ALLOCATION_STRATEGY` already
+  errors cleanly on the unselected option. No epic raised — wait
+  until an integrator asks for it.
+- **`FF_MAX_SS` override is simpler post-S11.09.** S21.03 should
+  pick this up — FatFs file pool now sizes off
+  `SOLIDSYSLOG_FATFSFILE_POOL_SIZE`, so the override path is one
+  tunable instead of three.
+- **Non-curated cppcheck-misra rules.** The fresh run surfaced
+  warnings on rules outside the D.001 – D.011 curated subset
+  (8.9 × 26, 14.4 × 19, 17.7 × 10, plus smaller buckets). These
+  have been emitting as CI warnings since S10.06; out of S11.11
+  scope; tracked under `project_e10_accumulated_scope` for E10
+  close-out.
+
+### Deferred
+
+- None from this story specifically. See "Deferred follow-ups"
+  above for E11-wide carry-forwards.
+
+### Open questions
+
+- None.
+
+---
+
 ## 2026-05-20 — S11.10: Retrofit SolidSyslog core onto PoolAllocator (handle API)
 
 Closes S11.10 (#413). The penultimate E11 story — retrofits the

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,13 +61,13 @@ Test progression follows ZOMBIES order.
   macros. Read it before adding any new public identifier.
 - MISRA C:2012 rule deviations are recorded in `docs/misra-deviations.md`.
 - Follows James Grenning's style (*TDD for Embedded C*) where consistent with clang-format
-- No dynamic memory allocation required — allocator is caller-injected. No unions, no anonymous structs, no `#ifdef` feature flags
+- No dynamic memory allocation — every stateful Created class lives in a library-internal static pool, sized by a per-class `SOLIDSYSLOG_<CLASS>_POOL_SIZE` tunable. No unions, no anonymous structs, no `#ifdef` feature flags
 - C99 baseline
 
 ## Architecture principles
 
 - OO-in-C: structs with function pointers (vtable pattern)
-- Dependency injection for transport, buffering, clock, hostname, allocator
+- Dependency injection for transport, buffering, clock, hostname, mutex, file, block device
 - Buffer abstraction decouples formatting from sending: `SolidSyslog_Log` writes to buffer,
   `SolidSyslog_Service` reads from buffer and sends. Implementations: PassthroughBuffer (direct send,
   single-task), CircularBuffer (portable ring with caller-allocated ring memory and an injected

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -578,8 +578,8 @@ The anonymous-enum named-constant idiom is itself unchanged — it's
 still the project's type-safe alternative to `#define` for integer
 constants, distinct in shape from tagged enums in purpose if not in
 casing. MISRA rule 2.4 (unused tag declarations) cppcheck-fires on
-anonymous enums; the project-wide deviation **D.010** covers all such
-sites — see `docs/misra-deviations.md#d010`.
+anonymous enums; the project-wide deviation **D.009** covers all such
+sites — see `docs/misra-deviations.md#d009`.
 
 This single-rule convention replaces the S10.07/S10.12 split where
 tagged-enum constants used `SolidSyslog<Class>_Constant` (PascalCase,

--- a/docs/misra-conformance.md
+++ b/docs/misra-conformance.md
@@ -6,6 +6,14 @@
 > conformance underway, the audit phase is closed. The live truth is
 > CI plus the two source-of-truth documents:
 >
+> **S11.11 update.** Deviation D.006-original (rule 1.4 / C11
+> `<stdatomic.h>`) was retired — cppcheck 2.10 no longer flags the
+> site. The remaining deviations were renumbered down by one
+> (old D.007–D.012 → new D.006–D.011). Cross-references in the
+> tables below have been updated to point at the new numbers; the
+> historical narrative (counts, original audit verdicts) is left
+> intact.
+>
 > - `docs/misra-deviations.md` — the deviation rationales and
 >   approvals. New per-site suppressions land here, not in this doc.
 > - `misra_suppressions.txt` — the cppcheck-misra suppressions list.
@@ -116,7 +124,7 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **10.4** | 92 → 0 *(landed in S10.10)* | Both operands of operator shall be in same essential type category | `SolidSyslogFormatter.c` (15), `SolidSyslog.c` (6), `SolidSyslogFileBlockDevice.c` (6) | **Fix — landed in S10.10** | Mostly `size_t + 1` where `1` is `int`. Mechanical U-suffix sweep across `Core/Source/`, `Core/Interface/`, and `Platform/*/`. Two byte-comparison sites (BOM strip in `SolidSyslog.c`, UTF-8 lead range in `SolidSyslogFormatter.c`) refactored to `unsigned char` + hex-literal comparisons where the `(char)` cast did not satisfy cppcheck-misra's essential-type tracking. `SOLIDSYSLOG_FORMATTER_STORAGE_SIZE` picked up U on the literal inside the macro so every expansion is uniform. | **S10.10** |
 | **8.9** (advisory) | 56 | Object referenced in one function should have block scope | `SolidSyslogFormatter.c` (8), `SolidSyslogMetaSd.c` (5), `SolidSyslogOriginSd.c` (5) | **Fix** | File-scope statics that should be locals or `static const` block-scope. Per-site review. | **S10.09** (if "abbreviation purge" widens to "code-shape hygiene") or **new sweep story** |
 | **5.7** | 54 | Tag names unique | `BlockSequence.c` (2), `SolidSyslogFileBlockDevice.c` (2), `SolidSyslogBlockStore.h` (1), and so on across many forward-decl + definition pairs | **Deviate** | NAMING.md's no-typedef-struct convention deliberately repeats the same `struct SolidSyslogX` tag wherever it's used (forward-decl in headers, definition in source). 5.7 fires on every repetition. Document as deviation. | **S10.06** (deviation D.003) |
-| **11.8** | 11 | Cast shall not remove const/volatile qualification | `SolidSyslog.c` (8), `BlockSequence.c` (1), `SolidSyslogBlockStore.c` (1), `SolidSyslogWinsockTcpStream.c` (1) | **Deviate** *(resolved in S10.06: all 11 sites)* | All 10 Core sites are field-access "false positives" — accessing a non-const-pointer field through a `const struct*` parameter; C standard §6.5.2.3 ¶3 says the member-access yields an unqualified pointer rvalue, so this is not a real const-strip. The Winsock `select()` site is the documented platform-API const-strip already commented in source. Captured as **D.007**. | landed in **S10.06** |
+| **11.8** | 11 | Cast shall not remove const/volatile qualification | `SolidSyslog.c` (8), `BlockSequence.c` (1), `SolidSyslogBlockStore.c` (1), `SolidSyslogWinsockTcpStream.c` (1) | **Deviate** *(resolved in S10.06: all 11 sites)* | All 10 Core sites are field-access "false positives" — accessing a non-const-pointer field through a `const struct*` parameter; C standard §6.5.2.3 ¶3 says the member-access yields an unqualified pointer rvalue, so this is not a real const-strip. The Winsock `select()` site is the documented platform-API const-strip already commented in source. Captured as **D.006**. | landed in **S10.06** |
 | **17.7** | 11 | Value returned by non-void function shall be used | `RecordStore.c` (5), `SolidSyslogCircularBuffer.c` (4), `SolidSyslog.c` (1) | **Fix** | Use the return value or cast to `(void)` with comment. | **New sweep story** or **S10.10** (Buffer pilot) where most concentrate |
 | **10.1** | 11 → 0 *(landed in S10.10)* | Operands shall not be of inappropriate essential type | `SolidSyslogUtf8.h` (5), `SolidSyslogFormatter.c` (5), `SolidSyslogCrc16.c` (1) | **Fix — landed in S10.10** | Bitwise operators on plain `char` are inappropriate (char is essentially-character, bitwise operators require essentially-unsigned). Cast `char` operands to `unsigned char` and U-suffix the hex literal masks they are tested against. The Crc16 data-byte shift uses a literal `8U` instead of the `BITS_PER_BYTE` anonymous-enum constant (which cppcheck-misra still tracks as essentially-signed even with a U-suffixed initialiser). | **S10.10** |
 | **15.7** | 10 → 0 *(landed in S10.10)* | All if/else-if shall be terminated with `else` | `BlockSequence.c` (3), `SolidSyslogFormatter.c` (2), `SolidSyslogTlsStream.c` (1) | **Fix — landed in S10.10** | Added trailing `else { /* explanatory comment */ }` to ten if/else-if chains spanning Core and Platform. Empty bodies document the residual case the existing branches do not cover. | **S10.10** |
@@ -124,40 +132,40 @@ Each row carries the cppcheck addon's count. The verdict reflects how the rule s
 | **8.4** | 8 | Compatible declaration shall be visible | `SolidSyslogStdAtomicU32.c` (4), `SolidSyslogWindowsAtomicU32.c` (4) | **Fix** | Atomics adapters define functions whose external prototype lives in a header that should be visible at definition. Add include or forward decl. | **S10.11** (security policies + CRC + sync primitives) |
 | **12.1** (advisory) | 5 → 0 *(landed in S10.10; +3 sites surfaced after the 10.4 sweep were swept along; +2 surfaced after the STATIC_ASSERT polyfill switch were also cleared)* | Operator precedence should be explicit | `SolidSyslogCircularBuffer.c` (3), `SolidSyslogAtomicCounter.c` (1), `SolidSyslogTlsStream.c` (1) | **Fix — landed in S10.10** | Added explicit parens around sub-expressions mixing comparison with arithmetic or logical operators. One ternary in `SolidSyslogUdpPayload_FromMtu` refactored to an if/return — cppcheck-misra continued to flag the return-of-ternary form even after bracketing both arms. | **S10.10** |
 | **17.8** | 5 | Function parameter should not be modified | `SolidSyslogFormatter.c` (3), `SolidSyslogError.c` (1), `SolidSyslogUdpPayload.c` (1) | **Fix** | Introduce a local copy. | **S10.17** for Formatter; mixed for the rest |
-| **5.6** | 5 → 0 *(landed in S10.10)* | Typedef names unique | `SolidSyslogBlockStore.c` (1), `SolidSyslogCircularBuffer.c` (1), `SolidSyslogFileBlockDevice.c` (1) | **Fix — landed in S10.10** | Audit verdict had been "per-site review"; the actual cause was the project's `SOLIDSYSLOG_STATIC_ASSERT` polyfill emitting the same `typedef char solidsyslog_static_assert_[...]` in every TU. Replaced the negative-array polyfill with a C11 `_Static_assert` wrapper (the library compiles at `--std=c11`); the new form has no typedef and so cannot trigger 5.6. The unavoidable `#` stringify in the wrapper is captured by deviation **D.011** (Rule 20.10). | **S10.10** |
+| **5.6** | 5 → 0 *(landed in S10.10)* | Typedef names unique | `SolidSyslogBlockStore.c` (1), `SolidSyslogCircularBuffer.c` (1), `SolidSyslogFileBlockDevice.c` (1) | **Fix — landed in S10.10** | Audit verdict had been "per-site review"; the actual cause was the project's `SOLIDSYSLOG_STATIC_ASSERT` polyfill emitting the same `typedef char solidsyslog_static_assert_[...]` in every TU. Replaced the negative-array polyfill with a C11 `_Static_assert` wrapper (the library compiles at `--std=c11`); the new form has no typedef and so cannot trigger 5.6. The unavoidable `#` stringify in the wrapper is captured by deviation **D.010** (Rule 20.10). | **S10.10** |
 | **18.4** (advisory) | 4 | `+`, `-`, `+=`, `-=` shall not be applied to pointer types | `RecordStore.c` (4) | **Deviate** | RecordStore manipulates record buffers using pointer arithmetic by design (magic byte offset → length offset → message offset, etc.). This is the natural C expression for the algorithm. Document as deviation. | **S10.06** (D.004) |
 | **15.5** (advisory) | 4 | Function should have single exit point | `SolidSyslogFormatter.c` (3), `SolidSyslog.c` (1) | **Fix** | Already a documented project preference ("Production code (Tier 1, Core/Source/) — Single return per function" in CLAUDE.md). Real drift. | **S10.17** (core message pipeline) |
 | **11.5** | 4 | Conversion from pointer to void to pointer to object | `SolidSyslogWinsockTcpStream.c` (2), `SolidSyslogUdpSender.c` (1), `SolidSyslogWinsockDatagram.c` (1) | **Deviate** | Same opaque-type / vtable pattern as 11.3. | **S10.06** (with D.002) |
-| **21.10** | 3 | `wchar.h` shall not be used | `SolidSyslogPosixClock.c` (1), `SolidSyslogPosixSleep.c` (1), `SolidSyslogPosixSysUpTime.c` (1) | **Deviate** *(resolved in S10.06)* | All three sites are `#include <time.h>` — glibc transitively pulls in `<wchar.h>` via `bits/types/struct_tm.h`. No direct `<wchar.h>` use anywhere in the project. Captured as **D.008**. | landed in **S10.06** |
+| **21.10** | 3 | `wchar.h` shall not be used | `SolidSyslogPosixClock.c` (1), `SolidSyslogPosixSleep.c` (1), `SolidSyslogPosixSysUpTime.c` (1) | **Deviate** *(resolved in S10.06)* | All three sites are `#include <time.h>` — glibc transitively pulls in `<wchar.h>` via `bits/types/struct_tm.h`. No direct `<wchar.h>` use anywhere in the project. Captured as **D.007**. | landed in **S10.06** |
 | **22.10** | 3 | The value of `errno` shall be checked only after a function that may set it | `SolidSyslogPosixTcpStream.c` (2), `SolidSyslogPosixDatagram.c` (1) | **Fix** | We currently read `errno` in some places where the preceding function isn't documented to set it (or we check before re-calling). Per-site review. | **S10.15** (sender platform impls) |
 | **8.6** | 3 | Identifier with external linkage shall have exactly one external definition | `SolidSyslogAddress.c` (1 each across Posix/Windows/FreeRtos) | **Fix** | Either missing definition or duplicate declaration of `Address` helpers — needs per-site investigation. | **S10.15** |
 | **10.8** | 2 → 0 *(landed in S10.10)* | Composite-expression cast to wider essential type | `SolidSyslog.c` (2) | **Fix — landed in S10.10** | Hoisted the `(uint32_t)` cast to the top of `SolidSyslog_FormatNonZeroUtcOffset` so the hours/minutes split uses `uint32_t / 60U` and `% 60U` without casting a composite expression. | **S10.10** |
 | **18.7** (advisory) | 2 | Flexible array members shall not be declared | `SolidSyslogCircularBuffer.c` (1), `SolidSyslogFormatter.c` (1) | **Deviate** | Flexible array members are the storage mechanism for `SolidSyslogFormatter` and `SolidSyslogCircularBuffer` — they hold caller-supplied storage of variable size. Removing them would require copying or fixed-size buffers. Document as deviation. | **S10.06** (D.005) |
-| **1.4** (advisory) | 2 | Emergent language features shall not be used | `SolidSyslogStdAtomicU32.c` (1), `SolidSyslogWindowsAtomicU32.c` (1) | **Deviate** | C11 `<stdatomic.h>` is the project's atomic primitive on POSIX/clang/gcc/modern MSVC; we deliberately use C11 here and the alternative (`InterlockedCompareExchange`) is selected at link time on legacy MSVC. Use of C11 atomics is intentional, not accidental. | **S10.06** (D.006) |
-| **2.5** (advisory) | 2 → 0 *(landed in S10.10)* | Unused macro | `SolidSyslogCircularBuffer.h` (2) | **Deviate — landed in S10.10** | Audit verdict had been "delete them" — that was wrong. The two `SOLIDSYSLOG_CIRCULAR_BUFFER_STORAGE_SIZE[_BYTES]` macros are part of the public API; their consumers live under `Tests/` (Consistency-only tier) and `Bdd/Targets/` (Out of scope), so cppcheck-misra cannot see the call sites. Captured as **D.012**. | **S10.10** |
+| **1.4** (advisory) | 2 | Emergent language features shall not be used | `SolidSyslogStdAtomicU32.c` (1), `SolidSyslogWindowsAtomicU32.c` (1) | **Deviate** *(retired in S11.11)* | C11 `<stdatomic.h>` is the project's atomic primitive on POSIX/clang/gcc/modern MSVC; we deliberately use C11 here and the alternative (`InterlockedCompareExchange`) is selected at link time on legacy MSVC. Use of C11 atomics is intentional, not accidental. | **S10.06** (D.006-original — retired in **S11.11**: cppcheck 2.10 no longer flags this site) |
+| **2.5** (advisory) | 2 → 0 *(landed in S10.10)* | Unused macro | `SolidSyslogCircularBuffer.h` (2) | **Deviate — landed in S10.10** | Audit verdict had been "delete them" — that was wrong. The two `SOLIDSYSLOG_CIRCULAR_BUFFER_STORAGE_SIZE[_BYTES]` macros are part of the public API; their consumers live under `Tests/` (Consistency-only tier) and `Bdd/Targets/` (Out of scope), so cppcheck-misra cannot see the call sites. Captured as **D.011**. | **S10.10** |
 | **3.1** | 1 → 0 *(landed in S10.10)* | `/* */` shall not contain comment-start sequence | `SolidSyslogCrc16.c` (1) | **Fix — landed in S10.10** | The Crc16 banner contained a `https://` URL — the `//` inside the `/* */` is a nested comment-start. Dropped the protocol prefix and rephrased the citation. | **S10.10** |
 | **7.1** | 1 → 0 *(landed in S10.10)* | Octal constants shall not be used | `SolidSyslogPosixMessageQueueBuffer.c` (1) | **Fix — landed in S10.10** | `0600` (Posix file mode) replaced with a named hex enum `OWNER_READ_WRITE = 0x180U` in the file-scope anonymous-enum block. | **S10.10** |
-| **21.6** | 1 | The Standard Library `stdio.h` shall not be used | `SolidSyslogWindowsFile.c` (1) | **Deviate** *(resolved in S10.06)* | `WindowsFile.c` includes `<stdio.h>` solely for `SEEK_SET` / `SEEK_END` constants used by `_lseeki64` from `<io.h>`; no stdio function or type is referenced. Captured as **D.009**. | landed in **S10.06** |
+| **21.6** | 1 | The Standard Library `stdio.h` shall not be used | `SolidSyslogWindowsFile.c` (1) | **Deviate** *(resolved in S10.06)* | `WindowsFile.c` includes `<stdio.h>` solely for `SEEK_SET` / `SEEK_END` constants used by `_lseeki64` from `<io.h>`; no stdio function or type is referenced. Captured as **D.008**. | landed in **S10.06** |
 | **14.4** | 1 → 0 *(landed in S10.10)* | Controlling expression shall have essentially Boolean type | `SolidSyslogWindowsHostname.c` (1) | **Fix — landed in S10.10** | `GetComputerNameExA` returns `BOOL` (typedef `int`); the if now compares `!= FALSE` so the controlling expression is a real boolean result. | **S10.10** |
-| **2.4** (advisory) | 1 → 6 *(resolved in S10.06)* | A project should not contain unused tag declarations | Re-run with D.002–D.009 suppressions surfaced 5 more anonymous-`enum { … };` sites previously hidden behind 5.7 — the audit's original count understated the rule. All 6 sites are the project's anonymous-`enum` named-constant idiom (≈31 such blocks tree-wide). | **Deviate** | Captured as **D.010**. The anonymous-`enum` idiom is project-wide and intentional (type-safe constants without `#define`). | landed in **S10.06** |
+| **2.4** (advisory) | 1 → 6 *(resolved in S10.06)* | A project should not contain unused tag declarations | Re-run with D.002–D.008 suppressions surfaced 5 more anonymous-`enum { … };` sites previously hidden behind 5.7 — the audit's original count understated the rule. All 6 sites are the project's anonymous-`enum` named-constant idiom (≈31 such blocks tree-wide). | **Deviate** | Captured as **D.009**. The anonymous-`enum` idiom is project-wide and intentional (type-safe constants without `#define`). | landed in **S10.06** |
 
 ### MISRA totals by verdict
 
 | Verdict | Count | Rules |
 |---------|------:|-------|
 | **Fix — landed in S10.08** — rule 5.9 (static-function `Class_` prefix sweep) | 168 → 0 | 5.9 |
-| **Fix — landed in S10.10** — mechanical sweep (uniform U-suffixes, parens, trailing-else, …) + Rule 5.6 polyfill | 130 → 0 | 10.4 (92), 10.1 (11), 15.7 (10), 12.1 (5), 5.6 (5), 10.8 (2), 2.5 (2 — graduated to Deviate as D.012), 14.4 (1), 7.1 (1), 3.1 (1) |
+| **Fix — landed in S10.10** — mechanical sweep (uniform U-suffixes, parens, trailing-else, …) + Rule 5.6 polyfill | 130 → 0 | 10.4 (92), 10.1 (11), 15.7 (10), 12.1 (5), 5.6 (5), 10.8 (2), 2.5 (2 — graduated to Deviate as D.011), 14.4 (1), 7.1 (1), 3.1 (1) |
 | **Fix** — other rules (per-component sweeps S10.11+) | 90 | 8.9, 17.7, 8.4, 17.8, 15.5, 22.10, 8.6 |
-| **Deviate** — landed in S10.06 (D.002–D.010) | 187 | 11.3, 11.2, 11.5 *(D.002)*; 5.7 *(D.003)*; 18.4 *(D.004)*; 18.7 *(D.005)*; 1.4 *(D.006)*; 11.8 *(D.007)*; 21.10 *(D.008)*; 21.6 *(D.009)*; 2.4 *(D.010)* |
-| **Deviate** — landed in S10.10 (D.011, D.012) | 3 | 20.10 *(D.011, 1 site — `#` stringify in `_Static_assert` wrapper)*; 2.5 *(D.012, 2 sites — public API macros consumed under `Tests/` and `Bdd/Targets/`)* |
+| **Deviate** — landed in S10.06 (D.002–D.009; D.006-original / rule 1.4 retired in **S11.11**) | 187 | 11.3, 11.2, 11.5 *(D.002)*; 5.7 *(D.003)*; 18.4 *(D.004)*; 18.7 *(D.005)*; 1.4 *(retired S11.11)*; 11.8 *(D.006)*; 21.10 *(D.007)*; 21.6 *(D.008)*; 2.4 *(D.009)* |
+| **Deviate** — landed in S10.10 (D.010, D.011) | 3 | 20.10 *(D.010, 1 site — `#` stringify in `_Static_assert` wrapper)*; 2.5 *(D.011, 2 sites — public API macros consumed under `Tests/` and `Bdd/Targets/`)* |
 | **Disable** | 0 | — |
-| **Total reconciled** | **388 Fix + 190 Deviate = 575** (rule 2.5 moved from Fix to Deviate per D.012; raw `Fix` reduced by 2, raw `Deviate` increased by 3 with the new D.011 = +1) | Raw count includes 5 dual-rule overlaps (same code site reported under two rules, e.g. 11.2 + 11.3 cast in `Address.c`). |
+| **Total reconciled** | **388 Fix + 190 Deviate = 575** (rule 2.5 moved from Fix to Deviate per D.011; raw `Fix` reduced by 2, raw `Deviate` increased by 3 with the new D.010 = +1) | Raw count includes 5 dual-rule overlaps (same code site reported under two rules, e.g. 11.2 + 11.3 cast in `Address.c`). |
 
 The verdict surface evolved from the audit's headline:
-- S10.06 added D.008 / D.009 (Investigate items) and D.010 (D.003
+- S10.06 added D.007 / D.008 (Investigate items) and D.009 (D.003
   suppression revealed 5 more 2.4 findings).
-- S10.10 added D.011 (20.10 — stringify in the new `_Static_assert`
-  polyfill wrapper) and D.012 (2.5 — re-categorised from "delete
+- S10.10 added D.010 (20.10 — stringify in the new `_Static_assert`
+  polyfill wrapper) and D.011 (2.5 — re-categorised from "delete
   unused" when the audit's verdict was found to be wrong; the macros
   are consumed outside the cppcheck-misra scope).
 
@@ -193,7 +201,7 @@ Rough order-of-magnitude for sweep planning. These are **upper bounds** (some Fi
 | S10.09 *(was the S10.07-sibling slot; named in S10.09 issue)* | Data members lowerCamelCase → PascalCase per Tier 4 re-statement — **landed** | 186 → 0 |
 | S10.08 | Static functions → `Class_Function` (MISRA 5.9) | 168 |
 | Abbreviation purge *(deferred — separate cross-cutting story, not yet raised)* | Locals/parameters and function-name abbreviations — different lens, scope still to be sized | TBD |
-| **S10.10** *(was "Mechanical MISRA sweep" — picked up the next free story number)* | Tree-wide hybrid mechanical fixes — **landed**: 10.4 (92), 10.1 (11), 15.7 (10), 12.1 (5+drift), 5.6 (5), 10.8 (2), 2.5 (2, became D.012), 14.4 (1), 7.1 (1), 3.1 (1). +2 new deviations: D.011 (20.10), D.012 (2.5). | 130 → 0 |
+| **S10.10** *(was "Mechanical MISRA sweep" — picked up the next free story number)* | Tree-wide hybrid mechanical fixes — **landed**: 10.4 (92), 10.1 (11), 15.7 (10), 12.1 (5+drift), 5.6 (5), 10.8 (2), 2.5 (2, became D.011), 14.4 (1), 7.1 (1), 3.1 (1). +2 new deviations: D.010 (20.10), D.011 (2.5). | 130 → 0 |
 | S10.11 *(was S10.10 in audit-era numbering)* | Buffers pilot — receives 8.9 + 17.7 + 17.8 fragments | small (~5–10) |
 | S10.12 | SecurityPolicies + CRC + Sync — receives 8.4 + 2.5 fragments | ~10 |
 | S10.13 | Config + platform helpers — receives 14.4 fragment | small (~5) |
@@ -221,17 +229,17 @@ under a single review:
 |------|------------:|------------:|-----------|
 | 10.4 | 92 | 0 | Add `U` suffix to integer literals; occasional cast |
 | 12.1 | 5 | 0 | Add explicit precedence parentheses |
-| 2.5 | 2 | 0 | Audit said "delete"; actually consumed outside cppcheck scope — became D.012 |
+| 2.5 | 2 | 0 | Audit said "delete"; actually consumed outside cppcheck scope — became D.011 |
 | 15.7 | 10 | 0 | Add trailing `else { /* exhaustive */ }` |
 | 10.8 | 2 | 0 | Hoist cast above composite expression |
 | 10.1 | 11 | 0 | Bool/char essential-type mismatch — cast to `unsigned char` + hex literals |
 | 5.6 | 5 | 0 | Switch `SOLIDSYSLOG_STATIC_ASSERT` polyfill to C11 `_Static_assert` |
-| 2.4 | 1 → graduated to Deviate in S10.06 (D.010) before S10.10 ran | — | — |
+| 2.4 | 1 → graduated to Deviate in S10.06 (D.009) before S10.10 ran | — | — |
 | 3.1 | 1 | 0 | Disambiguate `//` inside a `/* */` URL |
 | 7.1 | 1 | 0 | Replace `0600` octal with named hex `OWNER_READ_WRITE = 0x180U` |
 | 14.4 | 1 | 0 | `BOOL` comparison with `!= FALSE` instead of bare value |
 | **S10.10 total** | **131** *(126 mechanical + 5 polyfill)* | **0** | |
-| **New deviations introduced as byproducts** | — | — | D.011 (20.10, 1 site — stringify); D.012 (2.5, 2 sites — public API macros) |
+| **New deviations introduced as byproducts** | — | — | D.010 (20.10, 1 site — stringify); D.011 (2.5, 2 sites — public API macros) |
 
 **Per-component sweep targets** *(absorbed into S10.10–S10.17)* —
 fixes that need local file context to apply correctly:

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -110,7 +110,7 @@ document under [S10.01](https://github.com/DavidCozens/solid-syslog/issues/357).
 
 ---
 
-## D.002 — Rules 11.2 / 11.3 / 11.5: opaque-impl + caller-supplied-storage
+## D.002 — Rules 11.2 / 11.3 / 11.5: vtable downcasts + Address + Formatter
 
 ### Rule
 
@@ -125,70 +125,75 @@ document under [S10.01](https://github.com/DavidCozens/solid-syslog/issues/357).
 
 ### Deviation
 
-SolidSyslog accepts pointer conversions between caller-supplied storage
-buffers and the implementation struct that owns the storage. The
-conversion takes one of three shapes:
+SolidSyslog accepts three structural pointer conversions that are
+identified in code as `SelfFromBase` (vtable) or `(struct X*) storage`
+(Address / Formatter). All three are reviewed once here, not per call
+site.
+
+#### (a) Vtable downcasts — every pool-allocated class
+
+Every implementation class that participates in a vtable interface
+(`SolidSyslogBuffer`, `SolidSyslogSender`, `SolidSyslogStream`,
+`SolidSyslogDatagram`, `SolidSyslogStore`, `SolidSyslogMutex`,
+`SolidSyslogFile`, `SolidSyslogBlockDevice`, `SolidSyslogAtomicCounter`,
+`SolidSyslogResolver`, `SolidSyslogStructuredData`,
+`SolidSyslogSecurityPolicy`) carries a `static inline ... *SelfFromBase(...)`
+helper that downcasts the public base pointer back to the concrete
+implementation struct so vtable methods can reach their own state:
 
 ```c
-struct SolidSyslogXImpl* impl = (struct SolidSyslogXImpl*) storage;
+static inline struct SolidSyslogCircularBuffer*
+CircularBuffer_SelfFromBase(struct SolidSyslogBuffer* base)
+{
+    return (struct SolidSyslogCircularBuffer*) base;
+}
 ```
 
-where `storage` is a `SolidSyslogXStorage*` (an opaque public type whose
-size is exposed via `SOLIDSYSLOG_X_STORAGE_SIZE`), or where the
-conversion goes via `void*` at vtable boundaries.
+Rule 11.3 fires on every such cast. This is the standard OO-in-C
+"interface pointer back to derived implementation" cast that every
+vtable method needs.
 
-### Scope
+#### (b) `SolidSyslogAddress` — strict-tier opaque value type
 
-- **Strict tier** — every `_Create` function in `Core/Source/` that
-  uses the caller-supplied-storage pattern (≈30 classes).
-- **Pragmatic tier** — every platform-specific `_Create` and `Address`
-  helper under `Platform/*/Source/`.
+`Address.h` exposes an opaque public type with a caller-supplied
+storage shape (`SolidSyslogAddressStorage` + `SOLIDSYSLOG_ADDRESS_SIZE`)
+across three platform-specific implementations
+(`Platform/{FreeRtos,Posix,Windows}/Source/SolidSyslogAddressInternal.h`).
+Address is a transient value type, not a Created object — it has no
+`_Create`/`_Destroy` lifecycle and so was deliberately left out of E11's
+pool migration. Rules 11.2 / 11.3 / 11.5 all fire on the casts between
+`SolidSyslogAddress*` (incomplete public type) and the platform
+implementation struct.
+
+#### (c) `SolidSyslogFormatter` — variable-size stack builder
+
+`SolidSyslogFormatter` is a transient stack-built builder whose backing
+storage is sized at the call site via the
+`SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(n)` macro. Variable-size means it
+cannot fit the fixed-pool pattern used elsewhere in the library — its
+lifecycle is fundamentally per-call, not per-class. Rules 11.2 / 11.3
+fire on the cast between `SolidSyslogFormatterStorage*` and `struct
+SolidSyslogFormatter*`.
 
 ### Rationale
 
-The caller-supplied-storage pattern is foundational to SolidSyslog's
-embedded-friendly design — every `_Create` takes a pointer to caller
-memory of the size advertised by the matching `SOLIDSYSLOG_X_STORAGE_SIZE`
-constant, places the implementation struct in that memory, and returns
-a pointer of the opaque public type. The alternatives all conflict with
-project constraints:
-
-| Alternative | Why rejected |
-|-------------|--------------|
-| Dynamic allocation (`malloc`) | Not available on bare-metal, FreeRTOS-static-allocation, or DO-178C-style targets. SolidSyslog is callable from boot before any heap exists. |
-| Public concrete types | Leaks the implementation through the public API; ties integrators to internal layout and breaks ABI stability. |
-| Pass-by-value structs | Doubles the parameter footprint of every `_Create`; breaks the vtable indirection that decouples Core from Platform. |
-
-`Address.h` (Strict tier, opaque `SolidSyslogAddress`) and every
-caller-storage class (BlockStore, Formatter, the
-FreeRTOS/Posix/Windows mutexes and streams, …) hit the same three
-rules for the same structural reason — one deviation document
-covers all of them.
-
-Note that `SolidSyslogCircularBuffer` moved off this pattern under
-E11 (S11.01): the instance struct now lives in a library-internal
-static pool, and the caller supplies only the ring memory as
-plain `uint8_t* ring, size_t ringBytes`. No `void*` storage cast on
-the instance; the ring pointer is held untyped inside the impl
-struct.
-
-The 11.3 suppression listed against `Core/Source/SolidSyslogCircularBuffer.c`
-post-E11 is therefore narrower than the rest of the entries above: it
-covers only the **vtable downcast** inside `CircularBuffer_SelfFromBase`
-(`struct SolidSyslogBuffer*` → `struct SolidSyslogCircularBuffer*`), the
-standard OO-in-C "interface pointer back to derived implementation" cast
-that every vtable method needs. The same downcast survives in every
-caller-storage class listed above as a separate concern from the
-caller-storage void* cast; this deviation covers both shapes under one
-heading because both are MISRA 11.3 firings driven by the same
-"interface decoupled from concrete type" design.
+The pool migration under E11 retired the caller-supplied-storage pattern
+for every class that has a Create/Destroy lifecycle, leaving only the
+vtable downcast (which is required by the OO-in-C interface decoupling)
+and the two non-pool exceptions above (Address as a value type,
+Formatter as a per-call builder). All three would otherwise require
+either dynamic allocation (not available on bare-metal / FreeRTOS-
+static-allocation / DO-178C-style targets — the library is callable from
+boot before any heap exists) or leaking the implementation struct
+through the public API (breaks ABI stability and the embedded-friendly
+opaque-type design).
 
 ### Risk and mitigation
 
-- **Type safety** — Each `_Create` is the only place in the library
-  that knows the relationship between `SolidSyslogXStorage` and
-  `struct SolidSyslogXImpl`. A `_Static_assert` immediately below
-  every impl definition pins the relationship at build time:
+- **Type safety** — For (b) Address and (c) Formatter, a
+  `_Static_assert` immediately below the impl definition pins the
+  relationship between the public storage type and the private impl
+  struct at build time:
 
   ```c
   SOLIDSYSLOG_STATIC_ASSERT(
@@ -197,21 +202,27 @@ heading because both are MISRA 11.3 firings driven by the same
   );
   ```
 
-  An integrator who allocates undersized storage is caught at
-  compile time, not at runtime.
-- **Alignment** — The storage type is declared as
-  `intptr_t storage[N]` (or a struct of the same shape), giving
-  alignment at least as strict as any pointer or scalar the impl
-  contains. The cast is therefore well-defined per §6.3.2.3.
+  An integrator who allocates undersized storage is caught at compile
+  time. For (a) vtable downcasts, type safety is enforced by the
+  contract that each vtable method receives is only called via the
+  vtable installed in its own `SelfFromBase`-aware implementation.
+- **Alignment** — Storage types are declared as `intptr_t storage[N]`
+  (or a struct of the same shape), giving alignment at least as strict
+  as any pointer or scalar the impl contains. The cast is therefore
+  well-defined per §6.3.2.3.
 - **Static analysis** — These rules are advisory (11.5) or required
-  (11.2, 11.3). All 109 findings are suppressed via
+  (11.2, 11.3). All current findings are suppressed via
   `misra_suppressions.txt` referencing this section. The pattern is
   reviewed once here, not per call site.
 
 ### Approval
 
 Project owner — David Cozens. Recorded under
-[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
+[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367); scope
+narrowed under
+[S11.11](https://github.com/DavidCozens/solid-syslog/issues/414) once
+every Create-lifecycle class moved off caller-supplied storage onto the
+pool allocator.
 
 ---
 

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -398,73 +398,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.006 — Rule 1.4: emergent C language features (C11 `<stdatomic.h>`)
-
-### Rule
-
-> **Rule 1.4 (Required)** — Emergent language features, such as
-> non-standard extensions and deprecated features, shall not be used.
-
-cppcheck-misra's interpretation of "emergent" includes C11 features in
-projects that otherwise target C99. SolidSyslog's `--std=c11` build flag
-is set because one source file needs `<stdatomic.h>`; the rest of the
-codebase is C99.
-
-### Deviation
-
-`Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c` includes
-`<stdatomic.h>` and uses `_Atomic uint32_t` plus
-`atomic_compare_exchange_strong_explicit`. Its sibling
-`Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c` does not
-use C11 atomics — it uses `volatile LONG` + `InterlockedCompareExchange`,
-selected at link time on toolchains without `<stdatomic.h>`.
-
-### Scope
-
-One source file:
-
-- `Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c`
-
-The Windows AtomicCounter sibling uses only Win32 APIs and stays
-C99-compatible — no 1.4 suppression needed for it.
-
-### Rationale
-
-The atomic counter (`SolidSyslogAtomicCounter`) needs a portable
-compare-and-swap primitive across hosted POSIX, hosted Windows, and
-FreeRTOS targets. Three primitives are practical:
-
-1. **`<stdatomic.h>`** — the C11 standard. Available on gcc/clang
-   universally, on MSVC 2022+, and explicitly selected by the Atomics
-   CMake module when `HAVE_STDATOMIC_H` is set.
-2. **`InterlockedCompareExchange`** — Win32 API. Selected by the same
-   CMake module when `HAVE_WINDOWS_INTERLOCKED` is set (legacy MSVC,
-   pre-2022, and MinGW configurations without `<stdatomic.h>`).
-3. **Hand-rolled CAS in assembly** — rejected: not portable, requires
-   per-target maintenance.
-
-The C11 primitive is the only option that is both portable across all
-hosted targets and visible to the cppcheck-misra audit. The Atomics
-module makes the choice at configure time; integrators on toolchains
-without `<stdatomic.h>` automatically get the Win32 path with no
-source-code change.
-
-### Risk and mitigation
-
-- **C99 baseline drift.** The project's C99 baseline is preserved
-  everywhere except in this TU (and the macros that gate it).
-  No C11 feature leaks into public headers.
-- **Future C standards.** If C23's deprecation paths affect
-  `<stdatomic.h>`, the Atomics module is the single migration point.
-
-### Approval
-
-Project owner — David Cozens. Recorded under
-[S10.06](https://github.com/DavidCozens/solid-syslog/issues/367).
-
----
-
-## D.007 — Rule 11.8: `const` qualification under field access of `const struct*`
+## D.006 — Rule 11.8: `const` qualification under field access of `const struct*`
 
 ### Rule
 
@@ -549,7 +483,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.008 — Rule 21.10: transitive `<wchar.h>` via `<time.h>`
+## D.007 — Rule 21.10: transitive `<wchar.h>` via `<time.h>`
 
 ### Rule
 
@@ -602,7 +536,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.009 — Rule 21.6: `<stdio.h>` for `SEEK_SET` / `SEEK_END` only
+## D.008 — Rule 21.6: `<stdio.h>` for `SEEK_SET` / `SEEK_END` only
 
 ### Rule
 
@@ -657,7 +591,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.010 — Rule 2.4: anonymous `enum` used as named-constant container
+## D.009 — Rule 2.4: anonymous `enum` used as named-constant container
 
 ### Rule
 
@@ -739,7 +673,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.011 — Rule 20.10: `#` stringification in `_Static_assert` polyfill
+## D.010 — Rule 20.10: `#` stringification in `_Static_assert` polyfill
 
 ### Rule
 
@@ -803,7 +737,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.012 — Rule 2.5: public API macros consumed outside the cppcheck-misra scope
+## D.011 — Rule 2.5: public API macros consumed outside the cppcheck-misra scope
 
 ### Rule
 

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -9,7 +9,7 @@
 # Format: misra-c2012-<rule>:<file>:<line>
 # Lines starting with # are comments.
 
-# D.002 — Rules 11.2 / 11.3 / 11.5: opaque-impl + caller-supplied-storage
+# D.002 — Rules 11.2 / 11.3 / 11.5: vtable downcasts + Address + Formatter
 # See docs/misra-deviations.md#d002
 misra-c2012-11.2:Core/Interface/SolidSyslogFormatter.h:30
 misra-c2012-11.2:Platform/FreeRtos/Source/SolidSyslogAddress.c:5

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -22,176 +22,176 @@ misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddress.c:5
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddressInternal.h:17
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogAddressInternal.h:23
 misra-c2012-11.3:Core/Interface/SolidSyslogFormatter.h:30
-misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:82
-misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:165
+misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:69
 misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:87
 misra-c2012-11.3:Core/Source/SolidSyslogFileBlockDevice.c:102
 misra-c2012-11.3:Core/Source/SolidSyslogFormatter.c:93
-misra-c2012-11.3:Core/Source/SolidSyslogMetaSd.c:83
-misra-c2012-11.3:Core/Source/SolidSyslogPassthroughBuffer.c:54
-misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:84
-misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:147
-misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:66
-misra-c2012-11.3:Core/Source/SolidSyslogTimeQualitySd.c:63
-misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:149
-misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:67
-misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:74
-misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:63
-misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:81
+misra-c2012-11.3:Core/Source/SolidSyslogMetaSd.c:51
+misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:69
+misra-c2012-11.3:Core/Source/SolidSyslogPassthroughBuffer.c:49
+misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:148
+misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:59
+misra-c2012-11.3:Core/Source/SolidSyslogTimeQualitySd.c:59
+misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:98
+misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:36
+misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:53
 misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddress.c:5
 misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:20
 misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogAddressInternal.h:26
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c:70
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c:82
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c:44
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c:57
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c:65
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c:76
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:104
-misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:116
-misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:97
-misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:110
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c:62
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c:52
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c:50
+misra-c2012-11.3:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:112
+misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:85
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddress.c:5
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddressInternal.h:18
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogAddressInternal.h:24
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:76
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:74
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:91
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:96
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:37
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:50
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:95
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:107
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:77
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixFile.c:66
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:99
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:47
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:88
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddress.c:5
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddressInternal.h:18
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogAddressInternal.h:24
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c:72
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c:79
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:78
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:95
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:37
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:50
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:114
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:174
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:186
-misra-c2012-11.5:Core/Source/SolidSyslogUdpSender.c:253
-misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:136
-misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:330
-misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:350
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c:40
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsFile.c:73
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsMutex.c:34
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:116
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:168
+misra-c2012-11.5:Core/Source/SolidSyslogUdpSender.c:202
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:138
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:312
+misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:332
 
-# D.003 — Rule 5.7: no-typedef-struct repeating tags
+# D.003 — Rule 5.7: repeating struct tags (no-typedef-struct convention)
 # See docs/misra-deviations.md#d003
 misra-c2012-5.7:Core/Interface/SolidSyslogAddress.h:10
-misra-c2012-5.7:Core/Interface/SolidSyslogBlockStore.h:52
+misra-c2012-5.7:Core/Interface/SolidSyslogAtomicCounter.h:11
 misra-c2012-5.7:Core/Interface/SolidSyslogCircularBuffer.h:17
 misra-c2012-5.7:Core/Interface/SolidSyslogEndpoint.h:11
-misra-c2012-5.7:Core/Interface/SolidSyslogFileBlockDevice.h:14
 misra-c2012-5.7:Core/Interface/SolidSyslogFormatter.h:14
 misra-c2012-5.7:Core/Interface/SolidSyslogSecurityPolicyDefinition.h:13
-misra-c2012-5.7:Core/Source/SolidSyslogStreamSender.c:19
 misra-c2012-5.7:Core/Interface/SolidSyslogTimeQuality.h:12
 misra-c2012-5.7:Core/Interface/SolidSyslogTransport.h:5
 misra-c2012-5.7:Core/Interface/SolidSyslogUdpPayload.h:15
-misra-c2012-5.7:Core/Source/BlockSequence.c:6
-misra-c2012-5.7:Core/Source/BlockSequence.c:92
+misra-c2012-5.7:Core/Source/BlockSequence.c:13
+misra-c2012-5.7:Core/Source/BlockSequence.c:107
+misra-c2012-5.7:Core/Source/RecordStore.c:14
+misra-c2012-5.7:Core/Source/RecordStorePrivate.h:14
+misra-c2012-5.7:Core/Source/SolidSyslog.c:30
 misra-c2012-5.7:Core/Source/SolidSyslogCircularBuffer.c:15
-misra-c2012-5.7:Core/Source/RecordStore.c:9
-misra-c2012-5.7:Core/Source/RecordStore.h:14
-misra-c2012-5.7:Core/Source/SolidSyslog.c:26
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16.c:12
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16Policy.c:10
 misra-c2012-5.7:Core/Source/SolidSyslogFileBlockDevice.c:16
 misra-c2012-5.7:Core/Source/SolidSyslogFileBlockDevice.c:23
-misra-c2012-5.7:Core/Source/SolidSyslogOriginSd.c:6
+misra-c2012-5.7:Core/Source/SolidSyslogOriginSdPrivate.h:9
+misra-c2012-5.7:Core/Source/SolidSyslogStreamSender.c:20
 misra-c2012-5.7:Core/Source/SolidSyslogUdpPayload.c:5
-misra-c2012-5.7:Core/Interface/SolidSyslogAtomicCounter.h:11
-misra-c2012-5.7:Platform/Atomics/Interface/SolidSyslogStdAtomicCounter.h:13
-misra-c2012-5.7:Platform/FatFs/Interface/SolidSyslogFatFsFile.h:20
-misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosDatagram.h:13
-misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosMutex.h:13
-misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosStaticResolver.h:13
-misra-c2012-5.7:Platform/FreeRtos/Interface/SolidSyslogFreeRtosTcpStream.h:13
 misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosSysUpTime.c:7
-misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:48
-misra-c2012-5.7:Platform/OpenSsl/Interface/SolidSyslogTlsStream.h:14
-misra-c2012-5.7:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:14
-misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixFile.h:13
-misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixMutex.h:13
-misra-c2012-5.7:Platform/Posix/Interface/SolidSyslogPosixTcpStream.h:13
-misra-c2012-5.7:Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c:18
-misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixDatagram.c:19
-misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixFile.c:17
+misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c:45
+misra-c2012-5.7:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:16
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogGetAddrInfoResolver.c:20
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixDatagram.c:21
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixFile.c:18
 misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixHostname.c:10
-misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:13
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:17
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixMessageQueueBufferPrivate.h:11
 misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixSleep.c:6
 misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixSysUpTime.c:6
-misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:23
-misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWindowsFile.h:11
-misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWindowsMutex.h:13
-misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWinsockTcpStream.h:11
-misra-c2012-5.7:Platform/Windows/Interface/SolidSyslogWindowsAtomicCounter.h:13
+misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:24
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsClock.c:21
-misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsFile.c:20
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsFile.c:24
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsHostname.c:19
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c:18
-misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockResolver.c:33
-misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:91
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockResolver.c:37
+misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:100
 
 # D.004 — Rule 18.4: pointer arithmetic on record buffers
 # See docs/misra-deviations.md#d004
-misra-c2012-18.4:Core/Source/RecordStore.c:32
 misra-c2012-18.4:Core/Source/RecordStore.c:37
 misra-c2012-18.4:Core/Source/RecordStore.c:42
 misra-c2012-18.4:Core/Source/RecordStore.c:47
+misra-c2012-18.4:Core/Source/RecordStore.c:52
 
 # D.005 — Rule 18.7: flexible array members
 # See docs/misra-deviations.md#d005
 misra-c2012-18.7:Core/Source/SolidSyslogFormatter.c:12
 
-# D.006 — Rule 1.4: C11 <stdatomic.h>
+# D.006 — Rule 11.8: const-strip false-positives + Winsock platform-API
 # See docs/misra-deviations.md#d006
-misra-c2012-1.4:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:21
+misra-c2012-11.8:Core/Source/BlockSequence.c:465
+misra-c2012-11.8:Core/Source/SolidSyslog.c:94
+misra-c2012-11.8:Core/Source/SolidSyslog.c:95
+misra-c2012-11.8:Core/Source/SolidSyslog.c:96
+misra-c2012-11.8:Core/Source/SolidSyslog.c:97
+misra-c2012-11.8:Core/Source/SolidSyslog.c:98
+misra-c2012-11.8:Core/Source/SolidSyslog.c:99
+misra-c2012-11.8:Core/Source/SolidSyslog.c:100
+misra-c2012-11.8:Core/Source/SolidSyslog.c:101
+misra-c2012-11.8:Core/Source/SolidSyslogBlockStoreStatic.c:39
+misra-c2012-11.8:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:91
 
-# D.007 — Rule 11.8: const-strip false-positives + Winsock platform-API
+# D.007 — Rule 21.10: transitive <wchar.h> via <time.h>
 # See docs/misra-deviations.md#d007
-misra-c2012-11.8:Core/Source/BlockSequence.c:438
-misra-c2012-11.8:Core/Source/SolidSyslog.c:147
-misra-c2012-11.8:Core/Source/SolidSyslog.c:148
-misra-c2012-11.8:Core/Source/SolidSyslog.c:149
-misra-c2012-11.8:Core/Source/SolidSyslog.c:150
-misra-c2012-11.8:Core/Source/SolidSyslog.c:151
-misra-c2012-11.8:Core/Source/SolidSyslog.c:152
-misra-c2012-11.8:Core/Source/SolidSyslog.c:153
-misra-c2012-11.8:Core/Source/SolidSyslog.c:154
-misra-c2012-11.8:Core/Source/SolidSyslogBlockStore.c:65
-misra-c2012-11.8:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:82
-
-# D.008 — Rule 21.10: transitive <wchar.h> via <time.h>
-# See docs/misra-deviations.md#d008
 misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixClock.c:4
 misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixSleep.c:3
 misra-c2012-21.10:Platform/Posix/Source/SolidSyslogPosixSysUpTime.c:3
 
-# D.009 — Rule 21.6: <stdio.h> for SEEK_* constants only
-# See docs/misra-deviations.md#d009
+# D.008 — Rule 21.6: <stdio.h> for SEEK_* constants only
+# See docs/misra-deviations.md#d008
 misra-c2012-21.6:Platform/Windows/Source/SolidSyslogWindowsFile.c:8
 
-# D.010 — Rule 2.4: anonymous enum used as named-constant container
-# See docs/misra-deviations.md#d010
-misra-c2012-2.4:Core/Interface/SolidSyslogBlockStore.h:52
-misra-c2012-2.4:Core/Interface/SolidSyslogCircularBuffer.h:17
-misra-c2012-2.4:Core/Interface/SolidSyslogSecurityPolicyDefinition.h:13
+# D.009 — Rule 2.4: anonymous enum used as named-constant container
+# See docs/misra-deviations.md#d009
 misra-c2012-2.4:Core/Interface/SolidSyslogTransport.h:5
-misra-c2012-2.4:Core/Source/BlockSequence.c:6
-misra-c2012-2.4:Core/Source/BlockSequence.c:92
-misra-c2012-2.4:Core/Source/SolidSyslogCircularBuffer.c:15
-misra-c2012-2.4:Core/Source/SolidSyslogStreamSender.c:19
+misra-c2012-2.4:Core/Source/BlockSequence.c:13
+misra-c2012-2.4:Core/Source/BlockSequence.c:107
+misra-c2012-2.4:Core/Source/RecordStore.c:14
+misra-c2012-2.4:Core/Source/SolidSyslogStreamSender.c:20
 
-# D.011 — Rule 20.10: `#` stringification in _Static_assert polyfill
-# See docs/misra-deviations.md#d011
+# D.010 — Rule 20.10: # stringification in _Static_assert polyfill
+# See docs/misra-deviations.md#d010
 misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:9
 
-# D.012 — Rule 2.5: public API macros consumed outside cppcheck-misra scope
-# See docs/misra-deviations.md#d012
+# D.011 — Rule 2.5: public API macros consumed outside cppcheck-misra scope
+# See docs/misra-deviations.md#d011
 misra-c2012-2.5:Core/Interface/SolidSyslogCircularBuffer.h:22
-
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:68
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:70
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:72
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:74
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:76
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:78
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:80
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:82
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:84
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:86
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:88
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:90
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:92
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:94
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:96
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:98
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:100
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:102
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:104
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:106
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:108
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:110
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:112
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:114
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:116
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:118
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:120
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:122
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:124
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:126
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:128
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:130
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:132
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:134
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:136
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:138
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:140
+misra-c2012-2.5:Core/Source/SolidSyslogErrorMessages.h:142


### PR DESCRIPTION
## Purpose

Closes #414 and **closes E11** (#29). Final E11 story — audits
`misra_suppressions.txt` for honesty, sweeps stale docs references,
and retires the now-empty D.006-original deviation.

Per `feedback_cppcheck_misra_invariant`, the suppressions file's
job is to assert "no new findings vs main". Stale entries quietly
defeat that, and S11.04 – S11.10 trimmed opportunistically —
nobody verified every remaining line still fires a finding. The
fresh-run rebuild guarantees they do.

## Change Description

**Suppressions rebuild (`05950a1`).** Dropped
`misra_suppressions.txt` body, ran cppcheck-misra fresh, restored
only the lines that produce a finding today. Two iterations to
converge (rule 2.4 surfaces only after 5.7 is suppressed, per
\`docs/misra-conformance.md\` historical note).

Per-rule honest counts:

| Rule | Pre-E11 | Post-S11.10 | Post-honesty |
|---|---|---|---|
| 5.7 | 55 | 55 | **40** (-15 stale) |
| 2.5 | 2 | 1 | **39** (+38 newly captured) |
| 11.3 | 56 | 53 | **38** (-15 stale) |
| 2.4 | 8 | 8 | **5** (line drift) |
| 1.4 | 1 | 1 | **0** (retired) |
| (others) | unchanged | | |

The rule-2.5 explosion is the canonical S11.11 signal — every
\`SOLIDSYSLOG_*_POOL_SIZE\` tunable, error-message macro, and
handle-API symbol the E11 sweep added had been firing as an
unsuppressed CI warning since each sweep landed. The deviation
rationale (\"public API macros consumed outside cppcheck-misra
scope\") still applies; the file just hadn't kept up.

**D.006-original retired + renumber.** Rule 1.4 (C11
\`<stdatomic.h>\`) is no longer flagged by cppcheck 2.10 on this
codebase; the source code hasn't changed (\`StdAtomicCounter.c\`
still includes \`<stdatomic.h>\`), the addon's behaviour has.
Deviations renumbered down by one — old D.007 – D.012 became
new D.006 – D.011 — across \`docs/misra-deviations.md\`,
\`docs/misra-conformance.md\`, \`docs/NAMING.md\`,
\`misra_suppressions.txt\`, and the
\`project_per_group_conformance_workflow\` memory entry. DEVLOG.md
is append-only and stays frozen. Safe rewrite because the library
is pre-alpha with no public consumers.

**D.002 compact (`36ec0cd`).** Pre-E11, D.002 covered ~30 classes'
caller-supplied-storage casts plus every vtable downcast.
Post-E11, the only surviving sites are three structural buckets:
(a) vtable downcasts (\`SelfFromBase\`) in every pool class,
(b) \`SolidSyslogAddress\` (strict-tier opaque value type, no
Create lifecycle), (c) \`SolidSyslogFormatter\` (variable-size
stack builder, per-call lifecycle). Reorganised around these,
dropped the historical alternatives-comparison table, noted the
S11.11 scope narrowing in the Approval section.

**CLAUDE.md + SKILL.md sweep (`0ced3f3`).** CLAUDE.md's
\"Storage injection:\" subsection under \"Callback Conventions\"
described the obsolete caller-storage pattern as canonical.
Replaced with a \"Pool Allocation (E11)\" section documenting
the post-E11 model: per-class \`POOL_SIZE\` tunable,
handle-returning Create, null-sibling pool-exhaustion fallback,
ConfigLock-guarded slot walks, shared PoolAllocator helper, two
non-pool exceptions (Formatter, Address). SKILL.md dropped
\"allocator\" from the dependency-injection list and rewrote the
\"No dynamic memory allocation\" line to name the pool-size
tunable mechanism.

**DEVLOG entry (`37217cc`).** Three-baseline suppressions delta
table, rule-2.5 explosion mechanics, deviation renumber rationale,
E11 epic retrospective (eleven stories, public-API surface
change, deferred follow-ups including the future
dynamic-allocation epic and S21.03's \`FF_MAX_SS\` simplification).

## Test Evidence

Docs-only change set — no C/C++ source touched. The relevant CI
gate is **cppcheck-misra** (warning mode); verified clean for the
curated D.001 – D.011 rule subset across two convergence iterations:

\`\`\`
=== iter 3: findings on curated rules (D.001-D.011 scope) — should be ZERO ===
(no output)
\`\`\`

Non-curated rules (8.9, 14.4, 17.7, 5.9, 17.8, 15.5, 8.6, 22.10,
8.7) still emit as CI warnings — existing state since S10.06
warning-mode policy, out of S11.11 scope, tracked under
\`project_e10_accumulated_scope\` for E10 close-out.

## Areas Affected

- \`misra_suppressions.txt\` — full rebuild (12 → 11 deviation blocks)
- \`docs/misra-deviations.md\` — D.006-original deleted; D.007 – D.012
  renumbered to D.006 – D.011; D.002 prose rewritten for narrowed
  post-E11 scope
- \`docs/misra-conformance.md\` — cross-refs renumbered; S11.11 banner
  added; rule-1.4 audit row marked as deviation retired
- \`docs/NAMING.md\` — anonymous-enum reference updated D.010 → D.009
- \`CLAUDE.md\` — \"Storage injection:\" replaced with
  \"Pool Allocation (E11)\" section
- \`SKILL.md\` — DI list + no-allocation line aligned with pool model
- \`DEVLOG.md\` — S11.11 retrospective + E11 close-out entry

Closes #414. **Closes E11 (#29) on merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guidance for pool allocation and callback conventions
  * Revised MISRA deviation tracking and cross-references for consistency
  * Reorganized suppression record with revised classification of deviation categories

* **Chores**
  * Rebuilt MISRA suppression list from fresh analysis run

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->