### PR TITLE
refactor: S24.08 enforce top-down function ordering across all .c files

### DIFF
--- a/Bdd/Targets/FreeRtos/diskio.c
+++ b/Bdd/Targets/FreeRtos/diskio.c
@@ -114,6 +114,76 @@ static bool DiskImageIsReady(void)
     return true;
 }
 
+static int SemihostingOpen(const char* path, int mode)
+{
+    const struct
+    {
+        const char* name;
+        int mode;
+        int length;
+    } args = {path, mode, (int) strlen(path)};
+
+    return Semihosting(SEMIHOSTING_SYS_OPEN, &args);
+}
+
+static int Semihosting(int op, const void* args)
+{
+    /* BKPT 0xAB is the Cortex-M Thumb semihosting trap. r0 is the
+     * operation number on entry and the return value on exit; r1
+     * is a pointer to a per-op parameter block. memory clobber so
+     * the compiler doesn't reorder around buffers passed by pointer. */
+    register int result __asm("r0") = op;
+    register const void* request __asm("r1") = args;
+    __asm volatile("bkpt 0xAB" : "+r"(result) : "r"(request) : "memory");
+    return result;
+}
+
+static int SemihostingFlen(int handle)
+{
+    /* SYS_FLEN returns the file length in bytes, -1 on error. */
+    const struct
+    {
+        int handle;
+    } args = {handle};
+
+    return Semihosting(SEMIHOSTING_SYS_FLEN, &args);
+}
+
+static int SemihostingClose(int handle)
+{
+    const struct
+    {
+        int handle;
+    } args = {handle};
+
+    return Semihosting(SEMIHOSTING_SYS_CLOSE, &args);
+}
+
+static int SemihostingSeek(int handle, int position)
+{
+    /* SYS_SEEK returns 0 on success, a negative value on error. */
+    const struct
+    {
+        int handle;
+        int position;
+    } args = {handle, position};
+
+    return Semihosting(SEMIHOSTING_SYS_SEEK, &args);
+}
+
+static int SemihostingWrite(int handle, const void* buffer, int count)
+{
+    /* SYS_WRITE returns the number of bytes NOT written (0 == full write). */
+    const struct
+    {
+        int handle;
+        const void* buffer;
+        int count;
+    } args = {handle, buffer, count};
+
+    return Semihosting(SEMIHOSTING_SYS_WRITE, &args);
+}
+
 DSTATUS disk_status(BYTE pdrv)
 {
     if (pdrv != 0)
@@ -144,6 +214,19 @@ DRESULT disk_read(BYTE pdrv, BYTE* buff, LBA_t sector, UINT count)
         return RES_ERROR;
     }
     return RES_OK;
+}
+
+static int SemihostingRead(int handle, void* buffer, int count)
+{
+    /* SYS_READ returns the number of bytes NOT read (0 == full read). */
+    const struct
+    {
+        int handle;
+        void* buffer;
+        int count;
+    } args = {handle, buffer, count};
+
+    return Semihosting(SEMIHOSTING_SYS_READ, &args);
 }
 
 DRESULT disk_write(BYTE pdrv, const BYTE* buff, LBA_t sector, UINT count)
@@ -195,87 +278,4 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void* buff)
         default:
             return RES_PARERR;
     }
-}
-
-static int Semihosting(int op, const void* args)
-{
-    /* BKPT 0xAB is the Cortex-M Thumb semihosting trap. r0 is the
-     * operation number on entry and the return value on exit; r1
-     * is a pointer to a per-op parameter block. memory clobber so
-     * the compiler doesn't reorder around buffers passed by pointer. */
-    register int result __asm("r0") = op;
-    register const void* request __asm("r1") = args;
-    __asm volatile("bkpt 0xAB" : "+r"(result) : "r"(request) : "memory");
-    return result;
-}
-
-static int SemihostingOpen(const char* path, int mode)
-{
-    const struct
-    {
-        const char* name;
-        int mode;
-        int length;
-    } args = {path, mode, (int) strlen(path)};
-
-    return Semihosting(SEMIHOSTING_SYS_OPEN, &args);
-}
-
-static int SemihostingRead(int handle, void* buffer, int count)
-{
-    /* SYS_READ returns the number of bytes NOT read (0 == full read). */
-    const struct
-    {
-        int handle;
-        void* buffer;
-        int count;
-    } args = {handle, buffer, count};
-
-    return Semihosting(SEMIHOSTING_SYS_READ, &args);
-}
-
-static int SemihostingWrite(int handle, const void* buffer, int count)
-{
-    /* SYS_WRITE returns the number of bytes NOT written (0 == full write). */
-    const struct
-    {
-        int handle;
-        const void* buffer;
-        int count;
-    } args = {handle, buffer, count};
-
-    return Semihosting(SEMIHOSTING_SYS_WRITE, &args);
-}
-
-static int SemihostingSeek(int handle, int position)
-{
-    /* SYS_SEEK returns 0 on success, a negative value on error. */
-    const struct
-    {
-        int handle;
-        int position;
-    } args = {handle, position};
-
-    return Semihosting(SEMIHOSTING_SYS_SEEK, &args);
-}
-
-static int SemihostingFlen(int handle)
-{
-    /* SYS_FLEN returns the file length in bytes, -1 on error. */
-    const struct
-    {
-        int handle;
-    } args = {handle};
-
-    return Semihosting(SEMIHOSTING_SYS_FLEN, &args);
-}
-
-static int SemihostingClose(int handle)
-{
-    const struct
-    {
-        int handle;
-    } args = {handle};
-
-    return Semihosting(SEMIHOSTING_SYS_CLOSE, &args);
 }

--- a/Bdd/Targets/FreeRtos/main.c
+++ b/Bdd/Targets/FreeRtos/main.c
@@ -117,6 +117,13 @@
  * absorbs it. */
 #define INTERACTIVE_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 48U)
 
+/* Drains the CircularBuffer in the background while the interactive task
+ * (and, in S08.04 slice 3, additional worker tasks) call SolidSyslog_Log.
+ * Equal priority to the producers — FreeRTOS round-robins time slices
+ * between same-priority ready tasks so the buffer is drained without the
+ * Service task starving slower producers. */
+#define SERVICE_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 16U)
+
 /* Static IPv4 wiring matching the QEMU slirp default. 10.0.2.15 is the
  * standard slirp DHCP-allocated guest address; we hardcode it here so no
  * DHCP server is required. The destination address — 10.0.2.2, the slirp
@@ -259,6 +266,10 @@ static TaskHandle_t serviceTaskHandle = NULL;
 
 extern NetworkInterface_t* pxMPS2_FillInterfaceDescriptor(BaseType_t xEMACIndex, NetworkInterface_t* pxInterface);
 
+static void SetEthernetIrqPriority(void);
+static void InteractiveTask(void* argument);
+static void ServiceTask(void* argument);
+
 static bool TryUpdateString(char* storage, size_t storageSize, const char* value);
 static bool TryParseUInt(const char* value, unsigned long* out);
 static bool RebuildWithFileStore(void);
@@ -298,6 +309,105 @@ static void RtosSleep(int milliseconds)
 }
 
 static const CmsdkUartMemoryAccess MMIO_ACCESS = {MmioRead32, MmioWrite32, RtosSleep};
+
+int main(void)
+{
+    CmsdkUart_Init(&MMIO_ACCESS, CMSDK_UART0_BASE_ADDRESS);
+
+    SetEthernetIrqPriority();
+
+    (void) pxMPS2_FillInterfaceDescriptor(0, &networkInterface);
+    FreeRTOS_FillEndPoint(
+        &networkInterface,
+        &networkEndPoint,
+        TEST_IP_ADDRESS,
+        TEST_NETMASK,
+        TEST_GATEWAY,
+        TEST_DNS,
+        TEST_MAC
+    );
+
+    if (FreeRTOS_IPInit_Multi() != pdPASS)
+    {
+        for (;;)
+        {
+        }
+    }
+
+    vTaskStartScheduler();
+
+    for (;;)
+    {
+    }
+    return 0;
+}
+
+void vApplicationIPNetworkEventHook_Multi(eIPCallbackEvent_t eNetworkEvent, struct xNetworkEndPoint* pxEndPoint)
+{
+    (void) pxEndPoint;
+    if ((eNetworkEvent == eNetworkUp) && (interactiveTaskCreated == pdFALSE))
+    {
+        if (xTaskCreate(
+                InteractiveTask,
+                "interactive",
+                INTERACTIVE_TASK_STACK_DEPTH,
+                NULL,
+                tskIDLE_PRIORITY + 1,
+                NULL
+            ) == pdPASS)
+        {
+            (void) xTaskCreate(
+                ServiceTask,
+                "service",
+                SERVICE_TASK_STACK_DEPTH,
+                NULL,
+                tskIDLE_PRIORITY + 1,
+                &serviceTaskHandle
+            );
+            interactiveTaskCreated = pdTRUE;
+        }
+    }
+}
+
+void vApplicationMallocFailedHook(void)
+{
+    for (;;)
+    {
+    }
+}
+
+void vApplicationStackOverflowHook(TaskHandle_t task, char* taskName)
+{
+    (void) task;
+    (void) taskName;
+    for (;;)
+    {
+    }
+}
+
+/* Plus-TCP requires the application to provide a per-endpoint random seed
+ * source for ARP / IP-ID generation. The QEMU mps2-an385 has no RNG; for a
+ * deterministic smoke test we return the run-time tick mixed with a fixed
+ * constant. */
+BaseType_t xApplicationGetRandomNumber(uint32_t* pulValue)
+{
+    *pulValue = (uint32_t) xTaskGetTickCount() ^ 0xA5A5A5A5U;
+    return pdPASS;
+}
+
+uint32_t ulApplicationGetNextSequenceNumber(
+    uint32_t ulSourceAddress,
+    uint16_t usSourcePort,
+    uint32_t ulDestinationAddress,
+    uint16_t usDestinationPort
+)
+{
+    (void) ulSourceAddress;
+    (void) usSourcePort;
+    (void) ulDestinationAddress;
+    (void) usDestinationPort;
+    return (uint32_t) xTaskGetTickCount();
+}
 
 static void SetEthernetIrqPriority(void)
 {
@@ -539,17 +649,37 @@ static bool OnSet(const char* name, const char* value)
     return false;
 }
 
-static enum SolidSyslogDiscardPolicy MapDiscardPolicy(const char* policy)
+static bool TryUpdateString(char* storage, size_t storageSize, const char* value)
 {
-    if (strcmp(policy, "newest") == 0)
+    size_t length = strlen(value);
+    if ((length == 0U) || (length >= storageSize))
     {
-        return SOLIDSYSLOG_DISCARD_POLICY_NEWEST;
+        return false;
     }
-    if (strcmp(policy, "halt") == 0)
+    memcpy(storage, value, length);
+    storage[length] = '\0';
+    return true;
+}
+
+static bool TryParseUInt(const char* value, unsigned long* out)
+{
+    if (*value == '\0')
     {
-        return SOLIDSYSLOG_DISCARD_POLICY_HALT;
+        return false;
     }
-    return SOLIDSYSLOG_DISCARD_POLICY_OLDEST;
+    char* end = NULL;
+    unsigned long parsed = strtoul(value, &end, 10);
+    /* strtoul accepts a leading '-' and wraps to a huge unsigned. The port
+     * call site bounds-checks against UINT16_MAX upstream; facility and
+     * severity intentionally don't, mirroring the Linux example's
+     * atoi-and-cast so wrapped values reach the library and encode as
+     * the internal-error PRIVAL. */
+    if (*end != '\0')
+    {
+        return false;
+    }
+    *out = parsed;
+    return true;
 }
 
 static bool RebuildWithFileStore(void)
@@ -609,6 +739,72 @@ static bool RebuildWithFileStore(void)
     return true;
 }
 
+/* Mount volume 0; format-on-first-use if the disk image has no FAT yet.
+ * Idempotent — subsequent calls short-circuit on fatfsMounted. The work
+ * buffer for f_mkfs is sized to FF_MAX_SS (512 B) which is the minimum
+ * f_mkfs accepts on a FAT12/16 volume. */
+static bool EnsureFatFsMounted(void)
+{
+    if (fatfsMounted)
+    {
+        return true;
+    }
+    FRESULT res = f_mount(
+        &fatfs,
+        "",
+        1
+    ); /* opt=1 → mount immediately, surface FR_NO_FILESYSTEM here rather than at first f_open */
+    if (res == FR_NO_FILESYSTEM)
+    {
+        /* Fresh disk image — lay down a FAT and re-mount. FAT12 is the
+         * natural choice for a 1 MiB volume (small enough that FAT32's
+         * cluster overhead would dominate). */
+        static BYTE workBuffer[FF_MAX_SS];
+        const MKFS_PARM opts = {.fmt = FM_FAT | FM_SFD, .n_fat = 1, .align = 1, .n_root = 0, .au_size = 0};
+        res = f_mkfs("", &opts, workBuffer, sizeof(workBuffer));
+        if (res == FR_OK)
+        {
+            res = f_mount(&fatfs, "", 1);
+        }
+    }
+    if (res != FR_OK)
+    {
+        (void) printf("[solidsyslog] fatfs mount failed: FRESULT=%d\n", (int) res);
+        return false;
+    }
+    fatfsMounted = true;
+    return true;
+}
+
+/* Tears down whichever store is currently installed (file-backed or null).
+ * Shared by RebuildWithFileStore (which then re-creates) and
+ * ShutdownGracefully (which then exits). FatFsFile_Destroy → Close →
+ * f_close flushes the underlying FIL's dir entry. */
+static void DestroyCurrentStore(void)
+{
+    if (currentStoreIsFile)
+    {
+        SolidSyslogBlockStore_Destroy(currentStore);
+        SolidSyslogFileBlockDevice_Destroy(storeBlockDevice);
+        SolidSyslogCrc16Policy_Destroy();
+        SolidSyslogFatFsFile_Destroy(storeFile);
+    }
+    /* else: NullStore is shared and immutable — nothing to destroy. */
+}
+
+static enum SolidSyslogDiscardPolicy MapDiscardPolicy(const char* policy)
+{
+    if (strcmp(policy, "newest") == 0)
+    {
+        return SOLIDSYSLOG_DISCARD_POLICY_NEWEST;
+    }
+    if (strcmp(policy, "halt") == 0)
+    {
+        return SOLIDSYSLOG_DISCARD_POLICY_HALT;
+    }
+    return SOLIDSYSLOG_DISCARD_POLICY_OLDEST;
+}
+
 static void OnStoreFull(void* context)
 {
     (void) context;
@@ -638,22 +834,6 @@ static void OnThresholdCrossed(void* context)
 {
     (void) context;
     (void) printf("[THRESHOLD-CROSSED]\r\n");
-}
-
-/* Tears down whichever store is currently installed (file-backed or null).
- * Shared by RebuildWithFileStore (which then re-creates) and
- * ShutdownGracefully (which then exits). FatFsFile_Destroy → Close →
- * f_close flushes the underlying FIL's dir entry. */
-static void DestroyCurrentStore(void)
-{
-    if (currentStoreIsFile)
-    {
-        SolidSyslogBlockStore_Destroy(currentStore);
-        SolidSyslogFileBlockDevice_Destroy(storeBlockDevice);
-        SolidSyslogCrc16Policy_Destroy();
-        SolidSyslogFatFsFile_Destroy(storeFile);
-    }
-    /* else: NullStore is shared and immutable — nothing to destroy. */
 }
 
 /* Full teardown of every resource InteractiveTask allocated during Setup.
@@ -711,43 +891,6 @@ static void TeardownAll(void)
     SolidSyslogFreeRtosStaticResolver_Destroy(resolver);
 }
 
-/* Mount volume 0; format-on-first-use if the disk image has no FAT yet.
- * Idempotent — subsequent calls short-circuit on fatfsMounted. The work
- * buffer for f_mkfs is sized to FF_MAX_SS (512 B) which is the minimum
- * f_mkfs accepts on a FAT12/16 volume. */
-static bool EnsureFatFsMounted(void)
-{
-    if (fatfsMounted)
-    {
-        return true;
-    }
-    FRESULT res = f_mount(
-        &fatfs,
-        "",
-        1
-    ); /* opt=1 → mount immediately, surface FR_NO_FILESYSTEM here rather than at first f_open */
-    if (res == FR_NO_FILESYSTEM)
-    {
-        /* Fresh disk image — lay down a FAT and re-mount. FAT12 is the
-         * natural choice for a 1 MiB volume (small enough that FAT32's
-         * cluster overhead would dominate). */
-        static BYTE workBuffer[FF_MAX_SS];
-        const MKFS_PARM opts = {.fmt = FM_FAT | FM_SFD, .n_fat = 1, .align = 1, .n_root = 0, .au_size = 0};
-        res = f_mkfs("", &opts, workBuffer, sizeof(workBuffer));
-        if (res == FR_OK)
-        {
-            res = f_mount(&fatfs, "", 1);
-        }
-    }
-    if (res != FR_OK)
-    {
-        (void) printf("[solidsyslog] fatfs mount failed: FRESULT=%d\n", (int) res);
-        return false;
-    }
-    fatfsMounted = true;
-    return true;
-}
-
 static void SemihostingExit(int status)
 {
     /* SYS_EXIT_EXTENDED (0x20) — the only ARM Semihosting exit form on
@@ -769,39 +912,6 @@ static void SemihostingExit(int status)
     for (;;)
     {
     }
-}
-
-static bool TryUpdateString(char* storage, size_t storageSize, const char* value)
-{
-    size_t length = strlen(value);
-    if ((length == 0U) || (length >= storageSize))
-    {
-        return false;
-    }
-    memcpy(storage, value, length);
-    storage[length] = '\0';
-    return true;
-}
-
-static bool TryParseUInt(const char* value, unsigned long* out)
-{
-    if (*value == '\0')
-    {
-        return false;
-    }
-    char* end = NULL;
-    unsigned long parsed = strtoul(value, &end, 10);
-    /* strtoul accepts a leading '-' and wraps to a huge unsigned. The port
-     * call site bounds-checks against UINT16_MAX upstream; facility and
-     * severity intentionally don't, mirroring the Linux example's
-     * atoi-and-cast so wrapped values reach the library and encode as
-     * the internal-error PRIVAL. */
-    if (*end != '\0')
-    {
-        return false;
-    }
-    *out = parsed;
-    return true;
 }
 
 static void InteractiveTask(void* argument)
@@ -951,13 +1061,6 @@ static void InteractiveTask(void* argument)
     vTaskDelete(NULL);
 }
 
-/* Drains the CircularBuffer in the background while the interactive task
- * (and, in S08.04 slice 3, additional worker tasks) call SolidSyslog_Log.
- * Equal priority to the producers — FreeRTOS round-robins time slices
- * between same-priority ready tasks so the buffer is drained without the
- * Service task starving slower producers. */
-#define SERVICE_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 16U)
-
 static void ServiceTask(void* argument)
 {
     (void) argument;
@@ -988,103 +1091,4 @@ static void ServiceTask(void* argument)
         SolidSyslogMutex_Unlock(lifecycleMutex);
         vTaskDelay(pdMS_TO_TICKS(1));
     }
-}
-
-void vApplicationIPNetworkEventHook_Multi(eIPCallbackEvent_t eNetworkEvent, struct xNetworkEndPoint* pxEndPoint)
-{
-    (void) pxEndPoint;
-    if ((eNetworkEvent == eNetworkUp) && (interactiveTaskCreated == pdFALSE))
-    {
-        if (xTaskCreate(
-                InteractiveTask,
-                "interactive",
-                INTERACTIVE_TASK_STACK_DEPTH,
-                NULL,
-                tskIDLE_PRIORITY + 1,
-                NULL
-            ) == pdPASS)
-        {
-            (void) xTaskCreate(
-                ServiceTask,
-                "service",
-                SERVICE_TASK_STACK_DEPTH,
-                NULL,
-                tskIDLE_PRIORITY + 1,
-                &serviceTaskHandle
-            );
-            interactiveTaskCreated = pdTRUE;
-        }
-    }
-}
-
-int main(void)
-{
-    CmsdkUart_Init(&MMIO_ACCESS, CMSDK_UART0_BASE_ADDRESS);
-
-    SetEthernetIrqPriority();
-
-    (void) pxMPS2_FillInterfaceDescriptor(0, &networkInterface);
-    FreeRTOS_FillEndPoint(
-        &networkInterface,
-        &networkEndPoint,
-        TEST_IP_ADDRESS,
-        TEST_NETMASK,
-        TEST_GATEWAY,
-        TEST_DNS,
-        TEST_MAC
-    );
-
-    if (FreeRTOS_IPInit_Multi() != pdPASS)
-    {
-        for (;;)
-        {
-        }
-    }
-
-    vTaskStartScheduler();
-
-    for (;;)
-    {
-    }
-    return 0;
-}
-
-void vApplicationMallocFailedHook(void)
-{
-    for (;;)
-    {
-    }
-}
-
-void vApplicationStackOverflowHook(TaskHandle_t task, char* taskName)
-{
-    (void) task;
-    (void) taskName;
-    for (;;)
-    {
-    }
-}
-
-/* Plus-TCP requires the application to provide a per-endpoint random seed
- * source for ARP / IP-ID generation. The QEMU mps2-an385 has no RNG; for a
- * deterministic smoke test we return the run-time tick mixed with a fixed
- * constant. */
-BaseType_t xApplicationGetRandomNumber(uint32_t* pulValue)
-{
-    *pulValue = (uint32_t) xTaskGetTickCount() ^ 0xA5A5A5A5U;
-    return pdPASS;
-}
-
-uint32_t ulApplicationGetNextSequenceNumber(
-    uint32_t ulSourceAddress,
-    uint16_t usSourcePort,
-    uint32_t ulDestinationAddress,
-    uint16_t usDestinationPort
-)
-{
-    (void) ulSourceAddress;
-    (void) usSourcePort;
-    (void) ulDestinationAddress;
-    (void) usDestinationPort;
-    return (uint32_t) xTaskGetTickCount();
 }

--- a/Core/Source/BlockSequence.c
+++ b/Core/Source/BlockSequence.c
@@ -205,6 +205,41 @@ static inline int BlockSequence_CircularPrev(int index)
     return (index + MAX_SEQUENCE - 1) % MAX_SEQUENCE;
 }
 
+static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence);
+static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold);
+
+static inline void BlockSequence_NotifyThresholdCrossed(struct BlockSequence* blockSequence)
+{
+    if (BlockSequence_ThresholdEnabled(blockSequence))
+    {
+        size_t threshold = blockSequence->GetCapacityThreshold(blockSequence->ThresholdContext);
+
+        if (!BlockSequence_IsAboveThreshold(blockSequence, threshold))
+        {
+            blockSequence->ThresholdCrossed = false;
+        }
+        else if (!blockSequence->ThresholdCrossed)
+        {
+            blockSequence->ThresholdCrossed = true;
+            blockSequence->OnThresholdCrossed(blockSequence->ThresholdContext);
+        }
+        else
+        {
+            /* still above threshold and already notified — no edge to report */
+        }
+    }
+}
+
+static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence)
+{
+    return (blockSequence->OnThresholdCrossed != NULL) && (blockSequence->GetCapacityThreshold != NULL);
+}
+
+static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold)
+{
+    return (threshold != 0U) && (BlockSequence_UsedBytes(blockSequence) >= threshold);
+}
+
 static inline bool BlockSequence_BlockIsFull(const struct BlockSequence* blockSequence, size_t recordSize);
 static inline bool BlockSequence_StoreIsFull(const struct BlockSequence* blockSequence);
 static inline void BlockSequence_NotifyStoreFull(struct BlockSequence* blockSequence);
@@ -372,41 +407,6 @@ void BlockSequence_NoteRecordWritten(struct BlockSequence* blockSequence, size_t
 {
     blockSequence->WritePosition += recordSize;
     BlockSequence_NotifyThresholdCrossed(blockSequence);
-}
-
-static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence);
-static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold);
-
-static inline void BlockSequence_NotifyThresholdCrossed(struct BlockSequence* blockSequence)
-{
-    if (BlockSequence_ThresholdEnabled(blockSequence))
-    {
-        size_t threshold = blockSequence->GetCapacityThreshold(blockSequence->ThresholdContext);
-
-        if (!BlockSequence_IsAboveThreshold(blockSequence, threshold))
-        {
-            blockSequence->ThresholdCrossed = false;
-        }
-        else if (!blockSequence->ThresholdCrossed)
-        {
-            blockSequence->ThresholdCrossed = true;
-            blockSequence->OnThresholdCrossed(blockSequence->ThresholdContext);
-        }
-        else
-        {
-            /* still above threshold and already notified — no edge to report */
-        }
-    }
-}
-
-static inline bool BlockSequence_ThresholdEnabled(const struct BlockSequence* blockSequence)
-{
-    return (blockSequence->OnThresholdCrossed != NULL) && (blockSequence->GetCapacityThreshold != NULL);
-}
-
-static inline bool BlockSequence_IsAboveThreshold(const struct BlockSequence* blockSequence, size_t threshold)
-{
-    return (threshold != 0U) && (BlockSequence_UsedBytes(blockSequence) >= threshold);
 }
 
 void BlockSequence_MarkWriteBlockCorrupt(struct BlockSequence* blockSequence)

--- a/Core/Source/SolidSyslogBlockStoreStatic.c
+++ b/Core/Source/SolidSyslogBlockStoreStatic.c
@@ -69,6 +69,40 @@ struct SolidSyslogStore* SolidSyslogBlockStore_Create(const struct SolidSyslogBl
     return result;
 }
 
+static struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
+{
+    struct SolidSyslogSecurityPolicy* resolved = configured;
+
+    if ((resolved == NULL) || (resolved->IntegritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE))
+    {
+        resolved = SolidSyslogNullSecurityPolicy_Get();
+    }
+
+    return resolved;
+}
+
+static struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
+    const struct SolidSyslogBlockStoreConfig* config,
+    const struct RecordStore* recordStore
+)
+{
+    size_t minBlockSize = RecordStore_RecordSize(recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+    size_t maxBlockSize = (config->MaxBlockSize < minBlockSize) ? minBlockSize : config->MaxBlockSize;
+
+    struct BlockSequenceConfig blockConfig = {
+        .BlockDevice = config->BlockDevice,
+        .MaxBlockSize = maxBlockSize,
+        .MaxBlocks = config->MaxBlocks,
+        .DiscardPolicy = config->DiscardPolicy,
+        .OnStoreFull = config->OnStoreFull,
+        .StoreFullContext = config->StoreFullContext,
+        .GetCapacityThreshold = config->GetCapacityThreshold,
+        .OnThresholdCrossed = config->OnThresholdCrossed,
+        .ThresholdContext = config->ThresholdContext,
+    };
+    return blockConfig;
+}
+
 void SolidSyslogBlockStore_Destroy(struct SolidSyslogStore* base)
 {
     size_t index = BlockStore_IndexFromHandle(base);
@@ -118,38 +152,4 @@ static inline void BlockStore_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     BlockStore_Cleanup(&BlockStore_Pool[index].Base);
-}
-
-static struct SolidSyslogSecurityPolicy* BlockStore_ResolveSecurityPolicy(struct SolidSyslogSecurityPolicy* configured)
-{
-    struct SolidSyslogSecurityPolicy* resolved = configured;
-
-    if ((resolved == NULL) || (resolved->IntegritySize > SOLIDSYSLOG_MAX_INTEGRITY_SIZE))
-    {
-        resolved = SolidSyslogNullSecurityPolicy_Get();
-    }
-
-    return resolved;
-}
-
-static struct BlockSequenceConfig BlockStore_BuildBlockSequenceConfig(
-    const struct SolidSyslogBlockStoreConfig* config,
-    const struct RecordStore* recordStore
-)
-{
-    size_t minBlockSize = RecordStore_RecordSize(recordStore, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
-    size_t maxBlockSize = (config->MaxBlockSize < minBlockSize) ? minBlockSize : config->MaxBlockSize;
-
-    struct BlockSequenceConfig blockConfig = {
-        .BlockDevice = config->BlockDevice,
-        .MaxBlockSize = maxBlockSize,
-        .MaxBlocks = config->MaxBlocks,
-        .DiscardPolicy = config->DiscardPolicy,
-        .OnStoreFull = config->OnStoreFull,
-        .StoreFullContext = config->StoreFullContext,
-        .GetCapacityThreshold = config->GetCapacityThreshold,
-        .OnThresholdCrossed = config->OnThresholdCrossed,
-        .ThresholdContext = config->ThresholdContext,
-    };
-    return blockConfig;
 }

--- a/Core/Source/SolidSyslogMetaSdStatic.c
+++ b/Core/Source/SolidSyslogMetaSdStatic.c
@@ -40,17 +40,6 @@ struct SolidSyslogStructuredData* SolidSyslogMetaSd_Create(const struct SolidSys
     return result;
 }
 
-void SolidSyslogMetaSd_Destroy(struct SolidSyslogStructuredData* base)
-{
-    size_t index = MetaSd_IndexFromHandle(base);
-    bool released = SolidSyslogPoolAllocator_IndexIsValid(&MetaSd_Allocator, index) &&
-                    SolidSyslogPoolAllocator_FreeIfInUse(&MetaSd_Allocator, index, MetaSd_CleanupAtIndex, NULL);
-    if (!released)
-    {
-        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_METASD_UNKNOWN_DESTROY);
-    }
-}
-
 static bool MetaSd_IsValidConfig(const struct SolidSyslogMetaSdConfig* config)
 {
     bool valid = false;
@@ -67,6 +56,17 @@ static bool MetaSd_IsValidConfig(const struct SolidSyslogMetaSdConfig* config)
         valid = true;
     }
     return valid;
+}
+
+void SolidSyslogMetaSd_Destroy(struct SolidSyslogStructuredData* base)
+{
+    size_t index = MetaSd_IndexFromHandle(base);
+    bool released = SolidSyslogPoolAllocator_IndexIsValid(&MetaSd_Allocator, index) &&
+                    SolidSyslogPoolAllocator_FreeIfInUse(&MetaSd_Allocator, index, MetaSd_CleanupAtIndex, NULL);
+    if (!released)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_METASD_UNKNOWN_DESTROY);
+    }
 }
 
 static inline size_t MetaSd_IndexFromHandle(const struct SolidSyslogStructuredData* base)

--- a/Core/Source/SolidSyslogStatic.c
+++ b/Core/Source/SolidSyslogStatic.c
@@ -54,6 +54,23 @@ struct SolidSyslog* SolidSyslog_Create(const struct SolidSyslogConfig* config)
     return result;
 }
 
+static void SolidSyslog_EnsureNullInstancePopulated(void)
+{
+    if (!SolidSyslog_NullInstancePopulated)
+    {
+        SolidSyslog_NullInstance.Buffer = SolidSyslogNullBuffer_Get();
+        SolidSyslog_NullInstance.Sender = SolidSyslogNullSender_Get();
+        SolidSyslog_NullInstance.Store = SolidSyslogNullStore_Get();
+        SolidSyslog_NullInstance.Clock = SolidSyslog_NullClock;
+        SolidSyslog_NullInstance.GetHostname = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.GetAppName = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.GetProcessId = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.Sd = NULL;
+        SolidSyslog_NullInstance.SdCount = 0;
+        SolidSyslog_NullInstancePopulated = true;
+    }
+}
+
 void SolidSyslog_Destroy(struct SolidSyslog* handle)
 {
     size_t index = SolidSyslog_IndexFromHandle(handle);
@@ -84,21 +101,4 @@ static inline void SolidSyslog_CleanupAtIndex(size_t index, void* context)
 {
     (void) context;
     SolidSyslog_Cleanup(&SolidSyslog_Pool[index]);
-}
-
-static void SolidSyslog_EnsureNullInstancePopulated(void)
-{
-    if (!SolidSyslog_NullInstancePopulated)
-    {
-        SolidSyslog_NullInstance.Buffer = SolidSyslogNullBuffer_Get();
-        SolidSyslog_NullInstance.Sender = SolidSyslogNullSender_Get();
-        SolidSyslog_NullInstance.Store = SolidSyslogNullStore_Get();
-        SolidSyslog_NullInstance.Clock = SolidSyslog_NullClock;
-        SolidSyslog_NullInstance.GetHostname = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.GetAppName = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.GetProcessId = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.Sd = NULL;
-        SolidSyslog_NullInstance.SdCount = 0;
-        SolidSyslog_NullInstancePopulated = true;
-    }
 }

--- a/Core/Source/SolidSyslogUdpSenderStatic.c
+++ b/Core/Source/SolidSyslogUdpSenderStatic.c
@@ -40,17 +40,6 @@ struct SolidSyslogSender* SolidSyslogUdpSender_Create(const struct SolidSyslogUd
     return result;
 }
 
-void SolidSyslogUdpSender_Destroy(struct SolidSyslogSender* base)
-{
-    size_t index = UdpSender_IndexFromHandle(base);
-    bool released = SolidSyslogPoolAllocator_IndexIsValid(&UdpSender_Allocator, index) &&
-                    SolidSyslogPoolAllocator_FreeIfInUse(&UdpSender_Allocator, index, UdpSender_CleanupAtIndex, NULL);
-    if (!released)
-    {
-        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_UNKNOWN_DESTROY);
-    }
-}
-
 static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* config)
 {
     bool valid = false;
@@ -79,6 +68,17 @@ static bool UdpSender_IsValidConfig(const struct SolidSyslogUdpSenderConfig* con
         valid = true;
     }
     return valid;
+}
+
+void SolidSyslogUdpSender_Destroy(struct SolidSyslogSender* base)
+{
+    size_t index = UdpSender_IndexFromHandle(base);
+    bool released = SolidSyslogPoolAllocator_IndexIsValid(&UdpSender_Allocator, index) &&
+                    SolidSyslogPoolAllocator_FreeIfInUse(&UdpSender_Allocator, index, UdpSender_CleanupAtIndex, NULL);
+    if (!released)
+    {
+        SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_UDPSENDER_UNKNOWN_DESTROY);
+    }
 }
 
 static inline size_t UdpSender_IndexFromHandle(const struct SolidSyslogSender* base)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,57 @@
 # Dev Log
 
+## 2026-05-22 — S24.08 top-down function ordering sweep
+
+Closes S24.08 (#423). Pure refactoring pass: re-applied the documented
+function-ordering convention (`_Create`/`_Destroy` first, public funcs
+next, static helpers defined immediately beneath their first caller) to
+every `.c` file under Core/Source, Platform/, and Bdd/Targets/. Move-only
+diff; no behaviour change.
+
+### Audit first, then move
+
+Three parallel Explore agents audited Core, Platform, and Tests/fakes
+against the strict rule. First pass under-flagged Core/Source and
+over-flagged a few simple files (PosixClock, WindowsClock,
+WinsockResolver, CmsdkUart all turned out to be compliant once
+re-examined). Second pass with the precise rule — "a helper is
+non-compliant only when a non-calling function intervenes between its
+first caller and its definition" — landed the real list: 5 Core files,
+13 Platform files, 2 Bdd/Targets files (`diskio.c`, FreeRTOS BDD
+`main.c`). Tests/fakes audited clean.
+
+### Convention clarifications gathered along the way
+
+- **Vtable methods called by `_Cleanup`.** TLS-style files
+  (`TlsStream`, `MbedTlsStream`, `WinsockTcpStream`) where `_Cleanup`
+  delegates the close logic to `_Close`: `_Close` moved up to sit
+  beneath `_Cleanup`. Files where `_Cleanup` inlines its own close
+  logic (`PosixTcpStream`) keep `_Close` at the end in API order.
+- **Helper-to-helper call order within a cluster.** The strict
+  "next non-calling function" reading was followed for clear
+  violations (helper sits after an unrelated public function).
+  Reordering helpers *within* a single caller's helper cluster purely
+  for call-order aesthetics was skipped to keep the diff focused.
+- **`main` is a special case.** Entry-point function comes first
+  (David's call); other rules apply normally. The FreeRTOS BDD
+  `main.c` was restructured so `main` plus the four `vApplication*`
+  OS-callback hooks sit at the top, with the OnSet helper cluster
+  reorganised into call-graph order (TryUpdateString, TryParseUInt,
+  RebuildWithFileStore + its helper cascade, TeardownAll,
+  SemihostingExit).
+
+### Pre-existing format-violation noise
+
+`analyze-format` will continue to flag `TlsStreamStatic.c` and
+`FatFsFileStatic.c` for a `bool released = ...` continuation indent —
+both untouched by this PR. Pre-existing; out of scope here.
+
+### Deferred
+
+- Strict helper-to-helper call ordering within a single caller's
+  helper cluster — left for a future tightening pass if the
+  convention is sharpened to require it.
+
 ## 2026-05-21 — S08.07 slice 6 + 7: FreeRTOS TLS via mbedTLS
 
 Closes S08.07 (#272). Lights up the TLS slot on the FreeRTOS QEMU BDD

--- a/Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c
+++ b/Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c
@@ -19,11 +19,9 @@ void StdAtomicCounter_Initialise(struct SolidSyslogAtomicCounter* base)
     StdAtomicCounter_Init(self, 0U);
 }
 
-void StdAtomicCounter_Cleanup(struct SolidSyslogAtomicCounter* base)
+static inline struct SolidSyslogStdAtomicCounter* StdAtomicCounter_SelfFromBase(struct SolidSyslogAtomicCounter* base)
 {
-    /* Overwrite the abstract base with the shared NullAtomicCounter vtable so
-     * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
-    *base = *SolidSyslogNullAtomicCounter_Get();
+    return (struct SolidSyslogStdAtomicCounter*) base;
 }
 
 void StdAtomicCounter_Init(struct SolidSyslogStdAtomicCounter* self, uint32_t value)
@@ -31,9 +29,11 @@ void StdAtomicCounter_Init(struct SolidSyslogStdAtomicCounter* self, uint32_t va
     atomic_init(&self->Value, value);
 }
 
-static inline struct SolidSyslogStdAtomicCounter* StdAtomicCounter_SelfFromBase(struct SolidSyslogAtomicCounter* base)
+void StdAtomicCounter_Cleanup(struct SolidSyslogAtomicCounter* base)
 {
-    return (struct SolidSyslogStdAtomicCounter*) base;
+    /* Overwrite the abstract base with the shared NullAtomicCounter vtable so
+     * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
+    *base = *SolidSyslogNullAtomicCounter_Get();
 }
 
 static uint32_t StdAtomicCounter_Increment(struct SolidSyslogAtomicCounter* base)

--- a/Platform/FatFs/Source/SolidSyslogFatFsFile.c
+++ b/Platform/FatFs/Source/SolidSyslogFatFsFile.c
@@ -40,25 +40,17 @@ void FatFsFile_Initialise(struct SolidSyslogFile* base)
     self->IsOpen = false;
 }
 
+static inline struct SolidSyslogFatFsFile* FatFsFile_SelfFromBase(struct SolidSyslogFile* base)
+{
+    return (struct SolidSyslogFatFsFile*) base;
+}
+
 void FatFsFile_Cleanup(struct SolidSyslogFile* base)
 {
     FatFsFile_Close(base);
     /* Overwrite the abstract base with the shared NullFile vtable so
      * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
     *base = *SolidSyslogNullFile_Get();
-}
-
-static inline struct SolidSyslogFatFsFile* FatFsFile_SelfFromBase(struct SolidSyslogFile* base)
-{
-    return (struct SolidSyslogFatFsFile*) base;
-}
-
-static bool FatFsFile_Open(struct SolidSyslogFile* base, const char* path)
-{
-    struct SolidSyslogFatFsFile* self = FatFsFile_SelfFromBase(base);
-    FRESULT result = f_open(&self->Fp, path, READ_WRITE_OR_CREATE);
-    self->IsOpen = (result == FR_OK);
-    return self->IsOpen;
 }
 
 static void FatFsFile_Close(struct SolidSyslogFile* base)
@@ -69,6 +61,14 @@ static void FatFsFile_Close(struct SolidSyslogFile* base)
         f_close(&self->Fp);
         self->IsOpen = false;
     }
+}
+
+static bool FatFsFile_Open(struct SolidSyslogFile* base, const char* path)
+{
+    struct SolidSyslogFatFsFile* self = FatFsFile_SelfFromBase(base);
+    FRESULT result = f_open(&self->Fp, path, READ_WRITE_OR_CREATE);
+    self->IsOpen = (result == FR_OK);
+    return self->IsOpen;
 }
 
 static bool FatFsFile_IsOpen(struct SolidSyslogFile* base)

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosAddressStatic.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosAddressStatic.c
@@ -46,6 +46,11 @@ struct SolidSyslogAddress* SolidSyslogFreeRtosAddress_Create(void)
     return handle;
 }
 
+static inline struct SolidSyslogAddress* FreeRtosAddress_HandleFromIndex(size_t index)
+{
+    return (struct SolidSyslogAddress*) &FreeRtosAddress_Pool[index];
+}
+
 void SolidSyslogFreeRtosAddress_Destroy(struct SolidSyslogAddress* base)
 {
     size_t index = FreeRtosAddress_IndexFromHandle(base);
@@ -56,11 +61,6 @@ void SolidSyslogFreeRtosAddress_Destroy(struct SolidSyslogAddress* base)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_FREERTOSADDRESS_UNKNOWN_DESTROY);
     }
-}
-
-static inline struct SolidSyslogAddress* FreeRtosAddress_HandleFromIndex(size_t index)
-{
-    return (struct SolidSyslogAddress*) &FreeRtosAddress_Pool[index];
 }
 
 static inline size_t FreeRtosAddress_IndexFromHandle(const struct SolidSyslogAddress* base)

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosDatagram.c
@@ -49,6 +49,11 @@ void FreeRtosDatagram_Initialise(struct SolidSyslogDatagram* base)
     self->Socket = FREERTOS_INVALID_SOCKET;
 }
 
+static inline struct SolidSyslogFreeRtosDatagram* FreeRtosDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
+{
+    return (struct SolidSyslogFreeRtosDatagram*) base;
+}
+
 void FreeRtosDatagram_Cleanup(struct SolidSyslogDatagram* base)
 {
     FreeRtosDatagram_Close(base);
@@ -57,9 +62,14 @@ void FreeRtosDatagram_Cleanup(struct SolidSyslogDatagram* base)
     *base = *SolidSyslogNullDatagram_Get();
 }
 
-static inline struct SolidSyslogFreeRtosDatagram* FreeRtosDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
+static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* base)
 {
-    return (struct SolidSyslogFreeRtosDatagram*) base;
+    struct SolidSyslogFreeRtosDatagram* self = FreeRtosDatagram_SelfFromBase(base);
+    if (FreeRtosDatagram_IsOpen(self))
+    {
+        (void) FreeRTOS_closesocket(self->Socket);
+        self->Socket = FREERTOS_INVALID_SOCKET;
+    }
 }
 
 static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* base)
@@ -70,6 +80,11 @@ static bool FreeRtosDatagram_Open(struct SolidSyslogDatagram* base)
         self->Socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP);
     }
     return FreeRtosDatagram_IsOpen(self);
+}
+
+static inline bool FreeRtosDatagram_IsOpen(const struct SolidSyslogFreeRtosDatagram* self)
+{
+    return self->Socket != FREERTOS_INVALID_SOCKET;
 }
 
 static enum SolidSyslogDatagramSendResult FreeRtosDatagram_SendTo(
@@ -109,25 +124,10 @@ static inline void FreeRtosDatagram_PrimeArpIfMissing(uint32_t ip)
     }
 }
 
-static inline bool FreeRtosDatagram_IsOpen(const struct SolidSyslogFreeRtosDatagram* self)
-{
-    return self->Socket != FREERTOS_INVALID_SOCKET;
-}
-
 static size_t FreeRtosDatagram_MaxPayload(struct SolidSyslogDatagram* base)
 {
     (void) base;
     return SOLIDSYSLOG_UDP_IPV6_SAFE_PAYLOAD;
-}
-
-static void FreeRtosDatagram_Close(struct SolidSyslogDatagram* base)
-{
-    struct SolidSyslogFreeRtosDatagram* self = FreeRtosDatagram_SelfFromBase(base);
-    if (FreeRtosDatagram_IsOpen(self))
-    {
-        (void) FreeRTOS_closesocket(self->Socket);
-        self->Socket = FREERTOS_INVALID_SOCKET;
-    }
 }
 
 // NOLINTEND(performance-no-int-to-ptr)

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c
@@ -35,6 +35,11 @@ void FreeRtosMutex_Initialise(struct SolidSyslogMutex* base)
     }
 }
 
+static inline struct SolidSyslogFreeRtosMutex* FreeRtosMutex_SelfFromBase(struct SolidSyslogMutex* base)
+{
+    return (struct SolidSyslogFreeRtosMutex*) base;
+}
+
 void FreeRtosMutex_Cleanup(struct SolidSyslogMutex* base)
 {
     struct SolidSyslogFreeRtosMutex* self = FreeRtosMutex_SelfFromBase(base);
@@ -45,11 +50,6 @@ void FreeRtosMutex_Cleanup(struct SolidSyslogMutex* base)
     /* Overwrite the abstract base with the shared NullMutex vtable so
      * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
     *base = *SolidSyslogNullMutex_Get();
-}
-
-static inline struct SolidSyslogFreeRtosMutex* FreeRtosMutex_SelfFromBase(struct SolidSyslogMutex* base)
-{
-    return (struct SolidSyslogFreeRtosMutex*) base;
 }
 
 static inline SemaphoreHandle_t FreeRtosMutex_AsHandle(struct SolidSyslogFreeRtosMutex* self)

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosStaticResolver.c
@@ -35,19 +35,19 @@ void FreeRtosStaticResolver_Initialise(struct SolidSyslogResolver* base, const u
     self->Octets[3] = ipv4Octets[3];
 }
 
+static inline struct SolidSyslogFreeRtosStaticResolver* FreeRtosStaticResolver_SelfFromBase(
+    struct SolidSyslogResolver* base
+)
+{
+    return (struct SolidSyslogFreeRtosStaticResolver*) base;
+}
+
 void FreeRtosStaticResolver_Cleanup(struct SolidSyslogResolver* base)
 {
     /* Overwrite the abstract base with the shared NullResolver vtable so
      * use-after-destroy resolves cleanly to a failed-lookup error path
      * rather than a NULL-fn-pointer crash. */
     *base = *SolidSyslogNullResolver_Get();
-}
-
-static inline struct SolidSyslogFreeRtosStaticResolver* FreeRtosStaticResolver_SelfFromBase(
-    struct SolidSyslogResolver* base
-)
-{
-    return (struct SolidSyslogFreeRtosStaticResolver*) base;
 }
 
 static bool FreeRtosStaticResolver_Resolve(

--- a/Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c
+++ b/Platform/FreeRtos/Source/SolidSyslogFreeRtosTcpStream.c
@@ -98,6 +98,11 @@ void FreeRtosTcpStream_Initialise(struct SolidSyslogStream* base)
     self->Socket = FREERTOS_INVALID_SOCKET;
 }
 
+static inline struct SolidSyslogFreeRtosTcpStream* FreeRtosTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+{
+    return (struct SolidSyslogFreeRtosTcpStream*) base;
+}
+
 void FreeRtosTcpStream_Cleanup(struct SolidSyslogStream* base)
 {
     struct SolidSyslogFreeRtosTcpStream* self = FreeRtosTcpStream_SelfFromBase(base);
@@ -107,9 +112,13 @@ void FreeRtosTcpStream_Cleanup(struct SolidSyslogStream* base)
     *base = *SolidSyslogNullStream_Get();
 }
 
-static inline struct SolidSyslogFreeRtosTcpStream* FreeRtosTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+static void FreeRtosTcpStream_CloseSocket(struct SolidSyslogFreeRtosTcpStream* self)
 {
-    return (struct SolidSyslogFreeRtosTcpStream*) base;
+    if (FreeRtosTcpStream_IsOpen(self))
+    {
+        (void) FreeRTOS_closesocket(self->Socket);
+        self->Socket = FREERTOS_INVALID_SOCKET;
+    }
 }
 
 static bool FreeRtosTcpStream_Open(struct SolidSyslogStream* base, const struct SolidSyslogAddress* addr)
@@ -270,15 +279,6 @@ static SolidSyslogSsize FreeRtosTcpStream_ReceiveOrCloseOnFailure(
 static void FreeRtosTcpStream_Close(struct SolidSyslogStream* base)
 {
     FreeRtosTcpStream_CloseSocket(FreeRtosTcpStream_SelfFromBase(base));
-}
-
-static void FreeRtosTcpStream_CloseSocket(struct SolidSyslogFreeRtosTcpStream* self)
-{
-    if (FreeRtosTcpStream_IsOpen(self))
-    {
-        (void) FreeRTOS_closesocket(self->Socket);
-        self->Socket = FREERTOS_INVALID_SOCKET;
-    }
 }
 
 // NOLINTEND(performance-no-int-to-ptr)

--- a/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
+++ b/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
@@ -55,6 +55,11 @@ void MbedTlsStream_Initialise(struct SolidSyslogStream* base, const struct Solid
     mbedtls_ssl_config_init(&self->SslConfig);
 }
 
+static inline struct SolidSyslogMbedTlsStream* MbedTlsStream_SelfFromBase(struct SolidSyslogStream* base)
+{
+    return (struct SolidSyslogMbedTlsStream*) base;
+}
+
 void MbedTlsStream_Cleanup(struct SolidSyslogStream* base)
 {
     /* Mirror the OpenSSL TlsStream pattern: an integrator who destroys a
@@ -65,9 +70,17 @@ void MbedTlsStream_Cleanup(struct SolidSyslogStream* base)
     *base = *SolidSyslogNullStream_Get();
 }
 
-static inline struct SolidSyslogMbedTlsStream* MbedTlsStream_SelfFromBase(struct SolidSyslogStream* base)
+/* Idempotent: a previous Close left the structs in mbedTLS's freed-equivalent
+ * (zeroed) state, so close_notify sees conf == NULL and returns harmlessly,
+ * and the *_free calls are no-ops on already-freed structs. Transport Close
+ * is itself idempotent on every Stream impl. */
+static inline void MbedTlsStream_Close(struct SolidSyslogStream* base)
 {
-    return (struct SolidSyslogMbedTlsStream*) base;
+    struct SolidSyslogMbedTlsStream* self = MbedTlsStream_SelfFromBase(base);
+    (void) mbedtls_ssl_close_notify(&self->SslContext);
+    mbedtls_ssl_free(&self->SslContext);
+    mbedtls_ssl_config_free(&self->SslConfig);
+    SolidSyslogStream_Close(self->Config.Transport);
 }
 
 static inline bool MbedTlsStream_Open(struct SolidSyslogStream* base, const struct SolidSyslogAddress* addr)
@@ -240,17 +253,4 @@ static inline SolidSyslogSsize MbedTlsStream_Read(struct SolidSyslogStream* base
         MbedTlsStream_Close(base);
     }
     return result;
-}
-
-/* Idempotent: a previous Close left the structs in mbedTLS's freed-equivalent
- * (zeroed) state, so close_notify sees conf == NULL and returns harmlessly,
- * and the *_free calls are no-ops on already-freed structs. Transport Close
- * is itself idempotent on every Stream impl. */
-static inline void MbedTlsStream_Close(struct SolidSyslogStream* base)
-{
-    struct SolidSyslogMbedTlsStream* self = MbedTlsStream_SelfFromBase(base);
-    (void) mbedtls_ssl_close_notify(&self->SslContext);
-    mbedtls_ssl_free(&self->SslContext);
-    mbedtls_ssl_config_free(&self->SslConfig);
-    SolidSyslogStream_Close(self->Config.Transport);
 }

--- a/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
+++ b/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
@@ -65,6 +65,11 @@ void TlsStream_Initialise(struct SolidSyslogStream* base, const struct SolidSysl
     self->BioMethod = NULL;
 }
 
+static inline struct SolidSyslogTlsStream* TlsStream_SelfFromBase(struct SolidSyslogStream* base)
+{
+    return (struct SolidSyslogTlsStream*) base;
+}
+
 void TlsStream_Cleanup(struct SolidSyslogStream* base)
 {
     struct SolidSyslogTlsStream* self = TlsStream_SelfFromBase(base);
@@ -80,9 +85,18 @@ void TlsStream_Cleanup(struct SolidSyslogStream* base)
     *base = *SolidSyslogNullStream_Get();
 }
 
-static inline struct SolidSyslogTlsStream* TlsStream_SelfFromBase(struct SolidSyslogStream* base)
+/* Idempotent: Send/Read may close internally on failure, after which the
+ * StreamSender's reconnect path or the caller's Destroy may call Close
+ * again. Skipping when ssl is already NULL keeps that safe. */
+static inline void TlsStream_Close(struct SolidSyslogStream* base)
 {
-    return (struct SolidSyslogTlsStream*) base;
+    struct SolidSyslogTlsStream* self = TlsStream_SelfFromBase(base);
+    if (self->Ssl != NULL)
+    {
+        SSL_shutdown(self->Ssl);
+        TlsStream_ReleaseHandshakeState(self);
+    }
+    SolidSyslogStream_Close(self->Config.Transport);
 }
 
 static inline void TlsStream_ReleaseHandshakeState(struct SolidSyslogTlsStream* self)
@@ -418,18 +432,4 @@ static inline SolidSyslogSsize TlsStream_Read(struct SolidSyslogStream* base, vo
         TlsStream_Close(base);
     }
     return result;
-}
-
-/* Idempotent: Send/Read may close internally on failure, after which the
- * StreamSender's reconnect path or the caller's Destroy may call Close
- * again. Skipping when ssl is already NULL keeps that safe. */
-static inline void TlsStream_Close(struct SolidSyslogStream* base)
-{
-    struct SolidSyslogTlsStream* self = TlsStream_SelfFromBase(base);
-    if (self->Ssl != NULL)
-    {
-        SSL_shutdown(self->Ssl);
-        TlsStream_ReleaseHandshakeState(self);
-    }
-    SolidSyslogStream_Close(self->Config.Transport);
 }

--- a/Platform/Posix/Source/SolidSyslogPosixAddressStatic.c
+++ b/Platform/Posix/Source/SolidSyslogPosixAddressStatic.c
@@ -43,6 +43,11 @@ struct SolidSyslogAddress* SolidSyslogPosixAddress_Create(void)
     return handle;
 }
 
+static inline struct SolidSyslogAddress* PosixAddress_HandleFromIndex(size_t index)
+{
+    return (struct SolidSyslogAddress*) &PosixAddress_Pool[index];
+}
+
 void SolidSyslogPosixAddress_Destroy(struct SolidSyslogAddress* base)
 {
     size_t index = PosixAddress_IndexFromHandle(base);
@@ -53,11 +58,6 @@ void SolidSyslogPosixAddress_Destroy(struct SolidSyslogAddress* base)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_POSIXADDRESS_UNKNOWN_DESTROY);
     }
-}
-
-static inline struct SolidSyslogAddress* PosixAddress_HandleFromIndex(size_t index)
-{
-    return (struct SolidSyslogAddress*) &PosixAddress_Pool[index];
 }
 
 static inline size_t PosixAddress_IndexFromHandle(const struct SolidSyslogAddress* base)

--- a/Platform/Posix/Source/SolidSyslogPosixDatagram.c
+++ b/Platform/Posix/Source/SolidSyslogPosixDatagram.c
@@ -50,6 +50,11 @@ void PosixDatagram_Initialise(struct SolidSyslogDatagram* base)
     self->Connected = false;
 }
 
+static inline struct SolidSyslogPosixDatagram* PosixDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
+{
+    return (struct SolidSyslogPosixDatagram*) base;
+}
+
 void PosixDatagram_Cleanup(struct SolidSyslogDatagram* base)
 {
     struct SolidSyslogPosixDatagram* self = PosixDatagram_SelfFromBase(base);
@@ -64,22 +69,17 @@ void PosixDatagram_Cleanup(struct SolidSyslogDatagram* base)
     *base = *SolidSyslogNullDatagram_Get();
 }
 
+static inline bool PosixDatagram_IsFileDescriptorValid(int fd)
+{
+    return fd >= 0;
+}
+
 static bool PosixDatagram_Open(struct SolidSyslogDatagram* base)
 {
     struct SolidSyslogPosixDatagram* self = PosixDatagram_SelfFromBase(base);
     self->Fd = socket(AF_INET, SOCK_DGRAM, 0);
     self->Connected = false;
     return PosixDatagram_IsFileDescriptorValid(self->Fd);
-}
-
-static inline struct SolidSyslogPosixDatagram* PosixDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
-{
-    return (struct SolidSyslogPosixDatagram*) base;
-}
-
-static inline bool PosixDatagram_IsFileDescriptorValid(int fd)
-{
-    return fd >= 0;
 }
 
 static enum SolidSyslogDatagramSendResult PosixDatagram_SendTo(

--- a/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
+++ b/Platform/Posix/Source/SolidSyslogPosixTcpStream.c
@@ -70,6 +70,11 @@ void PosixTcpStream_Initialise(struct SolidSyslogStream* base)
     self->Fd = INVALID_FD;
 }
 
+static inline struct SolidSyslogPosixTcpStream* PosixTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+{
+    return (struct SolidSyslogPosixTcpStream*) base;
+}
+
 void PosixTcpStream_Cleanup(struct SolidSyslogStream* base)
 {
     struct SolidSyslogPosixTcpStream* self = PosixTcpStream_SelfFromBase(base);
@@ -83,9 +88,9 @@ void PosixTcpStream_Cleanup(struct SolidSyslogStream* base)
     *base = *SolidSyslogNullStream_Get();
 }
 
-static inline struct SolidSyslogPosixTcpStream* PosixTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+static inline bool PosixTcpStream_IsFileDescriptorValid(int fd)
 {
-    return (struct SolidSyslogPosixTcpStream*) base;
+    return (fd >= 0);
 }
 
 static bool PosixTcpStream_Open(struct SolidSyslogStream* base, const struct SolidSyslogAddress* addr)
@@ -153,11 +158,6 @@ static bool PosixTcpStream_SetNonBlocking(int fd)
 {
     int flags = fcntl(fd, F_GETFL, 0);
     return (flags >= 0) && (fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1);
-}
-
-static inline bool PosixTcpStream_IsFileDescriptorValid(int fd)
-{
-    return (fd >= 0);
 }
 
 static bool PosixTcpStream_ConnectOrCloseOnFailure(

--- a/Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c
@@ -21,11 +21,11 @@ void WindowsAtomicCounter_Initialise(struct SolidSyslogAtomicCounter* base)
     WindowsAtomicCounter_Init(self, 0U);
 }
 
-void WindowsAtomicCounter_Cleanup(struct SolidSyslogAtomicCounter* base)
+static inline struct SolidSyslogWindowsAtomicCounter* WindowsAtomicCounter_SelfFromBase(
+    struct SolidSyslogAtomicCounter* base
+)
 {
-    /* Overwrite the abstract base with the shared NullAtomicCounter vtable so
-     * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
-    *base = *SolidSyslogNullAtomicCounter_Get();
+    return (struct SolidSyslogWindowsAtomicCounter*) base;
 }
 
 void WindowsAtomicCounter_Init(struct SolidSyslogWindowsAtomicCounter* self, uint32_t value)
@@ -33,11 +33,11 @@ void WindowsAtomicCounter_Init(struct SolidSyslogWindowsAtomicCounter* self, uin
     self->Value = (LONG) value;
 }
 
-static inline struct SolidSyslogWindowsAtomicCounter* WindowsAtomicCounter_SelfFromBase(
-    struct SolidSyslogAtomicCounter* base
-)
+void WindowsAtomicCounter_Cleanup(struct SolidSyslogAtomicCounter* base)
 {
-    return (struct SolidSyslogWindowsAtomicCounter*) base;
+    /* Overwrite the abstract base with the shared NullAtomicCounter vtable so
+     * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
+    *base = *SolidSyslogNullAtomicCounter_Get();
 }
 
 static uint32_t WindowsAtomicCounter_Increment(struct SolidSyslogAtomicCounter* base)

--- a/Platform/Windows/Source/SolidSyslogWinsockAddressStatic.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockAddressStatic.c
@@ -43,6 +43,11 @@ struct SolidSyslogAddress* SolidSyslogWinsockAddress_Create(void)
     return handle;
 }
 
+static inline struct SolidSyslogAddress* WinsockAddress_HandleFromIndex(size_t index)
+{
+    return (struct SolidSyslogAddress*) &WinsockAddress_Pool[index];
+}
+
 void SolidSyslogWinsockAddress_Destroy(struct SolidSyslogAddress* base)
 {
     size_t index = WinsockAddress_IndexFromHandle(base);
@@ -53,11 +58,6 @@ void SolidSyslogWinsockAddress_Destroy(struct SolidSyslogAddress* base)
     {
         SolidSyslog_Error(SOLIDSYSLOG_SEVERITY_WARNING, SOLIDSYSLOG_ERROR_MSG_WINSOCKADDRESS_UNKNOWN_DESTROY);
     }
-}
-
-static inline struct SolidSyslogAddress* WinsockAddress_HandleFromIndex(size_t index)
-{
-    return (struct SolidSyslogAddress*) &WinsockAddress_Pool[index];
 }
 
 static inline size_t WinsockAddress_IndexFromHandle(const struct SolidSyslogAddress* base)

--- a/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockDatagram.c
@@ -89,6 +89,11 @@ void WinsockDatagram_Initialise(struct SolidSyslogDatagram* base)
     self->Connected = false;
 }
 
+static inline struct SolidSyslogWinsockDatagram* WinsockDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
+{
+    return (struct SolidSyslogWinsockDatagram*) base;
+}
+
 void WinsockDatagram_Cleanup(struct SolidSyslogDatagram* base)
 {
     struct SolidSyslogWinsockDatagram* self = WinsockDatagram_SelfFromBase(base);
@@ -103,22 +108,17 @@ void WinsockDatagram_Cleanup(struct SolidSyslogDatagram* base)
     *base = *SolidSyslogNullDatagram_Get();
 }
 
+static inline bool WinsockDatagram_IsSocketValid(SOCKET fd)
+{
+    return fd != INVALID_SOCKET;
+}
+
 static bool WinsockDatagram_Open(struct SolidSyslogDatagram* base)
 {
     struct SolidSyslogWinsockDatagram* self = WinsockDatagram_SelfFromBase(base);
     self->Fd = Winsock_socket(AF_INET, SOCK_DGRAM, 0);
     self->Connected = false;
     return WinsockDatagram_IsSocketValid(self->Fd);
-}
-
-static inline struct SolidSyslogWinsockDatagram* WinsockDatagram_SelfFromBase(struct SolidSyslogDatagram* base)
-{
-    return (struct SolidSyslogWinsockDatagram*) base;
-}
-
-static inline bool WinsockDatagram_IsSocketValid(SOCKET fd)
-{
-    return fd != INVALID_SOCKET;
 }
 
 static enum SolidSyslogDatagramSendResult WinsockDatagram_SendTo(

--- a/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
+++ b/Platform/Windows/Source/SolidSyslogWinsockTcpStream.c
@@ -155,6 +155,11 @@ void WinsockTcpStream_Initialise(struct SolidSyslogStream* base)
     self->Fd = INVALID_SOCKET;
 }
 
+static inline struct SolidSyslogWinsockTcpStream* WinsockTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+{
+    return (struct SolidSyslogWinsockTcpStream*) base;
+}
+
 void WinsockTcpStream_Cleanup(struct SolidSyslogStream* base)
 {
     WinsockTcpStream_Close(base);
@@ -163,9 +168,14 @@ void WinsockTcpStream_Cleanup(struct SolidSyslogStream* base)
     *base = *SolidSyslogNullStream_Get();
 }
 
-static inline struct SolidSyslogWinsockTcpStream* WinsockTcpStream_SelfFromBase(struct SolidSyslogStream* base)
+static void WinsockTcpStream_Close(struct SolidSyslogStream* base)
 {
-    return (struct SolidSyslogWinsockTcpStream*) base;
+    struct SolidSyslogWinsockTcpStream* self = WinsockTcpStream_SelfFromBase(base);
+    if (WinsockTcpStream_IsSocketValid(self->Fd))
+    {
+        WinsockTcpStream_closesocket(self->Fd);
+        self->Fd = INVALID_SOCKET;
+    }
 }
 
 static bool WinsockTcpStream_Open(struct SolidSyslogStream* base, const struct SolidSyslogAddress* addr)
@@ -350,14 +360,4 @@ static SolidSyslogSsize WinsockTcpStream_Read(struct SolidSyslogStream* base, vo
 static inline bool WinsockTcpStream_WouldBlock(int wsaError)
 {
     return wsaError == WSAEWOULDBLOCK;
-}
-
-static void WinsockTcpStream_Close(struct SolidSyslogStream* base)
-{
-    struct SolidSyslogWinsockTcpStream* self = WinsockTcpStream_SelfFromBase(base);
-    if (WinsockTcpStream_IsSocketValid(self->Fd))
-    {
-        WinsockTcpStream_closesocket(self->Fd);
-        self->Fd = INVALID_SOCKET;
-    }
 }


### PR DESCRIPTION
## Purpose

Closes #423. Re-applies the documented function-ordering convention (`_Create`/`_Destroy` first, public funcs next, static helpers defined immediately beneath their first caller) across the project tree. The convention had drifted in pool-class `*Static.c` files and a handful of platform adapters — caught by CodeRabbit on PR #422 (`SolidSyslogPosixAddressStatic.c::HandleFromIndex` sat after `_Destroy` despite its first caller being `_Create`).

## Change Description

Move-only refactor. No behaviour change.

**Files touched (24):**

- **Core/Source (5)** — `SolidSyslogStatic.c`, `SolidSyslogMetaSdStatic.c`, `SolidSyslogUdpSenderStatic.c`, `SolidSyslogBlockStoreStatic.c`, `BlockSequence.c`.
- **Platform (13)** — Atomics, FatFs, FreeRtos (Address/Datagram/Mutex/StaticResolver/TcpStream), MbedTls, OpenSsl, Posix (Address/Datagram/TcpStream), Windows (AtomicCounter, WinsockAddress/Datagram/TcpStream). Files audited as compliant and left alone: PosixClock, WindowsClock, WinsockResolver.
- **Bdd/Targets (2)** — `diskio.c` (Semihosting helpers regrouped into call-graph order), FreeRTOS BDD `main.c` (`main` + four `vApplication*` OS-callback hooks lifted to the top, OnSet cluster reorganised into call-graph order, three forward decls added for `SetEthernetIrqPriority`/`InteractiveTask`/`ServiceTask`).
- **DEVLOG.md** — entry documenting the audit method and the two convention clarifications gathered along the way.

**Convention clarifications applied:**

- **Vtable methods called by `_Cleanup`.** When `_Cleanup` delegates to `_Close` (TlsStream / MbedTlsStream / WinsockTcpStream), `_Close` moved up beneath `_Cleanup`. When `_Cleanup` inlines its own close logic (PosixTcpStream), `_Close` stays at the end in API order.
- **`main` is a special case** (per direction during review): entry-point first, other rules apply normally.

**Helper-to-helper micro-ordering within a single caller's helper cluster** (e.g. ordering of `BreakDownFileTime` / `MicrosecondsFromFileTime` / `PopulateTimestamp` under `_GetTimestamp`) was left alone — the strict reading would touch many compliant files for stylistic gain only.

## Test Evidence

- Local: `cmake --preset debug && cmake --build --preset debug --target junit` — all tests green (host tests + MbedTls integration tests in the `cpputest-freertos` container).
- Local: `clang-format --dry-run --Werror` on changed files — clean.
- CI will run the full matrix.

Pre-existing format violation in `TlsStreamStatic.c` and `FatFsFileStatic.c` (`bool released = ...` continuation indent) is **out of scope** — both files untouched by this PR.

## Areas Affected

- Source organisation only. No public-API or behaviour changes.
- Diff is move-only: every change is a function definition (and sometimes its leading comment block) relocated within the same file. No semantic edits.
- Tests/ explicitly out of scope per the issue body. Fakes were audited anyway and turned out to be compliant — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure across multiple platform and core components to follow project conventions for function placement and ordering. Functions and static helpers are repositioned for improved code organization and maintainability without affecting functionality.

* **Chores**
  * Updated development documentation to record the code organization audit and conventions applied during this refactoring sweep.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->