### PR TITLE
chore: S24.12 audit inline cppcheck-suppress and NOLINT comments tree-wide

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
   readability-*,
   -modernize-use-trailing-return-type,
   -modernize-use-using,
+  -modernize-redundant-void-arg,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -readability-magic-numbers,
   -cppcoreguidelines-avoid-magic-numbers,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,6 +581,7 @@ jobs:
           cppcheck
           --enable=warning,style,performance,portability
           --suppress=missingIncludeSystem
+          --suppressions-list=cppcheck_suppressions_tests.txt
           --inline-suppr
           --std=c11
           -ICore/Interface

--- a/Bdd/Targets/Common/BddTargetIps.h
+++ b/Bdd/Targets/Common/BddTargetIps.h
@@ -9,7 +9,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogFormatter;
 
-    size_t BddTargetIps_Count(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    size_t BddTargetIps_Count(void);
     void BddTargetIps_At(struct SolidSyslogFormatter * formatter, size_t index);
 
 EXTERN_C_END

--- a/Bdd/Targets/Common/BddTargetSwitchConfig.h
+++ b/Bdd/Targets/Common/BddTargetSwitchConfig.h
@@ -17,14 +17,14 @@ EXTERN_C_BEGIN
     };
 
     void BddTargetSwitchConfig_SetByName(const char* name);
-    uint8_t BddTargetSwitchConfig_Selector(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    uint8_t BddTargetSwitchConfig_Selector(void);
     /* tls and mtls share the same Switching slot (BDD_TARGET_SWITCH_TLS) so
      * the TLS sender / TLS stream / underlying TCP socket get reused across
      * the two modes. The FreeRTOS BDD target reads this at TLS Connect time
      * to pick between the syslog-ng oracle's port 6514 (TLS) and 6515 (mTLS);
      * the client cert is wired regardless of mode, so the port is the only
      * thing that has to flip. */
-    bool BddTargetSwitchConfig_IsMtlsMode(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    bool BddTargetSwitchConfig_IsMtlsMode(void);
 
 EXTERN_C_END
 

--- a/Bdd/Targets/FreeRtos/Common/CmsdkUart.c
+++ b/Bdd/Targets/FreeRtos/Common/CmsdkUart.c
@@ -3,27 +3,27 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// The CMSDK UART register-offset, control-bit and status-bit macros below
+// The CMSDK UART register-offset, control-bit and status-bit values below
 // mirror the ARM CMSDK UART hardware datasheet exactly, plus the integer-
-// valued YIELD_MILLISECONDS yield interval. The macro form is intentional —
-// a future reader can grep `DATA_OFFSET` against vendor docs and land on
-// these definitions verbatim. Converting them to enums would obscure that
-// mapping, so we keep them as #defines. Mirrors the suppression in
-// Tests/FreeRtos/CmsdkUartFake.c.
-// NOLINTBEGIN(cppcoreguidelines-macro-to-enum,modernize-macro-to-enum)
-#define DATA_OFFSET 0x000U
-#define STATE_OFFSET 0x004U
-#define CTRL_OFFSET 0x008U
-#define BAUDDIV_OFFSET 0x010U
+// valued YIELD_MILLISECONDS yield interval. Grouped into an anonymous enum
+// so a future reader can grep `DATA_OFFSET` against vendor docs and land on
+// these definitions verbatim, while gaining a typed identifier over the
+// historical #define form. Mirrors the values in Tests/FreeRtos/CmsdkUartFake.c.
+enum
+{
+    DATA_OFFSET = 0x000,
+    STATE_OFFSET = 0x004,
+    CTRL_OFFSET = 0x008,
+    BAUDDIV_OFFSET = 0x010,
 
-#define BAUD_DIVISOR 16U
-#define TX_ENABLE 0x01U
-#define RX_ENABLE 0x02U
-#define TX_FULL_BIT 0x01U
-#define RX_FULL_BIT 0x02U
+    BAUD_DIVISOR = 16,
+    TX_ENABLE = 0x01,
+    RX_ENABLE = 0x02,
+    TX_FULL_BIT = 0x01,
+    RX_FULL_BIT = 0x02,
 
-#define YIELD_MILLISECONDS 1
-// NOLINTEND(cppcoreguidelines-macro-to-enum,modernize-macro-to-enum)
+    YIELD_MILLISECONDS = 1,
+};
 
 static const CmsdkUartMemoryAccess* memoryAccess = NULL;
 static uintptr_t base = 0U;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if(ENABLE_CPPCHECK)
             "--enable=warning,style,performance,portability"
             "--error-exitcode=1"
             "--suppress=missingIncludeSystem"
+            "--suppressions-list=${CMAKE_SOURCE_DIR}/cppcheck_suppressions_tests.txt"
             "--inline-suppr"
             "--std=c11"
         )
@@ -62,6 +63,7 @@ if(ENABLE_CPPCHECK)
             "--error-exitcode=1"
             "--suppress=missingIncludeSystem"
             "--suppress=useStlAlgorithm"
+            "--suppressions-list=${CMAKE_SOURCE_DIR}/cppcheck_suppressions_tests.txt"
             "--inline-suppr"
             "--std=c++17"
         )

--- a/Core/Interface/.clang-tidy
+++ b/Core/Interface/.clang-tidy
@@ -1,0 +1,17 @@
+---
+# Public-header tier per docs/NAMING.md — Tier 1.
+#
+# Inherits the root .clang-tidy and disables one rule:
+#
+# -cppcoreguidelines-macro-usage
+#   Core/Interface/ is C-macro-heavy by design — `SOLIDSYSLOG_*_POOL_SIZE`
+#   defaults must be visible to the preprocessor (`#if`-checked floors) and
+#   usable as array-size const-expressions in dependent headers. Replacing
+#   with `static const` or `constexpr` loses both properties. The same idiom
+#   appears in SolidSyslogFormatter.h (worst-case output sizing macros),
+#   SolidSyslogCircularBuffer.h (ring-bytes helper) and ExternC.h
+#   (extern "C" linkage block). The rule fires on every entry, the
+#   rationale is uniform, so disable tier-wide here rather than carry the
+#   same NOLINT comment on dozens of macro definitions.
+InheritParentConfig: true
+Checks: '-cppcoreguidelines-macro-usage'

--- a/Core/Interface/ExternC.h
+++ b/Core/Interface/ExternC.h
@@ -1,7 +1,6 @@
 #ifndef EXTERNC_H
 #define EXTERNC_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- no language alternative for extern "C" linkage blocks
 #ifdef __cplusplus
 #define EXTERN_C_BEGIN \
     extern "C"         \
@@ -11,6 +10,5 @@
 #define EXTERN_C_BEGIN
 #define EXTERN_C_END
 #endif
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* EXTERNC_H */

--- a/Core/Interface/SolidSyslogCircularBuffer.h
+++ b/Core/Interface/SolidSyslogCircularBuffer.h
@@ -18,7 +18,6 @@ EXTERN_C_BEGIN
         SOLIDSYSLOG_CIRCULAR_BUFFER_HEADER_BYTES = sizeof(uint16_t)
     };
 
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- C array-size const-expr; not a function-like expression */
 #define SOLIDSYSLOG_CIRCULAR_BUFFER_RING_BYTES(maxMessages) \
     ((maxMessages) * (SOLIDSYSLOG_MAX_MESSAGE_SIZE + SOLIDSYSLOG_CIRCULAR_BUFFER_HEADER_BYTES))
 

--- a/Core/Interface/SolidSyslogConfigLock.h
+++ b/Core/Interface/SolidSyslogConfigLock.h
@@ -5,7 +5,7 @@
 
 EXTERN_C_BEGIN
 
-    typedef void (*SolidSyslogConfigLockFunction)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    typedef void (*SolidSyslogConfigLockFunction)(void);
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- deliberate pair API: lock and unlock are installed together and conceptually inseparable; matches SolidSyslog_SetErrorHandler's pair shape
     void SolidSyslog_SetConfigLock(SolidSyslogConfigLockFunction lockFn, SolidSyslogConfigLockFunction unlockFn);

--- a/Core/Interface/SolidSyslogEndpoint.h
+++ b/Core/Interface/SolidSyslogEndpoint.h
@@ -23,7 +23,7 @@ EXTERN_C_BEGIN
     /* Cheap pure function returning a monotonic version counter the user bumps on any change to host or port.
        The sender polls this on every Send and only re-pulls the endpoint when the version differs from the
        last value it acted on. */
-    typedef uint32_t (*SolidSyslogEndpointVersionFunction)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    typedef uint32_t (*SolidSyslogEndpointVersionFunction)(void);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogFormatter.h
+++ b/Core/Interface/SolidSyslogFormatter.h
@@ -15,12 +15,10 @@ EXTERN_C_BEGIN
         SOLIDSYSLOG_FORMATTER_OVERHEAD = 2U
     };
 
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- cannot compute array size as a constexpr in C */
 #define SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(bufferSize) \
     (SOLIDSYSLOG_FORMATTER_OVERHEAD +                  \
      (((bufferSize) + sizeof(SolidSyslogFormatterStorage) - 1U) / sizeof(SolidSyslogFormatterStorage)))
 
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- compile-time worst-case size for EscapedString output */
 #define SOLIDSYSLOG_ESCAPED_MAX_SIZE(maxDecodedLength) (2U * (maxDecodedLength))
 
     struct SolidSyslogFormatter;

--- a/Core/Interface/SolidSyslogMetaSd.h
+++ b/Core/Interface/SolidSyslogMetaSd.h
@@ -11,7 +11,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogAtomicCounter;
     struct SolidSyslogStructuredData;
 
-    typedef uint32_t (*SolidSyslogSysUpTimeFunction)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    typedef uint32_t (*SolidSyslogSysUpTimeFunction)(void);
 
     struct SolidSyslogMetaSdConfig
     {

--- a/Core/Interface/SolidSyslogOriginSd.h
+++ b/Core/Interface/SolidSyslogOriginSd.h
@@ -10,7 +10,7 @@ EXTERN_C_BEGIN
     struct SolidSyslogFormatter;
     struct SolidSyslogStructuredData;
 
-    typedef size_t (*SolidSyslogOriginIpCountFunction)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    typedef size_t (*SolidSyslogOriginIpCountFunction)(void);
     typedef void (*SolidSyslogOriginIpAtFunction)(struct SolidSyslogFormatter* formatter, size_t index);
 
     struct SolidSyslogOriginSdConfig

--- a/Core/Interface/SolidSyslogSwitchingSender.h
+++ b/Core/Interface/SolidSyslogSwitchingSender.h
@@ -10,7 +10,7 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogSender;
 
-    typedef uint8_t (*SolidSyslogSwitchingSenderSelector)(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    typedef uint8_t (*SolidSyslogSwitchingSenderSelector)(void);
 
     struct SolidSyslogSwitchingSenderConfig
     {

--- a/Core/Interface/SolidSyslogTunablesDefaults.h
+++ b/Core/Interface/SolidSyslogTunablesDefaults.h
@@ -20,7 +20,6 @@
  * Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_MAX_MESSAGE_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_MAX_MESSAGE_SIZE 2048U /* RFC 5424 section 6.1 SHOULD value */
 #endif
 
@@ -40,7 +39,6 @@
  * filesystem location. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_MAX_PATH_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_MAX_PATH_SIZE 128U
 #endif
 
@@ -60,7 +58,6 @@
  * rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_MAX_INTEGRITY_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_MAX_INTEGRITY_SIZE 32U
 #endif
 
@@ -80,7 +77,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POOL_SIZE 1U
 #endif
 
@@ -102,7 +98,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_CIRCULAR_BUFFER_POOL_SIZE 1U
 #endif
 
@@ -123,7 +118,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE 1U
 #endif
 
@@ -143,7 +137,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE 1U
 #endif
 
@@ -164,7 +157,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE 1U
 #endif
 
@@ -184,7 +176,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POSIX_FILE_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POSIX_FILE_POOL_SIZE 1U
 #endif
 
@@ -207,7 +198,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE 2U
 #endif
 
@@ -229,7 +219,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE 1U
 #endif
 
@@ -250,7 +239,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_PASSTHROUGH_BUFFER_POOL_SIZE 1U
 #endif
 
@@ -272,7 +260,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_UDP_SENDER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_UDP_SENDER_POOL_SIZE 1U
 #endif
 
@@ -291,7 +278,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_SWITCHING_SENDER_POOL_SIZE 1U
 #endif
 
@@ -314,7 +300,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_STREAM_SENDER_POOL_SIZE 2U
 #endif
 
@@ -339,7 +324,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_BLOCK_STORE_POOL_SIZE 1U
 #endif
 
@@ -359,7 +343,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_FILE_BLOCK_DEVICE_POOL_SIZE 1U
 #endif
 
@@ -375,7 +358,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_META_SD_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_META_SD_POOL_SIZE 1U
 #endif
 
@@ -390,7 +372,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE 1U
 #endif
 
@@ -410,7 +391,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_ORIGIN_SD_POOL_SIZE 1U
 #endif
 
@@ -431,7 +411,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE 1U
 #endif
 
@@ -451,7 +430,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE 1U
 #endif
 
@@ -470,7 +448,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE 1U
 #endif
 
@@ -489,7 +466,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE 1U
 #endif
 
@@ -508,7 +484,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE 2U
 #endif
 
@@ -530,7 +505,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_FREE_RTOS_MUTEX_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_FREE_RTOS_MUTEX_POOL_SIZE 1U
 #endif
 
@@ -550,7 +524,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_PLUS_TCP_DATAGRAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_PLUS_TCP_DATAGRAM_POOL_SIZE 1U
 #endif
 
@@ -570,7 +543,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_PLUS_TCP_RESOLVER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_PLUS_TCP_RESOLVER_POOL_SIZE 1U
 #endif
 
@@ -590,7 +562,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_LWIP_RAW_RESOLVER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_LWIP_RAW_RESOLVER_POOL_SIZE 1U
 #endif
 
@@ -613,7 +584,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_PLUS_TCP_TCP_STREAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_PLUS_TCP_TCP_STREAM_POOL_SIZE 2U
 #endif
 
@@ -634,7 +604,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_STD_ATOMIC_COUNTER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_STD_ATOMIC_COUNTER_POOL_SIZE 1U
 #endif
 
@@ -656,7 +625,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_WINDOWS_ATOMIC_COUNTER_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_WINDOWS_ATOMIC_COUNTER_POOL_SIZE 1U
 #endif
 
@@ -677,7 +645,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_FATFS_FILE_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_FATFS_FILE_POOL_SIZE 1U
 #endif
 
@@ -699,7 +666,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_TLS_STREAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_TLS_STREAM_POOL_SIZE 1U
 #endif
 
@@ -722,7 +688,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_MBED_TLS_STREAM_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_MBED_TLS_STREAM_POOL_SIZE 1U
 #endif
 
@@ -748,7 +713,6 @@
  * Floor: 1. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_ADDRESS_POOL_SIZE
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_ADDRESS_POOL_SIZE 3U
 #endif
 
@@ -770,7 +734,6 @@
  * Floor: 1 ms. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_TCP_CONNECT_TIMEOUT_MS
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_TCP_CONNECT_TIMEOUT_MS 200U
 #endif
 
@@ -792,7 +755,6 @@
  * Floor: 1 ms. Sub-floor values rejected at compile time.
  */
 #ifndef SOLIDSYSLOG_TLS_HANDSHAKE_TIMEOUT_MS
-/* NOLINTNEXTLINE(cppcoreguidelines-macro-usage) -- macro form required for preprocessor visibility (floor #if) and C array-size const-expr. */
 #define SOLIDSYSLOG_TLS_HANDSHAKE_TIMEOUT_MS 5000U
 #endif
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,121 @@
 # Dev Log
 
+## 2026-05-26 — S24.12 inline cppcheck-suppress and NOLINT audit
+
+E24 code-hygiene story #461. The session-end of S24.11 left 213 inline
+`// cppcheck-suppress` and ~340 inline `NOLINT*` comments tree-wide.
+David's open question was the residual count of non-MISRA cppcheck
+inline suppressions after triaging per the story's priority order
+(tier-level > fix > misra_suppressions > inline).
+
+### Decisions
+
+- **One PR, three commits.** Per David's preference for fewer slices
+  with rule-disable + inline-strip in the same commit, the audit lands
+  as `chore: S24.12 …` × 3 on `ci/s24-12-inline-suppression-audit`:
+  (1) clang-tidy tier promotions + CmsdkUart enum conversion,
+  (2) cppcheck Tests/* glob suppressions + Platform AddressPrivate.h
+  cstyleCast, (3) further Tests-tier promotions surfaced during the
+  residual audit + DEVLOG.
+
+- **Promoted to root `.clang-tidy`:** `modernize-redundant-void-arg`.
+  We're a C codebase; the rule is meaningless. Dropped ~8 identical
+  "C idiom" NOLINTs.
+
+- **New `Core/Interface/.clang-tidy`:** disables
+  `cppcoreguidelines-macro-usage`. Public headers carry preprocessor-
+  visible (`#if` floor) and array-size const-expr macros by design.
+  Dropped ~37 identical NOLINTs — 33 of them on `SolidSyslogTunablesDefaults.h`
+  alone, where the pattern repeats per pool tunable.
+
+- **Extended `Tests/.clang-tidy`** with four further tier disables:
+  `google-build-using-namespace` (the `using namespace CososoTesting`
+  pattern at file scope), `cppcoreguidelines-macro-usage` and
+  `cppcoreguidelines-avoid-do-while` (paired for `CHECK_*` macros
+  preserving `__FILE__/__LINE__`), and
+  `cppcoreguidelines-pro-type-reinterpret-cast` (vtable downcasts to
+  Fake/Spy structs + sentinel/forge pointers for fault-injection
+  tests). Together these removed ~140 inline NOLINTs.
+
+- **CmsdkUart register macros converted to anonymous enums.** Per
+  David's "fix beats suppress" steer. The SoC-manual grep traceability
+  is preserved by keeping the names verbatim; the type-check the rule
+  wanted is gained. Applied symmetrically to
+  `Bdd/Targets/FreeRtos/Common/CmsdkUart.c` and
+  `Tests/FreeRtos/CmsdkUartFake.c`.
+
+- **New `cppcheck_suppressions_tests.txt`** with project-glob entries
+  for the CppUTest-macro-model false-positive cluster
+  (`unreadVariable`, `variableScope`, `constVariable`,
+  `knownConditionTrueFalse`, `unusedStructMember`,
+  `constVariablePointer`). Wired into the cppcheck preset via
+  `CMAKE_C_CPPCHECK` / `CMAKE_CXX_CPPCHECK` and into the CI
+  analyze-cppcheck report step. Cppcheck's glob matcher anchors at
+  both ends and `*` does match `/`, so paths use `*Tests/*` to allow
+  any absolute prefix (the cppcheck invocation in CMake passes
+  absolute paths). The same file carries `cstyleCast:*Platform/*/Source/*AddressPrivate.h`
+  for the eight opaque-to-impl downcasts whose `cstyleCast` warning
+  only fires when the C header is included from a C++ test
+  compilation unit.
+
+- **misra_suppressions.txt line drift handled.** Inline NOLINT
+  deletions shifted two lines on `SolidSyslogFormatter.h`, one on
+  `SolidSyslogCircularBuffer.h`. Pass-1 of `scripts/misra_renumber.py`
+  caught those automatically. Slice 2's `cstyleCast` deletion in the
+  `*AddressPrivate.h` headers shifted both 11.2 and 11.3 entries on
+  Posix/Windows/PlusTcp — and the rule-dedup-unmask pattern
+  (`feedback_cppcheck_dedup_unmask`) bit again: pass-1 only saw the
+  11.2 shift; the 11.3 entries needed manual update once 11.2 was
+  out of the way. Recipe holds — re-run cppcheck after every
+  suppression edit; manually patch when pass-2 hits the multi-entry
+  guard.
+
+- **Residual NOLINTs kept inline.** The remaining 124 NOLINTs have
+  per-site rationales that don't share a tier-level pattern:
+  `bugprone-easily-swappable-parameters` (72; vtable signatures,
+  pair APIs, byte-value semantics — rationales vary per site),
+  `readability-inconsistent-declaration-parameter-name` (16; POSIX
+  API mirroring in MqFake / SocketFake / ClockFake),
+  `performance-no-int-to-ptr` (9; MMIO + `FREERTOS_INVALID_SOCKET`
+  sentinel), `readability-non-const-parameter` (7; third-party
+  signature contracts), and a long tail of one-offs.
+
+- **Residual non-MISRA inline `cppcheck-suppress`: 4.** David's
+  question answered.
+  - `Tests/Support/ClockFake.{c,h}` — `constParameter`; API allows
+    `NULL` to signal failure.
+  - `Bdd/Targets/Common/BddTargetServiceThread.c` — `constParameter`;
+    `volatile bool` written by another thread.
+  - `Core/Interface/SolidSyslogTunables.h` — `preprocessorErrorDirective`;
+    build-time macro path supplied via `-D`.
+
+  Down from 213; 209 eliminated this session (98% reduction).
+
+### Deferred
+
+- **`Core/Source/SolidSyslogMacros.h`** keeps its
+  `cppcoreguidelines-macro-usage` NOLINTBEGIN/END pair for the
+  `_Static_assert` wrapper. Disabling the rule for `Core/Source/`
+  tree-wide would be too coarse — the file is the only legitimate
+  site. Self-contained inline pair is the right scope.
+
+- **Future Bdd-tier reconsideration.** `Bdd/.clang-tidy` currently
+  only disables `readability-identifier-naming`. The five
+  `performance-no-int-to-ptr` NOLINTs in `Bdd/Targets/FreeRtos/main.c`
+  (MMIO + NVIC IPR) and the `readability-non-const-parameter` on
+  `BddTargetWindows.c` (_beginthreadex signature) are third-party-
+  contract patterns that would justify tier-level rules if the BDD
+  target count grows further. Not worth doing for the current
+  count.
+
+### Open questions
+
+- None outstanding for this story. The pre-existing AMBIGUOUS
+  warnings in `scripts/misra_renumber.py` (cppcheck 2.10 in the
+  container missing findings that CI's cppcheck version still sees)
+  were noted in the prior DEVLOG (S24.11 close) and remain;
+  they are a tooling-version mismatch, not a code finding.
+
 ## 2026-05-26 — S28.03 SolidSyslogLwipRawAddress + SolidSyslogLwipRawResolver (literal IPv4, no DNS)
 
 Third story in E28 (#457, parent #439). First real lwIP code: the

--- a/Platform/FreeRtos/Interface/SolidSyslogFreeRtosSysUpTime.h
+++ b/Platform/FreeRtos/Interface/SolidSyslogFreeRtosSysUpTime.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_BEGIN
 
-    uint32_t SolidSyslogFreeRtosSysUpTime_Get(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    uint32_t SolidSyslogFreeRtosSysUpTime_Get(void);
 
 EXTERN_C_END
 

--- a/Platform/LwipRaw/Source/SolidSyslogLwipRawAddressPrivate.h
+++ b/Platform/LwipRaw/Source/SolidSyslogLwipRawAddressPrivate.h
@@ -21,7 +21,6 @@ void LwipRawAddress_Cleanup(struct SolidSyslogAddress* base);
 
 static inline struct SolidSyslogLwipRawAddress* SolidSyslogLwipRawAddress_As(struct SolidSyslogAddress* base)
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogLwipRawAddress
     return (struct SolidSyslogLwipRawAddress*) base;
 }
 
@@ -29,7 +28,6 @@ static inline const struct SolidSyslogLwipRawAddress* SolidSyslogLwipRawAddress_
     const struct SolidSyslogAddress* base
 )
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogLwipRawAddress
     return (const struct SolidSyslogLwipRawAddress*) base;
 }
 

--- a/Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h
+++ b/Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h
@@ -16,7 +16,6 @@ void PlusTcpAddress_Cleanup(struct SolidSyslogAddress* base);
 
 static inline struct freertos_sockaddr* SolidSyslogPlusTcpAddress_AsFreertosSockaddr(struct SolidSyslogAddress* base)
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogPlusTcpAddress
     return &((struct SolidSyslogPlusTcpAddress*) base)->Sockaddr;
 }
 
@@ -24,7 +23,6 @@ static inline const struct freertos_sockaddr* SolidSyslogPlusTcpAddress_AsConstF
     const struct SolidSyslogAddress* base
 )
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogPlusTcpAddress
     return &((const struct SolidSyslogPlusTcpAddress*) base)->Sockaddr;
 }
 

--- a/Platform/Posix/Interface/SolidSyslogPosixSysUpTime.h
+++ b/Platform/Posix/Interface/SolidSyslogPosixSysUpTime.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_BEGIN
 
-    uint32_t SolidSyslogPosixSysUpTime_Get(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    uint32_t SolidSyslogPosixSysUpTime_Get(void);
 
 EXTERN_C_END
 

--- a/Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h
+++ b/Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h
@@ -16,13 +16,11 @@ void PosixAddress_Cleanup(struct SolidSyslogAddress* base);
 
 static inline struct sockaddr_in* SolidSyslogPosixAddress_AsSockaddrIn(struct SolidSyslogAddress* base)
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogPosixAddress
     return &((struct SolidSyslogPosixAddress*) base)->Sockaddr;
 }
 
 static inline const struct sockaddr_in* SolidSyslogPosixAddress_AsConstSockaddrIn(const struct SolidSyslogAddress* base)
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogPosixAddress
     return &((const struct SolidSyslogPosixAddress*) base)->Sockaddr;
 }
 

--- a/Platform/Windows/Interface/SolidSyslogWindowsSysUpTime.h
+++ b/Platform/Windows/Interface/SolidSyslogWindowsSysUpTime.h
@@ -7,7 +7,7 @@
 
 EXTERN_C_BEGIN
 
-    uint32_t SolidSyslogWindowsSysUpTime_Get(void); // NOLINT(modernize-redundant-void-arg) -- C idiom
+    uint32_t SolidSyslogWindowsSysUpTime_Get(void);
 
 EXTERN_C_END
 

--- a/Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h
+++ b/Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h
@@ -16,7 +16,6 @@ void WinsockAddress_Cleanup(struct SolidSyslogAddress* base);
 
 static inline struct sockaddr_in* SolidSyslogWinsockAddress_AsSockaddrIn(struct SolidSyslogAddress* base)
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogWinsockAddress
     return &((struct SolidSyslogWinsockAddress*) base)->Sockaddr;
 }
 
@@ -24,7 +23,6 @@ static inline const struct sockaddr_in* SolidSyslogWinsockAddress_AsConstSockadd
     const struct SolidSyslogAddress* base
 )
 {
-    // cppcheck-suppress cstyleCast -- opaque-to-impl downcast: pool slot is a real SolidSyslogWinsockAddress
     return &((const struct SolidSyslogWinsockAddress*) base)->Sockaddr;
 }
 

--- a/Tests/.clang-tidy
+++ b/Tests/.clang-tidy
@@ -27,8 +27,36 @@
 #   scope at the call site. The scope is one .cpp file and the symbols are
 #   intentional sugar; the rule's "don't pollute global scope" concern does
 #   not apply to test-only translation units.
+#
+# -cppcoreguidelines-macro-usage
+#   Test code uses macros to preserve __FILE__/__LINE__ at the call site
+#   (CppUTest convention) — the rule's "prefer function" alternative
+#   destroys the failure-location information that makes test reports
+#   navigable. Same constraint applies to test fake config headers
+#   (FreeRTOSConfig.h, lwipopts.h, …) which the test harness includes:
+#   the upstream symbols must remain macros.
+#
+# -cppcoreguidelines-avoid-do-while
+#   Paired with the macro-usage relaxation above: do { ... } while (0)
+#   is the standard idiom for wrapping a multi-statement macro body so
+#   it remains a single statement at the call site. Without the wrapper,
+#   the macros lose composability inside if/else.
+#
+# -cppcoreguidelines-pro-type-reinterpret-cast
+#   Test fixtures legitimately reinterpret-cast for two patterns:
+#   (a) vtable downcast from base to a FakeX struct that embeds the base
+#       as its first field — the project's vtable contract guarantees the
+#       layout, and the cast is the way tests reach the spy/fake state;
+#   (b) sentinel pointer values for fault-injection (Open returns an
+#       opaque handle that the test only compares to nullptr, never
+#       dereferences) and "forged" handles to drive bad-setup paths.
+#   Both are deliberate fixture machinery; neither pattern occurs in
+#   production code.
 InheritParentConfig: true
 Checks: >
   -readability-identifier-naming,
   -bugprone-easily-swappable-parameters,
-  -google-build-using-namespace
+  -google-build-using-namespace,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-pro-type-reinterpret-cast

--- a/Tests/.clang-tidy
+++ b/Tests/.clang-tidy
@@ -20,7 +20,15 @@
 #   the types carry semantic distinction the rule can't see. Disabled tier-
 #   wide because the rule fires too often for legitimate patterns; real
 #   argument-order bugs in tests get caught by the tests themselves.
+#
+# -google-build-using-namespace
+#   Test files use `using namespace CososoTesting;` at file scope to bring
+#   the CALLED_FAKE multiplicity tokens (NEVER, ONCE, TWICE, THRICE) into
+#   scope at the call site. The scope is one .cpp file and the symbols are
+#   intentional sugar; the rule's "don't pollute global scope" concern does
+#   not apply to test-only translation units.
 InheritParentConfig: true
 Checks: >
   -readability-identifier-naming,
-  -bugprone-easily-swappable-parameters
+  -bugprone-easily-swappable-parameters,
+  -google-build-using-namespace

--- a/Tests/Bdd/Targets/BddTargetAppNameTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetAppNameTest.cpp
@@ -11,12 +11,10 @@ enum
 TEST_GROUP(BddTargetAppName)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFormatter* formatter = nullptr;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
     }
 

--- a/Tests/Bdd/Targets/BddTargetIpsTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetIpsTest.cpp
@@ -11,12 +11,10 @@ enum
 TEST_GROUP(BddTargetIps)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFormatter* formatter = nullptr;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
     }
 

--- a/Tests/Bdd/Targets/BddTargetLanguageTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetLanguageTest.cpp
@@ -11,12 +11,10 @@ enum
 TEST_GROUP(BddTargetLanguage)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFormatter* formatter = nullptr;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
     }
 

--- a/Tests/Bdd/Targets/BddTargetServiceThreadTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetServiceThreadTest.cpp
@@ -19,8 +19,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 static int SleepFakeCallCount;
 static int lastSleepMs;

--- a/Tests/Bdd/Targets/BddTargetServiceThreadTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetServiceThreadTest.cpp
@@ -56,7 +56,6 @@ TEST_GROUP(BddTargetServiceThread)
     struct SolidSyslogDatagram* datagram = nullptr;
     struct SolidSyslogResolver* resolver = nullptr;
     struct SolidSyslogAddress*  address  = nullptr;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     volatile bool               shutdown;
 
     void setup() override
@@ -78,7 +77,6 @@ TEST_GROUP(BddTargetServiceThread)
         store  = SolidSyslogNullStore_Get();
 
         SolidSyslogConfig config = {buffer, sender, nullptr, nullptr, nullptr, nullptr, store, nullptr, 0};
-        // cppcheck-suppress unreadVariable -- read via Run() in tests; cppcheck does not model CppUTest macros
         solidSyslog = SolidSyslog_Create(&config);
     }
 

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -39,7 +39,6 @@ struct ScanFake
 
 inline ScanFake& ToFake(struct SolidSyslogBlockDevice* self)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- vtable downcast: base is the first member of ScanFake
     return *reinterpret_cast<ScanFake*>(self);
 }
 

--- a/Tests/BlockSequenceTest.cpp
+++ b/Tests/BlockSequenceTest.cpp
@@ -24,9 +24,7 @@ enum class CallType
 
 struct DeviceCall
 {
-    // cppcheck-suppress unusedStructMember -- read by DisposePrecedesAcquire / loop assertions; cppcheck does not model std::vector element access
     CallType type;
-    // cppcheck-suppress unusedStructMember -- read by DisposePrecedesAcquire; cppcheck does not model std::vector element access
     size_t BlockIndex;
 };
 
@@ -156,7 +154,6 @@ TEST_GROUP(BlockSequenceScan)
         fakeDevice.Base.Append  = FakeAppend;
         fakeDevice.Base.WriteAt = FakeWriteAt;
         fakeDevice.Base.Size    = FakeSize;
-        // cppcheck-suppress unreadVariable -- read indirectly via FakeExists; cppcheck does not model the function-pointer indirection
         fakeDevice.existing     = &existing;
 
         struct BlockSequenceConfig config = {};
@@ -164,7 +161,6 @@ TEST_GROUP(BlockSequenceScan)
         config.MaxBlockSize                = 1000;
         config.MaxBlocks                   = 99;
         config.DiscardPolicy              = SOLIDSYSLOG_DISCARD_POLICY_OLDEST;
-        // cppcheck-suppress unreadVariable -- read across TEST_GROUP methods; cppcheck does not model CppUTest macros
         sequence = BlockSequence_Create(&config);
     }
 
@@ -248,11 +244,8 @@ TEST_GROUP(BlockSequenceRotation)
         fakeDevice.Base.Append  = FakeAppend;
         fakeDevice.Base.WriteAt = FakeWriteAt;
         fakeDevice.Base.Size    = FakeSize;
-        // cppcheck-suppress unreadVariable -- read indirectly via FakeExists; cppcheck does not model the function-pointer indirection
         fakeDevice.existing     = &existing;
-        // cppcheck-suppress unreadVariable -- read indirectly via RecordCall; cppcheck does not model the function-pointer indirection
         fakeDevice.calls        = &calls;
-        // cppcheck-suppress unreadVariable -- read indirectly via FakeSize; cppcheck does not model the function-pointer indirection
         fakeDevice.sizes        = &sizes;
 
         struct BlockSequenceConfig config = {};

--- a/Tests/BufferFakeTest.cpp
+++ b/Tests/BufferFakeTest.cpp
@@ -12,12 +12,10 @@ TEST_GROUP(BufferFake)
 {
     struct SolidSyslogBuffer* buffer = nullptr;
     char   readData[512];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     size_t readSize;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = BufferFake_Create();
         readSize = 0;
     }

--- a/Tests/DatagramFakeTest.cpp
+++ b/Tests/DatagramFakeTest.cpp
@@ -3,8 +3,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(DatagramFake)

--- a/Tests/DatagramFakeTest.cpp
+++ b/Tests/DatagramFakeTest.cpp
@@ -8,10 +8,8 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(DatagramFake)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogDatagram* datagram = nullptr;
 
-    // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
     void setup() override { datagram = DatagramFake_Create(); }
     void teardown() override { DatagramFake_Destroy(datagram); }
 };

--- a/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
@@ -16,7 +16,6 @@ extern "C"
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -30,7 +29,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFilePool)

--- a/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
@@ -16,7 +16,6 @@ extern "C"
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -28,7 +27,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFilePool)

--- a/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
@@ -14,7 +14,7 @@ extern "C"
 #include "SolidSyslogTunables.h"
 }
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
@@ -35,7 +35,6 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFilePool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogFile* pooled[SOLIDSYSLOG_FATFS_FILE_POOL_SIZE] = {};
     struct SolidSyslogFile* overflow                                 = nullptr;
 
@@ -53,7 +52,6 @@ TEST_GROUP(SolidSyslogFatFsFilePool)
                 SolidSyslogFatFsFile_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogFatFsFile_Destroy(overflow);

--- a/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
@@ -23,7 +23,6 @@ static const char* const TEST_PATH = "test.log";
 #define CHECK_STAT_PATH(path) STRCMP_EQUAL((path), FatFsFake_LastStatPath())
 #define CHECK_UNLINK_PATH(path) STRCMP_EQUAL((path), FatFsFake_LastUnlinkPath())
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFile)
 {

--- a/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
@@ -13,7 +13,6 @@ using namespace CososoTesting;
 
 static const char* const TEST_PATH = "test.log";
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define CHECK_FILE_IS_OPEN() CHECK_TRUE(SolidSyslogFile_IsOpen(file))
 #define CHECK_FILE_CLOSED() CHECK_FALSE(SolidSyslogFile_IsOpen(file))
 #define CHECK_OPEN_PATH(path) STRCMP_EQUAL((path), FatFsFake_LastOpenPath())
@@ -24,7 +23,6 @@ static const char* const TEST_PATH = "test.log";
 #define CHECK_STAT_PATH(path) STRCMP_EQUAL((path), FatFsFake_LastStatPath())
 #define CHECK_UNLINK_PATH(path) STRCMP_EQUAL((path), FatFsFake_LastUnlinkPath())
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFile)

--- a/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFileTest.cpp
@@ -30,13 +30,11 @@ static const char* const TEST_PATH = "test.log";
 TEST_GROUP(SolidSyslogFatFsFile)
 {
     struct SolidSyslogFile* file = nullptr;
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     char buffer[5] = {'h', 'e', 'l', 'l', 'o'};
 
     void setup() override
     {
         FatFsFake_Reset();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         file = SolidSyslogFatFsFile_Create();
     }
 

--- a/Tests/FileFakeTest.cpp
+++ b/Tests/FileFakeTest.cpp
@@ -12,7 +12,6 @@ TEST_GROUP(FileFake)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         api = FileFake_Create(&storage);
     }
 
@@ -287,7 +286,6 @@ TEST(FileFake, TwoInstancesShareFilesystem)
     SolidSyslogFile_Close(reader);
 
     /* Restore lastCreated to group-owned storage so teardown doesn't use dangling pointer */
-    // cppcheck-suppress unreadVariable -- restores lastCreated for teardown; cppcheck does not model CppUTest macros
     api = FileFake_Create(&storage);
 }
 
@@ -301,7 +299,6 @@ TEST(FileFake, OpenWhileAnotherInstanceHoldsPathOpenAsserts)
     CHECK_THROWS(std::runtime_error, SolidSyslogFile_Open(second, "shared.dat"));
 
     SolidSyslogFile_Close(api);
-    // cppcheck-suppress unreadVariable -- restores lastCreated for teardown; cppcheck does not model CppUTest macros
     api = FileFake_Create(&storage);
 }
 
@@ -352,7 +349,6 @@ TEST_GROUP(FileFakeAfterDestroy)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         api = FileFake_Create(&storage);
         FileFake_Destroy();
     }
@@ -429,9 +425,7 @@ TEST_GROUP(FileFakeStaleHandle)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         handleA = FileFake_Create(&storageA);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         handleB = FileFake_Create(&storageB);
     }
 

--- a/Tests/FreeRtos/CmsdkUartFake.c
+++ b/Tests/FreeRtos/CmsdkUartFake.c
@@ -1,22 +1,22 @@
 #include "CmsdkUartFake.h"
 
-// The CMSDK UART register-offset and status-bit macros below mirror the
-// ARM CMSDK UART hardware datasheet exactly. The macro form is intentional —
-// a future reader can grep for `DATA_OFFSET` against vendor docs and land on
-// these definitions verbatim. Converting them to enums would obscure that
-// mapping, so we keep them as #defines.
-// NOLINTBEGIN(cppcoreguidelines-macro-to-enum,modernize-macro-to-enum)
-#define DATA_OFFSET 0x000U
-#define STATE_OFFSET 0x004U
-#define CTRL_OFFSET 0x008U
-#define INTSTAT_OFFSET 0x00CU
-#define BAUDDIV_OFFSET 0x010U
+// The CMSDK UART register-offset and status-bit values below mirror the
+// ARM CMSDK UART hardware datasheet exactly. Grouped into an anonymous enum
+// so a future reader can grep for `DATA_OFFSET` against vendor docs and land
+// on these definitions verbatim, while gaining a typed identifier over the
+// historical #define form.
+enum
+{
+    DATA_OFFSET = 0x000,
+    STATE_OFFSET = 0x004,
+    CTRL_OFFSET = 0x008,
+    INTSTAT_OFFSET = 0x00C,
+    BAUDDIV_OFFSET = 0x010,
 
-#define TX_FULL_BIT 0x01U
-#define RX_FULL_BIT 0x02U
-#define TX_OVRE_BIT 0x04U
-
-// NOLINTEND(cppcoreguidelines-macro-to-enum,modernize-macro-to-enum)
+    TX_FULL_BIT = 0x01,
+    RX_FULL_BIT = 0x02,
+    TX_OVRE_BIT = 0x04,
+};
 
 static struct
 {

--- a/Tests/FreeRtos/CmsdkUartFake.c
+++ b/Tests/FreeRtos/CmsdkUartFake.c
@@ -47,7 +47,7 @@ static uint32_t Fake_Read32(uintptr_t address)
         }
         if (fake.readsRemainingBeforeTxReady == 0)
         {
-            fake.state &= ~TX_FULL_BIT;
+            fake.state &= ~(uint32_t) TX_FULL_BIT;
         }
         if (fake.readsRemainingBeforeRxReady > 0)
         {
@@ -64,7 +64,7 @@ static uint32_t Fake_Read32(uintptr_t address)
         if ((fake.state & RX_FULL_BIT) != 0U)
         {
             result = fake.receivedByte;
-            fake.state &= ~RX_FULL_BIT;
+            fake.state &= ~(uint32_t) RX_FULL_BIT;
         }
     }
     else if (offset == CTRL_OFFSET)
@@ -181,7 +181,7 @@ void CmsdkUartFake_SetReceivedByte(char byte)
     /* Clear leftover RX-ready state from a prior arm so back-to-back calls
      * don't carry RX_FULL_BIT or a stale countdown into the new mode. */
     fake.receivedByte = (uint32_t) (unsigned char) byte;
-    fake.state &= ~RX_FULL_BIT;
+    fake.state &= ~(uint32_t) RX_FULL_BIT;
     fake.readsRemainingBeforeRxReady = 0;
     if (fake.readsBeforeRxReadyDefault == 0)
     {

--- a/Tests/FreeRtos/CmsdkUartTest.cpp
+++ b/Tests/FreeRtos/CmsdkUartTest.cpp
@@ -3,8 +3,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "CmsdkUart.h"
 #include "CmsdkUartFake.h"

--- a/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "FreeRTOS.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -28,7 +27,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogFreeRtosMutex)

--- a/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "FreeRTOS.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogFreeRtosMutex)

--- a/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"

--- a/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
@@ -38,7 +38,6 @@ TEST_GROUP(SolidSyslogFreeRtosMutex)
     void setup() override
     {
         FreeRtosSemaphoreFake_Reset();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         mutex = SolidSyslogFreeRtosMutex_Create();
     }
 
@@ -84,7 +83,6 @@ TEST(SolidSyslogFreeRtosMutex, DestroyCallsSemaphoreDeleteOnce)
 // clang-format off
 TEST_GROUP(SolidSyslogFreeRtosMutexPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogMutex* pooled[SOLIDSYSLOG_FREE_RTOS_MUTEX_POOL_SIZE] = {};
     struct SolidSyslogMutex* overflow                                      = nullptr;
 
@@ -102,7 +100,6 @@ TEST_GROUP(SolidSyslogFreeRtosMutexPool)
                 SolidSyslogFreeRtosMutex_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogFreeRtosMutex_Destroy(overflow);

--- a/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -28,7 +27,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpAddress)

--- a/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpAddress)

--- a/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"

--- a/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
@@ -87,7 +87,6 @@ TEST(SolidSyslogPlusTcpAddress, CreateZeroesTheSockaddrFromAnyPriorSlotContents)
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpAddressPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAddress* pooled[SOLIDSYSLOG_ADDRESS_POOL_SIZE] = {};
     struct SolidSyslogAddress* overflow                              = nullptr;
 
@@ -100,7 +99,6 @@ TEST_GROUP(SolidSyslogPlusTcpAddressPool)
                 SolidSyslogPlusTcpAddress_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPlusTcpAddress_Destroy(overflow);

--- a/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
@@ -24,7 +24,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -38,7 +37,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 static const uint16_t TEST_PORT = 514;
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
@@ -4,8 +4,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"

--- a/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
@@ -24,7 +24,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -36,7 +35,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 static const uint16_t TEST_PORT = 514;
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
@@ -282,7 +282,6 @@ TEST(SolidSyslogPlusTcpDatagram, SendToForwardsLengthVerbatim)
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpDatagramPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogDatagram* pooled[SOLIDSYSLOG_PLUS_TCP_DATAGRAM_POOL_SIZE] = {};
     struct SolidSyslogDatagram* overflow                                         = nullptr;
 
@@ -300,7 +299,6 @@ TEST_GROUP(SolidSyslogPlusTcpDatagramPool)
                 SolidSyslogPlusTcpDatagram_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPlusTcpDatagram_Destroy(overflow);

--- a/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include <cstdint>
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -36,7 +35,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 static const char* const TEST_HOST = "10.0.2.2";
 static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";

--- a/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -34,7 +33,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 static const char* const TEST_HOST = "10.0.2.2";
 static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";

--- a/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
@@ -145,7 +145,6 @@ TEST(SolidSyslogPlusTcpResolverTest, FreesAddrInfoOnSuccess)
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpResolverPoolTest)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogResolver* pooled[SOLIDSYSLOG_PLUS_TCP_RESOLVER_POOL_SIZE] = {};
     struct SolidSyslogResolver* overflow                                         = nullptr;
 
@@ -158,7 +157,6 @@ TEST_GROUP(SolidSyslogPlusTcpResolverPoolTest)
                 SolidSyslogPlusTcpResolver_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPlusTcpResolver_Destroy(overflow);

--- a/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
@@ -4,8 +4,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"

--- a/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
@@ -23,7 +23,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -37,7 +36,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 static const uint16_t TEST_PORT = 514;
 static const char TEST_MESSAGE[] = "hello";
@@ -54,7 +52,6 @@ uint32_t FakeGetConnectTimeoutMs_ReturnValue = SOLIDSYSLOG_TCP_CONNECT_TIMEOUT_M
 void FakeGetConnectTimeoutMs_Reset()
 {
     FakeGetConnectTimeoutMs_CallCount = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- sentinel pointer; we never deref, only compare to nullptr after Open
     FakeGetConnectTimeoutMs_LastContext = reinterpret_cast<void*>(0x1U); /* sentinel — overwritten on first call */
     FakeGetConnectTimeoutMs_ReturnValue = SOLIDSYSLOG_TCP_CONNECT_TIMEOUT_MS;
 }
@@ -123,7 +120,6 @@ TEST_GROUP(SolidSyslogPlusTcpTcpStream)
 
 // clang-format on
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_SOCKET_CLOSED_ONCE()                                                                             \
     do                                                                                                         \
     {                                                                                                          \
@@ -131,7 +127,6 @@ TEST_GROUP(SolidSyslogPlusTcpTcpStream)
         POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastClosesocketSocket()); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 TEST(SolidSyslogPlusTcpTcpStream, CreateReturnsNonNullStream)
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
@@ -23,7 +23,6 @@ using namespace CososoTesting;
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -35,7 +34,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 static const uint16_t TEST_PORT = 514;
 static const char TEST_MESSAGE[] = "hello";
@@ -126,7 +124,6 @@ TEST_GROUP(SolidSyslogPlusTcpTcpStream)
         CALLED_FAKE(FreeRtosSocketsFake_Closesocket, ONCE);                                                    \
         POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastClosesocketSocket()); \
     } while (0)
-
 
 TEST(SolidSyslogPlusTcpTcpStream, CreateReturnsNonNullStream)
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
@@ -466,7 +466,6 @@ TEST(SolidSyslogPlusTcpTcpStream, DestroyAfterCloseDoesNotCloseAgain)
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpTcpStreamPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogStream* pooled[SOLIDSYSLOG_PLUS_TCP_TCP_STREAM_POOL_SIZE] = {};
     struct SolidSyslogStream* overflow                                           = nullptr;
 
@@ -484,7 +483,6 @@ TEST_GROUP(SolidSyslogPlusTcpTcpStreamPool)
                 SolidSyslogPlusTcpTcpStream_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPlusTcpTcpStream_Destroy(overflow);

--- a/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
@@ -13,7 +13,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "lwip/ip_addr.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -38,7 +37,6 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastCode()); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogLwipRawAddress)

--- a/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
@@ -2,8 +2,7 @@
 #include "CppUTest/TestHarness.h"
 #include "lwip/ip4_addr.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"

--- a/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
@@ -13,7 +13,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "lwip/ip_addr.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -36,7 +35,6 @@ using namespace CososoTesting;
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());  \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastCode()); \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogLwipRawAddress)

--- a/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
@@ -104,7 +104,6 @@ TEST(SolidSyslogLwipRawAddress, CreateZeroesIpAndPortFromAnyPriorSlotContents)
 // clang-format off
 TEST_GROUP(SolidSyslogLwipRawAddressPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAddress* pooled[SOLIDSYSLOG_ADDRESS_POOL_SIZE] = {};
     struct SolidSyslogAddress* overflow                              = nullptr;
 
@@ -117,7 +116,6 @@ TEST_GROUP(SolidSyslogLwipRawAddressPool)
                 SolidSyslogLwipRawAddress_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogLwipRawAddress_Destroy(overflow);

--- a/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
@@ -2,8 +2,7 @@
 #include "CppUTest/TestHarness.h"
 #include "lwip/ip4_addr.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include <cstdint>
 

--- a/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "lwip/ip_addr.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -44,7 +43,6 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastCode()); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 static const char* const TEST_HOST = "127.0.0.1";
 static const uint16_t TEST_PORT = 514;

--- a/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include "SolidSyslogTunables.h"
 #include "lwip/ip_addr.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -42,7 +41,6 @@ using namespace CososoTesting;
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());  \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastCode()); \
     } while (0)
-
 
 static const char* const TEST_HOST = "127.0.0.1";
 static const uint16_t TEST_PORT = 514;

--- a/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
@@ -132,7 +132,6 @@ TEST(SolidSyslogLwipRawResolver, ResolveReturnsFalseWhenIpaddrAtonRejectsHost)
 // clang-format off
 TEST_GROUP(SolidSyslogLwipRawResolverPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogResolver* pooled[SOLIDSYSLOG_LWIP_RAW_RESOLVER_POOL_SIZE] = {};
     struct SolidSyslogResolver* overflow                                         = nullptr;
 
@@ -145,7 +144,6 @@ TEST_GROUP(SolidSyslogLwipRawResolverPool)
                 SolidSyslogLwipRawResolver_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogLwipRawResolver_Destroy(overflow);

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
@@ -18,7 +18,6 @@ extern "C"
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -30,7 +29,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogMbedTlsStreamPool)

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
@@ -18,7 +18,6 @@ extern "C"
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -32,7 +31,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogMbedTlsStreamPool)

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
@@ -16,7 +16,7 @@ extern "C"
 
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
@@ -39,7 +39,6 @@ TEST_GROUP(SolidSyslogMbedTlsStreamPool)
 {
     struct SolidSyslogStream*             transport = nullptr;
     struct SolidSyslogMbedTlsStreamConfig config    = {};
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogStream* pooled[SOLIDSYSLOG_MBED_TLS_STREAM_POOL_SIZE] = {};
     struct SolidSyslogStream* overflow                                      = nullptr;
 
@@ -61,7 +60,6 @@ TEST_GROUP(SolidSyslogMbedTlsStreamPool)
                 SolidSyslogMbedTlsStream_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogMbedTlsStream_Destroy(overflow);

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
@@ -23,7 +23,6 @@ extern "C"
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves __FILE__/__LINE__ in failure output; do-while wraps the multi-statement body for safe single-statement use
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCode)                    \
     do                                                                            \
     {                                                                             \
@@ -35,7 +34,6 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastCode());        \
         LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_ERROR, ErrorHandlerFake_LastSeverity()); \
     } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 static int NoOpSleepCallCount;
 static int g_lastSleepMs;
@@ -55,7 +53,6 @@ uint32_t FakeGetHandshakeTimeoutMs_ReturnValue = SOLIDSYSLOG_TLS_HANDSHAKE_TIMEO
 void FakeGetHandshakeTimeoutMs_Reset()
 {
     FakeGetHandshakeTimeoutMs_CallCount = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- sentinel pointer; we never deref, only compare to nullptr after Open
     FakeGetHandshakeTimeoutMs_LastContext = reinterpret_cast<void*>(0x1U); /* sentinel — overwritten on first call */
     FakeGetHandshakeTimeoutMs_ReturnValue = SOLIDSYSLOG_TLS_HANDSHAKE_TIMEOUT_MS;
 }

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
@@ -21,7 +21,7 @@ extern "C"
 
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER/TWICE into scope for CALLED_FUNCTION / CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves __FILE__/__LINE__ in failure output; do-while wraps the multi-statement body for safe single-statement use
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCode)                    \

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
@@ -87,7 +87,6 @@ TEST_GROUP(SolidSyslogMbedTlsStream)
         config.Transport = transport;
         config.Sleep = NoOpSleep;
         handle = SolidSyslogMbedTlsStream_Create(&config);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         addr = AddressFake_Get();
     }
 

--- a/Tests/MqFakeTest.cpp
+++ b/Tests/MqFakeTest.cpp
@@ -9,8 +9,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 static mqd_t OpenTestQueue(const char* name, long maxMessages = 4, size_t maxMessageSize = 64)
 {

--- a/Tests/OpenSslFakeTest.cpp
+++ b/Tests/OpenSslFakeTest.cpp
@@ -7,8 +7,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(OpenSslFake)

--- a/Tests/SenderFakeTest.cpp
+++ b/Tests/SenderFakeTest.cpp
@@ -3,8 +3,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(SenderFake)

--- a/Tests/SenderFakeTest.cpp
+++ b/Tests/SenderFakeTest.cpp
@@ -12,7 +12,6 @@ TEST_GROUP(SenderFake)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         sender = SenderFake_Create();
     }
 
@@ -133,9 +132,7 @@ TEST_GROUP(SenderFakeInstances)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         a = SenderFake_Create();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         b = SenderFake_Create();
     }
 

--- a/Tests/SocketFakeTest.cpp
+++ b/Tests/SocketFakeTest.cpp
@@ -4,8 +4,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(SocketFake)

--- a/Tests/SolidSyslogBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogBlockDeviceTest.cpp
@@ -25,7 +25,6 @@ struct FakeBlockDevice
 
 inline FakeBlockDevice& ToFake(struct SolidSyslogBlockDevice* self)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- vtable downcast: base is the first member of FakeBlockDevice
     return *reinterpret_cast<FakeBlockDevice*>(self);
 }
 

--- a/Tests/SolidSyslogBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogBlockDeviceTest.cpp
@@ -104,7 +104,6 @@ TEST_GROUP(SolidSyslogBlockDevice)
         fake.Base.Append  = FakeAppend;
         fake.Base.WriteAt = FakeWriteAt;
         fake.Base.Size    = FakeSize;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         device = &fake.Base;
     }
 };

--- a/Tests/SolidSyslogBlockStoreDrainOrderingTest.cpp
+++ b/Tests/SolidSyslogBlockStoreDrainOrderingTest.cpp
@@ -54,7 +54,6 @@ struct SenderSpy
 
 static bool SenderSpy_Send(struct SolidSyslogSender* self, const void* buffer, size_t size)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- vtable downcast; SenderSpy embeds SolidSyslogSender as its first field
     auto* spy = reinterpret_cast<SenderSpy*>(self);
     if (spy->outage)
     {

--- a/Tests/SolidSyslogBlockStoreDrainOrderingTest.cpp
+++ b/Tests/SolidSyslogBlockStoreDrainOrderingTest.cpp
@@ -95,12 +95,9 @@ struct DrainTestConfig
 {
     /* cppcheck cannot follow CreateStore's reads through TEST_GROUP-
      * generated test classes; these fields ARE consumed there. */
-    // cppcheck-suppress unusedStructMember
     size_t MaxBlocks;
-    // cppcheck-suppress unusedStructMember
     size_t MaxBlockSize;
     size_t PayloadSize;
-    // cppcheck-suppress unusedStructMember
     enum SolidSyslogDiscardPolicy DiscardPolicy;
 };
 

--- a/Tests/SolidSyslogBlockStorePosixTest.cpp
+++ b/Tests/SolidSyslogBlockStorePosixTest.cpp
@@ -66,7 +66,6 @@ TEST_GROUP(SolidSyslogBlockStorePosix)
         config.MaxBlockSize  = maxBlockSize;
         config.MaxBlocks     = maxBlocks;
         config.DiscardPolicy = SOLIDSYSLOG_DISCARD_POLICY_OLDEST;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -14,8 +14,7 @@
 #include "FileFake.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 static const char* const TEST_PATH_PREFIX = "/tmp/test_store";
 static const char* const TEST_DATA = "hello";

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -103,7 +103,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStore, BlockDeviceTestBase)
     {
         setupBlockDeviceFakes();
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -332,13 +331,11 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreResume, BlockDeviceTestBase)
     void WritePreviousSession(int total, int markedSent)
     {
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
-        // cppcheck-suppress unreadVariable -- used by WriteMessages/DrainMessages; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
         WriteMessages(total);
         DrainMessages(markedSent);
         SolidSyslogBlockStore_Destroy(store);
 
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -480,7 +477,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreConfig, BlockDeviceTestBase)
     {
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
         config.MaxBlocks = maxBlocks;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -488,17 +484,14 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreConfig, BlockDeviceTestBase)
     {
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
         config.MaxBlockSize = maxBlockSize;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
     void CreateWithPathPrefix(const char* prefix)
     {
         SolidSyslogFileBlockDevice_Destroy(device);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         device = SolidSyslogFileBlockDevice_Create(file, prefix);
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -610,7 +603,6 @@ TEST(SolidSyslogBlockStoreConfig, OversizedSecurityPolicyLeavesNoIntegrityGap)
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreErrors, BlockDeviceTestBase)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStore*   store   = nullptr;
 
     void setup() override
@@ -718,7 +710,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreRotation, BlockDeviceTestBase)
         config.DiscardPolicy     = policy;
         config.OnStoreFull       = onStoreFull;
         config.StoreFullContext  = storeFullContext;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -1428,7 +1419,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreIntegrity, BlockDeviceTestBase)
         struct SolidSyslogBlockStoreConfig config = DEFAULT_CONFIG;
         config.BlockDevice    = device;
         config.SecurityPolicy = &spyPolicy;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -1529,7 +1519,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreCorruption, BlockDeviceTestBase)
     void CreateStore()
     {
         struct SolidSyslogBlockStoreConfig config = MakeConfig(device);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 };
@@ -1687,7 +1676,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreCorruptionRecovery, BlockDeviceTestBase)
         config.MaxBlockSize     = maxBlockSize;
         config.MaxBlocks        = maxBlocks;
         config.SecurityPolicy  = policy;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogBlockStore_Create(&config);
     }
 
@@ -1760,7 +1748,6 @@ TEST_GROUP_BASE(SolidSyslogBlockStoreCapacity, BlockDeviceTestBase)
 {
     static const size_t ONE_MAX_MSG_RECORD = SOLIDSYSLOG_MAX_MESSAGE_SIZE + TEST_RECORD_OVERHEAD;
 
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStore* store = nullptr;
     char maxMsg[SOLIDSYSLOG_MAX_MESSAGE_SIZE] = {};
 
@@ -1903,7 +1890,6 @@ static void CountThresholdCrossings(void* context)
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreCapacityThreshold, BlockDeviceTestBase)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStore* store = nullptr;
 
     void setup() override

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 
 // Assertion macros at file scope so failures report the test's own
 // __FILE__/__LINE__ rather than the helper's.
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts the last record read equals `expected` bytes of length `size`.
 // Depends on `readData` and `readSize` from CircularBufferFixture being in scope.
@@ -44,7 +43,6 @@ using namespace CososoTesting;
         }                                                                            \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 enum
 {

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -43,7 +43,6 @@ using namespace CososoTesting;
         }                                                                            \
     } while (0)
 
-
 enum
 {
     TEST_MAX_MESSAGES = 1,

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -15,7 +15,7 @@
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // Assertion macros at file scope so failures report the test's own
 // __FILE__/__LINE__ rather than the helper's.

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -91,7 +91,6 @@ TEST_GROUP_BASE(SolidSyslogCircularBuffer, CircularBufferFixture)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogCircularBuffer_Create(SolidSyslogNullMutex_Get(), ring, sizeof(ring));
     }
 
@@ -243,7 +242,6 @@ TEST_GROUP_BASE(SolidSyslogCircularBufferMutex, CircularBufferFixture)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogCircularBuffer_Create(MutexFake_Create(), ring, sizeof(ring));
     }
 
@@ -277,7 +275,6 @@ TEST_GROUP_BASE(SolidSyslogCircularBufferSmallRing, CircularBufferFixture)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogCircularBuffer_Create(SolidSyslogNullMutex_Get(), ring, sizeof(ring));
     }
 
@@ -387,7 +384,6 @@ TEST_GROUP(SolidSyslogCircularBufferPool)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         mutex = SolidSyslogNullMutex_Get();
     }
 

--- a/Tests/SolidSyslogConfigLockTest.cpp
+++ b/Tests/SolidSyslogConfigLockTest.cpp
@@ -4,7 +4,7 @@
 #include "SolidSyslogConfigLock.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 static int testLockCallCount;
 static int testUnlockCallCount;

--- a/Tests/SolidSyslogCrc16PolicyTest.cpp
+++ b/Tests/SolidSyslogCrc16PolicyTest.cpp
@@ -11,7 +11,6 @@ TEST_GROUP(SolidSyslogCrc16Policy)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         policy = SolidSyslogCrc16Policy_Create();
     }
 

--- a/Tests/SolidSyslogErrorTest.cpp
+++ b/Tests/SolidSyslogErrorTest.cpp
@@ -5,8 +5,7 @@
 #include "SolidSyslogPrival.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(SolidSyslogErrorEx)

--- a/Tests/SolidSyslogErrorTest.cpp
+++ b/Tests/SolidSyslogErrorTest.cpp
@@ -10,7 +10,6 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(SolidSyslogErrorEx)
 {
-    // cppcheck-suppress unreadVariable -- read via context-propagation test through CppUTest macros
     int sentinel = 0;
 };
 

--- a/Tests/SolidSyslogFileBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogFileBlockDeviceTest.cpp
@@ -27,7 +27,6 @@ static const char* const TEST_PATH_PREFIX = "/tmp/blockdev_";
         MEMCMP_EQUAL((expected), checkBuf, (length));                                                \
     } while (0)
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogFileBlockDevice)
 {

--- a/Tests/SolidSyslogFileBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogFileBlockDeviceTest.cpp
@@ -19,7 +19,6 @@ static const char* const TEST_PATH_PREFIX = "/tmp/blockdev_";
  * Mirrors the CHECK_PRIVAL family in SolidSyslogTest.cpp — names the intent so
  * tests read as "block N at offset O contains 'foo'" rather than buf+memcmp boilerplate.
  * Macro (not function) so test failures report the caller's __FILE__/__LINE__. */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves caller location in test failure output
 #define CHECK_BLOCK_CONTAINS(blockIndex, offset, expected, length)                                   \
     do                                                                                               \
     {                                                                                                \
@@ -28,7 +27,6 @@ static const char* const TEST_PATH_PREFIX = "/tmp/blockdev_";
         MEMCMP_EQUAL((expected), checkBuf, (length));                                                \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogFileBlockDevice)

--- a/Tests/SolidSyslogFileBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogFileBlockDeviceTest.cpp
@@ -40,7 +40,6 @@ TEST_GROUP(SolidSyslogFileBlockDevice)
     void setup() override
     {
         file = FileFake_Create(&fileStorage);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         device = SolidSyslogFileBlockDevice_Create(file, TEST_PATH_PREFIX);
     }
 

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -105,7 +105,6 @@ class TEST_SolidSyslogFormatter_ZeroSizeBoundedStringIsNoOp_Test;
 class TEST_SolidSyslogFormatter_ZeroSizeUint32IsNoOp_Test;
 struct TEST_GROUP_CppUTestGroupSolidSyslogFormatter;
 
-
 #define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
 
 #define CHECK_FORMATTED(expected)                                              \
@@ -113,7 +112,6 @@ struct TEST_GROUP_CppUTestGroupSolidSyslogFormatter;
     LONGS_EQUAL(strlen(expected), SolidSyslogFormatter_Length(formatter))
 
 #define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
-
 
 enum
 {

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -105,7 +105,6 @@ class TEST_SolidSyslogFormatter_ZeroSizeBoundedStringIsNoOp_Test;
 class TEST_SolidSyslogFormatter_ZeroSizeUint32IsNoOp_Test;
 struct TEST_GROUP_CppUTestGroupSolidSyslogFormatter;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- test helper macros for readability; CppUTest requires macros for correct failure location
 
 #define CREATE_FORMATTER(bufferSize) formatter = SolidSyslogFormatter_Create(storage, bufferSize)
 
@@ -115,7 +114,6 @@ struct TEST_GROUP_CppUTestGroupSolidSyslogFormatter;
 
 #define CHECK_LENGTH(expected) LONGS_EQUAL(expected, SolidSyslogFormatter_Length(formatter))
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 enum
 {

--- a/Tests/SolidSyslogFormatterTest.cpp
+++ b/Tests/SolidSyslogFormatterTest.cpp
@@ -126,12 +126,10 @@ enum
 TEST_GROUP(SolidSyslogFormatter)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslogFormatter* formatter;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- formatter is used across TEST() bodies via CppUTest macro
         CREATE_FORMATTER(TEST_BUFFER_SIZE);
     }
 

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -138,7 +138,6 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
         }                                                                              \
     } while (0)
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogGetAddrInfoResolverPool)
 {

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -127,7 +127,6 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
     CALLED_FAKE(SocketFake_FreeAddrInfo, ONCE);
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
     {                                                                                  \
@@ -139,7 +138,6 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogGetAddrInfoResolverPool)

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -18,8 +18,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -36,9 +36,7 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolver)
     void setup() override
     {
         SocketFake_Reset();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         resolver = SolidSyslogGetAddrInfoResolver_Create();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         result   = SolidSyslogPosixAddress_Create();
     }
 
@@ -146,7 +144,6 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
 // clang-format off
 TEST_GROUP(SolidSyslogGetAddrInfoResolverPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogResolver* pooled[SOLIDSYSLOG_GETADDRINFO_RESOLVER_POOL_SIZE] = {};
     struct SolidSyslogResolver* overflow                                            = nullptr;
 
@@ -159,7 +156,6 @@ TEST_GROUP(SolidSyslogGetAddrInfoResolverPool)
                 SolidSyslogGetAddrInfoResolver_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogGetAddrInfoResolver_Destroy(overflow);

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -60,7 +60,6 @@ static void FakeLanguage_Get(struct SolidSyslogFormatter* formatter)
 #define CHECK_LANGUAGE(expected) \
     STRCMP_EQUAL("[meta sequenceId=\"1\" language=\"" expected "\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter))
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogMetaSd)
 {

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -50,7 +50,6 @@ static void FakeLanguage_Get(struct SolidSyslogFormatter* formatter)
     SolidSyslogFormatter_EscapedString(formatter, fakeLanguageContent, fakeLanguageMaxLength);
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define CHECK_SEQUENCEID(expected) \
     STRCMP_EQUAL("[meta sequenceId=\"" expected "\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter))
 #define CHECK_SYSUPTIME(expected)                             \
@@ -61,7 +60,6 @@ static void FakeLanguage_Get(struct SolidSyslogFormatter* formatter)
 #define CHECK_LANGUAGE(expected) \
     STRCMP_EQUAL("[meta sequenceId=\"1\" language=\"" expected "\"]", SolidSyslogFormatter_AsFormattedBuffer(formatter))
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 // clang-format off
 TEST_GROUP(SolidSyslogMetaSd)

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -12,7 +12,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for the CALLED_FAKE macro
+using namespace CososoTesting;
 
 class TEST_SolidSyslogMetaSd_FirstFormatProducesSequenceId1_Test;
 class TEST_SolidSyslogMetaSd_FormatEscapesBackslashInLanguage_Test;

--- a/Tests/SolidSyslogMetaSdTest.cpp
+++ b/Tests/SolidSyslogMetaSdTest.cpp
@@ -66,15 +66,11 @@ static void FakeLanguage_Get(struct SolidSyslogFormatter* formatter)
 // clang-format off
 TEST_GROUP(SolidSyslogMetaSd)
 {
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogAtomicCounter* counter;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogStructuredData* sd;
     SolidSyslogMetaSdConfig config;
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogFormatter* formatter;
-    // cppcheck-suppress unreadVariable -- read via context-propagation through ErrorHandlerFake_Install
     int sentinel = 0;
 
     void setup() override

--- a/Tests/SolidSyslogNullAtomicCounterTest.cpp
+++ b/Tests/SolidSyslogNullAtomicCounterTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullAtomicCounter)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         counter = SolidSyslogNullAtomicCounter_Get();
     }
 };

--- a/Tests/SolidSyslogNullBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogNullBlockDeviceTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullBlockDevice)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         device = SolidSyslogNullBlockDevice_Get();
     }
 };

--- a/Tests/SolidSyslogNullBufferTest.cpp
+++ b/Tests/SolidSyslogNullBufferTest.cpp
@@ -11,7 +11,6 @@ TEST_GROUP(SolidSyslogNullBuffer)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogNullBuffer_Get();
     }
 };

--- a/Tests/SolidSyslogNullDatagramTest.cpp
+++ b/Tests/SolidSyslogNullDatagramTest.cpp
@@ -12,7 +12,6 @@ TEST_GROUP(SolidSyslogNullDatagram)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         datagram = SolidSyslogNullDatagram_Get();
     }
 };

--- a/Tests/SolidSyslogNullFileTest.cpp
+++ b/Tests/SolidSyslogNullFileTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullFile)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         file = SolidSyslogNullFile_Get();
     }
 };

--- a/Tests/SolidSyslogNullMutexTest.cpp
+++ b/Tests/SolidSyslogNullMutexTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullMutex)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         mutex = SolidSyslogNullMutex_Get();
     }
 };

--- a/Tests/SolidSyslogNullResolverTest.cpp
+++ b/Tests/SolidSyslogNullResolverTest.cpp
@@ -10,7 +10,6 @@ TEST_GROUP(SolidSyslogNullResolver)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         resolver = SolidSyslogNullResolver_Get();
     }
 };

--- a/Tests/SolidSyslogNullSdTest.cpp
+++ b/Tests/SolidSyslogNullSdTest.cpp
@@ -12,9 +12,7 @@ TEST_GROUP(SolidSyslogNullSd)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         sd = SolidSyslogNullSd_Get();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(formatterStorage, 32);
     }
 };

--- a/Tests/SolidSyslogNullSecurityPolicyTest.cpp
+++ b/Tests/SolidSyslogNullSecurityPolicyTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullSecurityPolicy)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         policy = SolidSyslogNullSecurityPolicy_Get();
     }
 };

--- a/Tests/SolidSyslogNullSenderTest.cpp
+++ b/Tests/SolidSyslogNullSenderTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullSender)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         sender = SolidSyslogNullSender_Get();
     }
 };

--- a/Tests/SolidSyslogNullStoreTest.cpp
+++ b/Tests/SolidSyslogNullStoreTest.cpp
@@ -11,7 +11,6 @@ TEST_GROUP(SolidSyslogNullStore)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = SolidSyslogNullStore_Get();
     }
 };

--- a/Tests/SolidSyslogNullStreamTest.cpp
+++ b/Tests/SolidSyslogNullStreamTest.cpp
@@ -9,7 +9,6 @@ TEST_GROUP(SolidSyslogNullStream)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         stream = SolidSyslogNullStream_Get();
     }
 };

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -51,7 +51,6 @@ static void FakeIpAt(struct SolidSyslogFormatter* f, size_t index)
         SolidSyslogFormatter_AsFormattedBuffer(formatter)                             \
     )
 
-
 namespace
 {
 std::string repeated(char c, size_t n)

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -40,7 +40,6 @@ static void FakeIpAt(struct SolidSyslogFormatter* f, size_t index)
     SolidSyslogFormatter_EscapedString(f, fakeIps.at(index), 64); // ORIGIN_IP_MAX
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define CHECK_ENTERPRISE_ID(expected)                                                           \
     STRCMP_EQUAL(                                                                               \
         "[origin software=\"TestSoftware\" swVersion=\"9.8.7\" enterpriseId=\"" expected "\"]", \
@@ -52,7 +51,6 @@ static void FakeIpAt(struct SolidSyslogFormatter* f, size_t index)
         SolidSyslogFormatter_AsFormattedBuffer(formatter)                             \
     )
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 namespace
 {

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -77,11 +77,9 @@ std::string escapeEach(const std::string& allSpecials)
 // clang-format off
 TEST_GROUP(SolidSyslogOriginSd)
 {
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogStructuredData* sd;
     SolidSyslogOriginSdConfig config;
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogFormatter* formatter;
 
     void setup() override

--- a/Tests/SolidSyslogPassthroughBufferTest.cpp
+++ b/Tests/SolidSyslogPassthroughBufferTest.cpp
@@ -3,8 +3,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogPassthroughBuffer.h"

--- a/Tests/SolidSyslogPassthroughBufferTest.cpp
+++ b/Tests/SolidSyslogPassthroughBufferTest.cpp
@@ -24,7 +24,6 @@ TEST_GROUP(SolidSyslogPassthroughBuffer)
     void setup() override
     {
         fakeSender = SenderFake_Create();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogPassthroughBuffer_Create(fakeSender);
     }
 
@@ -127,7 +126,6 @@ TEST_GROUP(SolidSyslogPassthroughBufferPool)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         fakeSender = SenderFake_Create();
     }
 

--- a/Tests/SolidSyslogPoolAllocatorTest.cpp
+++ b/Tests/SolidSyslogPoolAllocatorTest.cpp
@@ -6,7 +6,7 @@
 #include "SolidSyslogPoolAllocator.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 namespace
 {

--- a/Tests/SolidSyslogPoolTest.cpp
+++ b/Tests/SolidSyslogPoolTest.cpp
@@ -12,7 +12,7 @@
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogPoolTest.cpp
+++ b/Tests/SolidSyslogPoolTest.cpp
@@ -14,7 +14,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -28,7 +27,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPool)
@@ -148,7 +146,6 @@ TEST(SolidSyslogPool, DestroyOfUnknownHandleDoesNotLock)
     ConfigLockFake_Install();
     /* Any non-pool address — cast a stack byte, value never dereferenced. */
     char stackByte = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- forging an "unknown" handle to drive the bad-setup path
     auto* stranger = reinterpret_cast<struct SolidSyslog*>(&stackByte);
 
     SolidSyslog_Destroy(stranger);
@@ -161,7 +158,6 @@ TEST(SolidSyslogPool, DestroyOfUnknownHandleReportsWarning)
 {
     ErrorHandlerFake_Install(nullptr);
     char stackByte = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- forging an "unknown" handle to drive the bad-setup path
     auto* stranger = reinterpret_cast<struct SolidSyslog*>(&stackByte);
 
     SolidSyslog_Destroy(stranger);

--- a/Tests/SolidSyslogPoolTest.cpp
+++ b/Tests/SolidSyslogPoolTest.cpp
@@ -14,7 +14,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogPool)

--- a/Tests/SolidSyslogPoolTest.cpp
+++ b/Tests/SolidSyslogPoolTest.cpp
@@ -36,7 +36,6 @@ TEST_GROUP(SolidSyslogPool)
     struct SolidSyslogSender* fakeSender = nullptr;
     struct SolidSyslogBuffer* buffer = nullptr;
     SolidSyslogConfig config{};
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslog* pooled[SOLIDSYSLOG_POOL_SIZE] = {};
     struct SolidSyslog* overflow = nullptr;
 
@@ -57,7 +56,6 @@ TEST_GROUP(SolidSyslogPool)
                 SolidSyslog_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslog_Destroy(overflow);

--- a/Tests/SolidSyslogPosixAddressTest.cpp
+++ b/Tests/SolidSyslogPosixAddressTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 #include "SolidSyslogPrival.h"
 #include "SolidSyslogTunables.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -27,7 +26,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixAddress)

--- a/Tests/SolidSyslogPosixAddressTest.cpp
+++ b/Tests/SolidSyslogPosixAddressTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/Tests/SolidSyslogPosixAddressTest.cpp
+++ b/Tests/SolidSyslogPosixAddressTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 #include "SolidSyslogPrival.h"
 #include "SolidSyslogTunables.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -29,7 +28,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixAddress)

--- a/Tests/SolidSyslogPosixAddressTest.cpp
+++ b/Tests/SolidSyslogPosixAddressTest.cpp
@@ -38,7 +38,6 @@ TEST_GROUP(SolidSyslogPosixAddress)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         address = SolidSyslogPosixAddress_Create();
     }
 
@@ -86,7 +85,6 @@ TEST(SolidSyslogPosixAddress, CreateZeroesTheSockaddrFromAnyPriorSlotContents)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixAddressPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAddress* pooled[SOLIDSYSLOG_ADDRESS_POOL_SIZE] = {};
     struct SolidSyslogAddress* overflow                              = nullptr;
 
@@ -99,7 +97,6 @@ TEST_GROUP(SolidSyslogPosixAddressPool)
                 SolidSyslogPosixAddress_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixAddress_Destroy(overflow);

--- a/Tests/SolidSyslogPosixClockTest.cpp
+++ b/Tests/SolidSyslogPosixClockTest.cpp
@@ -9,7 +9,6 @@
 static const time_t TEST_EPOCH = 1743552000;
 
 // clang-format off
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define GET_TIMESTAMP()              getTimestamp()
 #define CHECK_YEAR(expected)         LONGS_EQUAL(expected, GET_TIMESTAMP().Year)
 #define CHECK_MONTH(expected)        LONGS_EQUAL(expected, GET_TIMESTAMP().Month)
@@ -20,7 +19,6 @@ static const time_t TEST_EPOCH = 1743552000;
 #define CHECK_MICROSECOND(expected)  LONGS_EQUAL(expected, GET_TIMESTAMP().Microsecond)
 #define CHECK_UTC_OFFSET(expected)   LONGS_EQUAL(expected, GET_TIMESTAMP().UtcOffsetMinutes)
 #define CHECK_MONTH_IS_INVALID()     LONGS_EQUAL(0, GET_TIMESTAMP().Month)
-// NOLINTEND(cppcoreguidelines-macro-usage)
 // clang-format on
 
 // clang-format off

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogDatagram.h"

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -20,7 +20,6 @@ using namespace CososoTesting;
 #include <netinet/in.h>
 #include <sys/socket.h>
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
     {                                                                                  \
@@ -31,7 +30,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 static const char* const TEST_MESSAGE     = "hello";

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -41,15 +41,12 @@ static const int         TEST_PORT        = 514;
 
 TEST_GROUP(SolidSyslogPosixDatagram)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogDatagram* datagram = nullptr;
-    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
     struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
     {
         SocketFake_Reset();
-        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         datagram        = SolidSyslogPosixDatagram_Create();
         addr            = SolidSyslogPosixAddress_Create();
         struct sockaddr_in* sin = SolidSyslogPosixAddress_AsSockaddrIn(addr);
@@ -269,7 +266,6 @@ TEST(SolidSyslogPosixDatagram, SendToReturnsFailedWhenConnectFails)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixDatagramPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogDatagram* pooled[SOLIDSYSLOG_POSIX_DATAGRAM_POOL_SIZE] = {};
     struct SolidSyslogDatagram* overflow                                     = nullptr;
 
@@ -282,7 +278,6 @@ TEST_GROUP(SolidSyslogPosixDatagramPool)
                 SolidSyslogPosixDatagram_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixDatagram_Destroy(overflow);

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -12,8 +12,7 @@
 
 #include <cstdio>
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
 

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -27,7 +27,6 @@ static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
         }                                                                              \
     } while (0)
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogPosixFile)
 {

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -16,7 +16,6 @@ using namespace CososoTesting;
 
 static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
     {                                                                                  \
@@ -28,7 +27,6 @@ static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixFile)

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -39,7 +39,6 @@ TEST_GROUP(SolidSyslogPosixFile)
     {
         SocketFake_Reset();
         remove(TEST_PATH);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         file = SolidSyslogPosixFile_Create();
     }
 
@@ -133,7 +132,6 @@ TEST(SolidSyslogPosixFile, DeleteReturnsFalseForNonexistentFile)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixFilePool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogFile* pooled[SOLIDSYSLOG_POSIX_FILE_POOL_SIZE] = {};
     struct SolidSyslogFile* overflow                                 = nullptr;
 
@@ -146,7 +144,6 @@ TEST_GROUP(SolidSyslogPosixFilePool)
                 SolidSyslogPosixFile_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixFile_Destroy(overflow);

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -206,7 +206,6 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
         }                                                                              \
     } while (0)
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMessageQueueBufferPool)
 {

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -4,8 +4,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "MqFake.h"

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -195,7 +195,6 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
     SenderFake_Destroy(fakeSender);
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
     {                                                                                  \
@@ -207,7 +206,6 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMessageQueueBufferPool)

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -29,13 +29,11 @@ TEST_GROUP(SolidSyslogPosixMessageQueueBuffer)
 {
     struct SolidSyslogBuffer* buffer = nullptr;
     char   readData[SOLIDSYSLOG_MAX_MESSAGE_SIZE];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     size_t readSize;
 
     void setup() override
     {
         MqFake_Reset();
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         buffer = SolidSyslogPosixMessageQueueBuffer_Create(SOLIDSYSLOG_MAX_MESSAGE_SIZE, 10);
         readSize = 0;
     }
@@ -214,7 +212,6 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMessageQueueBufferPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogBuffer* pooled[SOLIDSYSLOG_POSIX_MESSAGE_QUEUE_BUFFER_POOL_SIZE] = {};
     struct SolidSyslogBuffer* overflow                                                 = nullptr;
 
@@ -232,7 +229,6 @@ TEST_GROUP(SolidSyslogPosixMessageQueueBufferPool)
                 SolidSyslogPosixMessageQueueBuffer_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixMessageQueueBuffer_Destroy(overflow);

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -24,7 +23,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMutex)

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -10,7 +10,7 @@
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMutex)

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -35,7 +35,6 @@ TEST_GROUP(SolidSyslogPosixMutex)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         mutex = SolidSyslogPosixMutex_Create();
     }
 
@@ -60,7 +59,6 @@ TEST(SolidSyslogPosixMutex, LockUnlockDoesNotCrash)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMutexPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogMutex* pooled[SOLIDSYSLOG_POSIX_MUTEX_POOL_SIZE] = {};
     struct SolidSyslogMutex* overflow                                  = nullptr;
 
@@ -73,7 +71,6 @@ TEST_GROUP(SolidSyslogPosixMutexPool)
                 SolidSyslogPosixMutex_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixMutex_Destroy(overflow);

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -32,7 +32,6 @@ uint32_t FakeGetConnectTimeoutMs_ReturnValue = 200U;
 void FakeGetConnectTimeoutMs_Reset()
 {
     FakeGetConnectTimeoutMs_CallCount = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- sentinel pointer; we never deref, only compare to nullptr after Open
     FakeGetConnectTimeoutMs_LastContext = reinterpret_cast<void*>(0x1U); /* sentinel — overwritten on first call */
     FakeGetConnectTimeoutMs_ReturnValue = 200U;
 }
@@ -98,7 +97,6 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
 
 // clang-format on
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_SOCKET_CLOSED_ONCE()                                     \
     do                                                                 \
     {                                                                  \
@@ -106,7 +104,6 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
         LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd()); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
 {
@@ -567,7 +564,6 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
     CHECK_SOCKET_CLOSED_ONCE();
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
     {                                                                                  \
@@ -579,7 +575,6 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixTcpStreamPool)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -9,8 +9,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogPosixAddress.h"

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -104,7 +104,6 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
         LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd()); \
     } while (0)
 
-
 TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
 {
 }
@@ -574,7 +573,6 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixTcpStreamPool)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -53,16 +53,13 @@ static const int         TEST_PORT        = 514;
 
 TEST_GROUP(SolidSyslogPosixTcpStream)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStream* stream = nullptr;
-    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
     struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
     {
         SocketFake_Reset();
         FakeGetConnectTimeoutMs_Reset();
-        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         stream                  = SolidSyslogPosixTcpStream_Create(nullptr);
         addr                    = SolidSyslogPosixAddress_Create();
         struct sockaddr_in* sin = SolidSyslogPosixAddress_AsSockaddrIn(addr);
@@ -587,7 +584,6 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
 // clang-format off
 TEST_GROUP(SolidSyslogPosixTcpStreamPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogStream* pooled[SOLIDSYSLOG_POSIX_TCP_STREAM_POOL_SIZE] = {};
     struct SolidSyslogStream* overflow                                       = nullptr;
 
@@ -600,7 +596,6 @@ TEST_GROUP(SolidSyslogPosixTcpStreamPool)
                 SolidSyslogPosixTcpStream_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogPosixTcpStream_Destroy(overflow);

--- a/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogStdAtomicCounterPool)

--- a/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
@@ -10,7 +10,7 @@
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -24,7 +23,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogStdAtomicCounterPool)

--- a/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
@@ -31,7 +31,6 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(SolidSyslogStdAtomicCounterPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAtomicCounter* pooled[SOLIDSYSLOG_STD_ATOMIC_COUNTER_POOL_SIZE] = {};
     struct SolidSyslogAtomicCounter* overflow                                         = nullptr;
 
@@ -44,7 +43,6 @@ TEST_GROUP(SolidSyslogStdAtomicCounterPool)
                 SolidSyslogStdAtomicCounter_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogStdAtomicCounter_Destroy(overflow);

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -728,7 +728,6 @@ TEST(SolidSyslogStreamSenderPool, FillingPoolThenOverflowReturnsDistinctFallback
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastCode());        \
     } while (0)
 
-
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderBadSetup)
 {

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -719,7 +719,6 @@ TEST(SolidSyslogStreamSenderPool, FillingPoolThenOverflowReturnsDistinctFallback
 // SolidSyslogUdpSenderBadSetup contract from S12.06.
 
 /* Macro (not function) so test failures report the caller's __FILE__/__LINE__. */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves caller location in test failure output
 #define CHECK_STREAMSENDER_BAD_SETUP_ERROR(expectedCode)                          \
     do                                                                            \
     {                                                                             \
@@ -729,7 +728,6 @@ TEST(SolidSyslogStreamSenderPool, FillingPoolThenOverflowReturnsDistinctFallback
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastCode());        \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderBadSetup)

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -19,8 +19,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";
@@ -342,9 +341,9 @@ TEST(SolidSyslogStreamSender, EndpointVersionChangeUsesNewPortOnReconnect)
 TEST_GROUP(SolidSyslogStreamSenderConfig)
 {
     // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
-    const char* (*getHostFn)(void) = GetHost; // NOLINT(modernize-redundant-void-arg) -- C idiom
+    const char* (*getHostFn)(void) = GetHost;
     // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
-    int (*getPortFn)(void) = GetPort; // NOLINT(modernize-redundant-void-arg) -- C idiom
+    int (*getPortFn)(void) = GetPort;
     struct SolidSyslogStream*        stream   = nullptr;
     struct SolidSyslogResolver*      resolver = nullptr;
     struct SolidSyslogAddress*       address  = nullptr;

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -93,8 +93,6 @@ TEST_GROUP(SolidSyslogStreamSender)
     struct SolidSyslogStream*        stream = nullptr;
     struct SolidSyslogAddress*       address = nullptr;
     struct SolidSyslogStreamSenderConfig config;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
 
     void setup() override
@@ -107,7 +105,6 @@ TEST_GROUP(SolidSyslogStreamSender)
         stream          = SolidSyslogPosixTcpStream_Create(nullptr);
         address         = SolidSyslogPosixAddress_Create();
         config          = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogStreamSender_Create(&config);
     }
 
@@ -168,7 +165,6 @@ TEST_GROUP(SolidSyslogStreamSenderDestroy)
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create(nullptr);
         address         = SolidSyslogPosixAddress_Create();
-        // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
         config = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
     }
 
@@ -340,15 +336,11 @@ TEST(SolidSyslogStreamSender, EndpointVersionChangeUsesNewPortOnReconnect)
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderConfig)
 {
-    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
     const char* (*getHostFn)(void) = GetHost;
-    // cppcheck-suppress unreadVariable -- assigned in CreateSender; cppcheck does not model CppUTest macros
     int (*getPortFn)(void) = GetPort;
     struct SolidSyslogStream*        stream   = nullptr;
     struct SolidSyslogResolver*      resolver = nullptr;
     struct SolidSyslogAddress*       address  = nullptr;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
 
     void setup() override
@@ -377,7 +369,6 @@ TEST_GROUP(SolidSyslogStreamSenderConfig)
         stream   = SolidSyslogPosixTcpStream_Create(nullptr);
         address  = SolidSyslogPosixAddress_Create();
         struct SolidSyslogStreamSenderConfig config = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogStreamSender_Create(&config);
     }
 
@@ -456,8 +447,6 @@ TEST_GROUP(SolidSyslogStreamSenderFailure)
     struct SolidSyslogStream*        stream = nullptr;
     struct SolidSyslogAddress*       address = nullptr;
     struct SolidSyslogStreamSenderConfig config;
-    // cppcheck-suppress constVariablePointer -- Send requires non-const self; false positive from macro expansion
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
 
     void setup() override
@@ -470,7 +459,6 @@ TEST_GROUP(SolidSyslogStreamSenderFailure)
         stream          = SolidSyslogPosixTcpStream_Create(nullptr);
         address         = SolidSyslogPosixAddress_Create();
         config          = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
-        // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
         sender = SolidSyslogStreamSender_Create(&config);
     }
 
@@ -674,7 +662,6 @@ TEST_GROUP(SolidSyslogStreamSenderPool)
         resolver        = SolidSyslogGetAddrInfoResolver_Create();
         stream          = SolidSyslogPosixTcpStream_Create(nullptr);
         address         = SolidSyslogPosixAddress_Create();
-        // cppcheck-suppress unreadVariable -- read by MakeSender; cppcheck does not model CppUTest macros
         config = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
     }
 
@@ -751,7 +738,6 @@ TEST_GROUP(SolidSyslogStreamSenderBadSetup)
     struct SolidSyslogStream*            stream   = nullptr;
     struct SolidSyslogAddress*           address  = nullptr;
     struct SolidSyslogStreamSenderConfig config{};
-    // cppcheck-suppress unreadVariable -- assigned in tests; cppcheck does not model CppUTest macros
     struct SolidSyslogSender*            sender   = nullptr;
     int                                  sentinel = 0;
 
@@ -764,7 +750,6 @@ TEST_GROUP(SolidSyslogStreamSenderBadSetup)
         resolver = SolidSyslogGetAddrInfoResolver_Create();
         stream   = SolidSyslogPosixTcpStream_Create(nullptr);
         address  = SolidSyslogPosixAddress_Create();
-        // cppcheck-suppress unreadVariable -- used in test bodies; cppcheck does not model CppUTest macros
         config   = {resolver, stream, address, TestEndpoint, TestEndpointVersion};
         ErrorHandlerFake_Install(&sentinel);
     }

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -11,8 +11,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 /* Selector return values — named for the inner sender they select, so tests
  * read as `selectorReturn = INNER_B`. */
@@ -35,7 +34,7 @@ enum
 
 static uint8_t selectorReturn;
 
-static uint8_t TestSelector() // NOLINT(modernize-redundant-void-arg) -- matches C callback signature
+static uint8_t TestSelector()
 {
     return selectorReturn;
 }

--- a/Tests/SolidSyslogSwitchingSenderTest.cpp
+++ b/Tests/SolidSyslogSwitchingSenderTest.cpp
@@ -46,7 +46,6 @@ TEST_GROUP(SolidSyslogSwitchingSender)
     struct SolidSyslogSender* innerB = nullptr;
     struct SolidSyslogSender* innerC = nullptr;
     struct SolidSyslogSender* inners[3] = {nullptr, nullptr, nullptr};
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogSender* sender = nullptr;
 
     void setup() override
@@ -369,7 +368,6 @@ TEST_GROUP(SolidSyslogSwitchingSenderBadSetup)
     {
         innerA   = SenderFake_Create();
         inners[0] = innerA;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         config   = {inners, 1, TestSelector};
         ErrorHandlerFake_Install(&sentinel);
     }

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -150,7 +150,6 @@ static const int TIMESTAMP_MICROSECOND_LENGTH  = 7;
 static const int TIMESTAMP_OFFSET_OFFSET       = 26;
 // clang-format on
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define CHECK_PRIVAL(expected) \
     STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_HEADER).c_str(), strlen(expected))
 
@@ -218,7 +217,6 @@ static const int TIMESTAMP_OFFSET_OFFSET       = 26;
 
 #define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_MSGID).c_str())
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 static const char SD_SPY_TEXT[] = "[spy]";
 static const char SD_SPY2_TEXT[] = "[spy2]";
@@ -1776,7 +1774,6 @@ TEST(SolidSyslogLifecycle, DestroyWithUnknownHandleReportsWarning)
     /* Any non-pool address is "unknown" to IndexFromHandle. Cast a stack
        byte's address — its value never gets dereferenced, only compared. */
     char stackByte = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- forging an "unknown" handle to drive the bad-setup path
     auto* notAHandle = reinterpret_cast<struct SolidSyslog*>(&stackByte);
     ErrorHandlerFake_Install(nullptr);
 

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -217,7 +217,6 @@ static const int TIMESTAMP_OFFSET_OFFSET       = 26;
 
 #define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_MSGID).c_str())
 
-
 static const char SD_SPY_TEXT[] = "[spy]";
 static const char SD_SPY2_TEXT[] = "[spy2]";
 

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -28,8 +28,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 class TEST_SolidSyslogTimestamp_Day0ProducesNilvalue_Test;
 class TEST_SolidSyslogTimestamp_Day1FormatsAs01_Test;

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -354,23 +354,16 @@ TEST_GROUP(SolidSyslog)
 {
     SolidSyslogConfig config;
     SolidSyslogMessage message;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslog *solidSyslog;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogBuffer *buffer;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogStore  *store;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslogSender *fakeSender;
     /* Pool-backed handles owned by tests that exercise Meta/TimeQuality SD.
        Held as fixture state so teardown releases their pool slots even if a
        test body fails mid-assertion — otherwise the leaked slot returns the
        fallback to subsequent tests and cascades the failure. */
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslogAtomicCounter   *metaSdCounter;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslogStructuredData  *metaSd;
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     struct SolidSyslogStructuredData  *timeQualitySd;
 
     void setup() override
@@ -384,7 +377,6 @@ TEST_GROUP(SolidSyslog)
         timeQualitySd = nullptr;
         config = {buffer, nullptr, nullptr, StringFake_GetHostname, StringFake_GetAppName, StringFake_GetProcessId, store, nullptr, 0};
         solidSyslog = SolidSyslog_Create(&config);
-        // cppcheck-suppress unreadVariable -- read via Log() through &message; cppcheck does not model CppUTest macros
         message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFORMATIONAL, nullptr, nullptr};
     }
 
@@ -1564,7 +1556,6 @@ TEST_GROUP(SolidSyslogServiceEagerDrain)
         serviceConfig.Buffer            = circularBuffer;
         serviceConfig.Sender            = fakeSender;
         serviceConfig.Store             = fakeStore;
-        // cppcheck-suppress unreadVariable -- read via Service(solidSyslog) in tests; cppcheck does not model CppUTest macros
         solidSyslog = SolidSyslog_Create(&serviceConfig);
     }
 
@@ -1652,13 +1643,9 @@ TEST_GROUP(SolidSyslogLifecycle)
     void setup() override
     {
         solidSyslog = nullptr;
-        // cppcheck-suppress unreadVariable -- read via Log() in tests; cppcheck does not model CppUTest macros
         message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFORMATIONAL, nullptr, nullptr};
-        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
         sender = SenderFake_Create();
-        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
         buffer = BufferFake_Create();
-        // cppcheck-suppress unreadVariable -- read via validConfig() in tests; cppcheck does not model CppUTest macros
         store = SolidSyslogNullStore_Get();
     }
 

--- a/Tests/SolidSyslogTimeQualitySdTest.cpp
+++ b/Tests/SolidSyslogTimeQualitySdTest.cpp
@@ -12,7 +12,7 @@
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 struct SolidSyslogFormatter;
 struct SolidSyslogStructuredData;

--- a/Tests/SolidSyslogTimeQualitySdTest.cpp
+++ b/Tests/SolidSyslogTimeQualitySdTest.cpp
@@ -32,10 +32,8 @@ static void StubGetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 // clang-format off
 TEST_GROUP(SolidSyslogTimeQualitySd)
 {
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogStructuredData* sd;
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogFormatter* formatter;
 
     void setup() override
@@ -167,7 +165,6 @@ TEST(SolidSyslogTimeQualitySd, DestroyDoesNotCrash)
 // clang-format off
 TEST_GROUP(SolidSyslogTimeQualitySdPool)
 {
-    // cppcheck-suppress constVariable -- assigned in TEST() bodies; cppcheck does not model CppUTest macros
     struct SolidSyslogStructuredData* pooled[SOLIDSYSLOG_TIME_QUALITY_SD_POOL_SIZE] = {};
     struct SolidSyslogStructuredData* overflow                                       = nullptr;
 
@@ -180,7 +177,6 @@ TEST_GROUP(SolidSyslogTimeQualitySdPool)
                 SolidSyslogTimeQualitySd_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in TEST() bodies; cppcheck does not model CppUTest macros
         if (overflow != nullptr)
         {
             SolidSyslogTimeQualitySd_Destroy(overflow);

--- a/Tests/SolidSyslogTlsStreamPoolTest.cpp
+++ b/Tests/SolidSyslogTlsStreamPoolTest.cpp
@@ -26,7 +26,6 @@ void NoOpSleep(int milliseconds)
 }
 } // namespace
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -40,7 +39,6 @@ void NoOpSleep(int milliseconds)
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogTlsStreamPool)

--- a/Tests/SolidSyslogTlsStreamPoolTest.cpp
+++ b/Tests/SolidSyslogTlsStreamPoolTest.cpp
@@ -16,7 +16,7 @@ extern "C"
 
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 namespace
 {

--- a/Tests/SolidSyslogTlsStreamPoolTest.cpp
+++ b/Tests/SolidSyslogTlsStreamPoolTest.cpp
@@ -26,7 +26,6 @@ void NoOpSleep(int milliseconds)
 }
 } // namespace
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -38,7 +37,6 @@ void NoOpSleep(int milliseconds)
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogTlsStreamPool)

--- a/Tests/SolidSyslogTlsStreamPoolTest.cpp
+++ b/Tests/SolidSyslogTlsStreamPoolTest.cpp
@@ -47,7 +47,6 @@ TEST_GROUP(SolidSyslogTlsStreamPool)
 {
     struct SolidSyslogStream*         transport = nullptr;
     struct SolidSyslogTlsStreamConfig config    = {};
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogStream* pooled[SOLIDSYSLOG_TLS_STREAM_POOL_SIZE] = {};
     struct SolidSyslogStream* overflow                                 = nullptr;
 
@@ -68,7 +67,6 @@ TEST_GROUP(SolidSyslogTlsStreamPool)
                 SolidSyslogTlsStream_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogTlsStream_Destroy(overflow);

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -20,7 +20,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves __FILE__/__LINE__ in failure output; do-while wraps the multi-statement body for safe single-statement use
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCode)                    \
     do                                                                            \
     {                                                                             \
@@ -30,7 +29,6 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastCode());        \
         LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_ERROR, ErrorHandlerFake_LastSeverity()); \
     } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 class TEST_SolidSyslogTlsStream_ReadReturnsNegativeOneOnHardErrorAndClosesSsl_Test;
 class TEST_SolidSyslogTlsStream_ReadReturnsNegativeOneOnZeroReturnAndClosesSsl_Test;
@@ -54,7 +52,6 @@ uint32_t FakeGetHandshakeTimeoutMs_ReturnValue = SOLIDSYSLOG_TLS_HANDSHAKE_TIMEO
 void FakeGetHandshakeTimeoutMs_Reset()
 {
     FakeGetHandshakeTimeoutMs_CallCount = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- sentinel pointer; we never deref, only compare to nullptr after Open
     FakeGetHandshakeTimeoutMs_LastContext = reinterpret_cast<void*>(0x1U); /* sentinel — overwritten on first call */
     FakeGetHandshakeTimeoutMs_ReturnValue = SOLIDSYSLOG_TLS_HANDSHAKE_TIMEOUT_MS;
 }
@@ -192,7 +189,6 @@ TEST_GROUP(SolidSyslogTlsStream)
 
 // clang-format on
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_BIO_READ_RETRY_SIGNALLED()            \
     do                                              \
     {                                               \
@@ -220,7 +216,6 @@ TEST_GROUP(SolidSyslogTlsStream)
         CALLED_FAKE_ON(StreamFake_Close, transport, ONCE); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 TEST(SolidSyslogTlsStream, CreateSucceeds)
 {

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -18,8 +18,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macro preserves __FILE__/__LINE__ in failure output; do-while wraps the multi-statement body for safe single-statement use
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCode)                    \

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -216,7 +216,6 @@ TEST_GROUP(SolidSyslogTlsStream)
         CALLED_FAKE_ON(StreamFake_Close, transport, ONCE); \
     } while (0)
 
-
 TEST(SolidSyslogTlsStream, CreateSucceeds)
 {
     CHECK_TRUE(stream != nullptr);

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -85,9 +85,7 @@ TEST_GROUP(SolidSyslogTlsStream)
         transport        = StreamFake_Create();
         config.Transport = transport;
         config.Sleep     = NoOpSleep;
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         stream = SolidSyslogTlsStream_Create(&config);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         addr = AddressFake_Get();
     }
 

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -23,8 +23,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 class TEST_SolidSyslogUdpSenderRetry_DoubleOversizeDoesNotSendThird_Test;
 class TEST_SolidSyslogUdpSenderRetry_NonOversizeFailureDoesNotRetry_Test;

--- a/Tests/SolidSyslogUdpSenderTest.cpp
+++ b/Tests/SolidSyslogUdpSenderTest.cpp
@@ -573,10 +573,8 @@ TEST(SolidSyslogUdpSenderFailure, SendRecoversAfterTransientResolveFailure)
     CHECK_TRUE(Send());
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define CALLED_DATAGRAM_SEND(times) CALLED_FAKE_ON(DatagramFake_Send, datagram, times)
 #define CALLED_DATAGRAM_MAX_PAYLOAD(times) CALLED_FAKE_ON(DatagramFake_MaxPayload, datagram, times)
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogUdpSenderRetry, UdpSenderTestBase)

--- a/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsAtomicCounterPool)

--- a/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
@@ -10,7 +10,7 @@
 #include "SolidSyslogWindowsAtomicCounterErrors.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -24,7 +23,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsAtomicCounterPool)

--- a/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
@@ -31,7 +31,6 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsAtomicCounterPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAtomicCounter* pooled[SOLIDSYSLOG_WINDOWS_ATOMIC_COUNTER_POOL_SIZE] = {};
     struct SolidSyslogAtomicCounter* overflow                                             = nullptr;
 
@@ -44,7 +43,6 @@ TEST_GROUP(SolidSyslogWindowsAtomicCounterPool)
                 SolidSyslogWindowsAtomicCounter_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWindowsAtomicCounter_Destroy(overflow);

--- a/Tests/SolidSyslogWindowsClockTest.cpp
+++ b/Tests/SolidSyslogWindowsClockTest.cpp
@@ -22,7 +22,6 @@ static void WINAPI FakeGetSystemTimeAsFileTime(LPFILETIME fileTime)
 }
 
 // clang-format off
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- macros preserve __FILE__/__LINE__ in test failure output
 #define GET_TIMESTAMP()              getTimestamp()
 #define CHECK_YEAR(expected)         LONGS_EQUAL(expected, GET_TIMESTAMP().Year)
 #define CHECK_MONTH(expected)        LONGS_EQUAL(expected, GET_TIMESTAMP().Month)
@@ -33,7 +32,6 @@ static void WINAPI FakeGetSystemTimeAsFileTime(LPFILETIME fileTime)
 #define CHECK_MICROSECOND(expected)  LONGS_EQUAL(expected, GET_TIMESTAMP().Microsecond)
 #define CHECK_UTC_OFFSET(expected)   LONGS_EQUAL(expected, GET_TIMESTAMP().UtcOffsetMinutes)
 #define CHECK_MONTH_IS_INVALID()     LONGS_EQUAL(0, GET_TIMESTAMP().Month)
-// NOLINTEND(cppcoreguidelines-macro-usage)
 // clang-format on
 
 // clang-format off

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -16,7 +16,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -18,7 +18,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -32,7 +31,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -18,7 +18,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -30,7 +29,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -45,7 +45,6 @@ static std::string MakeTempPath(const char* filename)
 
 TEST_GROUP(SolidSyslogWindowsFile)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFile* file = nullptr;
     std::string testPath;
 
@@ -53,7 +52,6 @@ TEST_GROUP(SolidSyslogWindowsFile)
     {
         testPath = MakeTempPath("test_windows_file.dat");
         std::remove(testPath.c_str());
-        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         file = SolidSyslogWindowsFile_Create();
     }
 
@@ -163,7 +161,6 @@ TEST(SolidSyslogWindowsFile, DeleteReturnsFalseForNonexistentFile)
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsFilePool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogFile* pooled[SOLIDSYSLOG_WINDOWS_FILE_POOL_SIZE] = {};
     struct SolidSyslogFile* overflow                                   = nullptr;
 
@@ -176,7 +173,6 @@ TEST_GROUP(SolidSyslogWindowsFilePool)
                 SolidSyslogWindowsFile_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWindowsFile_Destroy(overflow);

--- a/Tests/SolidSyslogWindowsHostnameTest.cpp
+++ b/Tests/SolidSyslogWindowsHostnameTest.cpp
@@ -37,7 +37,6 @@ static BOOL WINAPI FakeGetComputerNameExA(COMPUTER_NAME_FORMAT nameType, LPSTR b
 TEST_GROUP(SolidSyslogWindowsHostname)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFormatter* formatter = nullptr;
 
     void setup() override
@@ -45,7 +44,6 @@ TEST_GROUP(SolidSyslogWindowsHostname)
         fakeHostname    = "winhost";
         fakeReturnValue = TRUE;
         UT_PTR_SET(WindowsHostname_GetComputerNameExA, FakeGetComputerNameExA);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
     }
 

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsMutex)

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -12,7 +12,6 @@
 
 using namespace CososoTesting;
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -24,7 +23,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsMutex)

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -10,7 +10,7 @@
 #include "SolidSyslogWindowsMutexErrors.h"
 #include "TestUtils.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings ONCE/NEVER into scope for CALLED_FAKE
+using namespace CososoTesting;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -35,7 +35,6 @@ TEST_GROUP(SolidSyslogWindowsMutex)
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         mutex = SolidSyslogWindowsMutex_Create();
     }
 
@@ -60,7 +59,6 @@ TEST(SolidSyslogWindowsMutex, LockUnlockDoesNotCrash)
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsMutexPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogMutex* pooled[SOLIDSYSLOG_WINDOWS_MUTEX_POOL_SIZE] = {};
     struct SolidSyslogMutex* overflow                                    = nullptr;
 
@@ -73,7 +71,6 @@ TEST_GROUP(SolidSyslogWindowsMutexPool)
                 SolidSyslogWindowsMutex_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWindowsMutex_Destroy(overflow);

--- a/Tests/SolidSyslogWindowsProcessIdTest.cpp
+++ b/Tests/SolidSyslogWindowsProcessIdTest.cpp
@@ -21,14 +21,12 @@ static DWORD WINAPI FakeGetCurrentProcessId(void)
 TEST_GROUP(SolidSyslogWindowsProcessId)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogFormatter* formatter = nullptr;
 
     void setup() override
     {
         fakePid = 4321;
         UT_PTR_SET(WindowsProcessId_GetCurrentProcessId, FakeGetCurrentProcessId);
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
     }
 

--- a/Tests/SolidSyslogWinsockAddressTest.cpp
+++ b/Tests/SolidSyslogWinsockAddressTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 #include <cstring>
 #include <winsock2.h>

--- a/Tests/SolidSyslogWinsockAddressTest.cpp
+++ b/Tests/SolidSyslogWinsockAddressTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "SolidSyslogWinsockAddressErrors.h"
 #include "SolidSyslogWinsockAddressPrivate.h"
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -28,7 +27,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockAddress)

--- a/Tests/SolidSyslogWinsockAddressTest.cpp
+++ b/Tests/SolidSyslogWinsockAddressTest.cpp
@@ -14,7 +14,6 @@ using namespace CososoTesting;
 #include "SolidSyslogWinsockAddressErrors.h"
 #include "SolidSyslogWinsockAddressPrivate.h"
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -26,7 +25,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockAddress)

--- a/Tests/SolidSyslogWinsockAddressTest.cpp
+++ b/Tests/SolidSyslogWinsockAddressTest.cpp
@@ -84,7 +84,6 @@ TEST(SolidSyslogWinsockAddress, CreateZeroesTheSockaddrFromAnyPriorSlotContents)
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockAddressPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogAddress* pooled[SOLIDSYSLOG_ADDRESS_POOL_SIZE] = {};
     struct SolidSyslogAddress* overflow                              = nullptr;
 
@@ -97,7 +96,6 @@ TEST_GROUP(SolidSyslogWinsockAddressPool)
                 SolidSyslogWinsockAddress_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWinsockAddress_Destroy(overflow);

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogWinsockAddress.h"

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -33,7 +32,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 static const char* const TEST_MESSAGE     = "hello";

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -31,7 +30,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 static const char* const TEST_MESSAGE     = "hello";

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -43,9 +43,7 @@ static const int         TEST_PORT        = 514;
 
 TEST_GROUP(SolidSyslogWinsockDatagram)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogDatagram* datagram = nullptr;
-    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
     struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
@@ -57,7 +55,6 @@ TEST_GROUP(SolidSyslogWinsockDatagram)
         UT_PTR_SET(Winsock_connect, WinsockFake_connect);
         UT_PTR_SET(Winsock_setsockopt, WinsockFake_setsockopt);
         UT_PTR_SET(Winsock_getsockopt, WinsockFake_getsockopt);
-        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         datagram                = SolidSyslogWinsockDatagram_Create();
         addr                    = SolidSyslogWinsockAddress_Create();
         struct sockaddr_in* sin = SolidSyslogWinsockAddress_AsSockaddrIn(addr);
@@ -277,7 +274,6 @@ TEST(SolidSyslogWinsockDatagram, MaxPayloadFallsBackWhenIpMtuLookupFails)
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockDatagramPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogDatagram* pooled[SOLIDSYSLOG_WINSOCK_DATAGRAM_POOL_SIZE] = {};
     struct SolidSyslogDatagram* overflow                                       = nullptr;
 
@@ -290,7 +286,6 @@ TEST_GROUP(SolidSyslogWinsockDatagramPool)
                 SolidSyslogWinsockDatagram_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWinsockDatagram_Destroy(overflow);

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogWinsockAddress.h"

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -18,7 +18,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -32,7 +31,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -18,7 +18,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -30,7 +29,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -146,7 +146,6 @@ TEST(SolidSyslogWinsockResolver, FreesAddrInfoOnSuccess)
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockResolverPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogResolver* pooled[SOLIDSYSLOG_WINSOCK_RESOLVER_POOL_SIZE] = {};
     struct SolidSyslogResolver* overflow                                       = nullptr;
 
@@ -159,7 +158,6 @@ TEST_GROUP(SolidSyslogWinsockResolverPool)
                 SolidSyslogWinsockResolver_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWinsockResolver_Destroy(overflow);

--- a/Tests/SolidSyslogWinsockTcpStreamTest.cpp
+++ b/Tests/SolidSyslogWinsockTcpStreamTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "ConfigLockFake.h"
 #include "ErrorHandlerFake.h"
 #include "SolidSyslogWinsockAddress.h"

--- a/Tests/SolidSyslogWinsockTcpStreamTest.cpp
+++ b/Tests/SolidSyslogWinsockTcpStreamTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while) -- macros preserve __FILE__/__LINE__ at the call site
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
@@ -33,7 +32,6 @@ using namespace CososoTesting;
         }                                                                              \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 namespace
 {
@@ -44,7 +42,6 @@ uint32_t FakeGetConnectTimeoutMs_ReturnValue = 200U;
 void FakeGetConnectTimeoutMs_Reset()
 {
     FakeGetConnectTimeoutMs_CallCount = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- sentinel pointer; we never deref, only compare to nullptr after Open
     FakeGetConnectTimeoutMs_LastContext = reinterpret_cast<void*>(0x1U); /* sentinel — overwritten on first call */
     FakeGetConnectTimeoutMs_ReturnValue = 200U;
 }
@@ -120,7 +117,6 @@ TEST_GROUP(SolidSyslogWinsockTcpStream)
 
 // clang-format on
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_SOCKET_CLOSED_ONCE()                                   \
     do                                                               \
     {                                                                \
@@ -128,7 +124,6 @@ TEST_GROUP(SolidSyslogWinsockTcpStream)
         CHECK(WinsockFake_SocketFd() == WinsockFake_LastClosedFd()); \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 TEST(SolidSyslogWinsockTcpStream, CreateDestroyWorksWithoutCrashing)
 {

--- a/Tests/SolidSyslogWinsockTcpStreamTest.cpp
+++ b/Tests/SolidSyslogWinsockTcpStreamTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
     do                                                                                 \
@@ -31,7 +30,6 @@ using namespace CososoTesting;
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
     } while (0)
-
 
 namespace
 {
@@ -123,7 +121,6 @@ TEST_GROUP(SolidSyslogWinsockTcpStream)
         CALLED_FAKE(WinsockFake_Close, ONCE);                        \
         CHECK(WinsockFake_SocketFd() == WinsockFake_LastClosedFd()); \
     } while (0)
-
 
 TEST(SolidSyslogWinsockTcpStream, CreateDestroyWorksWithoutCrashing)
 {

--- a/Tests/SolidSyslogWinsockTcpStreamTest.cpp
+++ b/Tests/SolidSyslogWinsockTcpStreamTest.cpp
@@ -65,9 +65,7 @@ static const int         TEST_PORT        = 514;
 
 TEST_GROUP(SolidSyslogWinsockTcpStream)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStream* stream = nullptr;
-    // cppcheck-suppress unreadVariable -- assigned in setup; cppcheck does not model CppUTest macros
     struct SolidSyslogAddress* addr = nullptr;
 
     void setup() override
@@ -84,7 +82,6 @@ TEST_GROUP(SolidSyslogWinsockTcpStream)
         UT_PTR_SET(WinsockTcpStream_ioctlsocket,      WinsockFake_ioctlsocket);
         UT_PTR_SET(WinsockTcpStream_select,           WinsockFake_select);
         UT_PTR_SET(WinsockTcpStream_WSAGetLastError,  WinsockFake_WSAGetLastError);
-        // cppcheck-suppress unreadVariable -- used in tests; cppcheck does not model CppUTest macros
         stream                  = SolidSyslogWinsockTcpStream_Create(nullptr);
         addr                    = SolidSyslogWinsockAddress_Create();
         struct sockaddr_in* sin = SolidSyslogWinsockAddress_AsSockaddrIn(addr);
@@ -543,7 +540,6 @@ TEST(SolidSyslogWinsockTcpStream, DestroyClosesOpenSocket)
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockTcpStreamPool)
 {
-    // cppcheck-suppress constVariable -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
     struct SolidSyslogStream* pooled[SOLIDSYSLOG_WINSOCK_TCP_STREAM_POOL_SIZE] = {};
     struct SolidSyslogStream* overflow                                         = nullptr;
 
@@ -556,7 +552,6 @@ TEST_GROUP(SolidSyslogWinsockTcpStreamPool)
                 SolidSyslogWinsockTcpStream_Destroy(handle);
             }
         }
-        // cppcheck-suppress knownConditionTrueFalse -- assigned in test bodies; cppcheck does not model CppUTest lifecycle
         if (overflow != nullptr)
         {
             SolidSyslogWinsockTcpStream_Destroy(overflow);

--- a/Tests/StoreFakeTest.cpp
+++ b/Tests/StoreFakeTest.cpp
@@ -5,8 +5,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 static const char* const TEST_MESSAGE = "hello";
 static const size_t TEST_MESSAGE_LEN = 5;

--- a/Tests/StoreFakeTest.cpp
+++ b/Tests/StoreFakeTest.cpp
@@ -15,12 +15,10 @@ TEST_GROUP(StoreFake)
 {
     struct SolidSyslogStore* store = nullptr;
     char   readData[512];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     size_t readSize;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
         store = StoreFake_Create();
         readSize = 0;
     }

--- a/Tests/StreamFakeTest.cpp
+++ b/Tests/StreamFakeTest.cpp
@@ -4,8 +4,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 
 // clang-format off
 TEST_GROUP(StreamFake)

--- a/Tests/StreamFakeTest.cpp
+++ b/Tests/StreamFakeTest.cpp
@@ -9,10 +9,8 @@ using namespace CososoTesting;
 // clang-format off
 TEST_GROUP(StreamFake)
 {
-    // cppcheck-suppress unreadVariable -- used across TEST_GROUP methods; cppcheck does not model CppUTest macros
     struct SolidSyslogStream* stream = nullptr;
 
-    // cppcheck-suppress unreadVariable -- read by teardown and tests; cppcheck does not model CppUTest lifecycle
     void setup() override { stream = StreamFake_Create(); }
     void teardown() override { StreamFake_Destroy(stream); }
 };

--- a/Tests/StringFakeTest.cpp
+++ b/Tests/StringFakeTest.cpp
@@ -13,12 +13,10 @@ enum
 TEST_GROUP(StringFake)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
-    // cppcheck-suppress variableScope -- member of TEST_GROUP; scope managed by CppUTest macro
     SolidSyslogFormatter* formatter;
 
     void setup() override
     {
-        // cppcheck-suppress unreadVariable -- formatter is used across TEST() bodies via CppUTest macro
         formatter = SolidSyslogFormatter_Create(storage, TEST_BUFFER_SIZE);
         StringFake_Reset();
     }

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
@@ -1,7 +1,6 @@
 #ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 #define SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- FreeRTOS API requires these to be #defines
 
 /* FreeRTOS-Plus-TCP's IPConfig defaults header checks this guard to confirm
  * FreeRTOSConfig.h was included before any IP header. */
@@ -70,6 +69,5 @@
         }               \
     } while (0)
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSConfig.h
@@ -1,7 +1,6 @@
 #ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 #define SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H
 
-
 /* FreeRTOS-Plus-TCP's IPConfig defaults header checks this guard to confirm
  * FreeRTOSConfig.h was included before any IP header. */
 #define FREERTOS_CONFIG_H
@@ -68,6 +67,5 @@
             }           \
         }               \
     } while (0)
-
 
 #endif /* SOLIDSYSLOG_TESTS_FREERTOSFAKES_FREERTOSCONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
@@ -21,5 +21,4 @@
 #define ipconfigZERO_COPY_RX_DRIVER 0
 #define ipconfigZERO_COPY_TX_DRIVER 0
 
-
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRTOSIPConfig.h
@@ -2,7 +2,6 @@
 #define FREERTOS_IP_CONFIG_H
 
 #include "FreeRTOS.h"
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- FreeRTOS-Plus-TCP API requires these to be #defines
 
 /* Host-suitable FreeRTOS-Plus-TCP config for unit-test fakes. The IP stack
  * itself is never run on the host — these values are only here so the
@@ -22,6 +21,5 @@
 #define ipconfigZERO_COPY_RX_DRIVER 0
 #define ipconfigZERO_COPY_TX_DRIVER 0
 
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/Tests/Support/FreeRtosFakes/Interface/portmacro.h
+++ b/Tests/Support/FreeRtosFakes/Interface/portmacro.h
@@ -1,8 +1,8 @@
 #ifndef SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
 #define SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses) -- FreeRTOS-Kernel port API requires these to be #defines, the function-declaration
-// macros can't parenthesise their args
+// NOLINTBEGIN(bugprone-macro-parentheses) -- FreeRTOS-Kernel port API:
+// the function-declaration macros can't parenthesise their args.
 
 /* Stub of FreeRTOS-Kernel's portmacro.h.
  *
@@ -54,6 +54,6 @@ typedef uint32_t StackType_t;
 #define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void* pvParameters)
 #define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void* pvParameters)
 
-// NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
+// NOLINTEND(bugprone-macro-parentheses)
 
 #endif /* SOLIDSYSLOG_TESTS_FREERTOSFAKES_PORTMACRO_H */

--- a/Tests/Support/LwipFakes/Interface/arch/cc.h
+++ b/Tests/Support/LwipFakes/Interface/arch/cc.h
@@ -6,7 +6,7 @@
 #ifndef LWIP_ARCH_CC_H
 #define LWIP_ARCH_CC_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses) -- lwIP API requires these to be #defines
+// NOLINTBEGIN(bugprone-macro-parentheses) -- lwIP API requires these to be #defines
 #define LWIP_PLATFORM_DIAG(x) \
     do                        \
     {                         \
@@ -17,6 +17,6 @@
     {                           \
         (void) (x);             \
     } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
+// NOLINTEND(bugprone-macro-parentheses)
 
 #endif /* LWIP_ARCH_CC_H */

--- a/Tests/Support/LwipFakes/Interface/lwipopts.h
+++ b/Tests/Support/LwipFakes/Interface/lwipopts.h
@@ -8,7 +8,6 @@
 #ifndef SOLIDSYSLOG_TEST_LWIPOPTS_H
 #define SOLIDSYSLOG_TEST_LWIPOPTS_H
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- lwIP API requires these to be #defines
 #define NO_SYS 1
 #define LWIP_RAW 1
 #define LWIP_UDP 1
@@ -23,6 +22,5 @@
 #define MEM_LIBC_MALLOC 1
 #define MEMP_MEM_MALLOC 1
 #define SYS_LIGHTWEIGHT_PROT 0
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* SOLIDSYSLOG_TEST_LWIPOPTS_H */

--- a/Tests/Support/TestUtils.h
+++ b/Tests/Support/TestUtils.h
@@ -32,10 +32,8 @@ enum
  *   CALLED_FAKE_ON(SenderFake_Send, inner, ONCE)
  *       -> LONGS_EQUAL(1, SenderFake_SendCallCount(inner))
  */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage) -- token paste enforces the <name>CallCount naming rule
 #define CALLED_FUNCTION(name, count) LONGS_EQUAL((count), name##CallCount)
 #define CALLED_FAKE(getter, count) LONGS_EQUAL((count), getter##CallCount())
 #define CALLED_FAKE_ON(getter, instance, count) LONGS_EQUAL((count), getter##CallCount(instance))
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif /* TESTUTILS_H */

--- a/Tests/WinsockFakeTest.cpp
+++ b/Tests/WinsockFakeTest.cpp
@@ -1,8 +1,7 @@
 #include "TestUtils.h"
 #include "CppUTest/TestHarness.h"
 
-using namespace CososoTesting; // NOLINT(google-build-using-namespace) -- test-file scope only; brings NEVER/ONCE/TWICE/THRICE into scope for the CALLED_*
-    // macros
+using namespace CososoTesting;
 #include "WinsockFake.h"
 #include <cstring>
 #include <winsock2.h>

--- a/cppcheck_suppressions_tests.txt
+++ b/cppcheck_suppressions_tests.txt
@@ -1,0 +1,46 @@
+# Non-MISRA cppcheck suppressions — test-compile-only false positives.
+# -
+# This file accompanies misra_suppressions.txt (which scopes MISRA-rule
+# suppressions in production code). It targets rules that only fire — or
+# only fire as false positives — when cppcheck runs over test-compilation
+# units, and consolidates what would otherwise be hundreds of identical
+# inline `// cppcheck-suppress` comments.
+# -
+# Wired into the cppcheck preset via CMAKE_C_CPPCHECK / CMAKE_CXX_CPPCHECK
+# in CMakeLists.txt, and into the CI report-generation step in
+# .github/workflows/ci.yml. Inline `cppcheck-suppress` still works
+# (--inline-suppr stays enabled) for site-specific rationales.
+# -
+# Format: <rule>:<file-glob>[:line]. cppcheck accepts * and ? in <file-glob>.
+# Lines starting with # are comments.
+
+# -----------------------------------------------------------------------
+# CppUTest harness model gap — Tests/*
+# -----------------------------------------------------------------------
+# CppUTest's TEST_GROUP / TEST / CHECK_* macros expand to a class whose
+# fields are accessed across setup, teardown, and TEST() bodies via
+# implicit `this` from the macros. cppcheck's data-flow model does not
+# see these expansions, so any field-typed TEST_GROUP member appears
+# `unreadVariable`, the assignments appear to leave `constVariable`-eligible
+# variables, branches read from helper fixtures look `knownConditionTrueFalse`,
+# and the macro-expanded CALLED_* multiplicity macros generate spurious
+# `constVariablePointer` findings. The signal-to-noise of these rules in
+# test code is poor enough to disable tree-wide for Tests/*.
+unreadVariable:*Tests/*
+variableScope:*Tests/*
+constVariable:*Tests/*
+knownConditionTrueFalse:*Tests/*
+unusedStructMember:*Tests/*
+constVariablePointer:*Tests/*
+
+# -----------------------------------------------------------------------
+# Opaque-to-impl downcast in Platform address-private headers
+# -----------------------------------------------------------------------
+# Platform/*/Source/SolidSyslog*AddressPrivate.h carries inline static
+# downcasts from the public `struct SolidSyslogAddress*` opaque type to
+# the platform-specific impl struct (D.002 in docs/misra-deviations.md).
+# The downcast is a C-style cast — necessary in a C header — and the
+# header is included from C++ test compilation units, where cppcheck's
+# `cstyleCast` rule fires. The MISRA halves (11.2 / 11.3) live in
+# misra_suppressions.txt; this is the non-MISRA half.
+cstyleCast:*Platform/*/Source/*AddressPrivate.h

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -11,7 +11,7 @@
 
 # D.002 — Rules 11.2 / 11.3 / 11.5: vtable downcasts + Formatter
 # See docs/misra-deviations.md#d002
-misra-c2012-11.2:Core/Interface/SolidSyslogFormatter.h:30
+misra-c2012-11.2:Core/Interface/SolidSyslogFormatter.h:28
 misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddress.c:10
 misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:20
 misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:28
@@ -21,7 +21,7 @@ misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:26
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddress.c:9
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:20
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:28
-misra-c2012-11.3:Core/Interface/SolidSyslogFormatter.h:30
+misra-c2012-11.3:Core/Interface/SolidSyslogFormatter.h:28
 misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:69
 misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:87
 misra-c2012-11.3:Core/Source/SolidSyslogFileBlockDevice.c:98
@@ -160,7 +160,7 @@ misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:9
 
 # D.011 — Rule 2.5: public API macros consumed outside cppcheck-misra scope
 # See docs/misra-deviations.md#d011
-misra-c2012-2.5:Core/Interface/SolidSyslogCircularBuffer.h:22
+misra-c2012-2.5:Core/Interface/SolidSyslogCircularBuffer.h:21
 
 # D.012 — Rule 8.9: file-scope static const referenced from a file-scope enum + one function
 # See docs/misra-deviations.md#d012

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -13,14 +13,14 @@
 # See docs/misra-deviations.md#d002
 misra-c2012-11.2:Core/Interface/SolidSyslogFormatter.h:28
 misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddress.c:10
-misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:20
-misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:28
+misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:19
+misra-c2012-11.2:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:26
 misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddress.c:10
-misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:20
-misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:26
+misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:19
+misra-c2012-11.2:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:24
 misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddress.c:9
-misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:20
-misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:28
+misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:19
+misra-c2012-11.2:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:26
 misra-c2012-11.3:Core/Interface/SolidSyslogFormatter.h:28
 misra-c2012-11.3:Core/Source/SolidSyslogBlockStore.c:69
 misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:87
@@ -36,8 +36,8 @@ misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:101
 misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:25
 misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:45
 misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddress.c:10
-misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:20
-misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:28
+misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:19
+misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressPrivate.h:26
 misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressStatic.c:34
 misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressStatic.c:54
 misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpDatagram.c:49
@@ -47,8 +47,8 @@ misra-c2012-11.3:Platform/PlusTcp/Source/SolidSyslogPlusTcpTcpStream.c:114
 misra-c2012-11.3:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:94
 misra-c2012-11.3:Platform/OpenSsl/Source/SolidSyslogTlsStream.c:82
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddress.c:10
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:20
-misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:26
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:19
+misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressPrivate.h:24
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressStatic.c:34
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixAddressStatic.c:54
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixDatagram.c:55
@@ -57,8 +57,8 @@ misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:129
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixMutex.c:47
 misra-c2012-11.3:Platform/Posix/Source/SolidSyslogPosixTcpStream.c:100
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddress.c:9
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:20
-misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:28
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:19
+misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressPrivate.h:26
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressStatic.c:34
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWinsockAddressStatic.c:54
 misra-c2012-11.3:Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c:29


### PR DESCRIPTION
## Purpose

E24 code-hygiene story #461. Triage every inline `// cppcheck-suppress`
and `// NOLINT*` comment across the tree per the priority order: tier-
level disable > fix the code > move to `misra_suppressions.txt` > keep
inline.

Closes #461.

## Change Description

Three commits, each `chore: S24.12 …`:

1. **Tier promotions + CmsdkUart enums.**
   - Root `.clang-tidy`: disable `modernize-redundant-void-arg`
     (meaningless in a C codebase).
   - New `Core/Interface/.clang-tidy`: disable
     `cppcoreguidelines-macro-usage` for public headers, which carry
     preprocessor-visible (`#if`) and array-size const-expression macros
     by design.
   - `Tests/.clang-tidy`: add `-google-build-using-namespace`.
   - `Bdd/Targets/FreeRtos/Common/CmsdkUart.c` +
     `Tests/FreeRtos/CmsdkUartFake.c`: register macros converted to
     anonymous enums (fix beats suppress, SoC-manual grep traceability
     preserved).

2. **Tests cppcheck CppUTest-macro consolidation.**
   - New `cppcheck_suppressions_tests.txt` with `*Tests/*` glob entries
     for the six rules that fire only as CppUTest-macro-expansion-model
     false positives (`unreadVariable`, `variableScope`,
     `constVariable`, `knownConditionTrueFalse`, `unusedStructMember`,
     `constVariablePointer`).
   - Same file also carries `cstyleCast:*Platform/*/Source/*AddressPrivate.h`
     for the opaque-to-impl downcasts that only trigger when C headers
     are included from C++ test compilation units (MISRA halves stay in
     `misra_suppressions.txt` under D.002).
   - Wired into the cppcheck CMake preset and CI's analyze-cppcheck
     report-generation step.
   - `misra_suppressions.txt` line numbers refreshed after the
     `cstyleCast` deletions surfaced rule-dedup-unmasking on the 11.3
     entries (the recipe from `feedback_cppcheck_dedup_unmask`).

3. **Further Tests-tier promotions + DEVLOG.**
   - `Tests/.clang-tidy` extended with `-cppcoreguidelines-macro-usage`,
     `-cppcoreguidelines-avoid-do-while` (paired for `CHECK_*` macros
     preserving `__FILE__/__LINE__`), and
     `-cppcoreguidelines-pro-type-reinterpret-cast` (vtable downcasts
     to test fakes + sentinel/forge pointers for fault-injection).
   - Residual NOLINTs kept inline with their per-site rationales.
   - DEVLOG entry captures the full audit and answers the story's
     residual-count question.

### Residual counts after audit

- Inline `cppcheck-suppress`: **213 → 4** (98% reduction). The four
  survivors are per-site rationales — `constParameter` in `ClockFake`
  and `BddTargetServiceThread`, `preprocessorErrorDirective` in
  `SolidSyslogTunables.h`.
- Inline `NOLINT*`: **340 → 124** (64% reduction). Remaining are
  `bugprone-easily-swappable-parameters` (72; per-site vtable / pair-API
  / byte-value rationales — kept inline per the design discussion),
  POSIX-API mirroring, MMIO / `INVALID_SOCKET` sentinel, third-party
  signature contracts, and a long tail of one-offs.

## Test Evidence

- `cmake --build --preset debug --target junit` — 1338/1338 tests
  green after each commit.
- `cmake --build --preset cppcheck` — clean (new glob suppressions file
  loaded by the preset; no `cppcheck-suppress` finding regression).
- `cppcheck --addon=misra --suppressions-list=misra_suppressions.txt
  --suppressions-list=cppcheck_suppressions_tests.txt` reproducing CI's
  cppcheck-misra lane: no findings.
- `scripts/misra_renumber.py` clean after the final commit (no proposed
  updates remain).
- `clang-format --dry-run --Werror` clean on the touched tree.

CI runs the full suite (tidy, sanitize, coverage, Windows MSVC,
integration, BDD) — none of which can run locally; deferred to CI per
the tiered pre-PR check budget in `docs/local-checks.md`.

## Areas Affected

- `.clang-tidy` (root): one rule disable added.
- `Core/Interface/.clang-tidy` (new file): public-header tier.
- `Tests/.clang-tidy`: four rule disables added.
- `cppcheck_suppressions_tests.txt` (new file).
- `CMakeLists.txt`: cppcheck preset arg list extended.
- `.github/workflows/ci.yml`: analyze-cppcheck report step arg list extended.
- `misra_suppressions.txt`: line numbers refreshed.
- `Bdd/Targets/FreeRtos/Common/CmsdkUart.c` + `Tests/FreeRtos/CmsdkUartFake.c`:
  register macros → anonymous enums.
- ~75 source files: inline NOLINT / cppcheck-suppress comment strips,
  no behaviour changes.

No public API change; no production logic change beyond the
macro-to-enum substitution in the BDD-target CMSDK UART driver and the
matching test fake (same identifier names, same values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rationalized static analysis configurations across the codebase by consolidating inline suppression comments into centralized configuration files, improving code readability and maintainability.
  * Refactored macro-based constants into typed enums for improved type safety and consistency.
  * Updated test infrastructure and MISRA suppression mappings to reflect code organization changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->