### PR TITLE
ci: S28.07 FreeRtosLwip cross link-probe (SOLIDSYSLOG_FREERTOS_NET=LWIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,6 +1014,50 @@ jobs:
           path: Bdd/features/steps/solidsyslog_tunables.py
           retention-days: 1
 
+  # Advisory (S28.07) — promoted to a required check in S28.11. Proves the
+  # Platform/LwipRaw tree cross-builds for FreeRTOS/ARM under
+  # SOLIDSYSLOG_FREERTOS_NET=LWIP with zero PlusTcp dependency. Deliberately
+  # absent from the `summary` needs list and the branch-protection required
+  # set so a break here does not block merges yet. No QEMU run.
+  build-freertos-target-lwip:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+      options: --user root
+    env:
+      GIT_CONFIG_COUNT: 1
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: '*'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Configure (ARM cross, NET=LWIP)
+        run: cmake --preset freertos-cross-lwip
+
+      - name: Cross-build FreeRTOS+lwIP link-probe ELF
+        run: cmake --build --preset freertos-cross-lwip --target SolidSyslogBddTargetLwip
+
+      - name: Assert no PlusTcp / Plus-TCP symbols linked
+        run: |
+          elf=build/freertos-cross-lwip/Bdd/Targets/FreeRtosLwip/SolidSyslogBddTargetLwip.elf
+          arm-none-eabi-nm "$elf" > /tmp/lwip-probe-symbols.txt
+          if grep -E -i 'PlusTcp|FreeRTOS_socket|FreeRTOS_sendto|FreeRTOS_recv|FreeRTOS_IPInit' /tmp/lwip-probe-symbols.txt; then
+            echo "::error::PlusTcp / FreeRTOS-Plus-TCP symbol linked into the lwIP probe ELF"
+            exit 1
+          fi
+          echo "OK: no PlusTcp / FreeRTOS-Plus-TCP symbols in the lwIP probe ELF"
+
+      - name: Upload FreeRTOS+lwIP link-probe ELF
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: solid-syslog-bdd-target-freertos-lwip
+          path: build/freertos-cross-lwip/Bdd/Targets/FreeRtosLwip/SolidSyslogBddTargetLwip.elf
+          retention-days: 1
+          compression-level: 0
+
   bdd-freertos-qemu-plustcp:
     needs: build-freertos-target-plustcp
     runs-on: ubuntu-latest

--- a/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
+++ b/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
@@ -1,0 +1,141 @@
+# FreeRTOS + lwIP (Raw API) link-probe ELF for QEMU mps2-an385 (Cortex-M3).
+#
+# S28.07: cross-build the Platform/LwipRaw adapter tree for a FreeRTOS/ARM
+# target, selected via SOLIDSYSLOG_FREERTOS_NET=LWIP, proving it links against
+# lwIP core with zero dependency on Platform/PlusTcp / FreeRTOS-Plus-TCP. No
+# LAN9118 netif driver and no QEMU run — those land with S28.09, which reuses
+# this directory's lwipopts.h / FreeRTOSConfig.h / arch/cc.h and grows main.c
+# into the real netif + tcpip integration.
+#
+# Source layout mirrors Bdd/Targets/FreeRtos/CMakeLists.txt: upstream
+# FreeRTOS-Kernel + lwIP-core sources compile into a separate OBJECT library
+# (`solid_syslog_freertos_lwip_upstream`) under a relaxed warning set; our own
+# code (main.c, the reused Cortex-M3 startup, and the Platform/LwipRaw adapter
+# sources) stays in the executable under the strict project warning bar.
+
+set(FREERTOS_KERNEL_PATH "$ENV{FREERTOS_KERNEL_PATH}")
+if(NOT FREERTOS_KERNEL_PATH)
+    message(FATAL_ERROR
+        "FREERTOS_KERNEL_PATH not set. Use the cpputest-freertos-cross "
+        "container, which sets this to /opt/freertos/kernel.")
+endif()
+
+set(LWIP_DIR "$ENV{LWIP_PATH}")
+if(NOT LWIP_DIR)
+    message(FATAL_ERROR
+        "LWIP_PATH not set. Use the cpputest-freertos-cross container, "
+        "which sets this to /opt/lwip.")
+endif()
+
+# lwIP ships its source lists as *_SRCS variables via Filelists.cmake (it is
+# explicitly NOT an add_subdirectory target). We consume the minimal IPv4 core
+# set — no api/ (NO_SYS=1, no sequential/socket API), no ipv6, no netif driver.
+include(${LWIP_DIR}/src/Filelists.cmake)
+
+set(FREERTOS_PORT_DIR "${FREERTOS_KERNEL_PATH}/portable/GCC/ARM_CM3")
+set(FREERTOS_COMMON_DIR "${CMAKE_SOURCE_DIR}/Bdd/Targets/FreeRtos/Common")
+
+# --- Upstream OBJECT library --------------------------------------------------
+#
+# FreeRTOS kernel (minimal: scheduler + heap) + lwIP IPv4 core, compiled with
+# the relaxed warning set those upstream sources require. The executable
+# consumes the objects via $<TARGET_OBJECTS:...> so the relaxations don't leak.
+
+add_library(solid_syslog_freertos_lwip_upstream OBJECT
+    ${FREERTOS_KERNEL_PATH}/tasks.c
+    ${FREERTOS_KERNEL_PATH}/queue.c
+    ${FREERTOS_KERNEL_PATH}/list.c
+    ${FREERTOS_PORT_DIR}/port.c
+    ${FREERTOS_KERNEL_PATH}/portable/MemMang/heap_4.c
+    ${lwipcore_SRCS}
+    ${lwipcore4_SRCS}
+)
+
+target_compile_options(solid_syslog_freertos_lwip_upstream PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -ffunction-sections
+    -fdata-sections
+    -fno-common
+    # FreeRTOS-Kernel + lwIP use non-prototype declarations, type-narrowing
+    # constructs, sign-conversion patterns, and shadowed locals that trip our
+    # strict host warnings. Scoped to this OBJECT library so the relaxations
+    # never reach project code.
+    -Wno-unused-parameter
+    -Wno-unused-but-set-variable
+    -Wno-implicit-fallthrough
+    -Wno-array-bounds
+    -Wno-conversion
+    -Wno-sign-conversion
+    -Wno-shadow
+    -Wno-pedantic
+)
+
+target_include_directories(solid_syslog_freertos_lwip_upstream PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h, lwipopts.h, arch/cc.h
+    ${FREERTOS_KERNEL_PATH}/include
+    ${FREERTOS_PORT_DIR}                              # portmacro.h
+    ${LWIP_DIR}/src/include
+)
+
+# --- Executable ---------------------------------------------------------------
+#
+# Project code only. Inherits the full project warning set from the top-level
+# CMakeLists.txt — no -Wno-* relaxations here.
+
+add_executable(SolidSyslogBddTargetLwip
+    main.c
+    ${FREERTOS_COMMON_DIR}/startup.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawAddress.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawAddressMessages.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawAddressStatic.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawResolver.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawResolverMessages.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawResolverStatic.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDatagram.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDatagramMessages.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDatagramStatic.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStream.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStreamMessages.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStreamStatic.c
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawMarshal.c
+    $<TARGET_OBJECTS:solid_syslog_freertos_lwip_upstream>
+)
+
+set_target_properties(SolidSyslogBddTargetLwip PROPERTIES SUFFIX ".elf")
+
+target_compile_options(SolidSyslogBddTargetLwip PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -ffunction-sections
+    -fdata-sections
+    -fno-common
+)
+
+target_include_directories(SolidSyslogBddTargetLwip PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}                       # FreeRTOSConfig.h, lwipopts.h, arch/cc.h
+    ${CMAKE_SOURCE_DIR}/Core/Interface                # SolidSyslog*.h
+    ${CMAKE_SOURCE_DIR}/Core/Source                   # internal headers consumed by adapters
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Interface    # SolidSyslogLwipRaw{Address,Resolver,Datagram,TcpStream}.h
+    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source        # SolidSyslogLwipRaw*Private.h
+    ${FREERTOS_KERNEL_PATH}/include
+    ${FREERTOS_PORT_DIR}                              # portmacro.h
+    ${LWIP_DIR}/src/include
+)
+
+target_link_libraries(SolidSyslogBddTargetLwip PRIVATE
+    ${PROJECT_NAME}                                   # libSolidSyslog.a (cross-compiled)
+)
+
+target_link_options(SolidSyslogBddTargetLwip PRIVATE
+    -mcpu=cortex-m3
+    -mthumb
+    -T${FREERTOS_COMMON_DIR}/mps2-an385.ld
+    --specs=nano.specs
+    --specs=nosys.specs
+    -Wl,--gc-sections
+    -Wl,-Map=$<TARGET_FILE:SolidSyslogBddTargetLwip>.map
+)
+
+set_target_properties(SolidSyslogBddTargetLwip PROPERTIES
+    LINK_DEPENDS ${FREERTOS_COMMON_DIR}/mps2-an385.ld)

--- a/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
+++ b/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
@@ -49,6 +49,10 @@ add_library(solid_syslog_freertos_lwip_upstream OBJECT
     ${FREERTOS_KERNEL_PATH}/portable/MemMang/heap_4.c
     ${lwipcore_SRCS}
     ${lwipcore4_SRCS}
+    # etharp (in core4) emits ARP frames via ethernet_output/ethbroadcast/
+    # ethzero from netif/ethernet.c — pull that one netif source in (but not
+    # bridgeif/slipif from lwipnetif_SRCS, which this probe has no use for).
+    ${LWIP_DIR}/src/netif/ethernet.c
 )
 
 target_compile_options(solid_syslog_freertos_lwip_upstream PRIVATE

--- a/Bdd/Targets/FreeRtosLwip/FreeRTOSConfig.h
+++ b/Bdd/Targets/FreeRtosLwip/FreeRTOSConfig.h
@@ -1,0 +1,68 @@
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/* FreeRTOS kernel configuration for the Cortex-M3 QEMU mps2-an385 lwIP
+ * link-probe (S28.07). Deliberately leaner than Bdd/Targets/FreeRtos/
+ * FreeRTOSConfig.h: this image only has to link the kernel alongside lwIP
+ * core + the Platform/LwipRaw adapters and start the scheduler with a single
+ * probe task that _Create/_Destroys each adapter. No timers, no static
+ * allocation, no IP-stack tasks, no hooks — so there is no hook boilerplate
+ * to carry. S28.09 introduces the real netif + tcpip integration on top of
+ * the fuller FreeRtos config. */
+
+#define configUSE_PREEMPTION 1
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TICK_HOOK 0
+#define configCPU_CLOCK_HZ ((unsigned long) 25000000)
+#define configTICK_RATE_HZ ((TickType_t) 100)
+#define configMAX_PRIORITIES 5
+#define configMINIMAL_STACK_SIZE ((unsigned short) 128)
+#define configTOTAL_HEAP_SIZE ((size_t) (32 * 1024))
+#define configMAX_TASK_NAME_LEN 16
+#define configUSE_TRACE_FACILITY 0
+#define configUSE_16_BIT_TICKS 0
+#define configIDLE_SHOULD_YIELD 1
+#define configUSE_MUTEXES 1
+#define configUSE_RECURSIVE_MUTEXES 0
+#define configUSE_COUNTING_SEMAPHORES 0
+#define configUSE_TIMERS 0
+#define configCHECK_FOR_STACK_OVERFLOW 0
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configSUPPORT_STATIC_ALLOCATION 0
+#define configSUPPORT_DYNAMIC_ALLOCATION 1
+
+#define configUSE_CO_ROUTINES 0
+#define configMAX_CO_ROUTINE_PRIORITIES 1
+
+#define INCLUDE_vTaskPrioritySet 0
+#define INCLUDE_uxTaskPriorityGet 0
+#define INCLUDE_vTaskDelete 0
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_vTaskDelayUntil 0
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+
+/* Cortex-M3 NVIC: top 3 priority bits implemented. */
+#define configPRIO_BITS 3
+#define configKERNEL_INTERRUPT_PRIORITY (7 << (8 - configPRIO_BITS))
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY (5 << (8 - configPRIO_BITS))
+
+/* Alias FreeRTOS port handlers to the standard CMSIS names so the vector
+ * table in Common/startup.c references SVC_Handler / PendSV_Handler /
+ * SysTick_Handler (and the FreeRTOS port supplies the bodies). */
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+#define xPortSysTickHandler SysTick_Handler
+
+#define configASSERT(x) \
+    do                  \
+    {                   \
+        if (!(x))       \
+        {               \
+            for (;;)    \
+            {           \
+            }           \
+        }               \
+    } while (0)
+
+#endif /* FREERTOS_CONFIG_H */

--- a/Bdd/Targets/FreeRtosLwip/README.md
+++ b/Bdd/Targets/FreeRtosLwip/README.md
@@ -1,0 +1,32 @@
+# FreeRTOS + lwIP (Raw API) link-probe target
+
+`SolidSyslogBddTargetLwip` is a **cross-build link probe**, not a runnable BDD
+target. It exists to prove — cheaply, in CI — that the `Platform/LwipRaw/`
+adapter tree (`Address`, `Resolver`, `Datagram`, `TcpStream`, `Marshal`)
+cross-compiles and links for a Cortex-M3 FreeRTOS target against lwIP core,
+**with zero dependency on `Platform/PlusTcp/` or FreeRTOS-Plus-TCP** (S28.07,
+epic E28).
+
+It is selected by `SOLIDSYSLOG_FREERTOS_NET=LWIP` (see the top-level
+`CMakeLists.txt`), built by the `freertos-cross-lwip` preset and the advisory
+`build-freertos-target-lwip` CI lane. There is no LAN9118 netif driver and no
+QEMU run: `main.c` starts the scheduler and a single probe task that
+`_Create`/`_Destroy`s each adapter, so the linker must resolve every adapter
+entry point and the lwIP core symbols behind it.
+
+`lwipopts.h` pins `NO_SYS=1` (the LwipRaw default direct-call marshal is
+correct for a single lwIP-owning context). The worked `NO_SYS=0` runtime — a
+real netif, `tcpip_init`, the `tcpip_callback` marshal (S28.06), and the UDP
+BDD feature green on QEMU — lands with **S28.09**, which reuses this
+directory's `lwipopts.h`, `FreeRTOSConfig.h`, and `arch/cc.h` and grows
+`main.c` into the full integration.
+
+## Build
+
+```sh
+cmake --preset freertos-cross-lwip
+cmake --build --preset freertos-cross-lwip --target SolidSyslogBddTargetLwip
+```
+
+Requires the `cpputest-freertos-cross` container (arm-none-eabi toolchain,
+`FREERTOS_KERNEL_PATH=/opt/freertos/kernel`, `LWIP_PATH=/opt/lwip`).

--- a/Bdd/Targets/FreeRtosLwip/arch/cc.h
+++ b/Bdd/Targets/FreeRtosLwip/arch/cc.h
@@ -1,0 +1,37 @@
+/* lwIP arch/cc.h for the QEMU mps2-an385 FreeRTOS+lwIP link-probe target.
+ *
+ * The minimum compiler-environment surface lwIP's arch.h asks an integrator
+ * to supply: the diagnostic / assert hooks and the randomness source. lwIP's
+ * own arch.h derives u8_t / u16_t / u32_t / s8_t / s16_t / s32_t from
+ * <stdint.h> when we do not redefine them — newlib on arm-none-eabi provides
+ * those, so we let lwIP's defaults stand.
+ *
+ * S28.07 cross-builds this image only to prove the Platform/LwipRaw tree
+ * links for a Cortex-M3 FreeRTOS target; it is never run on QEMU. DIAG is a
+ * no-op and ASSERT spins, matching how a deployed target would trap. LWIP_RAND
+ * is a tiny self-contained xorshift so TCP ISN selection has a definition to
+ * link against without dragging in newlib's rand() / a real entropy source —
+ * the worked NO_SYS=0 runtime config arrives with S28.09. */
+#ifndef LWIP_ARCH_CC_H
+#define LWIP_ARCH_CC_H
+
+// NOLINTBEGIN(bugprone-macro-parentheses) -- lwIP API requires these to be #defines
+#define LWIP_PLATFORM_DIAG(x) \
+    do                        \
+    {                         \
+        (void) 0;             \
+    } while (0)
+#define LWIP_PLATFORM_ASSERT(x) \
+    do                          \
+    {                           \
+        (void) (x);             \
+        for (;;)                \
+        {                       \
+        }                       \
+    } while (0)
+// NOLINTEND(bugprone-macro-parentheses)
+
+unsigned int LwipPortRand(void);
+#define LWIP_RAND() (LwipPortRand())
+
+#endif /* LWIP_ARCH_CC_H */

--- a/Bdd/Targets/FreeRtosLwip/lwipopts.h
+++ b/Bdd/Targets/FreeRtosLwip/lwipopts.h
@@ -1,0 +1,74 @@
+/* lwIP options for the QEMU mps2-an385 FreeRTOS+lwIP link-probe target.
+ *
+ * S28.07 scope: prove the Platform/LwipRaw adapters (Address, Resolver,
+ * Datagram, TcpStream, Marshal) cross-build and link against lwIP core for a
+ * Cortex-M3 FreeRTOS target, independent of Platform/PlusTcp. There is no
+ * netif driver and no QEMU run — this config only has to be self-consistent
+ * enough for lwIP core + the adapters to compile and link.
+ *
+ * NO_SYS=1: the LwipRaw adapters are OS-agnostic and the default direct-call
+ * marshal (SolidSyslogLwipRaw_SetMarshal, S28.06) is correct for a single
+ * lwIP-owning context. The worked NO_SYS=0 runtime (tcpip thread + the
+ * tcpip_callback marshal + a LAN9118 netif) lands with S28.09, which reuses
+ * this header and flips the OS-coupling options then.
+ *
+ * Memory is lwIP-pool managed (no libc malloc, no MEMP_MEM_MALLOC) so the
+ * footprint is the static, embedded-realistic shape an integrator ships —
+ * not the host-test shortcut (MEM_LIBC_MALLOC) in
+ * Tests/Support/LwipFakes/Interface/lwipopts.h. */
+#ifndef SOLIDSYSLOG_FREERTOS_LWIP_LWIPOPTS_H
+#define SOLIDSYSLOG_FREERTOS_LWIP_LWIPOPTS_H
+
+/* --- OS abstraction --------------------------------------------------- */
+#define NO_SYS 1
+#define SYS_LIGHTWEIGHT_PROT 0
+#define LWIP_NETCONN 0
+#define LWIP_SOCKET 0
+
+/* --- Protocol surface ------------------------------------------------- */
+#define LWIP_IPV4 1
+#define LWIP_IPV6 0
+#define LWIP_RAW 1
+#define LWIP_UDP 1
+#define LWIP_TCP 1
+#define LWIP_ARP 1
+#define LWIP_DHCP 0
+#define LWIP_DNS 0
+#define LWIP_ICMP 1
+#define LWIP_IGMP 0
+
+/* --- Memory: lwIP-managed static pools (no libc/posix heap) ----------- */
+#define MEM_LIBC_MALLOC 0
+#define MEMP_MEM_MALLOC 0
+#define MEM_ALIGNMENT 4
+#define MEM_SIZE (16 * 1024)
+
+#define MEMP_NUM_UDP_PCB 4
+#define MEMP_NUM_TCP_PCB 4
+#define MEMP_NUM_TCP_PCB_LISTEN 2
+#define MEMP_NUM_TCP_SEG 16
+#define MEMP_NUM_PBUF 16
+#define MEMP_NUM_RAW_PCB 2
+#define MEMP_NUM_ARP_QUEUE 4
+
+#define PBUF_POOL_SIZE 16
+
+/* --- TCP sizing ------------------------------------------------------- */
+#define TCP_MSS 1460
+#define TCP_WND (4 * TCP_MSS)
+#define TCP_SND_BUF (4 * TCP_MSS)
+#define TCP_QUEUE_OOSEQ 0
+
+/* --- Diagnostics: lean for the cross link probe ----------------------- */
+#define LWIP_STATS 0
+#define LWIP_NETIF_API 0
+#define LWIP_NETIF_STATUS_CALLBACK 0
+#define LWIP_NETIF_LINK_CALLBACK 0
+#define CHECKSUM_GEN_IP 1
+#define CHECKSUM_GEN_UDP 1
+#define CHECKSUM_GEN_TCP 1
+#define CHECKSUM_CHECK_IP 1
+#define CHECKSUM_CHECK_UDP 1
+#define CHECKSUM_CHECK_TCP 1
+
+#endif /* SOLIDSYSLOG_FREERTOS_LWIP_LWIPOPTS_H */

--- a/Bdd/Targets/FreeRtosLwip/main.c
+++ b/Bdd/Targets/FreeRtosLwip/main.c
@@ -1,0 +1,100 @@
+/* FreeRTOS + lwIP (Raw API) link-probe for QEMU mps2-an385 (Cortex-M3).
+ *
+ * S28.07: prove the Platform/LwipRaw adapter tree cross-builds and links for
+ * a FreeRTOS/ARM target, selected via SOLIDSYSLOG_FREERTOS_NET=LWIP, with zero
+ * dependency on Platform/PlusTcp or FreeRTOS-Plus-TCP. This de-risks the CMake
+ * backend switch end-to-end before the heavy netif + QEMU lift (S28.09).
+ *
+ * It is a *link* probe, not a runtime: there is no LAN9118 netif driver, no
+ * IP bring-up, and CI does not run it on QEMU. The single probe task calls
+ * lwip_init() and then _Create / _Destroy on each LwipRaw adapter so the
+ * linker must resolve every adapter entry point (and, transitively, the lwIP
+ * core symbols they call). Starting the scheduler keeps the FreeRTOS kernel
+ * symbols referenced too, so the artifact genuinely contains the kernel +
+ * lwIP + LwipRaw, mirroring the FreeRTOS-Plus-TCP target's shape.
+ *
+ * lwipopts.h pins NO_SYS=1, so the LwipRaw default direct-call marshal is
+ * correct and lwIP asks the integrator for two hooks only — sys_now() and
+ * LWIP_RAND() — both provided below. */
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "lwip/init.h"
+#include "lwip/sys.h"
+
+#include "SolidSyslogLwipRawAddress.h"
+#include "SolidSyslogLwipRawDatagram.h"
+#include "SolidSyslogLwipRawResolver.h"
+#include "SolidSyslogLwipRawTcpStream.h"
+
+/* The probe only _Create/_Destroys adapters then idles — 4x the kernel
+ * minimum is ample headroom and matches the StackType_t (word) units
+ * xTaskCreate expects. */
+#define PROBE_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 4U)
+
+/* lwIP NO_SYS=1 time source — milliseconds since boot, derived from the
+ * FreeRTOS tick. Drives lwIP's timeout wheel (which this probe never pumps). */
+u32_t sys_now(void)
+{
+    return (u32_t) ((uint64_t) xTaskGetTickCount() * (uint64_t) portTICK_PERIOD_MS);
+}
+
+/* lwIP randomness source (declared by Bdd/Targets/FreeRtosLwip/arch/cc.h's
+ * LWIP_RAND). A self-contained xorshift32 keeps TCP ISN selection linkable
+ * without pulling in newlib rand() or a real entropy backend — the worked
+ * runtime entropy story belongs to S28.09. */
+unsigned int LwipPortRand(void)
+{
+    static uint32_t state = 0x2545F491U;
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    return (unsigned int) state;
+}
+
+/* The bounded-connect spin in SolidSyslogLwipRawTcpStream takes a Sleep
+ * callback. This probe never opens a connection, so a no-op satisfies the
+ * required-field contract without behaviour. */
+static void ProbeSleep(int milliseconds)
+{
+    (void) milliseconds;
+}
+
+static void ProbeTask(void* parameters)
+{
+    (void) parameters;
+
+    lwip_init();
+
+    struct SolidSyslogAddress* address = SolidSyslogLwipRawAddress_Create();
+    struct SolidSyslogResolver* resolver = SolidSyslogLwipRawResolver_Create();
+    struct SolidSyslogDatagram* datagram = SolidSyslogLwipRawDatagram_Create();
+
+    struct SolidSyslogLwipRawTcpStreamConfig streamConfig = {
+        .GetConnectTimeoutMs = NULL,
+        .ConnectTimeoutContext = NULL,
+        .Sleep = ProbeSleep,
+    };
+    struct SolidSyslogStream* stream = SolidSyslogLwipRawTcpStream_Create(&streamConfig);
+
+    SolidSyslogLwipRawTcpStream_Destroy(stream);
+    SolidSyslogLwipRawDatagram_Destroy(datagram);
+    SolidSyslogLwipRawResolver_Destroy(resolver);
+    SolidSyslogLwipRawAddress_Destroy(address);
+
+    for (;;)
+    {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+int main(void)
+{
+    (void) xTaskCreate(ProbeTask, "probe", PROBE_TASK_STACK_DEPTH, NULL, tskIDLE_PRIORITY + 1, NULL);
+    vTaskStartScheduler();
+    for (;;)
+    {
+    }
+    return 0;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,13 +168,15 @@ if(NOT SOLIDSYSLOG_FREERTOS_NET STREQUAL "PLUSTCP"
 endif()
 if(SOLIDSYSLOG_FREERTOS_NET STREQUAL "LWIP")
     message(STATUS
-        "SOLIDSYSLOG_FREERTOS_NET=LWIP: lwIP backend partial — "
-        "Address+Resolver+Datagram+TcpStream only; BDD arrives in S28.06.")
+        "SOLIDSYSLOG_FREERTOS_NET=LWIP: cross builds the FreeRtosLwip "
+        "link-probe (Address+Resolver+Datagram+TcpStream+Marshal against "
+        "lwIP core); netif + QEMU BDD arrive in S28.09.")
 endif()
 if(SOLIDSYSLOG_FREERTOS_NET STREQUAL "BOTH")
     message(STATUS
-        "SOLIDSYSLOG_FREERTOS_NET=BOTH: lwIP backend partial — "
-        "Address+Resolver+Datagram+TcpStream only; BDD arrives in S28.06.")
+        "SOLIDSYSLOG_FREERTOS_NET=BOTH: cross builds the PlusTcp BDD target; "
+        "the lwIP backend cross-builds in isolation under NET=LWIP "
+        "(S28.07) — netif + QEMU BDD arrive in S28.09.")
 endif()
 
 # Build-time tunables (E21: Port-Time Configurability). Integrators override
@@ -268,11 +270,18 @@ if(DEFINED ENV{FATFS_PATH})
     add_subdirectory(Platform/FatFs)
 endif()
 
-# The cross-compiled FreeRTOS BDD target is selected by the arm-none-eabi
+# The cross-compiled FreeRTOS target is selected by the arm-none-eabi
 # toolchain file (see Bdd/Targets/FreeRtos/cmake/arm-none-eabi.cmake); it
-# only enters the build when a freertos-cross preset is active.
+# only enters the build when a freertos-cross preset is active. The chosen
+# networking backend picks which target: PLUSTCP/BOTH builds the full
+# FreeRTOS-Plus-TCP BDD target; LWIP builds the FreeRtosLwip link-probe
+# (S28.07) — a stub proving Platform/LwipRaw cross-links with no PlusTcp.
 if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-    add_subdirectory(Bdd/Targets/FreeRtos)
+    if(SOLIDSYSLOG_FREERTOS_NET STREQUAL "LWIP")
+        add_subdirectory(Bdd/Targets/FreeRtosLwip)
+    else()
+        add_subdirectory(Bdd/Targets/FreeRtos)
+    endif()
 endif()
 
 if(NOT CMAKE_CROSSCOMPILING)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -116,6 +116,17 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "SOLIDSYSLOG_USER_TUNABLES_FILE": "${sourceDir}/Bdd/Targets/FreeRtos/solidsyslog_user_tunables.h"
             }
+        },
+        {
+            "name": "freertos-cross-lwip",
+            "displayName": "FreeRTOS+lwIP cross link-probe (ARM Cortex-M3, mps2-an385)",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/Bdd/Targets/FreeRtos/cmake/arm-none-eabi.cmake",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "SOLIDSYSLOG_FREERTOS_NET": "LWIP"
+            }
         }
     ],
     "buildPresets": [
@@ -129,7 +140,8 @@
         { "name": "clang-debug",    "configurePreset": "clang-debug" },
         { "name": "iwyu",           "configurePreset": "iwyu" },
         { "name": "msvc-debug",     "configurePreset": "msvc-debug", "configuration": "Debug" },
-        { "name": "freertos-cross", "configurePreset": "freertos-cross" }
+        { "name": "freertos-cross", "configurePreset": "freertos-cross" },
+        { "name": "freertos-cross-lwip", "configurePreset": "freertos-cross-lwip" }
     ],
     "testPresets": [
         {

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,58 @@
 # Dev Log
 
+## 2026-05-29 — S28.07 FreeRtosLwip cross link-probe
+
+The real S28.07 (#471) turned out to be a CI/build-infra story, **not** the
+DNS resolver my memory pointed to. The original S28.07 note ("lwIP DNS
+resolver") was decomposed into ~3 stories; the LwipRaw resolver shipped
+literal-IPv4-only on purpose (S28.03), and DNS isn't on the near board.
+What #471 actually wants: prove the `Platform/LwipRaw/` tree cross-builds
+for a FreeRTOS/ARM target under `SOLIDSYSLOG_FREERTOS_NET=LWIP`, independent
+of `Platform/PlusTcp/`, with a stub `main` and no QEMU — cheap de-risk
+before the S28.09 netif + BDD lift.
+
+### What landed
+
+- **`Bdd/Targets/FreeRtosLwip/`** — a `NO_SYS=1` Cortex-M3 link-probe.
+  Stub `main.c` starts the scheduler + one task that `_Create`/`_Destroy`s
+  all four LwipRaw adapters, so the linker must resolve every adapter entry
+  point and the lwIP core behind it. Reuses the existing `Common/startup.c`
+  + `mps2-an385.ld`; seeds `lwipopts.h` / `FreeRTOSConfig.h` / `arch/cc.h`
+  (the two integrator hooks lwIP needs under `NO_SYS=1` — `sys_now()` and a
+  self-contained `LWIP_RAND()`) for S28.09 to grow into the real
+  `NO_SYS=0` + `tcpip_callback` runtime.
+- Top-level CMake **selects FreeRtos vs FreeRtosLwip on the backend** (the
+  one `add_subdirectory` under the cross branch became an if/else);
+  `freertos-cross-lwip` preset; advisory **`build-freertos-target-lwip`**
+  lane (asserts no PlusTcp symbols in the ELF, uploads it; deliberately not
+  in `summary` needs — promoted to required in S28.11).
+- docs/containers.md backend table corrected (LWIP was still `FATAL_ERROR`).
+
+### Following "what the existing build did"
+
+David's steer was to mirror the existing freertos-cross target structure.
+(His premise that the LwipRaw sources were already cross-built wasn't quite
+right — `Platform/LwipRaw` is an INTERFACE lib that's `add_subdirectory`'d
+when `LWIP_PATH` is set, but no executable compiled its `.c` sources, and
+lwIP core had never been cross-compiled. So this was net-new.) Mirrored the
+upstream-OBJECT-lib (relaxed warnings) + strict-executable split, the arm
+toolchain, and the linker script.
+
+### Host de-risk paid off; one cross-only gap
+
+Before the container flip I compiled lwIP core + all five LwipRaw adapters
+on host gcc under the strict bar (`-Wconversion -Wsign-conversion -Werror`)
+against the real lwIP headers — all clean, which is exactly what held at
+cross-compile. The only cross-only failure was a **link** gap: `LWIP_ARP=1`
+pulls `etharp` into the IPv4 core, which calls `ethernet_output` /
+`ethbroadcast` / `ethzero` from `netif/ethernet.c` — a file I'd excluded.
+Added just that one netif source (not bridgeif/slipif). Kept ARP on because
+it's the realistic config S28.09 reuses, not a probe shortcut.
+
+Result: a 278 KB statically-linked Cortex-M3 ELF carrying kernel + lwIP +
+13 LwipRaw symbols, zero PlusTcp symbols. The required PLUSTCP cross lane
+rebuilds green, so the gating change didn't regress it.
+
 ## 2026-05-28 — S28.06 LwipRaw marshal injection
 
 Sixth story under E28. Added `SolidSyslogLwipRaw_SetMarshal` — a

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -45,12 +45,13 @@ between them at CMake time via `SOLIDSYSLOG_FREERTOS_NET`:
 
 | Value | Behaviour |
 |---|---|
-| `PLUSTCP` (default) | Compiles `Platform/PlusTcp/` against FreeRTOS-Plus-TCP. Current first-class backend. |
-| `LWIP` | `FATAL_ERROR` — `Platform/LwipRaw/` is in progress under epic E28 (stories S28.03–S28.05). |
-| `BOTH` | Compiles `PLUSTCP` only and emits a `STATUS` message until the lwIP backend lands (E28 S28.06). Lets dev-container users keep `BOTH` set without breaking their build during the gap. |
+| `PLUSTCP` (default) | Cross-builds the full FreeRTOS-Plus-TCP BDD target (`Bdd/Targets/FreeRtos/`). Current first-class backend. |
+| `LWIP` | Cross-builds the `Bdd/Targets/FreeRtosLwip/` link-probe — a stub proving `Platform/LwipRaw/` links against lwIP core for FreeRTOS/ARM with no PlusTcp dependency (E28 S28.07). The worked netif + QEMU UDP BDD integration lands in S28.09. |
+| `BOTH` | Cross-builds the `PLUSTCP` target only and emits a `STATUS` message noting the lwIP backend builds in isolation under `LWIP`. Lets dev-container users keep `BOTH` set without breaking their build. |
 
-CI runs `PLUSTCP` and (once E28 S28.06 lands) `LWIP` in isolation; the
-`BOTH` value is a dev-container convenience and is not exercised by CI.
+CI runs `PLUSTCP` (required) and `LWIP` (advisory `build-freertos-target-lwip`
+lane, S28.07) in isolation; the `BOTH` value is a dev-container convenience and
+is not exercised by CI.
 
 ## Running the clang build locally
 


### PR DESCRIPTION
Closes #471.

Proves the `Platform/LwipRaw/` adapter tree cross-builds for a FreeRTOS/ARM
target under `SOLIDSYSLOG_FREERTOS_NET=LWIP`, independent of `Platform/PlusTcp/`
/ FreeRTOS-Plus-TCP — the cheap de-risk before the S28.09 netif + QEMU lift.

## What landed

- **`Bdd/Targets/FreeRtosLwip/`** — a `NO_SYS=1` Cortex-M3 link-probe. Stub
  `main.c` starts the scheduler + one task that `_Create`/`_Destroy`s all four
  LwipRaw adapters, so the linker must resolve every adapter entry point and the
  lwIP core behind it. Reuses the existing `Common/startup.c` + `mps2-an385.ld`;
  seeds `lwipopts.h` / `FreeRTOSConfig.h` / `arch/cc.h` (with the two integrator
  hooks lwIP needs under `NO_SYS=1` — `sys_now()` and a self-contained
  `LWIP_RAND()`) for S28.09 to grow into the real `NO_SYS=0` + `tcpip_callback`
  runtime.
- Top-level CMake **selects FreeRtos vs FreeRtosLwip on the backend**;
  `freertos-cross-lwip` preset added.
- Advisory **`build-freertos-target-lwip`** CI lane: configure `NET=LWIP`,
  cross-build the ELF, assert no PlusTcp symbols, upload the artifact.
  Deliberately **not** in the `summary` needs list / branch-protection required
  set — a break here won't block merges (promoted to required in S28.11).
- `docs/containers.md` backend table corrected (LWIP was still documented as
  `FATAL_ERROR`).

## Verification (locally, on the freertos-target cross toolchain)

- `freertos-cross-lwip` builds a 278 KB statically-linked Cortex-M3 ELF
  carrying kernel + lwIP core + 13 LwipRaw symbols; `arm-none-eabi-nm` shows
  **zero** PlusTcp / FreeRTOS-Plus-TCP symbols.
- The required PLUSTCP cross lane (`freertos-cross` → `SolidSyslogBddTarget`)
  rebuilds green — the gating change didn't regress it.
- lwIP core + all five LwipRaw adapters compile strict-clean
  (`-Wconversion -Wsign-conversion -Werror`) against the real lwIP headers.

## Out of scope (S28.09, #472)

LAN9118 netif driver, `NO_SYS=0` + `tcpip_callback` marshal wiring, the UDP BDD
feature on QEMU. This story is link-proof only — no QEMU run.

## Acceptance criteria

- [x] CI cross-builds a `NET=LWIP` FreeRTOS image containing only the LwipRaw tree (no PlusTcp symbols linked).
- [x] PlusTcp lanes unchanged and green.
- [x] Lane is advisory (promoted to required in S28.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FreeRTOS + lwIP cross-build target for ARM Cortex-M3 platforms
  * New CMake preset (`freertos-cross-lwip`) for lwIP configurations
  * New CI validation job for lwIP builds

* **Documentation**
  * Updated build and container documentation with lwIP backend details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavidCozens/solid-syslog/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->