### PR TITLE
docs: sync CLAUDE.md branch-protection list with live required checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ what matters — it becomes the permanent commit message on `main` on squash mer
 
 **Branch protection rules (configured on GitHub):**
 - Direct pushes to `main` are blocked
-- PRs require all status checks to pass before merging: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, analyze-iwyu, integration-linux-openssl, integration-windows-openssl, bdd-linux-syslog-ng, bdd-windows-otel, bdd-freertos-qemu-plustcp, build-freertos-host-tdd-plustcp, build-freertos-target-plustcp, summary
+- PRs require all status checks to pass before merging: build-linux-gcc, build-linux-clang, build-windows-msvc, sanitize-linux-gcc, coverage-linux-gcc, analyze-tidy, analyze-cppcheck, analyze-format, analyze-iwyu, integration-linux-openssl, integration-linux-mbedtls, integration-windows-openssl, bdd-linux-syslog-ng, bdd-windows-otel, bdd-freertos-qemu-plustcp, build-freertos-host-tdd-plustcp, build-freertos-target-plustcp, analyze-tidy-freertos-plustcp, analyze-iwyu-freertos-plustcp, bdd-freertos-qemu-lwip, build-freertos-target-lwip, analyze-tidy-freertos-lwip, analyze-iwyu-freertos-lwip, summary
 - Squash merge only — other merge strategies are disabled
 - Branches are deleted automatically after merge
 


### PR DESCRIPTION
## Purpose

The branch-protection required-checks list in `CLAUDE.md` had drifted from the live ruleset on `main`. This brings the doc back in sync.

## Change Description

Updates the single bullet under **Branch protection rules** to list all 24 checks now required on `main`. Additions vs the previous doc text:

- `integration-linux-mbedtls` — already required, was missing from the doc.
- `analyze-tidy-freertos-plustcp`, `analyze-iwyu-freertos-plustcp` — backfilled so both FreeRTOS backends are gated symmetrically across build / bdd / analyze.
- `bdd-freertos-qemu-lwip`, `build-freertos-target-lwip`, `analyze-tidy-freertos-lwip`, `analyze-iwyu-freertos-lwip` — the lwIP lanes promoted to required after S28.11 (#474).

Docs only — no code or CI change.

## Test Evidence

List matched verbatim against the live API:

```
gh api repos/DavidCozens/solid-syslog/branches/main/protection/required_status_checks
→ 24 contexts, strict:false
```

## Areas Affected

- `CLAUDE.md` (documentation only)