### PR TITLE
chore: disable CodeRabbit auto-start task in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
     },
     "[powershell]": {
         "files.eol": "\r\n"
-    }
+    },
+    "coderabbit.autoStartTask": false
 }


### PR DESCRIPTION
Sets `coderabbit.autoStartTask: false` in `.vscode/settings.json` so the CodeRabbit extension doesn't auto-launch a review task on open — reviews are driven on the PR instead.

Editor-config only; no build, source, or CI behaviour impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)