### PR TITLE
docs: add Bash execution rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,3 +657,23 @@ SafeString is compiled into test executables only — never linked into the prod
 
 `_CRT_SECURE_NO_WARNINGS` was removed from CMakeLists.txt and must not be re-added.
 `memset`, `memcpy`, and `strcmp` are not SDL-banned and do not trigger MSVC C4996.
+
+---
+
+## Bash execution rules
+
+- The Bash tool runs in a persistent session. The working directory is
+  dynamic — it is NOT fixed at the launch directory and persists across calls.
+- Prefer absolute paths in all file and shell operations. Do not rely on the
+  current working directory being where you expect it.
+- Do not use bare `cd` to move between dependent steps. If a sequence needs a
+  specific directory, chain it in ONE command with `&&`
+  (e.g. `cd /abs/path && cmd`) so the directory and the command succeed or
+  fail together.
+- Never issue multiple parallel Bash calls that depend on shared session state
+  (working directory, environment variables, or each other's output). Run
+  interdependent commands sequentially in a single Bash call.
+- Only parallelise Bash calls that are genuinely independent and read-only
+  (e.g. `git status`, `git diff`, `git log`).
+- If a command fails, do not assume the session state (including cwd) is intact;
+  re-establish it explicitly before continuing.


### PR DESCRIPTION
Adds a **Bash execution rules** section to `CLAUDE.md` capturing the persistent-session hazards that bit earlier sessions:

- The Bash tool's working directory is dynamic and persists across calls — don't assume it.
- Prefer absolute paths everywhere.
- Chain dependent steps in one `&&` command rather than bare `cd` between calls.
- Never parallelise Bash calls that share session state (cwd, env, each other's output); only parallelise genuinely independent read-only calls.
- After a failure, re-establish state explicitly rather than assuming cwd survived.

Documentation only — no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance documentation with updated Bash execution best practices, including session management, working-directory persistence, path handling, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->