### PR TITLE
fix: free SSL_CTX on TlsStream Close to stop reopen leak

### DIFF
--- a/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
+++ b/Platform/OpenSsl/Source/SolidSyslogTlsStream.c
@@ -84,14 +84,12 @@ static inline struct SolidSyslogTlsStream* TlsStream_SelfFromBase(struct SolidSy
 
 void TlsStream_Cleanup(struct SolidSyslogStream* base)
 {
-    struct SolidSyslogTlsStream* self = TlsStream_SelfFromBase(base);
     /* Close first so an integrator who destroys a still-Open stream doesn't
-     * leak the underlying transport. Close is idempotent (guards on Ssl !=
-     * NULL for the TLS-side teardown; transport Close is itself idempotent
-     * on every Stream impl), so the normal Open → Close → Destroy lifecycle
-     * is unaffected. */
+     * leak the underlying transport. Close now releases the SSL, BIO_METHOD
+     * and SSL_CTX, and is idempotent (the TLS-side teardown guards on Ssl /
+     * Ctx != NULL; transport Close is itself idempotent on every Stream
+     * impl), so the normal Open → Close → Destroy lifecycle is unaffected. */
     TlsStream_Close(base);
-    TlsStream_ReleaseSslContext(self);
     /* Overwrite the abstract base with the shared NullStream vtable so
      * use-after-destroy is a safe no-op rather than a NULL-fn-pointer crash. */
     *base = *SolidSyslogNullStream_Get();
@@ -108,6 +106,11 @@ static inline void TlsStream_Close(struct SolidSyslogStream* base)
         SSL_shutdown(self->Ssl);
         TlsStream_ReleaseHandshakeState(self);
     }
+    /* Each Open rebuilds the CTX (cert-rotation contract), so Close must free
+       the current one or the fail-fast Open -> Close -> Open reconnect cycle
+       leaks an SSL_CTX every round. NULL-guarded, so the Open-failure tail and
+       Cleanup that also call it stay double-free safe. */
+    TlsStream_ReleaseSslContext(self);
     SolidSyslogStream_Close(self->Config.Transport);
 }
 
@@ -153,7 +156,6 @@ static inline bool TlsStream_Open(struct SolidSyslogStream* base, const struct S
     if (!ok)
     {
         TlsStream_Close(base);
-        TlsStream_ReleaseSslContext(self);
     }
     return ok;
 }

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -548,6 +548,20 @@ TEST(SolidSyslogTlsStream, DestroyAfterCloseDoesNotDoubleFreeSsl)
     CALLED_FAKE(OpenSslFake_Free, ONCE);
 }
 
+TEST(SolidSyslogTlsStream, ReopenAfterCloseDoesNotLeakSslContext)
+{
+    /* Each Open rebuilds the SSL_CTX (the cert-rotation contract — a fresh CTX
+       per connection picks up trust-store / client-identity changes). The
+       fail-fast reconnect model therefore drives Open -> Close -> Open on a
+       single stream instance repeatedly; Close must free the CTX so the next
+       Open does not leak the previous one. */
+    SolidSyslogStream_Open(stream, addr);
+    SolidSyslogStream_Close(stream);
+    SolidSyslogStream_Open(stream, addr);
+    LONGS_EQUAL(2, OpenSslFake_CtxNewCallCount());
+    LONGS_EQUAL(1, OpenSslFake_CtxFreeCallCount());
+}
+
 /* -------------------------------------------------------------------------
  * Pointer-chain assertions: each OpenSSL call must receive the handle
  * returned by the preceding call, not some stale or NULL pointer.


### PR DESCRIPTION
Each `TlsStream_Open` rebuilds the `SSL_CTX` (the cert-rotation contract — a fresh CTX per connection picks up trust-store / client-identity changes), but `Close` only freed the `SSL` and `BIO_METHOD`, not the CTX. Under the S12.14 fail-fast reconnect model the stream is driven `Open -> Close -> Open` repeatedly on a single instance, leaking one `SSL_CTX` every cycle.

**Fix:** move the CTX release into `Close` (mirrors the mbedTLS adapter, whose `Close` frees both config and context). `TlsStream_ReleaseSslContext` is NULL-guarded, so the now-redundant calls in the `Open`-failure tail and `Cleanup` are removed without any double-free risk.

**Test:** `ReopenAfterCloseDoesNotLeakSslContext` pins `Open -> Close -> Open` to 2 `CTX_new` / 1 `CTX_free`.

Independent of the TLS-session-resumption work — that direction is being dropped (see DEVLOG); this is a genuine leak found alongside it and kept on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)