### PR TITLE
fix: replace fixed-sleep mutex destroy with service-stop handshake (S24.15)

### DIFF
--- a/Bdd/Targets/FreeRtos/main.c
+++ b/Bdd/Targets/FreeRtos/main.c
@@ -276,6 +276,22 @@ static BaseType_t interactiveTaskCreated = pdFALSE;
  * report its peak stack usage alongside its own on `quit`. */
 static TaskHandle_t serviceTaskHandle = NULL;
 
+/* The task awaiting ServiceTask's exit during teardown. Set by TeardownAll
+ * (inside the lifecycle critical section, so ServiceTask reads it atomically
+ * with the teardown flag); ServiceTask notifies it the instant before it
+ * self-deletes, letting TeardownAll destroy the lifecycle mutex on a real
+ * "service stopped" signal instead of a fixed delay. */
+static TaskHandle_t serviceStopWaiter = NULL;
+
+/* Upper bound on the teardown wait for ServiceTask to self-delete. ServiceTask
+ * observes the flag within one ~1 ms iteration, so this is only ever reached if
+ * the Service task never started (xTaskCreate failure); it bounds teardown
+ * rather than timing it. */
+enum
+{
+    SERVICE_STOP_TIMEOUT_MS = 1000,
+};
+
 extern NetworkInterface_t* pxMPS2_FillInterfaceDescriptor(BaseType_t xEMACIndex, NetworkInterface_t* pxInterface);
 
 static void SetEthernetIrqPriority(void);
@@ -869,6 +885,7 @@ static void OnThresholdCrossed(void* context)
 static void TeardownAll(void)
 {
     SolidSyslogMutex_Lock(lifecycleMutex);
+    serviceStopWaiter = xTaskGetCurrentTaskHandle();
     solidSyslogTeardown = true;
     solidSyslogReady = false;
     SolidSyslog_Destroy(solidSyslog);
@@ -885,11 +902,16 @@ static void TeardownAll(void)
     }
     SolidSyslogMutex_Unlock(lifecycleMutex);
 
-    /* Give Service one full iteration (vTaskDelay 1ms + lock-check) to
-     * observe the teardown flag and vTaskDelete itself before we destroy
-     * the lifecycle mutex out from under it. 20ms is generous against
-     * Service's worst-case iteration time. */
-    vTaskDelay(pdMS_TO_TICKS(20));
+    /* Wait for Service to observe the teardown flag and vTaskDelete itself
+     * before we destroy the lifecycle mutex out from under it. ServiceTask
+     * notifies us from its self-delete path, so this returns the moment it
+     * has actually exited rather than after a fixed guess. Bounded so a
+     * Service task that never started (xTaskCreate failure → NULL handle)
+     * cannot wedge teardown. */
+    if (serviceTaskHandle != NULL)
+    {
+        (void) ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(SERVICE_STOP_TIMEOUT_MS));
+    }
     serviceTaskHandle = NULL;
 
     SolidSyslogCircularBuffer_Destroy(buffer);
@@ -1113,10 +1135,16 @@ static void ServiceTask(void* argument)
         SolidSyslogMutex_Lock(lifecycleMutex);
         if (solidSyslogTeardown)
         {
-            /* Teardown set this flag inside the lifecycle critical section,
-             * then is sleeping briefly waiting for us to exit. Release and
+            /* Teardown set this flag inside the lifecycle critical section and
+             * is now blocked waiting for us to exit. Capture the waiter under
+             * the lock, release, notify it that Service has stopped, then
              * self-delete before Teardown destroys the mutex. */
+            TaskHandle_t waiter = serviceStopWaiter;
             SolidSyslogMutex_Unlock(lifecycleMutex);
+            if (waiter != NULL)
+            {
+                (void) xTaskNotifyGive(waiter);
+            }
             vTaskDelete(NULL);
         }
         if (solidSyslogReady)

--- a/Bdd/Targets/FreeRtosLwip/main.c
+++ b/Bdd/Targets/FreeRtosLwip/main.c
@@ -148,6 +148,22 @@ static struct SolidSyslogMutex* bufferMutex = NULL;
 
 static TaskHandle_t serviceTaskHandle = NULL;
 
+/* The task awaiting ServiceTask's exit during teardown. Set by TeardownAll
+ * (inside the lifecycle critical section, so ServiceTask reads it atomically
+ * with the teardown flag); ServiceTask notifies it the instant before it
+ * self-deletes, letting TeardownAll destroy the lifecycle mutex on a real
+ * "service stopped" signal instead of a fixed delay. */
+static TaskHandle_t serviceStopWaiter = NULL;
+
+/* Upper bound on the teardown wait for ServiceTask to self-delete. ServiceTask
+ * observes the flag within one ~1 ms iteration, so this is only ever reached if
+ * the Service task never started (xTaskCreate failure); it bounds teardown
+ * rather than timing it. */
+enum
+{
+    SERVICE_STOP_TIMEOUT_MS = 1000,
+};
+
 static void InteractiveTask(void* argument);
 static void ServiceTask(void* argument);
 static void LwipTcpipMarshal(SolidSyslogLwipRawCallback callback, void* context);
@@ -624,7 +640,15 @@ static void ServiceTask(void* argument)
         SolidSyslogMutex_Lock(lifecycleMutex);
         if (solidSyslogTeardown)
         {
+            /* Capture the waiter under the lock, release, notify it that
+             * Service has stopped, then self-delete before Teardown destroys
+             * the mutex. */
+            TaskHandle_t waiter = serviceStopWaiter;
             SolidSyslogMutex_Unlock(lifecycleMutex);
+            if (waiter != NULL)
+            {
+                (void) xTaskNotifyGive(waiter);
+            }
             vTaskDelete(NULL);
         }
         if (solidSyslogReady)
@@ -639,6 +663,7 @@ static void ServiceTask(void* argument)
 static void TeardownAll(void)
 {
     SolidSyslogMutex_Lock(lifecycleMutex);
+    serviceStopWaiter = xTaskGetCurrentTaskHandle();
     solidSyslogTeardown = true;
     solidSyslogReady = false;
     SolidSyslog_Destroy(solidSyslog);
@@ -649,9 +674,15 @@ static void TeardownAll(void)
     SolidSyslogStdAtomicCounter_Destroy(atomicCounter);
     SolidSyslogMutex_Unlock(lifecycleMutex);
 
-    /* Give Service one iteration to observe the teardown flag and self-delete
-     * before the lifecycle mutex is destroyed under it. */
-    vTaskDelay(pdMS_TO_TICKS(20));
+    /* Wait for Service to observe the teardown flag and vTaskDelete itself
+     * before the lifecycle mutex is destroyed under it. ServiceTask notifies
+     * us from its self-delete path, so this returns the moment it has actually
+     * exited rather than after a fixed guess. Bounded so a Service task that
+     * never started (xTaskCreate failure → NULL handle) cannot wedge teardown. */
+    if (serviceTaskHandle != NULL)
+    {
+        (void) ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(SERVICE_STOP_TIMEOUT_MS));
+    }
     serviceTaskHandle = NULL;
 
     SolidSyslogCircularBuffer_Destroy(buffer);


### PR DESCRIPTION
## What

Replaces the fixed `vTaskDelay(pdMS_TO_TICKS(20))` that guarded `lifecycleMutex` destruction in `TeardownAll` with an explicit task-notification handshake, in **both** FreeRTOS BDD targets.

Closes #478.

## Why

`TeardownAll` set `solidSyslogTeardown`, slept a fixed 20 ms hoping `ServiceTask` had observed the flag and self-deleted, then destroyed `lifecycleMutex`. The 20 ms was a guess: if `ServiceTask` had not yet reached its lock-check, the mutex could be destroyed while that task can still lock/unlock it. Benign on current QEMU runs (Service iterates every 1 ms, comfortably inside 20 ms) but a real race on slower/contended targets.

## How

- `TeardownAll` records its own task handle in `serviceStopWaiter` — set **inside the lifecycle critical section**, so `ServiceTask` reads it atomically with the teardown flag it's already synchronised on.
- It then blocks on `ulTaskNotifyTake`; `ServiceTask` calls `xTaskNotifyGive` on that handle the instant before `vTaskDelete(NULL)`.
- The wait is bounded by `SERVICE_STOP_TIMEOUT_MS` (1000 ms) and skipped entirely when `serviceTaskHandle == NULL`, so a Service task that never started (xTaskCreate failure) cannot wedge teardown. The bound is a safety ceiling, not the expected wait — the normal path returns within one ~1 ms Service iteration.

Applied identically to `Bdd/Targets/FreeRtos/main.c` and `Bdd/Targets/FreeRtosLwip/main.c`; the lwIP target inherited the pattern from the FreeRTOS-Plus-TCP sibling, so both are fixed together.

## Notes

- No new includes — `xTaskNotifyGive` / `ulTaskNotifyTake` / `xTaskGetCurrentTaskHandle` / `TaskHandle_t` all live in `<task.h>`, already included; `configUSE_TASK_NOTIFICATIONS` defaults to enabled.
- Tier-3 BDD-target code. Verified by the `build-freertos-target-*` and `bdd-freertos-qemu-*` CI lanes; no host unit test covers these `main.c` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by replacing fixed delays with deterministic synchronization between teardown and service processes, preventing potential race conditions during system shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->