### PR TITLE
refactor: C99-portable static assert + compile-checked atomics gating (S24.16)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,18 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# CppUTest is only needed when the unit-test suite is built. Library-only
+# configurations (e.g. the `c99` portability preset) set BUILD_TESTING=OFF so
+# they configure without it present. Threads is needed more widely (the host
+# BDD targets link it), so it stays outside the BUILD_TESTING guard.
+option(BUILD_TESTING "Build the unit test suite" ON)
+
 if(NOT CMAKE_CROSSCOMPILING)
-    find_package(CppUTest REQUIRED)
     find_package(Threads REQUIRED)
+endif()
+
+if(BUILD_TESTING AND NOT CMAKE_CROSSCOMPILING)
+    find_package(CppUTest REQUIRED)
 endif()
 
 if(MSVC)
@@ -309,7 +318,7 @@ if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
     endif()
 endif()
 
-if(NOT CMAKE_CROSSCOMPILING)
+if(BUILD_TESTING AND NOT CMAKE_CROSSCOMPILING)
     enable_testing()
     add_subdirectory(Tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,12 @@ include(LayerGuard)
 solidsyslog_enforce_layering()
 include(Iwyu)
 
-set(CMAKE_C_STANDARD 11)
+# Default to C11 (for the optional C11 atomics counter), but let an externally
+# supplied standard win so the pre-release C99 portability check can build the
+# library at -std=c99 without editing this file. See docs/local-checks.md.
+if(NOT DEFINED CMAKE_C_STANDARD)
+    set(CMAKE_C_STANDARD 11)
+endif()
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -83,8 +88,29 @@ set(CMAKE_REQUIRED_LIBRARIES "${_SOLIDSYSLOG_PREV_CMAKE_REQUIRED_LIBRARIES}")
 unset(_SOLIDSYSLOG_PREV_CMAKE_REQUIRED_LIBRARIES)
 option(SOLIDSYSLOG_WINSOCK "Include Winsock UDP sender" ${HAVE_WINSOCK})
 
-include(CheckIncludeFile)
-check_include_file(stdatomic.h HAVE_STDATOMIC_H)
+include(CheckCSourceCompiles)
+# Detect real C11 atomics by *compiling* an _Atomic snippet rather than probing
+# for <stdatomic.h>, which exists on every toolchain regardless of whether the
+# _Atomic keyword is actually supported. The probe fails on a toolchain without
+# working C11 atomics, excluding Platform/Atomics in favour of the Windows or
+# Null counter. (The C99 portability preset declares HAVE_STDATOMIC_H=OFF up
+# front — see docs/local-checks.md — so a C99 target skips the C11 atomics by
+# design rather than relying on the probe to infer their absence.)
+check_c_source_compiles(
+    "#include <stdatomic.h>
+#include <stdint.h>
+int main(void)
+{
+    _Atomic uint32_t value;
+    uint32_t expected = 0u;
+    atomic_init(&value, 0u);
+    (void) atomic_compare_exchange_strong_explicit(
+        &value, &expected, 1u, memory_order_relaxed, memory_order_relaxed);
+    return (int) atomic_load_explicit(&value, memory_order_relaxed);
+}
+"
+    HAVE_STDATOMIC_H
+)
 check_symbol_exists(InterlockedIncrement "windows.h" HAVE_WINDOWS_INTERLOCKED)
 check_symbol_exists(GetSystemTimeAsFileTime "windows.h" HAVE_WINDOWS_PLATFORM)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,7 +75,8 @@
             "inherits": "debug",
             "cacheVariables": {
                 "CMAKE_C_STANDARD": "99",
-                "HAVE_STDATOMIC_H": "OFF"
+                "HAVE_STDATOMIC_H": "OFF",
+                "BUILD_TESTING": "OFF"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -70,6 +70,15 @@
             }
         },
         {
+            "name": "c99",
+            "displayName": "C99 language portability check (library only)",
+            "inherits": "debug",
+            "cacheVariables": {
+                "CMAKE_C_STANDARD": "99",
+                "HAVE_STDATOMIC_H": "OFF"
+            }
+        },
+        {
             "name": "clang-debug",
             "displayName": "Clang Debug",
             "inherits": "base",
@@ -138,6 +147,7 @@
         { "name": "coverage",       "configurePreset": "coverage" },
         { "name": "tidy",           "configurePreset": "tidy" },
         { "name": "cppcheck",       "configurePreset": "cppcheck" },
+        { "name": "c99",            "configurePreset": "c99", "targets": ["SolidSyslog"] },
         { "name": "clang-debug",    "configurePreset": "clang-debug" },
         { "name": "iwyu",           "configurePreset": "iwyu" },
         { "name": "msvc-debug",     "configurePreset": "msvc-debug", "configuration": "Debug" },

--- a/Core/Source/SolidSyslogMacros.h
+++ b/Core/Source/SolidSyslogMacros.h
@@ -1,29 +1,25 @@
 #ifndef SOLIDSYSLOGMACROS_H
 #define SOLIDSYSLOGMACROS_H
 
-/* Compile-time assertion. C11 (and C++) have a native primitive that carries
-   the message into the diagnostic and leaves no unused tag behind, so it is
-   used on the day-to-day build. A strict C99 toolchain — the optional
+/* Compile-time assertion. C++ and C11 have native primitives that carry the
+   message into the diagnostic; a strict C99 toolchain — the optional
    portability target, exercised by the pre-release `c99` preset (see
-   docs/local-checks.md) — has no _Static_assert, so it falls back to a
-   uniquely-named struct holding one unsigned bit-field whose width goes
-   negative (a constraint violation every C99 compiler rejects) when cond is
-   false. The bit-field is unsigned and one bit wide on success: MISRA 6.1 and
-   6.2 compliant. The fallback has no home for msg in the diagnostic, so it is
-   intentionally unreferenced there. */
+   docs/local-checks.md) — has neither, so it falls back to declaring an array
+   whose length goes negative (a constraint violation every C99 compiler
+   rejects) when cond is false. The fallback uses a fixed name: repeated
+   identical extern declarations in one translation unit are compatible, so no
+   per-site uniqueness (and no ## token-pasting) is needed, and it declares no
+   object or member that an unused-entity analyser would flag. The fallback has
+   no home for msg in the diagnostic, so it is intentionally unreferenced. */
 /* NOLINTBEGIN(cppcoreguidelines-macro-usage) */
-#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING(s) SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s)
+#if defined(__cplusplus)
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) _Static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
 #else
-#define SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b) a##b
-#define SOLIDSYSLOG_STATIC_ASSERT_PASTE(a, b) SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b)
-#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)                                   \
-    struct SOLIDSYSLOG_STATIC_ASSERT_PASTE(SolidSyslogStaticAssert_, __LINE__) \
-    {                                                                          \
-        unsigned int SolidSyslogStaticAssertViolated : ((cond) ? 1 : -1);      \
-    }
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) extern char SolidSyslogStaticAssertViolated[(cond) ? 1 : -1]
 #endif
 /* NOLINTEND(cppcoreguidelines-macro-usage) */
 

--- a/Core/Source/SolidSyslogMacros.h
+++ b/Core/Source/SolidSyslogMacros.h
@@ -1,14 +1,30 @@
 #ifndef SOLIDSYSLOGMACROS_H
 #define SOLIDSYSLOGMACROS_H
 
-/* Compile-time assertion. The library compiles at --std=c11 so we use the
-   standard C11 _Static_assert primitive directly; the msg parameter is named
-   at the call site for human readability and stringified by the caller via
-   the SOLIDSYSLOG_STATIC_ASSERT_STRING wrapper. */
+/* Compile-time assertion. C11 (and C++) have a native primitive that carries
+   the message into the diagnostic and leaves no unused tag behind, so it is
+   used on the day-to-day build. A strict C99 toolchain — the optional
+   portability target, exercised by the pre-release `c99` preset (see
+   docs/local-checks.md) — has no _Static_assert, so it falls back to a
+   uniquely-named struct holding one unsigned bit-field whose width goes
+   negative (a constraint violation every C99 compiler rejects) when cond is
+   false. The bit-field is unsigned and one bit wide on success: MISRA 6.1 and
+   6.2 compliant. The fallback has no home for msg in the diagnostic, so it is
+   intentionally unreferenced there. */
 /* NOLINTBEGIN(cppcoreguidelines-macro-usage) */
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING(s) SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s)
 #define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) _Static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
+#else
+#define SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b) a##b
+#define SOLIDSYSLOG_STATIC_ASSERT_PASTE(a, b) SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b)
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)                                   \
+    struct SOLIDSYSLOG_STATIC_ASSERT_PASTE(SolidSyslogStaticAssert_, __LINE__) \
+    {                                                                          \
+        unsigned int SolidSyslogStaticAssertViolated : ((cond) ? 1 : -1);      \
+    }
+#endif
 /* NOLINTEND(cppcoreguidelines-macro-usage) */
 
 #endif /* SOLIDSYSLOGMACROS_H */

--- a/docs/local-checks.md
+++ b/docs/local-checks.md
@@ -71,6 +71,35 @@ docker compose -f .devcontainer/docker-compose.yml run --rm freertos-host \
 CI runs both lanes advisory — findings appear in the `iwyu-report` and
 `iwyu-report-freertos-plustcp` artifacts and don't block the build.
 
+## Pre-release checks
+
+Some properties drift too rarely to be worth a per-PR CI lane but must hold
+at release. Run these once while preparing a release, not on every branch.
+
+### C99 language portability
+
+The library is meant to stay C99-capable, with C11 atomics as an *optional*
+add-on (the `SolidSyslogStdAtomicCounter`; a strict-C99 target falls back to
+`SolidSyslogWindowsAtomicCounter` or `SolidSyslogNullAtomicCounter`). Nothing
+per-PR enforces this, so verify it before a release with a one-shot build of
+the library at the C99 language standard:
+
+```bash
+cmake --preset c99 && cmake --build --preset c99
+```
+
+The `c99` preset builds at `-std=gnu99` (C99 *language* with the platform's
+normal library feature-test macros, so POSIX adapters still see
+`clock_gettime` etc.) and declares `HAVE_STDATOMIC_H=OFF`, so the optional
+C11 atomics counter is excluded exactly as it would be on a real C99 target.
+The build runs under the project's standing `-Wpedantic -Werror`, so any C11
+language construct that has crept into the portable code (`_Static_assert`,
+`_Atomic`, statement-expressions, …) fails the build and names the file:line.
+
+A clean build means the portable surface is still C99. If it fails, either
+fix the construct or — if it genuinely belongs to a C11-only component —
+gate that component the way `Platform/Atomics` is gated.
+
 ## What CI runs and you should not run locally
 
 - `tidy`, `sanitize`, `coverage` — minutes each, all gated by CI

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -705,7 +705,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.010 — Rule 20.10: `#` stringification and `##` tag-pasting in the `SOLIDSYSLOG_STATIC_ASSERT` polyfill
+## D.010 — Rule 20.10: `#` stringification in the `SOLIDSYSLOG_STATIC_ASSERT` polyfill
 
 ### Rule
 
@@ -714,43 +714,40 @@ Project owner — David Cozens. Recorded under
 
 ### Deviation
 
-`Core/Source/SolidSyslogMacros.h` defines `SOLIDSYSLOG_STATIC_ASSERT` with two
-expansions selected on the language standard:
+`Core/Source/SolidSyslogMacros.h` defines `SOLIDSYSLOG_STATIC_ASSERT`. The
+native C++/C11 expansions need a string-literal message, so the macro
+stringifies its `msg` argument via the standard two-step `#`-operator idiom:
 
 ```c
-#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))
-#define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s                            /* <- # */
+#define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s                    /* <- # */
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING(s)       SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s)
+#if defined(__cplusplus)
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)      static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)      _Static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
 #else
-#define SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b) a##b                        /* <- ## */
-#define SOLIDSYSLOG_STATIC_ASSERT_PASTE(a, b)       SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b)
-#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) \
-    struct SOLIDSYSLOG_STATIC_ASSERT_PASTE(SolidSyslogStaticAssert_, __LINE__) { ... }
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)      extern char SolidSyslogStaticAssertViolated[(cond) ? 1 : -1]
 #endif
 ```
 
-Two operators are the deviation:
-
-- The `#s` in the **C11/C++ branch** — stringifies the call-site message for
-  `_Static_assert`'s string-literal second argument.
-- The `a##b` in the **C99 fallback branch** — pastes `__LINE__` onto the struct
-  tag so each negative-width-bitfield assertion has a translation-unit-unique
-  name (MISRA 5.6 / 5.7).
+The `#s` operator is the deviation. The C99 fallback (`extern char` array) uses
+no preprocessor operators — a fixed name suffices because identical extern
+declarations in one translation unit are compatible, so no `__LINE__` pasting
+(and no `##`) is required.
 
 ### Scope
 
-`Core/Source/SolidSyslogMacros.h` only. Two lines — the
-`SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER` definition (`#`) and the
-`SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER` definition (`##`).
+`Core/Source/SolidSyslogMacros.h` only. One line — the
+`SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER` definition.
 
 ### Rationale
 
-`_Static_assert` is C11's standard compile-time assertion primitive and the
-project compiles at `--std=c11`, so that is the active branch on every normal
-and CI build — including the cppcheck-misra lane. Its second argument is a
-string literal, and there is no way to convert an arbitrary identifier-shaped
-message into one without `#`. The alternatives all regress:
+C++ `static_assert` and C11 `_Static_assert` are the standard compile-time
+assertion primitives, and the project compiles at `--std=c11` (so the
+`_Static_assert` branch is what every normal and CI build — including the
+cppcheck-misra lane — compiles). Their message argument is a string literal,
+and there is no way to convert an arbitrary identifier-shaped message into one
+without `#`. The alternatives all regress:
 
 | Alternative | Why rejected |
 |-------------|--------------|
@@ -758,27 +755,18 @@ message into one without `#`. The alternatives all regress:
 | Force every caller to pass a string literal | Spreads strings across the call sites and gives up the per-site identifier form some files already use. |
 | Drop the message argument entirely | Loses readability at the assertion site. |
 
-The `##` in the C99 fallback is the price of C99 portability (S24.16): a strict
-C99 toolchain has no `_Static_assert`, so the macro falls back to a uniquely
-named struct carrying a bit-field whose width goes negative when the condition
-is false. The unique name needs `__LINE__` pasting. This is the same family of
-trade-off the C11 branch makes — both are the standard, documented preprocessor
-idioms for their respective standards, neither opaque nor novel. Crucially, the
-`##` lives **only in the `#else` branch, which the C11 build never compiles**;
-the active-path operator situation is unchanged from before this story.
-cppcheck-misra nonetheless analyses the inactive branch, so the `##` line
-carries its own suppression.
+The advisory rule's intent is to discourage opaque token games. The two-step
+stringify idiom here is the standard, documented C preprocessor pattern and has
+been since C89; it is neither opaque nor novel.
 
 ### Risk and mitigation
 
 - **Single-site exposure.** The deviation is the macro definition
-  itself — two specific lines in one file. Any future `#`/`##` use
-  elsewhere would surface as a fresh 20.10 finding, not absorbed by
-  these suppressions.
+  itself, line-specific. Any future `#`/`##` use elsewhere would
+  surface as a fresh 20.10 finding, not absorbed by this suppression.
 - **Elimination path.** If the project ever drops the `msg` parameter
   (or moves entirely to inline `_Static_assert((cond), "literal")` at
-  call sites), the `#` line can be retired. The `##` line retires if the
-  C99 portability target is ever dropped.
+  call sites), the deviation can be retired.
 
 ### Approval
 

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -705,7 +705,7 @@ Project owner — David Cozens. Recorded under
 
 ---
 
-## D.010 — Rule 20.10: `#` stringification in `_Static_assert` polyfill
+## D.010 — Rule 20.10: `#` stringification and `##` tag-pasting in the `SOLIDSYSLOG_STATIC_ASSERT` polyfill
 
 ### Rule
 
@@ -714,53 +714,71 @@ Project owner — David Cozens. Recorded under
 
 ### Deviation
 
-`Core/Source/SolidSyslogMacros.h` defines the `SOLIDSYSLOG_STATIC_ASSERT`
-macro on top of C11 `_Static_assert`. `_Static_assert`'s second argument
-must be a string literal; the project's macro accepts the message as an
-identifier or any token sequence at the call site and stringifies it via
-the standard two-step `#`-operator idiom:
+`Core/Source/SolidSyslogMacros.h` defines `SOLIDSYSLOG_STATIC_ASSERT` with two
+expansions selected on the language standard:
 
 ```c
-#define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))
+#define SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s) #s                            /* <- # */
 #define SOLIDSYSLOG_STATIC_ASSERT_STRING(s)       SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER(s)
 #define SOLIDSYSLOG_STATIC_ASSERT(cond, msg)      _Static_assert((cond), SOLIDSYSLOG_STATIC_ASSERT_STRING(msg))
+#else
+#define SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b) a##b                        /* <- ## */
+#define SOLIDSYSLOG_STATIC_ASSERT_PASTE(a, b)       SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER(a, b)
+#define SOLIDSYSLOG_STATIC_ASSERT(cond, msg) \
+    struct SOLIDSYSLOG_STATIC_ASSERT_PASTE(SolidSyslogStaticAssert_, __LINE__) { ... }
+#endif
 ```
 
-The inner `#s` operator is the deviation.
+Two operators are the deviation:
+
+- The `#s` in the **C11/C++ branch** — stringifies the call-site message for
+  `_Static_assert`'s string-literal second argument.
+- The `a##b` in the **C99 fallback branch** — pastes `__LINE__` onto the struct
+  tag so each negative-width-bitfield assertion has a translation-unit-unique
+  name (MISRA 5.6 / 5.7).
 
 ### Scope
 
-`Core/Source/SolidSyslogMacros.h` only. One line — the
-`SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER` definition.
+`Core/Source/SolidSyslogMacros.h` only. Two lines — the
+`SOLIDSYSLOG_STATIC_ASSERT_STRING_INNER` definition (`#`) and the
+`SOLIDSYSLOG_STATIC_ASSERT_PASTE_INNER` definition (`##`).
 
 ### Rationale
 
-`_Static_assert` is C11's standard compile-time assertion primitive and
-the project compiles at `--std=c11`. Its second argument is a string
-literal — there is no way to convert an arbitrary identifier-shaped
-message at the call site into that string literal without the `#`
-operator. The alternatives all regress:
+`_Static_assert` is C11's standard compile-time assertion primitive and the
+project compiles at `--std=c11`, so that is the active branch on every normal
+and CI build — including the cppcheck-misra lane. Its second argument is a
+string literal, and there is no way to convert an arbitrary identifier-shaped
+message into one without `#`. The alternatives all regress:
 
 | Alternative | Why rejected |
 |-------------|--------------|
 | Hard-coded literal message in the macro | Loses per-site context — every assertion would report the same generic string. |
-| Force every caller to pass a string literal | Spreads strings across ~16 call sites and gives up the per-site identifier form some files already use. |
+| Force every caller to pass a string literal | Spreads strings across the call sites and gives up the per-site identifier form some files already use. |
 | Drop the message argument entirely | Loses readability at the assertion site. |
-| Hand-rolled negative-array-size trick (pre-C11 idiom) | The previous form. It collided with MISRA 5.6 (typedef name uniqueness) across translation units; resolving that required a `##` deviation anyway, which is worse than the current `#` one. |
 
-The advisory rule's intent is to discourage opaque token games. The
-two-step stringify idiom here is the standard, documented C
-preprocessor pattern and has been since C89; it is neither opaque nor
-novel.
+The `##` in the C99 fallback is the price of C99 portability (S24.16): a strict
+C99 toolchain has no `_Static_assert`, so the macro falls back to a uniquely
+named struct carrying a bit-field whose width goes negative when the condition
+is false. The unique name needs `__LINE__` pasting. This is the same family of
+trade-off the C11 branch makes — both are the standard, documented preprocessor
+idioms for their respective standards, neither opaque nor novel. Crucially, the
+`##` lives **only in the `#else` branch, which the C11 build never compiles**;
+the active-path operator situation is unchanged from before this story.
+cppcheck-misra nonetheless analyses the inactive branch, so the `##` line
+carries its own suppression.
 
 ### Risk and mitigation
 
 - **Single-site exposure.** The deviation is the macro definition
-  itself, line-specific. Any future `#`/`##` use elsewhere would
-  surface as a fresh 20.10 finding, not absorbed by this suppression.
+  itself — two specific lines in one file. Any future `#`/`##` use
+  elsewhere would surface as a fresh 20.10 finding, not absorbed by
+  these suppressions.
 - **Elimination path.** If the project ever drops the `msg` parameter
   (or moves entirely to inline `_Static_assert((cond), "literal")` at
-  call sites), the deviation can be retired.
+  call sites), the `#` line can be retired. The `##` line retires if the
+  C99 portability target is ever dropped.
 
 ### Approval
 

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -169,11 +169,9 @@ misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsClock.c:21
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsHostname.c:19
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c:18
 
-# D.010 — Rule 20.10: # stringification (C11 path) and ## tag-pasting (C99
-# fallback) in the SOLIDSYSLOG_STATIC_ASSERT polyfill
+# D.010 — Rule 20.10: # stringification in SOLIDSYSLOG_STATIC_ASSERT polyfill
 # See docs/misra-deviations.md#d010
-misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:16
-misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:20
+misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:15
 
 # D.011 — Rule 2.5: public API macros consumed outside cppcheck-misra scope
 # See docs/misra-deviations.md#d011

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -169,9 +169,11 @@ misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsClock.c:21
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsHostname.c:19
 misra-c2012-5.7:Platform/Windows/Source/SolidSyslogWindowsSysUpTime.c:18
 
-# D.010 — Rule 20.10: # stringification in _Static_assert polyfill
+# D.010 — Rule 20.10: # stringification (C11 path) and ## tag-pasting (C99
+# fallback) in the SOLIDSYSLOG_STATIC_ASSERT polyfill
 # See docs/misra-deviations.md#d010
-misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:9
+misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:16
+misra-c2012-20.10:Core/Source/SolidSyslogMacros.h:20
 
 # D.011 — Rule 2.5: public API macros consumed outside cppcheck-misra scope
 # See docs/misra-deviations.md#d011


### PR DESCRIPTION
## What

Keeps the library buildable on a strict C99 toolchain (with C11 atomics as an *optional* add-on) and adds a **pre-release check** to keep that promise honest. Closes #495.

An audit of the whole tree under `-std=gnu99 -Wpedantic -Werror` found the codebase is already almost entirely C99-clean — only **two** C11 constructs, both addressed here.

## Changes

- **`Core/Source/SolidSyslogMacros.h`** — `SOLIDSYSLOG_STATIC_ASSERT` now selects on the language standard:
  - **C11 / C++** keep the native `_Static_assert` — *unchanged from today*. Carries the message into the diagnostic, leaves no unused tag, and is the branch the cppcheck-misra lane actually compiles.
  - **strict C99** falls back to a uniquely-named struct with a negative-width **unsigned** bit-field (MISRA 6.1 / 6.2 clean). Compiled only by the pre-release check, so it can't bit-rot.
- **`CMakeLists.txt`** — detect C11 atomics by *compiling* an `_Atomic` snippet instead of probing for `<stdatomic.h>` (which exists on every toolchain regardless of `_Atomic` support — a latent mis-detection). Toolchains without working atomics exclude `Platform/Atomics` in favour of the Windows/Null counter. `CMAKE_C_STANDARD` is now overridable (default still 11).
- **`CMakePresets.json`** — new `c99` preset (`-std=gnu99`, `HAVE_STDATOMIC_H=OFF`, library target only) so the check is one command.
- **`docs/local-checks.md`** — new *pre-release* tier: `cmake --preset c99 && cmake --build --preset c99`.
- **`docs/misra-deviations.md` + `misra_suppressions.txt`** — extend D.010 (Rule 20.10) to cover the `##` tag-paste in the C99 fallback branch alongside the existing `#` stringify.

## Design decisions (discussed)

- **Pre-release check, not a per-PR CI lane** — C99 conformance drifts too rarely to gate every PR. Accepted trade-off: a C11-ism could land and sit until the next release; the release compile pinpoints it instantly.
- **Conditional macro, not unconditional** — an unconditional portable form introduced a MISRA 2.4 (unused tag) on the *always-compiled* C11 path. Conditional keeps the C11/MISRA path pristine; the pre-release check exercises the C99 branch so it doesn't rot.
- **Simple atomics probe + preset declares `HAVE_STDATOMIC_H=OFF`** — the probe just fails when atomics are genuinely missing (real C99 targets); the C99 preset declares "no C11 atomics" by design rather than relying on pedantic-flag gymnastics in the probe.

## Verification

- `cmake --preset c99 && cmake --build --preset c99` → clean (atomics excluded, builds under `-std=gnu99 -Wpedantic -Werror`).
- `cmake --preset debug && cmake --build --preset debug --target junit` → green, atomics detected and included, full test suite passes.
- `clang-format` clean; MISRA suppression line-drift handled.

## Notes for review

- The one judgement call is the **`##` in the C99 fallback branch** (line 20), which D.010's prior rationale argued against. It's now confined to the `#else` branch the C11 build never compiles; cppcheck-misra still scans the inactive branch, so it carries its own 20.10 suppression. The exact line cppcheck flags couldn't be reproduced on the isolated header locally (addon quirk) — worth a sanity check that the `analyze-cppcheck` lane is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with C99 toolchains while maintaining C11 atomic operations support when available.

* **Chores**
  * Added C99 build preset for compatibility verification.
  * Enhanced build system to respect externally-supplied C standard settings.

* **Documentation**
  * Added pre-release C99 portability verification guidance.
  * Updated MISRA compliance documentation for static assertion macro portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->