### PR TITLE
refactor: S12.21 extract SolidSyslogMessageFormatter

### DIFF
--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     SolidSyslogBuffer.c
     SolidSyslogFormatter.c
     SolidSyslogTimestampFormatter.c
+    SolidSyslogMessageFormatter.c
     SolidSyslogMetaSd.c
     SolidSyslogMetaSdMessages.c
     SolidSyslogMetaSdStatic.c

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -17,9 +17,7 @@
 #include "SolidSyslogSender.h"
 #include "SolidSyslogStore.h"
 #include "SolidSyslogStringFunction.h"
-#include "SolidSyslogStructuredData.h"
 #include "SolidSyslogTimestamp.h"
-#include "SolidSyslogTimestampFormatter.h"
 #include "SolidSyslogTunables.h"
 
 struct SolidSyslogBuffer;

--- a/Core/Source/SolidSyslog.c
+++ b/Core/Source/SolidSyslog.c
@@ -9,6 +9,7 @@
 #include "SolidSyslogError.h"
 #include "SolidSyslogErrors.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogMessageFormatter.h"
 #include "SolidSyslogNullBuffer.h"
 #include "SolidSyslogNullSender.h"
 #include "SolidSyslogNullStore.h"
@@ -27,37 +28,8 @@ struct SolidSyslogSender;
 struct SolidSyslogStore;
 struct SolidSyslogStructuredData;
 
-enum
-{
-    SOLIDSYSLOG_MAX_APP_NAME_SIZE = 49,
-    SOLIDSYSLOG_MAX_HOSTNAME_SIZE = 256,
-    SOLIDSYSLOG_MAX_MSGID_SIZE = 33,
-    SOLIDSYSLOG_MAX_PROCESS_ID_SIZE = 129
-};
-
-static inline uint8_t SolidSyslog_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
-static inline bool SolidSyslog_FacilityIsValid(uint8_t facility);
 static inline void SolidSyslog_DrainBufferIntoStore(struct SolidSyslog* self);
 static inline void SolidSyslog_SendOneFromStore(struct SolidSyslog* self);
-static inline void SolidSyslog_FormatMessage(
-    struct SolidSyslogFormatter* f,
-    struct SolidSyslog* self,
-    const struct SolidSyslogMessage* message
-);
-static inline void SolidSyslog_FormatMsg(struct SolidSyslogFormatter* f, const char* msg);
-static inline void SolidSyslog_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId);
-static inline void SolidSyslog_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival);
-static inline void SolidSyslog_FormatStringField(
-    struct SolidSyslogFormatter* f,
-    SolidSyslogStringFunction fn,
-    size_t maxSize
-);
-static inline void SolidSyslog_FormatStructuredData(
-    struct SolidSyslogFormatter* f,
-    struct SolidSyslogStructuredData** sd,
-    size_t sdCount
-);
-static inline void SolidSyslog_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock);
 static void SolidSyslog_InstallAppName(struct SolidSyslog* self, SolidSyslogStringFunction configured);
 static void SolidSyslog_InstallBuffer(struct SolidSyslog* self, struct SolidSyslogBuffer* configured);
 static void SolidSyslog_InstallClock(struct SolidSyslog* self, SolidSyslogClockFunction configured);
@@ -71,13 +43,8 @@ static void SolidSyslog_InstallStructuredData(
     size_t count
 );
 static inline bool SolidSyslog_IsServiceEnabled(struct SolidSyslog* self);
-static inline uint8_t SolidSyslog_MakePrival(const struct SolidSyslogMessage* message);
-static inline bool SolidSyslog_PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
 static void SolidSyslog_ProcessMessages(struct SolidSyslog* self);
 static void SolidSyslog_ResetToDefaults(struct SolidSyslog* self);
-static inline bool SolidSyslog_SeverityIsValid(uint8_t severity);
-static inline const char* SolidSyslog_SkipLeadingBom(const char* msg);
-static inline bool SolidSyslog_StringIsValid(const char* value);
 
 void SolidSyslog_Initialise(struct SolidSyslog* self, const struct SolidSyslogConfig* config)
 {
@@ -105,12 +72,12 @@ static void SolidSyslog_ResetToDefaults(struct SolidSyslog* self)
     self->Buffer = SolidSyslogNullBuffer_Get();
     self->Sender = SolidSyslogNullSender_Get();
     self->Store = SolidSyslogNullStore_Get();
-    self->Clock = SolidSyslog_NullClock;
-    self->GetHostname = SolidSyslog_NullStringFunction;
-    self->GetAppName = SolidSyslog_NullStringFunction;
-    self->GetProcessId = SolidSyslog_NullStringFunction;
-    self->Sd = NULL;
-    self->SdCount = 0;
+    self->Format.Clock = SolidSyslog_NullClock;
+    self->Format.GetHostname = SolidSyslog_NullStringFunction;
+    self->Format.GetAppName = SolidSyslog_NullStringFunction;
+    self->Format.GetProcessId = SolidSyslog_NullStringFunction;
+    self->Format.Sd = NULL;
+    self->Format.SdCount = 0;
 }
 
 static void SolidSyslog_InstallBuffer(struct SolidSyslog* self, struct SolidSyslogBuffer* configured)
@@ -165,7 +132,7 @@ static void SolidSyslog_InstallClock(struct SolidSyslog* self, SolidSyslogClockF
 {
     if (configured != NULL)
     {
-        self->Clock = configured;
+        self->Format.Clock = configured;
     }
 }
 
@@ -173,7 +140,7 @@ static void SolidSyslog_InstallHostname(struct SolidSyslog* self, SolidSyslogStr
 {
     if (configured != NULL)
     {
-        self->GetHostname = configured;
+        self->Format.GetHostname = configured;
     }
 }
 
@@ -181,7 +148,7 @@ static void SolidSyslog_InstallAppName(struct SolidSyslog* self, SolidSyslogStri
 {
     if (configured != NULL)
     {
-        self->GetAppName = configured;
+        self->Format.GetAppName = configured;
     }
 }
 
@@ -189,7 +156,7 @@ static void SolidSyslog_InstallProcessId(struct SolidSyslog* self, SolidSyslogSt
 {
     if (configured != NULL)
     {
-        self->GetProcessId = configured;
+        self->Format.GetProcessId = configured;
     }
 }
 
@@ -199,8 +166,8 @@ static void SolidSyslog_InstallStructuredData(
     size_t count
 )
 {
-    self->Sd = configured;
-    self->SdCount = count;
+    self->Format.Sd = configured;
+    self->Format.SdCount = count;
 }
 
 void SolidSyslog_Service(struct SolidSyslog* handle)
@@ -292,171 +259,13 @@ void SolidSyslog_Log(struct SolidSyslog* handle, const struct SolidSyslogMessage
         SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
         struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
 
-        SolidSyslog_FormatMessage(f, handle, message);
+        SolidSyslogMessageFormatter_Format(f, message, &handle->Format);
         SolidSyslogBuffer_Write(
             handle->Buffer,
             SolidSyslogFormatter_AsFormattedBuffer(f),
             SolidSyslogFormatter_Length(f)
         );
     }
-}
-
-static inline void SolidSyslog_FormatMessage(
-    struct SolidSyslogFormatter* f,
-    struct SolidSyslog* self,
-    const struct SolidSyslogMessage* message
-)
-{
-    SolidSyslog_FormatPrival(f, SolidSyslog_MakePrival(message));
-    SolidSyslogFormatter_AsciiCharacter(f, '1');
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatTimestamp(f, self->Clock);
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatStringField(f, self->GetHostname, SOLIDSYSLOG_MAX_HOSTNAME_SIZE);
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatStringField(f, self->GetAppName, SOLIDSYSLOG_MAX_APP_NAME_SIZE);
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatStringField(f, self->GetProcessId, SOLIDSYSLOG_MAX_PROCESS_ID_SIZE);
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatMsgId(f, message->MessageId);
-    SolidSyslogFormatter_AsciiCharacter(f, ' ');
-    SolidSyslog_FormatStructuredData(f, self->Sd, self->SdCount);
-    SolidSyslog_FormatMsg(f, message->Msg);
-}
-
-static inline void SolidSyslog_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival)
-{
-    SolidSyslogFormatter_AsciiCharacter(f, '<');
-    SolidSyslogFormatter_Uint32(f, prival);
-    SolidSyslogFormatter_AsciiCharacter(f, '>');
-}
-
-static inline uint8_t SolidSyslog_MakePrival(const struct SolidSyslogMessage* message)
-{
-    uint8_t f = (uint8_t) message->Facility;
-    uint8_t s = (uint8_t) message->Severity;
-    uint8_t prival = SolidSyslog_CombineFacilityAndSeverity(SOLIDSYSLOG_FACILITY_SYSLOG, SOLIDSYSLOG_SEVERITY_ERROR);
-
-    if (SolidSyslog_PrivalComponentsAreValid(f, s))
-    {
-        prival = SolidSyslog_CombineFacilityAndSeverity(f, s);
-    }
-
-    return prival;
-}
-
-static inline uint8_t SolidSyslog_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity)
-{
-    return (uint8_t) ((facility * UINT8_C(8)) + severity);
-}
-
-static inline bool SolidSyslog_PrivalComponentsAreValid(uint8_t facility, uint8_t severity)
-{
-    return SolidSyslog_FacilityIsValid(facility) && SolidSyslog_SeverityIsValid(severity);
-}
-
-static inline bool SolidSyslog_FacilityIsValid(uint8_t facility)
-{
-    return facility <= (uint8_t) SOLIDSYSLOG_FACILITY_LOCAL7;
-}
-
-static inline bool SolidSyslog_SeverityIsValid(uint8_t severity)
-{
-    return severity <= (uint8_t) SOLIDSYSLOG_SEVERITY_DEBUG;
-}
-
-static inline void SolidSyslog_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock)
-{
-    struct SolidSyslogTimestamp ts = {0};
-
-    clock(&ts);
-    SolidSyslogTimestampFormatter_Format(f, &ts);
-}
-
-static inline void SolidSyslog_FormatStringField(
-    struct SolidSyslogFormatter* f,
-    SolidSyslogStringFunction fn,
-    size_t maxSize
-)
-{
-    SolidSyslogFormatterStorage fieldStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOSTNAME_SIZE)];
-    struct SolidSyslogFormatter* field = SolidSyslogFormatter_Create(fieldStorage, maxSize);
-
-    fn(field);
-
-    size_t fieldLength = SolidSyslogFormatter_Length(field);
-
-    if (fieldLength > 0U)
-    {
-        SolidSyslogFormatter_PrintUsAsciiString(f, SolidSyslogFormatter_AsFormattedBuffer(field), fieldLength);
-    }
-    else
-    {
-        SolidSyslogFormatter_NilValue(f);
-    }
-}
-
-static inline void SolidSyslog_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId)
-{
-    size_t lengthBefore = SolidSyslogFormatter_Length(f);
-
-    if (SolidSyslog_StringIsValid(messageId))
-    {
-        SolidSyslogFormatter_PrintUsAsciiString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
-    }
-
-    if (SolidSyslogFormatter_Length(f) == lengthBefore)
-    {
-        SolidSyslogFormatter_NilValue(f);
-    }
-}
-
-static inline bool SolidSyslog_StringIsValid(const char* value)
-{
-    return (value != NULL) && (value[0] != '\0');
-}
-
-static inline void SolidSyslog_FormatStructuredData(
-    struct SolidSyslogFormatter* f,
-    struct SolidSyslogStructuredData** sd,
-    size_t sdCount
-)
-{
-    size_t lengthBefore = SolidSyslogFormatter_Length(f);
-
-    for (size_t i = 0; i < sdCount; i++)
-    {
-        SolidSyslogStructuredData_Format(sd[i], f);
-    }
-
-    if (SolidSyslogFormatter_Length(f) == lengthBefore)
-    {
-        SolidSyslogFormatter_NilValue(f);
-    }
-}
-
-static inline void SolidSyslog_FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
-{
-    if (SolidSyslog_StringIsValid(msg))
-    {
-        SolidSyslogFormatter_AsciiCharacter(f, ' ');
-        SolidSyslogFormatter_Bom(f);
-        SolidSyslogFormatter_BoundedString(f, SolidSyslog_SkipLeadingBom(msg), SOLIDSYSLOG_MAX_MESSAGE_SIZE);
-    }
-}
-
-/* MSG body MUST start with the UTF-8 BOM per RFC 5424 §6.4. We always
- * emit the BOM ourselves; if the caller already prefixed one, strip it
- * so the wire frame contains exactly one. */
-static inline const char* SolidSyslog_SkipLeadingBom(const char* msg)
-{
-    const unsigned char* bytes = (const unsigned char*) msg;
-    const char* result = msg;
-    if ((bytes[0] == 0xEFU) && (bytes[1] == 0xBBU) && (bytes[2] == 0xBFU))
-    {
-        result = &msg[3];
-    }
-    return result;
 }
 
 void SolidSyslog_NullClock(struct SolidSyslogTimestamp* ts)

--- a/Core/Source/SolidSyslogMessageFormatter.c
+++ b/Core/Source/SolidSyslogMessageFormatter.c
@@ -1,0 +1,205 @@
+#include "SolidSyslogMessageFormatter.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "SolidSyslog.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogPrival.h"
+#include "SolidSyslogStringFunction.h"
+#include "SolidSyslogStructuredData.h"
+#include "SolidSyslogTimestamp.h"
+#include "SolidSyslogTimestampFormatter.h"
+#include "SolidSyslogTunables.h"
+
+struct SolidSyslogFormatter;
+
+enum
+{
+    SOLIDSYSLOG_MAX_APP_NAME_SIZE = 49,
+    SOLIDSYSLOG_MAX_HOSTNAME_SIZE = 256,
+    SOLIDSYSLOG_MAX_MSGID_SIZE = 33,
+    SOLIDSYSLOG_MAX_PROCESS_ID_SIZE = 129
+};
+
+static inline void MessageFormatter_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival);
+static inline uint8_t MessageFormatter_MakePrival(const struct SolidSyslogMessage* message);
+static inline uint8_t MessageFormatter_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity);
+static inline bool MessageFormatter_PrivalComponentsAreValid(uint8_t facility, uint8_t severity);
+static inline bool MessageFormatter_FacilityIsValid(uint8_t facility);
+static inline bool MessageFormatter_SeverityIsValid(uint8_t severity);
+static inline void MessageFormatter_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock);
+static inline void MessageFormatter_FormatStringField(
+    struct SolidSyslogFormatter* f,
+    SolidSyslogStringFunction fn,
+    size_t maxSize
+);
+static inline void MessageFormatter_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId);
+static inline bool MessageFormatter_StringIsValid(const char* value);
+static inline void MessageFormatter_FormatStructuredData(
+    struct SolidSyslogFormatter* f,
+    struct SolidSyslogStructuredData** sd,
+    size_t sdCount
+);
+static inline void MessageFormatter_FormatMsg(struct SolidSyslogFormatter* f, const char* msg);
+static inline const char* MessageFormatter_SkipLeadingBom(const char* msg);
+
+void SolidSyslogMessageFormatter_Format(
+    struct SolidSyslogFormatter* f,
+    const struct SolidSyslogMessage* message,
+    const struct SolidSyslogMessageFormatterContext* context
+)
+{
+    MessageFormatter_FormatPrival(f, MessageFormatter_MakePrival(message));
+    SolidSyslogFormatter_AsciiCharacter(f, '1');
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatTimestamp(f, context->Clock);
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatStringField(f, context->GetHostname, SOLIDSYSLOG_MAX_HOSTNAME_SIZE);
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatStringField(f, context->GetAppName, SOLIDSYSLOG_MAX_APP_NAME_SIZE);
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatStringField(f, context->GetProcessId, SOLIDSYSLOG_MAX_PROCESS_ID_SIZE);
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatMsgId(f, message->MessageId);
+    SolidSyslogFormatter_AsciiCharacter(f, ' ');
+    MessageFormatter_FormatStructuredData(f, context->Sd, context->SdCount);
+    MessageFormatter_FormatMsg(f, message->Msg);
+}
+
+static inline void MessageFormatter_FormatPrival(struct SolidSyslogFormatter* f, uint8_t prival)
+{
+    SolidSyslogFormatter_AsciiCharacter(f, '<');
+    SolidSyslogFormatter_Uint32(f, prival);
+    SolidSyslogFormatter_AsciiCharacter(f, '>');
+}
+
+static inline uint8_t MessageFormatter_MakePrival(const struct SolidSyslogMessage* message)
+{
+    uint8_t f = (uint8_t) message->Facility;
+    uint8_t s = (uint8_t) message->Severity;
+    uint8_t prival =
+        MessageFormatter_CombineFacilityAndSeverity(SOLIDSYSLOG_FACILITY_SYSLOG, SOLIDSYSLOG_SEVERITY_ERROR);
+
+    if (MessageFormatter_PrivalComponentsAreValid(f, s))
+    {
+        prival = MessageFormatter_CombineFacilityAndSeverity(f, s);
+    }
+
+    return prival;
+}
+
+static inline uint8_t MessageFormatter_CombineFacilityAndSeverity(uint8_t facility, uint8_t severity)
+{
+    return (uint8_t) ((facility * UINT8_C(8)) + severity);
+}
+
+static inline bool MessageFormatter_PrivalComponentsAreValid(uint8_t facility, uint8_t severity)
+{
+    return MessageFormatter_FacilityIsValid(facility) && MessageFormatter_SeverityIsValid(severity);
+}
+
+static inline bool MessageFormatter_FacilityIsValid(uint8_t facility)
+{
+    return facility <= (uint8_t) SOLIDSYSLOG_FACILITY_LOCAL7;
+}
+
+static inline bool MessageFormatter_SeverityIsValid(uint8_t severity)
+{
+    return severity <= (uint8_t) SOLIDSYSLOG_SEVERITY_DEBUG;
+}
+
+static inline void MessageFormatter_FormatTimestamp(struct SolidSyslogFormatter* f, SolidSyslogClockFunction clock)
+{
+    struct SolidSyslogTimestamp ts = {0};
+
+    clock(&ts);
+    SolidSyslogTimestampFormatter_Format(f, &ts);
+}
+
+static inline void MessageFormatter_FormatStringField(
+    struct SolidSyslogFormatter* f,
+    SolidSyslogStringFunction fn,
+    size_t maxSize
+)
+{
+    SolidSyslogFormatterStorage fieldStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_HOSTNAME_SIZE)];
+    struct SolidSyslogFormatter* field = SolidSyslogFormatter_Create(fieldStorage, maxSize);
+
+    fn(field);
+
+    size_t fieldLength = SolidSyslogFormatter_Length(field);
+
+    if (fieldLength > 0U)
+    {
+        SolidSyslogFormatter_PrintUsAsciiString(f, SolidSyslogFormatter_AsFormattedBuffer(field), fieldLength);
+    }
+    else
+    {
+        SolidSyslogFormatter_NilValue(f);
+    }
+}
+
+static inline void MessageFormatter_FormatMsgId(struct SolidSyslogFormatter* f, const char* messageId)
+{
+    size_t lengthBefore = SolidSyslogFormatter_Length(f);
+
+    if (MessageFormatter_StringIsValid(messageId))
+    {
+        SolidSyslogFormatter_PrintUsAsciiString(f, messageId, SOLIDSYSLOG_MAX_MSGID_SIZE - 1);
+    }
+
+    if (SolidSyslogFormatter_Length(f) == lengthBefore)
+    {
+        SolidSyslogFormatter_NilValue(f);
+    }
+}
+
+static inline bool MessageFormatter_StringIsValid(const char* value)
+{
+    return (value != NULL) && (value[0] != '\0');
+}
+
+static inline void MessageFormatter_FormatStructuredData(
+    struct SolidSyslogFormatter* f,
+    struct SolidSyslogStructuredData** sd,
+    size_t sdCount
+)
+{
+    size_t lengthBefore = SolidSyslogFormatter_Length(f);
+
+    for (size_t i = 0; i < sdCount; i++)
+    {
+        SolidSyslogStructuredData_Format(sd[i], f);
+    }
+
+    if (SolidSyslogFormatter_Length(f) == lengthBefore)
+    {
+        SolidSyslogFormatter_NilValue(f);
+    }
+}
+
+static inline void MessageFormatter_FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
+{
+    if (MessageFormatter_StringIsValid(msg))
+    {
+        SolidSyslogFormatter_AsciiCharacter(f, ' ');
+        SolidSyslogFormatter_Bom(f);
+        SolidSyslogFormatter_BoundedString(f, MessageFormatter_SkipLeadingBom(msg), SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+    }
+}
+
+/* MSG body MUST start with the UTF-8 BOM per RFC 5424 §6.4. We always
+ * emit the BOM ourselves; if the caller already prefixed one, strip it
+ * so the wire frame contains exactly one. */
+static inline const char* MessageFormatter_SkipLeadingBom(const char* msg)
+{
+    const unsigned char* bytes = (const unsigned char*) msg;
+    const char* result = msg;
+    if ((bytes[0] == 0xEFU) && (bytes[1] == 0xBBU) && (bytes[2] == 0xBFU))
+    {
+        result = &msg[3];
+    }
+    return result;
+}

--- a/Core/Source/SolidSyslogMessageFormatter.c
+++ b/Core/Source/SolidSyslogMessageFormatter.c
@@ -182,11 +182,19 @@ static inline void MessageFormatter_FormatStructuredData(
 
 static inline void MessageFormatter_FormatMsg(struct SolidSyslogFormatter* f, const char* msg)
 {
+    /* Guard msg before SkipLeadingBom dereferences it, then guard the
+     * post-strip body so a caller-supplied BOM-only string emits no
+     * dangling SP-BOM (RFC 5424 §6.4 — the BOM belongs to a non-empty MSG). */
     if (MessageFormatter_StringIsValid(msg))
     {
-        SolidSyslogFormatter_AsciiCharacter(f, ' ');
-        SolidSyslogFormatter_Bom(f);
-        SolidSyslogFormatter_BoundedString(f, MessageFormatter_SkipLeadingBom(msg), SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+        const char* body = MessageFormatter_SkipLeadingBom(msg);
+
+        if (MessageFormatter_StringIsValid(body))
+        {
+            SolidSyslogFormatter_AsciiCharacter(f, ' ');
+            SolidSyslogFormatter_Bom(f);
+            SolidSyslogFormatter_BoundedString(f, body, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+        }
     }
 }
 

--- a/Core/Source/SolidSyslogMessageFormatter.h
+++ b/Core/Source/SolidSyslogMessageFormatter.h
@@ -1,0 +1,42 @@
+#ifndef SOLIDSYSLOGMESSAGEFORMATTER_H
+#define SOLIDSYSLOGMESSAGEFORMATTER_H
+
+#include "ExternC.h"
+
+#include <stddef.h>
+
+#include "SolidSyslogStringFunction.h"
+#include "SolidSyslogTimestamp.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogFormatter;
+    struct SolidSyslogMessage;
+    struct SolidSyslogStructuredData;
+
+    /* The per-instance inputs the message formatter reads while building an
+     * RFC 5424 frame. Owned by struct SolidSyslog as its single copy; the
+     * install/reset sites write through it. */
+    struct SolidSyslogMessageFormatterContext
+    {
+        SolidSyslogClockFunction Clock;
+        SolidSyslogStringFunction GetHostname;
+        SolidSyslogStringFunction GetAppName;
+        SolidSyslogStringFunction GetProcessId;
+        struct SolidSyslogStructuredData** Sd;
+        size_t SdCount;
+    };
+
+    /* Emits a full RFC 5424 SYSLOG-MSG into f:
+     * <PRIVAL>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID SD [SP BOM MSG].
+     * Captures the timestamp via context->Clock and delegates its formatting
+     * to SolidSyslogTimestampFormatter_Format. */
+    void SolidSyslogMessageFormatter_Format(
+        struct SolidSyslogFormatter * formatter,
+        const struct SolidSyslogMessage* message,
+        const struct SolidSyslogMessageFormatterContext* context
+    );
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGMESSAGEFORMATTER_H */

--- a/Core/Source/SolidSyslogPrivate.h
+++ b/Core/Source/SolidSyslogPrivate.h
@@ -1,9 +1,7 @@
 #ifndef SOLIDSYSLOGPRIVATE_H
 #define SOLIDSYSLOGPRIVATE_H
 
-#include <stddef.h>
-
-#include "SolidSyslogStringFunction.h"
+#include "SolidSyslogMessageFormatter.h"
 #include "SolidSyslogTimestamp.h"
 
 struct SolidSyslogBuffer;
@@ -11,19 +9,13 @@ struct SolidSyslogConfig;
 struct SolidSyslogFormatter;
 struct SolidSyslogSender;
 struct SolidSyslogStore;
-struct SolidSyslogStructuredData;
 
 struct SolidSyslog
 {
     struct SolidSyslogBuffer* Buffer;
     struct SolidSyslogSender* Sender;
-    SolidSyslogClockFunction Clock;
-    SolidSyslogStringFunction GetHostname;
-    SolidSyslogStringFunction GetAppName;
-    SolidSyslogStringFunction GetProcessId;
     struct SolidSyslogStore* Store;
-    struct SolidSyslogStructuredData** Sd;
-    size_t SdCount;
+    struct SolidSyslogMessageFormatterContext Format;
 };
 
 void SolidSyslog_Initialise(struct SolidSyslog* self, const struct SolidSyslogConfig* config);

--- a/Core/Source/SolidSyslogStatic.c
+++ b/Core/Source/SolidSyslogStatic.c
@@ -70,12 +70,12 @@ static void SolidSyslog_EnsureNullInstancePopulated(void)
         SolidSyslog_NullInstance.Buffer = SolidSyslogNullBuffer_Get();
         SolidSyslog_NullInstance.Sender = SolidSyslogNullSender_Get();
         SolidSyslog_NullInstance.Store = SolidSyslogNullStore_Get();
-        SolidSyslog_NullInstance.Clock = SolidSyslog_NullClock;
-        SolidSyslog_NullInstance.GetHostname = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.GetAppName = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.GetProcessId = SolidSyslog_NullStringFunction;
-        SolidSyslog_NullInstance.Sd = NULL;
-        SolidSyslog_NullInstance.SdCount = 0;
+        SolidSyslog_NullInstance.Format.Clock = SolidSyslog_NullClock;
+        SolidSyslog_NullInstance.Format.GetHostname = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.Format.GetAppName = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.Format.GetProcessId = SolidSyslog_NullStringFunction;
+        SolidSyslog_NullInstance.Format.Sd = NULL;
+        SolidSyslog_NullInstance.Format.SdCount = 0;
         populated = true;
     }
 }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,55 @@
 # Dev Log
 
+## 2026-06-01 — S12.21 Extract SolidSyslogMessageFormatter
+
+Lifted the rest of the RFC 5424 wire-format knowledge (PRIVAL, header layout,
+per-field truncation/PRINTUSASCII, SD iteration, MSG/BOM) out of `SolidSyslog.c`
+into a private module, reducing the singleton to lifecycle + Service + Nil
+collaborators. Sliced into three reviewable commits per the agreed plan.
+
+### Decisions
+
+- **Three slices.** (0) Promote the `SyslogField`/`SYSLOG_FIELD_*` parser to
+  `Tests/Support/SyslogFieldParser.{cpp,h}` (standalone, unblocks the unit test).
+  (1) Extract the module + reshape `struct SolidSyslog` to embed a
+  `SolidSyslogMessageFormatterContext Format` + migrate ~35 field tests. (2) The
+  BOM-empty-MSG fix as an isolated red/green commit. The behaviour change was
+  kept out of the move so Slice 1 stayed a verifiable no-op.
+
+- **Migration scope follows the formatter/integration boundary.** Migrated the
+  pure (message, context) → output tests (PRIVAL, hostname/app/proc, msgid,
+  all-fields) to the unit file; left SD/MSG-body/buffer-truncation/Service/
+  lifecycle as integration coverage of the full `_Log` pipeline. As in S12.20's
+  NullClock split, the three `NullGet*ProducesNilvalue` tests stay in
+  `SolidSyslogTest.cpp` (they assert Create's nil-object substitution, not
+  formatter behaviour); the formatter's empty→NILVALUE path is `Empty*` in the
+  unit file.
+
+- **BOM-empty-MSG fix.** A caller-supplied BOM-only message (`"\xEF\xBB\xBF"`)
+  stripped to an empty body but still emitted SP+BOM. Now the post-strip body is
+  guarded — emit SP+BOM+body only when non-empty. The `msg` NULL/empty guard
+  stays *outside* the strip (SkipLeadingBom dereferences `msg`). Confirmed the
+  SD SP BOM body byte order against RFC 5424 §6 ABNF and pinned it with a
+  byte-sequence guard test.
+
+- **MISRA: extend D.006, don't weaken the signature.** Making
+  `MessageFormatter_Format` take a `const context` reproduced the exact 11.8
+  const-strip false positive `SolidSyslog_Create(const config)` already carries
+  (reading a non-const pointer member through a `const struct*`). Kept the
+  `const` (the formatter must not mutate the context) and extended D.006 from 10
+  to 15 field-access sites rather than drop `const` to silence cppcheck.
+  Verified with the full `cppcheck --suppressions-list`: no unsuppressed
+  violations, no unmatched suppressions.
+
+### Deferred
+
+- SD per-element NULL guards and the SD config-pair consistency check remain
+  S12.06's territory.
+
+### Open questions
+
+- None outstanding.
+
 ## 2026-06-01 — S12.20 Extract SolidSyslogTimestampFormatter
 
 Lifted timestamp validation + RFC 3339 formatting (seven functions, ~75 lines)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -12,7 +12,7 @@ collaborators. Sliced into three reviewable commits per the agreed plan.
 - **Three slices.** (0) Promote the `SyslogField`/`SYSLOG_FIELD_*` parser to
   `Tests/Support/SyslogFieldParser.{cpp,h}` (standalone, unblocks the unit test).
   (1) Extract the module + reshape `struct SolidSyslog` to embed a
-  `SolidSyslogMessageFormatterContext Format` + migrate ~35 field tests. (2) The
+  `SolidSyslogMessageFormatterContext Format` + migrate 35 field tests. (2) The
   BOM-empty-MSG fix as an isolated red/green commit. The behaviour change was
   kept out of the move so Slice 1 stayed a verifiable no-op.
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TEST_SOURCES
     SolidSyslogFormatterTest.cpp
     SolidSyslogTimestampFormatterTest.cpp
     SolidSyslogUdpPayloadTest.cpp
+    Support/SyslogFieldParser.cpp
     BufferFakeTest.cpp
     AddressFake.c
     BufferFake.c

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TEST_SOURCES
     SolidSyslogConfigLockTest.cpp
     SolidSyslogFormatterTest.cpp
     SolidSyslogTimestampFormatterTest.cpp
+    SolidSyslogMessageFormatterTest.cpp
     SolidSyslogUdpPayloadTest.cpp
     Support/SyslogFieldParser.cpp
     BufferFakeTest.cpp

--- a/Tests/SolidSyslogMessageFormatterTest.cpp
+++ b/Tests/SolidSyslogMessageFormatterTest.cpp
@@ -1,0 +1,344 @@
+#include <cstring>
+#include <string>
+
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslog.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogMessageFormatter.h"
+#include "SolidSyslogPrival.h"
+#include "SolidSyslogTimestamp.h"
+#include "SolidSyslogTunables.h"
+#include "StringFake.h"
+#include "SyslogFieldParser.h"
+
+static struct SolidSyslogTimestamp stubTimestamp;
+
+static void MessageFormatterTestClock(struct SolidSyslogTimestamp* timestamp)
+{
+    *timestamp = stubTimestamp;
+}
+
+#define OUTPUT() SolidSyslogFormatter_AsFormattedBuffer(formatter)
+
+#define CHECK_PRIVAL(expected) \
+    STRNCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_HEADER).c_str(), strlen(expected))
+#define CHECK_TIMESTAMP(expected) STRCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_TIMESTAMP).c_str())
+#define CHECK_HOSTNAME(expected) STRCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_HOSTNAME).c_str())
+#define CHECK_APP_NAME(expected) STRCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_APP_NAME).c_str())
+#define CHECK_PROCID(expected) STRCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_PROCID).c_str())
+#define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(OUTPUT(), SYSLOG_FIELD_MSGID).c_str())
+
+TEST_GROUP(SolidSyslogMessageFormatter)
+{
+    SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(SOLIDSYSLOG_MAX_MESSAGE_SIZE)];
+    struct SolidSyslogFormatter* formatter;
+    struct SolidSyslogMessage message;
+    struct SolidSyslogMessageFormatterContext context;
+
+    void setup() override
+    {
+        formatter = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+        StringFake_Reset();
+        stubTimestamp = {};
+        context = {
+            MessageFormatterTestClock,
+            StringFake_GetHostname,
+            StringFake_GetAppName,
+            StringFake_GetProcessId,
+            nullptr,
+            0
+        };
+        message = {SOLIDSYSLOG_FACILITY_LOCAL0, SOLIDSYSLOG_SEVERITY_INFORMATIONAL, nullptr, nullptr};
+    }
+
+    void format()
+    {
+        SolidSyslogMessageFormatter_Format(formatter, &message, &context);
+    }
+};
+
+TEST(SolidSyslogMessageFormatter, PriValIs134)
+{
+    format();
+    CHECK_PRIVAL("<134>");
+}
+
+TEST(SolidSyslogMessageFormatter, FacilityAppearsInPrival)
+{
+    message.Facility = SOLIDSYSLOG_FACILITY_NEWS;
+    format();
+    CHECK_PRIVAL("<62>");
+}
+
+TEST(SolidSyslogMessageFormatter, SeverityAppearsInPrival)
+{
+    message.Severity = SOLIDSYSLOG_SEVERITY_CRITICAL;
+    format();
+    CHECK_PRIVAL("<130>");
+}
+
+TEST(SolidSyslogMessageFormatter, LowestFacilityProducesCorrectPrival)
+{
+    message.Facility = SOLIDSYSLOG_FACILITY_KERN;
+    format();
+    CHECK_PRIVAL("<6>");
+}
+
+TEST(SolidSyslogMessageFormatter, HighestFacilityProducesCorrectPrival)
+{
+    message.Facility = SOLIDSYSLOG_FACILITY_LOCAL7;
+    format();
+    CHECK_PRIVAL("<190>");
+}
+
+TEST(SolidSyslogMessageFormatter, LowestSeverityProducesCorrectPrival)
+{
+    message.Severity = SOLIDSYSLOG_SEVERITY_EMERGENCY;
+    format();
+    CHECK_PRIVAL("<128>");
+}
+
+TEST(SolidSyslogMessageFormatter, HighestSeverityProducesCorrectPrival)
+{
+    message.Severity = SOLIDSYSLOG_SEVERITY_DEBUG;
+    format();
+    CHECK_PRIVAL("<135>");
+}
+
+TEST(SolidSyslogMessageFormatter, OutOfRangeFacilityProducesErrorPrival)
+{
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) -- intentionally testing out-of-range input
+    message.Facility = (enum SolidSyslogFacility) 24;
+    format();
+    CHECK_PRIVAL("<43>");
+}
+
+TEST(SolidSyslogMessageFormatter, OutOfRangeSeverityProducesErrorPrival)
+{
+    enum SolidSyslogSeverity invalid = SOLIDSYSLOG_SEVERITY_DEBUG;
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) -- intentionally testing out-of-range input
+    invalid = static_cast<enum SolidSyslogSeverity>(static_cast<int>(invalid) + 1);
+    message.Severity = invalid;
+    format();
+    CHECK_PRIVAL("<43>");
+}
+
+TEST(SolidSyslogMessageFormatter, HostnameFromGetHostnameAppearsInMessage)
+{
+    StringFake_SetHostname("MyHost");
+    format();
+    CHECK_HOSTNAME("MyHost");
+}
+
+TEST(SolidSyslogMessageFormatter, HostnameCallbackIsInvokedPerFormatCall)
+{
+    StringFake_SetHostname("FirstHost");
+    format();
+    CHECK_HOSTNAME("FirstHost");
+    setup();
+    StringFake_SetHostname("SecondHost");
+    format();
+    CHECK_HOSTNAME("SecondHost");
+}
+
+TEST(SolidSyslogMessageFormatter, HostnameAt255CharsIsAccepted)
+{
+    std::string longHostname(255, 'H');
+    StringFake_SetHostname(longHostname.c_str());
+    format();
+    CHECK_HOSTNAME(longHostname.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, HostnameAt256CharsIsTruncatedTo255)
+{
+    std::string longHostname(256, 'H');
+    StringFake_SetHostname(longHostname.c_str());
+    format();
+    std::string expected(255, 'H');
+    CHECK_HOSTNAME(expected.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, HostnameNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetHostname("a\x01"
+                           "b");
+    format();
+    CHECK_HOSTNAME("a?b");
+}
+
+TEST(SolidSyslogMessageFormatter, EmptyHostnameProducesNilvalue)
+{
+    StringFake_SetHostname("");
+    format();
+    CHECK_HOSTNAME("-");
+}
+
+TEST(SolidSyslogMessageFormatter, AppNameFromGetAppNameAppearsInMessage)
+{
+    StringFake_SetAppName("MyApp");
+    format();
+    CHECK_APP_NAME("MyApp");
+}
+
+TEST(SolidSyslogMessageFormatter, AppNameCallbackIsInvokedPerFormatCall)
+{
+    StringFake_SetAppName("FirstApp");
+    format();
+    CHECK_APP_NAME("FirstApp");
+    setup();
+    StringFake_SetAppName("SecondApp");
+    format();
+    CHECK_APP_NAME("SecondApp");
+}
+
+TEST(SolidSyslogMessageFormatter, AppNameAt48CharsIsAccepted)
+{
+    std::string longAppName(48, 'A');
+    StringFake_SetAppName(longAppName.c_str());
+    format();
+    CHECK_APP_NAME(longAppName.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, AppNameAt49CharsIsTruncatedTo48)
+{
+    std::string longAppName(49, 'A');
+    StringFake_SetAppName(longAppName.c_str());
+    format();
+    std::string expected(48, 'A');
+    CHECK_APP_NAME(expected.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, AppNameNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetAppName("a\x7F"
+                          "b");
+    format();
+    CHECK_APP_NAME("a?b");
+}
+
+TEST(SolidSyslogMessageFormatter, EmptyAppNameProducesNilvalue)
+{
+    StringFake_SetAppName("");
+    format();
+    CHECK_APP_NAME("-");
+}
+
+TEST(SolidSyslogMessageFormatter, ProcessIdFromGetProcessIdAppearsInMessage)
+{
+    StringFake_SetProcessId("9999");
+    format();
+    CHECK_PROCID("9999");
+}
+
+TEST(SolidSyslogMessageFormatter, ProcessIdCallbackIsInvokedPerFormatCall)
+{
+    StringFake_SetProcessId("1111");
+    format();
+    CHECK_PROCID("1111");
+    setup();
+    StringFake_SetProcessId("2222");
+    format();
+    CHECK_PROCID("2222");
+}
+
+TEST(SolidSyslogMessageFormatter, ProcessIdAt128CharsIsAccepted)
+{
+    std::string longProcessId(128, 'P');
+    StringFake_SetProcessId(longProcessId.c_str());
+    format();
+    CHECK_PROCID(longProcessId.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, ProcessIdAt129CharsIsTruncatedTo128)
+{
+    std::string longProcessId(129, 'P');
+    StringFake_SetProcessId(longProcessId.c_str());
+    format();
+    std::string expected(128, 'P');
+    CHECK_PROCID(expected.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    StringFake_SetProcessId("a\xC3"
+                            "b");
+    format();
+    CHECK_PROCID("a?b");
+}
+
+TEST(SolidSyslogMessageFormatter, EmptyProcessIdProducesNilvalue)
+{
+    StringFake_SetProcessId("");
+    format();
+    CHECK_PROCID("-");
+}
+
+TEST(SolidSyslogMessageFormatter, NullMessageIdProducesNilvalue)
+{
+    format();
+    CHECK_MSGID("-");
+}
+
+TEST(SolidSyslogMessageFormatter, MessageIdAppearsInMessage)
+{
+    message.MessageId = "ID47";
+    format();
+    CHECK_MSGID("ID47");
+}
+
+TEST(SolidSyslogMessageFormatter, MessageIdIsNotHardCoded)
+{
+    message.MessageId = "54";
+    format();
+    CHECK_MSGID("54");
+}
+
+TEST(SolidSyslogMessageFormatter, EmptyMessageIdProducesNilvalue)
+{
+    message.MessageId = "";
+    format();
+    CHECK_MSGID("-");
+}
+
+TEST(SolidSyslogMessageFormatter, MessageIdAt32CharsIsAccepted)
+{
+    std::string maxMsgId(32, 'M');
+    message.MessageId = maxMsgId.c_str();
+    format();
+    CHECK_MSGID(maxMsgId.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, MessageIdAt33CharsIsTruncatedTo32)
+{
+    std::string longMsgId(33, 'M');
+    message.MessageId = longMsgId.c_str();
+    format();
+    std::string expected(32, 'M');
+    CHECK_MSGID(expected.c_str());
+}
+
+TEST(SolidSyslogMessageFormatter, MessageIdNonPrintableByteIsSubstitutedWithQuestionMark)
+{
+    message.MessageId = "a b";
+    format();
+    CHECK_MSGID("a?b");
+}
+
+TEST(SolidSyslogMessageFormatter, AllFieldsAtMaxLengthProducesValidMessage)
+{
+    std::string maxHostname(255, 'H');
+    std::string maxAppName(48, 'A');
+    std::string maxProcessId(128, 'P');
+    StringFake_SetHostname(maxHostname.c_str());
+    StringFake_SetAppName(maxAppName.c_str());
+    StringFake_SetProcessId(maxProcessId.c_str());
+    stubTimestamp = {9999, 12, 31, 23, 59, 59, 999999, 840};
+    message.Facility = SOLIDSYSLOG_FACILITY_LOCAL7;
+    message.Severity = SOLIDSYSLOG_SEVERITY_DEBUG;
+    format();
+    CHECK_PRIVAL("<191>");
+    CHECK_TIMESTAMP("9999-12-31T23:59:59.999999+14:00");
+    CHECK_HOSTNAME(maxHostname.c_str());
+    CHECK_APP_NAME(maxAppName.c_str());
+    CHECK_PROCID(maxProcessId.c_str());
+}

--- a/Tests/SolidSyslogMessageFormatterTest.cpp
+++ b/Tests/SolidSyslogMessageFormatterTest.cpp
@@ -342,3 +342,18 @@ TEST(SolidSyslogMessageFormatter, AllFieldsAtMaxLengthProducesValidMessage)
     CHECK_APP_NAME(maxAppName.c_str());
     CHECK_PROCID(maxProcessId.c_str());
 }
+
+// RFC 5424 §6: SD then SP (outer framing) then BOM (first byte of MSG-UTF8).
+TEST(SolidSyslogMessageFormatter, MsgFieldIsSpaceThenBomThenBody)
+{
+    message.Msg = "hello";
+    format();
+    STRCMP_EQUAL("<134>1 - - - - - - \xEF\xBB\xBFhello", OUTPUT());
+}
+
+TEST(SolidSyslogMessageFormatter, BomOnlyMessageProducesEmptyMsgField)
+{
+    message.Msg = "\xEF\xBB\xBF";
+    format();
+    STRCMP_EQUAL("<134>1 - - - - - -", OUTPUT());
+}

--- a/Tests/SolidSyslogMessageFormatterTest.cpp
+++ b/Tests/SolidSyslogMessageFormatterTest.cpp
@@ -55,6 +55,14 @@ TEST_GROUP(SolidSyslogMessageFormatter)
     {
         SolidSyslogMessageFormatter_Format(formatter, &message, &context);
     }
+
+    // Clears the output buffer between two format() calls without rebuilding
+    // the context, so "callback invoked per call" tests exercise consecutive
+    // formats on the same fixture (a cached callback result would be caught).
+    void resetFormatter()
+    {
+        formatter = SolidSyslogFormatter_Create(storage, SOLIDSYSLOG_MAX_MESSAGE_SIZE);
+    }
 };
 
 TEST(SolidSyslogMessageFormatter, PriValIs134)
@@ -135,7 +143,7 @@ TEST(SolidSyslogMessageFormatter, HostnameCallbackIsInvokedPerFormatCall)
     StringFake_SetHostname("FirstHost");
     format();
     CHECK_HOSTNAME("FirstHost");
-    setup();
+    resetFormatter();
     StringFake_SetHostname("SecondHost");
     format();
     CHECK_HOSTNAME("SecondHost");
@@ -185,7 +193,7 @@ TEST(SolidSyslogMessageFormatter, AppNameCallbackIsInvokedPerFormatCall)
     StringFake_SetAppName("FirstApp");
     format();
     CHECK_APP_NAME("FirstApp");
-    setup();
+    resetFormatter();
     StringFake_SetAppName("SecondApp");
     format();
     CHECK_APP_NAME("SecondApp");
@@ -235,7 +243,7 @@ TEST(SolidSyslogMessageFormatter, ProcessIdCallbackIsInvokedPerFormatCall)
     StringFake_SetProcessId("1111");
     format();
     CHECK_PROCID("1111");
-    setup();
+    resetFormatter();
     StringFake_SetProcessId("2222");
     format();
     CHECK_PROCID("2222");

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -20,6 +20,7 @@
 #include "StoreFake.h"
 #include "SenderFake.h"
 #include "StringFake.h"
+#include "SyslogFieldParser.h"
 #include "SolidSyslogBuffer.h"
 #include "SolidSyslogPrival.h"
 #include "SolidSyslogStore.h"
@@ -81,14 +82,6 @@ static const char * const TEST_PRIVAL    = "<134>";
 static const char * const TEST_MSGID     = "54";
 static const char * const TEST_SDATA     = "-";
 static const char * const TEST_MSG       = "hello world";
-
-static const int SYSLOG_FIELD_HEADER    = 0;
-static const int SYSLOG_FIELD_TIMESTAMP = 1;
-static const int SYSLOG_FIELD_HOSTNAME  = 2;
-static const int SYSLOG_FIELD_APP_NAME  = 3;
-static const int SYSLOG_FIELD_PROCID    = 4;
-static const int SYSLOG_FIELD_MSGID     = 5;
-static const int SYSLOG_FIELD_SDATA     = 6;
 // clang-format on
 
 #define CHECK_PRIVAL(expected) \
@@ -132,107 +125,6 @@ static struct SolidSyslogStructuredData sdFail = {SdFailFormat};
 static void IntegrationGetTimeQuality(struct SolidSyslogTimeQuality* timeQuality)
 {
     *timeQuality = {true, true, SOLIDSYSLOG_SYNC_ACCURACY_OMIT};
-}
-
-static std::string::size_type SkipSdata(const std::string& s, std::string::size_type pos)
-{
-    if (pos < s.size() && s[pos] == '[')
-    {
-        while (pos < s.size() && s[pos] == '[')
-        {
-            pos = s.find(']', pos);
-            if (pos == std::string::npos)
-            {
-                return std::string::npos;
-            }
-            pos++;
-        }
-        return pos;
-    }
-    auto end = s.find(' ', pos);
-    return end == std::string::npos ? s.size() : end;
-}
-
-static std::string::size_type FindFieldStart(const std::string& s, int n)
-{
-    std::string::size_type pos = 0;
-    for (int i = 0; i < n; i++)
-    {
-        if (i == SYSLOG_FIELD_SDATA)
-        {
-            pos = SkipSdata(s, pos);
-        }
-        else
-        {
-            pos = s.find(' ', pos);
-        }
-        if (pos == std::string::npos)
-        {
-            return std::string::npos;
-        }
-        if (s[pos] == ' ')
-        {
-            pos++;
-        }
-    }
-    return pos;
-}
-
-static std::string SyslogField(const char* buffer, int n)
-{
-    std::string s(buffer);
-    std::string::size_type pos = FindFieldStart(s, n);
-    if (pos == std::string::npos)
-    {
-        return {};
-    }
-
-    std::string::size_type end = (n == SYSLOG_FIELD_SDATA) ? SkipSdata(s, pos) : s.find(' ', pos);
-    return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
-}
-
-static const char UTF8_BOM[] = "\xEF\xBB\xBF";
-static const auto UTF8_BOM_LENGTH = sizeof(UTF8_BOM) - 1;
-
-static std::string::size_type SyslogMsgStart(const std::string& s)
-{
-    std::string::size_type pos = FindFieldStart(s, SYSLOG_FIELD_SDATA);
-    if (pos == std::string::npos)
-    {
-        return std::string::npos;
-    }
-    pos = SkipSdata(s, pos);
-    if (pos == std::string::npos || pos >= s.size())
-    {
-        return std::string::npos;
-    }
-    if (s[pos] == ' ')
-    {
-        pos++;
-    }
-    return pos;
-}
-
-static bool SyslogMsgHasBom(const char* buffer)
-{
-    std::string s(buffer);
-    std::string::size_type pos = SyslogMsgStart(s);
-    return (pos != std::string::npos) && (s.compare(pos, UTF8_BOM_LENGTH, UTF8_BOM) == 0);
-}
-
-static std::string SyslogMsg(const char* buffer)
-{
-    std::string s(buffer);
-    std::string::size_type pos = SyslogMsgStart(s);
-    if (pos == std::string::npos)
-    {
-        return {};
-    }
-    if (s.compare(pos, UTF8_BOM_LENGTH, UTF8_BOM) == 0)
-    {
-        pos += UTF8_BOM_LENGTH;
-    }
-    return s.substr(pos);
 }
 
 // clang-format off

--- a/Tests/SolidSyslogTest.cpp
+++ b/Tests/SolidSyslogTest.cpp
@@ -33,59 +33,19 @@ using namespace CososoTesting;
 
 class TEST_SolidSyslogTimestamp_NullClockProducesNilvalue_Test;
 class TEST_SolidSyslogTimestamp_TimestampAppearsInCorrectMessageFieldPosition_Test;
-class TEST_SolidSyslog_AllFieldsAtMaxLengthProducesValidMessage_Test;
-class TEST_SolidSyslog_AppNameAt48CharsIsAccepted_Test;
-class TEST_SolidSyslog_AppNameAt49CharsIsTruncatedTo48_Test;
-class TEST_SolidSyslog_AppNameCallbackIsInvokedPerLogCall_Test;
-class TEST_SolidSyslog_AppNameFromGetAppNameAppearsInMessage_Test;
-class TEST_SolidSyslog_AppNameNonPrintableByteIsSubstitutedWithQuestionMark_Test;
-class TEST_SolidSyslog_EmptyAppNameProducesNilvalue_Test;
-class TEST_SolidSyslog_EmptyHostnameProducesNilvalue_Test;
-class TEST_SolidSyslog_EmptyMessageIdProducesNilvalue_Test;
-class TEST_SolidSyslog_EmptyProcessIdProducesNilvalue_Test;
-class TEST_SolidSyslog_FacilityAppearsInPrival_Test;
-class TEST_SolidSyslog_HighestFacilityProducesCorrectPrival_Test;
-class TEST_SolidSyslog_HighestSeverityProducesCorrectPrival_Test;
-class TEST_SolidSyslog_HostnameAt255CharsIsAccepted_Test;
-class TEST_SolidSyslog_HostnameAt256CharsIsTruncatedTo255_Test;
-class TEST_SolidSyslog_HostnameCallbackIsInvokedPerLogCall_Test;
-class TEST_SolidSyslog_HostnameFromGetHostnameAppearsInMessage_Test;
-class TEST_SolidSyslog_HostnameNonPrintableByteIsSubstitutedWithQuestionMark_Test;
 class TEST_SolidSyslog_LogAfterDestroyAndRecreateWithNullFunctionsProducesNilvalues_Test;
-class TEST_SolidSyslog_LowestFacilityProducesCorrectPrival_Test;
-class TEST_SolidSyslog_LowestSeverityProducesCorrectPrival_Test;
-class TEST_SolidSyslog_MessageIdAppearsInMessage_Test;
-class TEST_SolidSyslog_MessageIdAt32CharsIsAccepted_Test;
-class TEST_SolidSyslog_MessageIdAt33CharsIsTruncatedTo32_Test;
-class TEST_SolidSyslog_MessageIdIsNotHardCoded_Test;
-class TEST_SolidSyslog_MessageIdNonPrintableByteIsSubstitutedWithQuestionMark_Test;
 class TEST_SolidSyslog_NullGetAppNameProducesNilvalue_Test;
 class TEST_SolidSyslog_NullGetHostnameProducesNilvalue_Test;
 class TEST_SolidSyslog_NullGetProcessIdProducesNilvalue_Test;
-class TEST_SolidSyslog_NullMessageIdProducesNilvalue_Test;
-class TEST_SolidSyslog_OutOfRangeFacilityProducesErrorPrival_Test;
-class TEST_SolidSyslog_OutOfRangeSeverityProducesErrorPrival_Test;
-class TEST_SolidSyslog_PriValIs134_Test;
-class TEST_SolidSyslog_ProcessIdAt128CharsIsAccepted_Test;
-class TEST_SolidSyslog_ProcessIdAt129CharsIsTruncatedTo128_Test;
-class TEST_SolidSyslog_ProcessIdCallbackIsInvokedPerLogCall_Test;
-class TEST_SolidSyslog_ProcessIdFromGetProcessIdAppearsInMessage_Test;
-class TEST_SolidSyslog_ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark_Test;
-class TEST_SolidSyslog_SeverityAppearsInPrival_Test;
 struct SolidSyslogAtomicCounter;
 struct SolidSyslogBuffer;
 struct SolidSyslogSender;
 struct SolidSyslogStore;
 
 // clang-format off
-static const char * const TEST_PRIVAL    = "<134>";
-static const char * const TEST_MSGID     = "54";
 static const char * const TEST_SDATA     = "-";
 static const char * const TEST_MSG       = "hello world";
 // clang-format on
-
-#define CHECK_PRIVAL(expected) \
-    STRNCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_HEADER).c_str(), strlen(expected))
 
 #define CHECK_TIMESTAMP(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_TIMESTAMP).c_str())
 
@@ -96,8 +56,6 @@ static const char * const TEST_MSG       = "hello world";
 #define CHECK_APP_NAME(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_APP_NAME).c_str())
 
 #define CHECK_PROCID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_PROCID).c_str())
-
-#define CHECK_MSGID(expected) STRCMP_EQUAL(expected, SyslogField(lastMessage(), SYSLOG_FIELD_MSGID).c_str())
 
 static const char SD_SPY_TEXT[] = "[spy]";
 static const char SD_SPY2_TEXT[] = "[spy2]";
@@ -205,72 +163,6 @@ TEST(SolidSyslog, SingleLogCallResultsInOneSend)
     CALLED_FAKE_ON(SenderFake_Send, fakeSender, ONCE);
 }
 
-TEST(SolidSyslog, PriValIs134)
-{
-    Log();
-    CHECK_PRIVAL(TEST_PRIVAL);
-}
-
-TEST(SolidSyslog, FacilityAppearsInPrival)
-{
-    message.Facility = SOLIDSYSLOG_FACILITY_NEWS;
-    Log();
-    CHECK_PRIVAL("<62>");
-}
-
-TEST(SolidSyslog, SeverityAppearsInPrival)
-{
-    message.Severity = SOLIDSYSLOG_SEVERITY_CRITICAL;
-    Log();
-    CHECK_PRIVAL("<130>");
-}
-
-TEST(SolidSyslog, LowestFacilityProducesCorrectPrival)
-{
-    message.Facility = SOLIDSYSLOG_FACILITY_KERN;
-    Log();
-    CHECK_PRIVAL("<6>");
-}
-
-TEST(SolidSyslog, HighestFacilityProducesCorrectPrival)
-{
-    message.Facility = SOLIDSYSLOG_FACILITY_LOCAL7;
-    Log();
-    CHECK_PRIVAL("<190>");
-}
-
-TEST(SolidSyslog, LowestSeverityProducesCorrectPrival)
-{
-    message.Severity = SOLIDSYSLOG_SEVERITY_EMERGENCY;
-    Log();
-    CHECK_PRIVAL("<128>");
-}
-
-TEST(SolidSyslog, HighestSeverityProducesCorrectPrival)
-{
-    message.Severity = SOLIDSYSLOG_SEVERITY_DEBUG;
-    Log();
-    CHECK_PRIVAL("<135>");
-}
-
-TEST(SolidSyslog, OutOfRangeFacilityProducesErrorPrival)
-{
-    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) -- intentionally testing out-of-range input
-    message.Facility = (enum SolidSyslogFacility) 24;
-    Log();
-    CHECK_PRIVAL("<43>");
-}
-
-TEST(SolidSyslog, OutOfRangeSeverityProducesErrorPrival)
-{
-    enum SolidSyslogSeverity invalid = SOLIDSYSLOG_SEVERITY_DEBUG;
-    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) -- intentionally testing out-of-range input
-    invalid = static_cast<enum SolidSyslogSeverity>(static_cast<int>(invalid) + 1);
-    message.Severity = invalid;
-    Log();
-    CHECK_PRIVAL("<43>");
-}
-
 TEST(SolidSyslog, VersionIs1)
 {
     Log();
@@ -288,23 +180,6 @@ TEST(SolidSyslog, NullGetHostnameProducesNilvalue)
     CHECK_HOSTNAME("-");
 }
 
-TEST(SolidSyslog, HostnameFromGetHostnameAppearsInMessage)
-{
-    StringFake_SetHostname("MyHost");
-    Log();
-    CHECK_HOSTNAME("MyHost");
-}
-
-TEST(SolidSyslog, HostnameCallbackIsInvokedPerLogCall)
-{
-    StringFake_SetHostname("FirstHost");
-    Log();
-    CHECK_HOSTNAME("FirstHost");
-    StringFake_SetHostname("SecondHost");
-    Log();
-    CHECK_HOSTNAME("SecondHost");
-}
-
 TEST(SolidSyslog, NullGetAppNameProducesNilvalue)
 {
     config.GetAppName = nullptr;
@@ -314,23 +189,6 @@ TEST(SolidSyslog, NullGetAppNameProducesNilvalue)
     CHECK_APP_NAME("-");
 }
 
-TEST(SolidSyslog, AppNameFromGetAppNameAppearsInMessage)
-{
-    StringFake_SetAppName("MyApp");
-    Log();
-    CHECK_APP_NAME("MyApp");
-}
-
-TEST(SolidSyslog, AppNameCallbackIsInvokedPerLogCall)
-{
-    StringFake_SetAppName("FirstApp");
-    Log();
-    CHECK_APP_NAME("FirstApp");
-    StringFake_SetAppName("SecondApp");
-    Log();
-    CHECK_APP_NAME("SecondApp");
-}
-
 TEST(SolidSyslog, NullGetProcessIdProducesNilvalue)
 {
     config.GetProcessId = nullptr;
@@ -338,74 +196,6 @@ TEST(SolidSyslog, NullGetProcessIdProducesNilvalue)
     solidSyslog = SolidSyslog_Create(&config);
     Log();
     CHECK_PROCID("-");
-}
-
-TEST(SolidSyslog, ProcessIdFromGetProcessIdAppearsInMessage)
-{
-    StringFake_SetProcessId("9999");
-    Log();
-    CHECK_PROCID("9999");
-}
-
-TEST(SolidSyslog, ProcessIdCallbackIsInvokedPerLogCall)
-{
-    StringFake_SetProcessId("1111");
-    Log();
-    CHECK_PROCID("1111");
-    StringFake_SetProcessId("2222");
-    Log();
-    CHECK_PROCID("2222");
-}
-
-TEST(SolidSyslog, NullMessageIdProducesNilvalue)
-{
-    Log();
-    CHECK_MSGID("-");
-}
-
-TEST(SolidSyslog, MessageIdAppearsInMessage)
-{
-    message.MessageId = "ID47";
-    Log();
-    CHECK_MSGID("ID47");
-}
-
-TEST(SolidSyslog, MessageIdIsNotHardCoded)
-{
-    message.MessageId = TEST_MSGID;
-    Log();
-    CHECK_MSGID(TEST_MSGID);
-}
-
-TEST(SolidSyslog, EmptyMessageIdProducesNilvalue)
-{
-    message.MessageId = "";
-    Log();
-    CHECK_MSGID("-");
-}
-
-TEST(SolidSyslog, MessageIdAt32CharsIsAccepted)
-{
-    std::string maxMsgId(32, 'M');
-    message.MessageId = maxMsgId.c_str();
-    Log();
-    CHECK_MSGID(maxMsgId.c_str());
-}
-
-TEST(SolidSyslog, MessageIdAt33CharsIsTruncatedTo32)
-{
-    std::string longMsgId(33, 'M');
-    message.MessageId = longMsgId.c_str();
-    Log();
-    std::string expected(32, 'M');
-    CHECK_MSGID(expected.c_str());
-}
-
-TEST(SolidSyslog, MessageIdNonPrintableByteIsSubstitutedWithQuestionMark)
-{
-    message.MessageId = "a b";
-    Log();
-    CHECK_MSGID("a?b");
 }
 
 TEST(SolidSyslog, StructuredDataIsNilValue)
@@ -672,124 +462,6 @@ TEST(SolidSyslogTimestamp, TimestampAppearsInCorrectMessageFieldPosition)
 {
     Log();
     CHECK_TIMESTAMP("2026-04-02T14:30:07.000042Z");
-}
-
-TEST(SolidSyslog, HostnameAt255CharsIsAccepted)
-{
-    std::string longHostname(255, 'H');
-    StringFake_SetHostname(longHostname.c_str());
-    Log();
-    CHECK_HOSTNAME(longHostname.c_str());
-}
-
-TEST(SolidSyslog, HostnameAt256CharsIsTruncatedTo255)
-{
-    std::string longHostname(256, 'H');
-    StringFake_SetHostname(longHostname.c_str());
-    Log();
-    std::string expected(255, 'H');
-    CHECK_HOSTNAME(expected.c_str());
-}
-
-TEST(SolidSyslog, HostnameNonPrintableByteIsSubstitutedWithQuestionMark)
-{
-    StringFake_SetHostname("a\x01"
-                           "b");
-    Log();
-    CHECK_HOSTNAME("a?b");
-}
-
-TEST(SolidSyslog, AppNameAt48CharsIsAccepted)
-{
-    std::string longAppName(48, 'A');
-    StringFake_SetAppName(longAppName.c_str());
-    Log();
-    CHECK_APP_NAME(longAppName.c_str());
-}
-
-TEST(SolidSyslog, AppNameAt49CharsIsTruncatedTo48)
-{
-    std::string longAppName(49, 'A');
-    StringFake_SetAppName(longAppName.c_str());
-    Log();
-    std::string expected(48, 'A');
-    CHECK_APP_NAME(expected.c_str());
-}
-
-TEST(SolidSyslog, AppNameNonPrintableByteIsSubstitutedWithQuestionMark)
-{
-    StringFake_SetAppName("a\x7F"
-                          "b");
-    Log();
-    CHECK_APP_NAME("a?b");
-}
-
-TEST(SolidSyslog, ProcessIdAt128CharsIsAccepted)
-{
-    std::string longProcessId(128, 'P');
-    StringFake_SetProcessId(longProcessId.c_str());
-    Log();
-    CHECK_PROCID(longProcessId.c_str());
-}
-
-TEST(SolidSyslog, ProcessIdAt129CharsIsTruncatedTo128)
-{
-    std::string longProcessId(129, 'P');
-    StringFake_SetProcessId(longProcessId.c_str());
-    Log();
-    std::string expected(128, 'P');
-    CHECK_PROCID(expected.c_str());
-}
-
-TEST(SolidSyslog, ProcessIdNonPrintableByteIsSubstitutedWithQuestionMark)
-{
-    StringFake_SetProcessId("a\xC3"
-                            "b");
-    Log();
-    CHECK_PROCID("a?b");
-}
-
-TEST(SolidSyslog, AllFieldsAtMaxLengthProducesValidMessage)
-{
-    std::string maxHostname(255, 'H');
-    std::string maxAppName(48, 'A');
-    std::string maxProcessId(128, 'P');
-    StringFake_SetHostname(maxHostname.c_str());
-    StringFake_SetAppName(maxAppName.c_str());
-    StringFake_SetProcessId(maxProcessId.c_str());
-    stubTimestamp = {9999, 12, 31, 23, 59, 59, 999999, 840};
-    config.Clock = StubClock;
-    SolidSyslog_Destroy(solidSyslog);
-    solidSyslog = SolidSyslog_Create(&config);
-    message.Facility = SOLIDSYSLOG_FACILITY_LOCAL7;
-    message.Severity = SOLIDSYSLOG_SEVERITY_DEBUG;
-    Log();
-    CHECK_PRIVAL("<191>");
-    CHECK_TIMESTAMP("9999-12-31T23:59:59.999999+14:00");
-    CHECK_HOSTNAME(maxHostname.c_str());
-    CHECK_APP_NAME(maxAppName.c_str());
-    CHECK_PROCID(maxProcessId.c_str());
-}
-
-TEST(SolidSyslog, EmptyHostnameProducesNilvalue)
-{
-    StringFake_SetHostname("");
-    Log();
-    CHECK_HOSTNAME("-");
-}
-
-TEST(SolidSyslog, EmptyAppNameProducesNilvalue)
-{
-    StringFake_SetAppName("");
-    Log();
-    CHECK_APP_NAME("-");
-}
-
-TEST(SolidSyslog, EmptyProcessIdProducesNilvalue)
-{
-    StringFake_SetProcessId("");
-    Log();
-    CHECK_PROCID("-");
 }
 
 TEST(SolidSyslog, ServiceSendsMessageReadFromBuffer)

--- a/Tests/Support/SyslogFieldParser.cpp
+++ b/Tests/Support/SyslogFieldParser.cpp
@@ -1,0 +1,104 @@
+#include "SyslogFieldParser.h"
+
+#include <string>
+
+const char UTF8_BOM[] = "\xEF\xBB\xBF";
+static const auto UTF8_BOM_LENGTH = sizeof(UTF8_BOM) - 1;
+
+static std::string::size_type SkipSdata(const std::string& s, std::string::size_type pos)
+{
+    if (pos < s.size() && s[pos] == '[')
+    {
+        while (pos < s.size() && s[pos] == '[')
+        {
+            pos = s.find(']', pos);
+            if (pos == std::string::npos)
+            {
+                return std::string::npos;
+            }
+            pos++;
+        }
+        return pos;
+    }
+    auto end = s.find(' ', pos);
+    return end == std::string::npos ? s.size() : end;
+}
+
+static std::string::size_type FindFieldStart(const std::string& s, int n)
+{
+    std::string::size_type pos = 0;
+    for (int i = 0; i < n; i++)
+    {
+        if (i == SYSLOG_FIELD_SDATA)
+        {
+            pos = SkipSdata(s, pos);
+        }
+        else
+        {
+            pos = s.find(' ', pos);
+        }
+        if (pos == std::string::npos)
+        {
+            return std::string::npos;
+        }
+        if (s[pos] == ' ')
+        {
+            pos++;
+        }
+    }
+    return pos;
+}
+
+std::string SyslogField(const char* buffer, int n)
+{
+    std::string s(buffer);
+    std::string::size_type pos = FindFieldStart(s, n);
+    if (pos == std::string::npos)
+    {
+        return {};
+    }
+
+    std::string::size_type end = (n == SYSLOG_FIELD_SDATA) ? SkipSdata(s, pos) : s.find(' ', pos);
+    return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+}
+
+static std::string::size_type SyslogMsgStart(const std::string& s)
+{
+    std::string::size_type pos = FindFieldStart(s, SYSLOG_FIELD_SDATA);
+    if (pos == std::string::npos)
+    {
+        return std::string::npos;
+    }
+    pos = SkipSdata(s, pos);
+    if (pos == std::string::npos || pos >= s.size())
+    {
+        return std::string::npos;
+    }
+    if (s[pos] == ' ')
+    {
+        pos++;
+    }
+    return pos;
+}
+
+bool SyslogMsgHasBom(const char* buffer)
+{
+    std::string s(buffer);
+    std::string::size_type pos = SyslogMsgStart(s);
+    return (pos != std::string::npos) && (s.compare(pos, UTF8_BOM_LENGTH, UTF8_BOM) == 0);
+}
+
+std::string SyslogMsg(const char* buffer)
+{
+    std::string s(buffer);
+    std::string::size_type pos = SyslogMsgStart(s);
+    if (pos == std::string::npos)
+    {
+        return {};
+    }
+    if (s.compare(pos, UTF8_BOM_LENGTH, UTF8_BOM) == 0)
+    {
+        pos += UTF8_BOM_LENGTH;
+    }
+    return s.substr(pos);
+}

--- a/Tests/Support/SyslogFieldParser.h
+++ b/Tests/Support/SyslogFieldParser.h
@@ -1,0 +1,32 @@
+#ifndef SYSLOGFIELDPARSER_H
+#define SYSLOGFIELDPARSER_H
+
+#include <string>
+
+// The UTF-8 BOM (U+FEFF) that prefixes an RFC 5424 MSG-UTF8 body.
+extern const char UTF8_BOM[];
+
+// RFC 5424 SYSLOG-MSG field indices, counting space-separated header fields
+// from 0; SDATA (6) and the MSG body need bracket/BOM-aware skipping rather
+// than plain space splitting.
+enum
+{
+    SYSLOG_FIELD_HEADER = 0,
+    SYSLOG_FIELD_TIMESTAMP = 1,
+    SYSLOG_FIELD_HOSTNAME = 2,
+    SYSLOG_FIELD_APP_NAME = 3,
+    SYSLOG_FIELD_PROCID = 4,
+    SYSLOG_FIELD_MSGID = 5,
+    SYSLOG_FIELD_SDATA = 6
+};
+
+// Returns field n of a NUL-terminated RFC 5424 wire frame, or "" if absent.
+std::string SyslogField(const char* buffer, int n);
+
+// Returns the MSG body with any leading UTF-8 BOM stripped, or "" if absent.
+std::string SyslogMsg(const char* buffer);
+
+// True if the MSG body begins with the UTF-8 BOM.
+bool SyslogMsgHasBom(const char* buffer);
+
+#endif /* SYSLOGFIELDPARSER_H */

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -391,7 +391,7 @@ Project owner — David Cozens. Recorded under
 
 Two distinct site categories trigger this rule:
 
-1. **Field-access "false positive" (10 sites)** — reading a non-const
+1. **Field-access "false positive" (15 sites)** — reading a non-const
    pointer field through a `const struct*` parameter:
 
    ```c
@@ -412,6 +412,15 @@ Two distinct site categories trigger this rule:
    expression. The accepted interpretation in the MISRA community is
    that 11.8 applies to *pointer casts*, not to member-access yielding
    a non-`const`-qualified pointer rvalue.
+
+   The same pattern recurs in
+   `SolidSyslogMessageFormatter_Format(const struct
+   SolidSyslogMessageFormatterContext* context)` (5 sites — `context->Clock`,
+   `GetHostname`, `GetAppName`, `GetProcessId`, `Sd`), which reads its
+   read-only context exactly as `_Create` reads its config. The `const`
+   is deliberate (the formatter must not mutate the context); keeping it
+   and accepting the false positive is preferred over weakening the
+   signature to silence the tool.
 
 2. **Platform-API const-strip (2 sites)** —
 

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -460,9 +460,12 @@ Two distinct site categories trigger this rule:
 
 ### Scope
 
-- **Strict tier** — 10 field-access sites: 8 in `Core/Source/SolidSyslog.c`
+- **Strict tier** — 15 field-access sites: 8 in `Core/Source/SolidSyslog.c`
   (the `SolidSyslog_Install*` functions reading `config->` pointer
-  fields), 1 in `Core/Source/BlockSequence.c`
+  fields), 5 in `Core/Source/SolidSyslogMessageFormatter.c`
+  (`SolidSyslogMessageFormatter_Format` reading `context->Clock`,
+  `GetHostname`, `GetAppName`, `GetProcessId`, `Sd`), 1 in
+  `Core/Source/BlockSequence.c`
   (`BlockSequence_IsReadBlockFullyDrained` passing
   `blockSequence->BlockDevice` to `SolidSyslogBlockDevice_Size`), and
   1 in `Core/Source/SolidSyslogBlockStoreStatic.c`

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -100,14 +100,19 @@ misra-c2012-18.7:Core/Source/SolidSyslogFormatter.c:12
 # D.006 — Rule 11.8: const-strip false-positives + platform-API (Winsock, lwIP)
 # See docs/misra-deviations.md#d006
 misra-c2012-11.8:Core/Source/BlockSequence.c:465
-misra-c2012-11.8:Core/Source/SolidSyslog.c:85
-misra-c2012-11.8:Core/Source/SolidSyslog.c:86
-misra-c2012-11.8:Core/Source/SolidSyslog.c:87
-misra-c2012-11.8:Core/Source/SolidSyslog.c:88
-misra-c2012-11.8:Core/Source/SolidSyslog.c:89
-misra-c2012-11.8:Core/Source/SolidSyslog.c:90
-misra-c2012-11.8:Core/Source/SolidSyslog.c:91
-misra-c2012-11.8:Core/Source/SolidSyslog.c:92
+misra-c2012-11.8:Core/Source/SolidSyslog.c:52
+misra-c2012-11.8:Core/Source/SolidSyslog.c:53
+misra-c2012-11.8:Core/Source/SolidSyslog.c:54
+misra-c2012-11.8:Core/Source/SolidSyslog.c:55
+misra-c2012-11.8:Core/Source/SolidSyslog.c:56
+misra-c2012-11.8:Core/Source/SolidSyslog.c:57
+misra-c2012-11.8:Core/Source/SolidSyslog.c:58
+misra-c2012-11.8:Core/Source/SolidSyslog.c:59
+misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:57
+misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:59
+misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:61
+misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:63
+misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:67
 misra-c2012-11.8:Core/Source/SolidSyslogBlockStoreStatic.c:40
 misra-c2012-11.8:Platform/LwipRaw/Source/SolidSyslogLwipRawDatagram.c:155
 misra-c2012-11.8:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:93
@@ -159,7 +164,7 @@ misra-c2012-5.7:Core/Interface/SolidSyslogFormatter.h:14
 misra-c2012-5.7:Core/Interface/SolidSyslogSecurityPolicyDefinition.h:13
 misra-c2012-5.7:Core/Interface/SolidSyslogTimeQuality.h:12
 misra-c2012-5.7:Core/Interface/SolidSyslogTransport.h:5
-misra-c2012-5.7:Core/Source/SolidSyslog.c:31
+misra-c2012-5.7:Core/Source/SolidSyslogMessageFormatter.c:19
 misra-c2012-5.7:Core/Source/SolidSyslogCircularBuffer.c:15
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16.c:12
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16Policy.c:10

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -100,14 +100,14 @@ misra-c2012-18.7:Core/Source/SolidSyslogFormatter.c:12
 # D.006 — Rule 11.8: const-strip false-positives + platform-API (Winsock, lwIP)
 # See docs/misra-deviations.md#d006
 misra-c2012-11.8:Core/Source/BlockSequence.c:465
+misra-c2012-11.8:Core/Source/SolidSyslog.c:50
+misra-c2012-11.8:Core/Source/SolidSyslog.c:51
 misra-c2012-11.8:Core/Source/SolidSyslog.c:52
 misra-c2012-11.8:Core/Source/SolidSyslog.c:53
 misra-c2012-11.8:Core/Source/SolidSyslog.c:54
 misra-c2012-11.8:Core/Source/SolidSyslog.c:55
 misra-c2012-11.8:Core/Source/SolidSyslog.c:56
 misra-c2012-11.8:Core/Source/SolidSyslog.c:57
-misra-c2012-11.8:Core/Source/SolidSyslog.c:58
-misra-c2012-11.8:Core/Source/SolidSyslog.c:59
 misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:57
 misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:59
 misra-c2012-11.8:Core/Source/SolidSyslogMessageFormatter.c:61


### PR DESCRIPTION
## Purpose

Closes #329 (S12.21). Final structural extraction of E12: lift the remaining RFC
5424 wire-format knowledge out of `SolidSyslog.c` into a focused, directly-testable
private module, leaving the singleton as lifecycle + Service pipeline + Nil
collaborators (−221 lines).

## Change Description

Three slices, seven commits, each green:

- **Slice 0** — promote the `SyslogField` / `SYSLOG_FIELD_*` parser into a shared
  `Tests/Support/SyslogFieldParser.{cpp,h}` (it returns `std::string`, so C++).
  Standalone, no production change; unblocks the new unit test.
- **Slice 1** — extract `SolidSyslogMessageFormatter` (PRIVAL math, header layout,
  per-field truncation/PRINTUSASCII, SD iteration, MSG/BOM). The formatter's
  per-instance inputs (clock + string callbacks + SD array) move into a
  `SolidSyslogMessageFormatterContext` embedded in `struct SolidSyslog` as its
  single copy; install/reset/NullInstance sites write through `handle->Format`.
  `_Log` is now guard + Formatter setup + `SolidSyslogMessageFormatter_Format` +
  `Buffer_Write`. Pure refactor — existing wire-parser tests prove the move.
- **Slice 2** — isolated red/green BOM-empty-MSG fix (below).

`NullGet*ProducesNilvalue` (Create's nil-object substitution) stay in
`SolidSyslogTest.cpp`, like S12.20's NullClock split; the formatter's
empty→NILVALUE path is `Empty*` in the unit file. SD / MSG-body / buffer-truncation
/ Service / lifecycle tests stay as integration coverage. No public-header changes.

### BOM-empty-MSG fix (behaviour change)

A caller-supplied BOM-only message (`"\xEF\xBB\xBF"`) stripped to an empty body but
still emitted ` ` + BOM, leaving a dangling SP-BOM on the wire. Now SP+BOM+body is
emitted only when the post-strip body is non-empty (RFC 5424 §6.4 — the BOM belongs
to a non-empty MSG-UTF8). The `msg` NULL/empty guard stays outside the strip
(`SkipLeadingBom` dereferences `msg`). Closes the defect noted in the S12.04 review.
Kept as a separate commit so the extraction stays a verifiable no-op.

## Test Evidence

- **Slice 0**: existing ~50 tests prove the parser behaves identically after the move.
- **Slice 1**: new `SolidSyslogMessageFormatterTest.cpp` drives
  `SolidSyslogMessageFormatter_Format` directly (struct message + context + output
  buffer parsed via the promoted parser); 35 field tests migrated 1:1 and
  mutation-checked; the existing wire-parser tests stay green across the cutover.
- **Slice 2**: `BomOnlyMessageProducesEmptyMsgField` red → fix → green, plus a
  `MsgFieldIsSpaceThenBomThenBody` byte-sequence guard pinning the confirmed-correct
  SD SP BOM body order.

`debug` preset: **1352 tests pass**. Whole-tree clang-format clean; IWYU clean
(pruned 2 dead includes); MISRA verified via full `cppcheck --suppressions-list`
(no unsuppressed violations, no unmatched suppressions). Every branch of the new
module is exercised — CI's coverage lane confirms the 100% target.

## MISRA

Making `SolidSyslogMessageFormatter_Format` take a `const` context reproduced the
exact D.006 11.8 const-strip false positive that `SolidSyslog_Create(const config)`
already carries (reading a non-const pointer member through a `const struct*`). The
`const` is kept (the formatter must not mutate the context) and D.006 extended 10→15
field-access sites in `docs/misra-deviations.md`, rather than weakening the signature
to silence cppcheck. The field-size enum's 5.7 suppression relocated with the enum.

## Areas Affected

- **New**: `Core/Source/SolidSyslogMessageFormatter.{c,h}` (private, Tier 1),
  `Tests/Support/SyslogFieldParser.{cpp,h}`.
- **Changed**: `SolidSyslog.c` (−221), `SolidSyslogPrivate.h` / `SolidSyslogStatic.c`
  (struct reshape), CMake lists, `misra_suppressions.txt`, `docs/misra-deviations.md`,
  DEVLOG.
- Integrator API unaffected — no public-header changes.

## Dependency

S12.20 (#328) landed — `MessageFormatter_Format` delegates to `TimestampFormatter_Format`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected RFC 5424 syslog message formatting to properly handle UTF-8 byte order marks, ensuring the BOM is emitted only when the message body is non-empty.

* **Tests**
  * Added comprehensive unit tests for syslog message formatting, covering priority values, header fields, message IDs, and RFC 5424 compliance.

* **Chores**
  * Refactored internal message formatting logic into a dedicated module for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->