### PR TITLE
chore: bump container image to sha-0b93766 (FreeRTOS-Plus-FAT)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     command: sleep infinity
 
   freertos-host:
-    image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+    image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
@@ -153,7 +153,7 @@ services:
           - syslog-ng
 
   freertos-target:
-    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-0b93766
     volumes:
       - ..:/workspaces/SolidSyslog:cached
       - syslog-ng-ctl-freertos:/var/lib/syslog-ng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     # cpputest-freertos image carries /opt/mbedtls (and exports MBEDTLS_DIR);
     # Tests/MbedTlsIntegration/CMakeLists.txt requires that env var.
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -505,7 +505,7 @@ jobs:
   analyze-tidy-freertos-plustcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -541,7 +541,7 @@ jobs:
   analyze-iwyu-freertos-plustcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -578,7 +578,7 @@ jobs:
   analyze-tidy-freertos-lwip:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -611,7 +611,7 @@ jobs:
   analyze-iwyu-freertos-lwip:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -1043,7 +1043,7 @@ jobs:
       contents: read
       checks: write
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -1089,7 +1089,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1
@@ -1132,7 +1132,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+      image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-0b93766
       options: --user root
     env:
       GIT_CONFIG_COUNT: 1

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,47 @@
 # Dev Log
 
+## 2026-06-03 — S29.02 Re-provision FreeRTOS container images with FreeRTOS-Plus-FAT
+
+Container/infra prep for E29: brings FreeRTOS-Plus-FAT back into the
+`cpputest-freertos` images **alongside** FatFs (it was swapped out for FatFs in
+CppUTestFreertosDocker `ef27fc0`), so a later story can run a Plus-FAT-backed
+store on the Plus-TCP target while the lwIP target keeps FatFs. No solid-syslog
+source — provisioned-but-unused until S29.04 wires the `Platform/PlusFat/` pack.
+
+### Decisions
+
+- **Pin `8d38036` (main HEAD).** FreeRTOS-Plus-FAT is a FreeRTOS *Labs* project
+  (`Lab-Project-FreeRTOS-FAT`) with **no release tags / no LTS** — verified
+  `git ls-remote --tags` is empty. Its `main` HEAD is the exact SHA the images
+  carried before the swap, so known-good == latest. SHA-gated in the dockerfile
+  like every other upstream; a moved `main` fails the build loudly. Documented to
+  switch to a release tag if upstream ever publishes one. Pin-checked `ff_seteof`
+  (plus `ff_fopen` / `ff_filelength` / `ff_fflush` / `FF_Disk_t`) present in the
+  pinned tree — the ops the planned PlusFat adapter maps onto.
+- **No template backport needed — verified, not assumed.** `docs/template-updates.md`
+  lists `ci.yml` / `ci/docker-compose.bdd.yml` / `docs/` as template-owned, but
+  checked CppUTestTemplate directly: it has **zero** references to the
+  `cpputest-freertos*` images (FreeRTOS support is a solid-syslog E08+ addition,
+  absent from the base template). So the image SHA + the Plus-FAT doc additions
+  are entirely solid-syslog-local; nothing flows back to the template.
+- **Fixed an incomplete propagation list.** `docs/containers.md`'s
+  `cpputest-freertos-cross` "files to update" row omitted `ci/docker-compose.bdd.yml`
+  (which references the image twice) — a latent missed-update trap; added it.
+
+### Phases / validation
+
+- **Phase 1** (CppUTestFreertosDocker PR #5, merged → `0b93766`): added the
+  Plus-FAT clone to `dockerfile.host`. Built the host image locally and verified
+  in the running image — `FREERTOS_PLUS_FAT_PATH=/opt/freertos/plus-fat`, HEAD
+  pinned, `ff_seteof` present, owned by `developer`, all other upstreams intact.
+  The publish workflow republished both images at `sha-0b93766` (green).
+- **Phase 2** (this commit): bumped `sha-a0c1c0a → sha-0b93766` across the 14
+  propagation refs (`.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml`,
+  `ci/docker-compose.bdd.yml`, `docs/containers.md`); added Plus-FAT to the
+  containers.md image descriptions. Both new image tags confirmed live on ghcr.
+  CI proves the existing FreeRTOS lanes (host-TDD, cross, lwIP, BDD) stay green on
+  the additive image.
+
 ## 2026-06-03 — S29.01 FatFs store on the lwIP BDD target + 8 MiB FAT16 geometry
 
 First story of E29 (FreeRTOS-Plus-FAT support & coherent FS/TCP pairings). Gives

--- a/ci/docker-compose.bdd.yml
+++ b/ci/docker-compose.bdd.yml
@@ -87,7 +87,7 @@ services:
 
   behave-freertos:
     # Cross image carries qemu-system-arm + python3 + behave.
-    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-0b93766
     user: "0"
     volumes:
       - ..:/workspaces/SolidSyslog
@@ -164,7 +164,7 @@ services:
 
   behave-freertos-lwip:
     # Cross image carries qemu-system-arm + python3 + behave.
-    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-a0c1c0a
+    image: ghcr.io/davidcozens/cpputest-freertos-cross:sha-0b93766
     user: "0"
     volumes:
       - ..:/workspaces/SolidSyslog

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -6,8 +6,8 @@
 |---|---|---|
 | `ghcr.io/davidcozens/cpputest` | `sha-2c7b76b` | devcontainer (`gcc` service), most CI jobs. Now ships `include-what-you-use 0.23 (clang_19)` matching the `cpputest-clang` build, so local `iwyu` runs work in the gcc container |
 | `ghcr.io/davidcozens/cpputest-clang` | `sha-7eac3ab` | `clang` compose service, `build-linux-clang` CI job, `analyze-iwyu` CI job |
-| `ghcr.io/davidcozens/cpputest-freertos` | `sha-a0c1c0a` | `freertos-host` compose service, `build-freertos-host-tdd-plustcp` CI job — adds FreeRTOS-Kernel / Plus-TCP / lwIP / FatFs / Mbed TLS sources for host-TDD of FreeRTOS adapters against fakes; inherits IWYU from the rebased `cpputest` base, enabling the freertos-aware `analyze-iwyu` lane |
-| `ghcr.io/davidcozens/cpputest-freertos-cross` | `sha-a0c1c0a` | `freertos-target` compose service, `build-freertos-target-plustcp` CI job, `behave-freertos` BDD service, `bdd-freertos-qemu-plustcp` CI job — adds `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `gdb-multiarch` (aliased as `arm-none-eabi-gdb`), `qemu-system-arm`, `python3` + `behave`, FreeRTOS-Kernel / Plus-TCP / lwIP / FatFs sources at `/opt/freertos-kernel` / `/opt/freertos-plus-tcp` / `/opt/lwip` / `/opt/fatfs` for cross builds, on-QEMU runs, and BDD scenarios driving a QEMU target |
+| `ghcr.io/davidcozens/cpputest-freertos` | `sha-0b93766` | `freertos-host` compose service, `build-freertos-host-tdd-plustcp` CI job — adds FreeRTOS-Kernel / Plus-TCP / Plus-FAT / lwIP / FatFs / Mbed TLS sources for host-TDD of FreeRTOS adapters against fakes; inherits IWYU from the rebased `cpputest` base, enabling the freertos-aware `analyze-iwyu` lane |
+| `ghcr.io/davidcozens/cpputest-freertos-cross` | `sha-0b93766` | `freertos-target` compose service, `build-freertos-target-plustcp` CI job, `behave-freertos` BDD service, `bdd-freertos-qemu-plustcp` CI job — adds `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `gdb-multiarch` (aliased as `arm-none-eabi-gdb`), `qemu-system-arm`, `python3` + `behave`, FreeRTOS-Kernel / Plus-TCP / Plus-FAT / lwIP / FatFs sources at `/opt/freertos-kernel` / `/opt/freertos-plus-tcp` / `/opt/freertos/plus-fat` / `/opt/lwip` / `/opt/fatfs` for cross builds, on-QEMU runs, and BDD scenarios driving a QEMU target |
 | `balabit/syslog-ng` | `4.8.2` | `syslog-ng-linux` and `syslog-ng-freertos` services — BDD test oracles, one per target pair. Pinned to the 4.8 LTS line; 4.11.0 (`latest` as of 2026-02-24) regressed by aborting on `STATS` over the control socket, which crashed the oracle and cascaded to the dev-container network when `freertos-target` shares the namespace. |
 | `ghcr.io/davidcozens/behave` | `sha-3faff14` | `behave-linux` service — Debian trixie + Python 3.12 + Behave for Linux BDD scenarios. The FreeRTOS BDD runner uses the `cpputest-freertos-cross` image instead (which carries QEMU + Behave). |
 
@@ -79,7 +79,7 @@ When a new image tag is available:
 | `cpputest` | `.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml` |
 | `cpputest-clang` | `.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml` |
 | `cpputest-freertos` | `.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml`, `docs/containers.md` |
-| `cpputest-freertos-cross` | `.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml`, `docs/containers.md` |
+| `cpputest-freertos-cross` | `.devcontainer/docker-compose.yml`, `.github/workflows/ci.yml`, `ci/docker-compose.bdd.yml`, `docs/containers.md` |
 | `behave` | `.devcontainer/docker-compose.yml`, `ci/docker-compose.bdd.yml` |
 
 The `cpputest-freertos` and `cpputest-freertos-cross` images both come from


### PR DESCRIPTION
## Purpose

S29.02 phase 2 (Closes #517). Point solid-syslog at the re-provisioned FreeRTOS container images, which now carry **FreeRTOS-Plus-FAT** at `/opt/freertos/plus-fat` (env `FREERTOS_PLUS_FAT_PATH`) alongside FatFs — re-added in [CppUTestFreertosDocker #5](https://github.com/DavidCozens/CppUTestFreertosDocker/pull/5) (merge `0b93766`). This unblocks S29.04 (`Platform/PlusFat/`). The image is **provisioned-but-unused** until then — additive only, no other upstream changed.

## Change Description

- Bump `cpputest-freertos` / `cpputest-freertos-cross` from `sha-a0c1c0a → sha-0b93766` across the **14 propagation refs**: `.devcontainer/docker-compose.yml` (×2), `.github/workflows/ci.yml` (×8), `ci/docker-compose.bdd.yml` (×2), `docs/containers.md` (×2).
- `docs/containers.md`: add Plus-FAT to both image descriptions; add the previously-**missing** `ci/docker-compose.bdd.yml` to the `cpputest-freertos-cross` "files to update" row (it references the image twice — a latent missed-update trap).
- **No template backport** — verified CppUTestTemplate has zero `cpputest-freertos*` references (FreeRTOS is a solid-syslog-local E08+ addition, absent from the base template), so the bump and Plus-FAT doc edits are local-only. The `docs/template-updates.md` "template-owned" list is a simplification that doesn't hold for the FreeRTOS-specific content.
- DEVLOG entry added.

## Test Evidence

- Phase 1: built `dockerfile.host` locally and verified in the running image — `FREERTOS_PLUS_FAT_PATH=/opt/freertos/plus-fat`, HEAD pinned to `8d38036`, `ff_seteof` (+ `ff_fopen` / `ff_filelength` / `ff_fflush` / `FF_Disk_t`) present, dir owned by `developer`, all other upstreams intact.
- The CppUTestFreertosDocker publish workflow republished both images at `sha-0b93766` (green); both tags confirmed live on ghcr via `docker manifest inspect`.
- This PR's CI is the regression gate: all existing FreeRTOS lanes (host-TDD, cross build, lwIP, BDD on QEMU) must stay green on the additive image.

## Areas Affected

- CI/devcontainer image references only (`.devcontainer/`, `.github/workflows/ci.yml`, `ci/`, `docs/containers.md`). No source, no Tier-1/2 code.

> **Deferred (manual, per the epic):** branch-protection required-checks are unchanged — this story adds no new lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
