### PR TITLE
ci: make Windows vcpkg cache restore non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,15 @@ jobs:
       # on a runner-image-set env var (the linter can't see those).
       - name: Cache vcpkg installed tree
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        # The cache is a pure speed optimisation — a flaky restore must never
+        # skip the build+test. actions/cache can fail mid-restore (even after
+        # reporting a hit); without continue-on-error that failure trips the
+        # default `if: success()` on every following step, so Install / Configure
+        # / Build-and-test all skip and the job goes red without ever compiling.
+        # On a miss or partial restore the `vcpkg install` below rebuilds the
+        # tree (backed by the x-gha binary cache), so the only cost is a slower
+        # run.
+        continue-on-error: true
         with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-cpputest-openssl-v1
@@ -822,6 +831,15 @@ jobs:
       # entry. See that job's comment for rationale and key-bump policy.
       - name: Cache vcpkg installed tree
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        # The cache is a pure speed optimisation — a flaky restore must never
+        # skip the build+test. actions/cache can fail mid-restore (even after
+        # reporting a hit); without continue-on-error that failure trips the
+        # default `if: success()` on every following step, so Install / Configure
+        # / Build-and-test all skip and the job goes red without ever compiling.
+        # On a miss or partial restore the `vcpkg install` below rebuilds the
+        # tree (backed by the x-gha binary cache), so the only cost is a slower
+        # run.
+        continue-on-error: true
         with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-cpputest-openssl-v1


### PR DESCRIPTION
## Purpose

`build-windows-msvc` keeps flaking red **without ever compiling the code**. Root cause is infrastructure, not our build.

## Diagnosis

On run [26906824446](https://github.com/DavidCozens/solid-syslog/actions/runs/26906824446) the step sequence was:

| Step | Result |
|---|---|
| Cache vcpkg installed tree | **failure** (reported "Cache hit", then the restore aborted) |
| Install CppUTest and OpenSSL | skipped |
| Configure | skipped |
| **Build and test** | **skipped** |
| Test Report | failure ("No file matches `cpputest_*.xml`") |

`actions/cache` can fail mid-restore. Because `Install` / `Configure` / `Build and test` have no `if:`, they default to `if: success()` and **skip** when an earlier step fails — so a transient cache error fails the job without touching the code, and `bdd-windows-otel` (which `needs:` this job) skips in turn. A pure optimisation was sitting on the critical path.

This is not the "skip on cache hit" it looks like — there is no `cache-hit` gate anywhere; it's the cache *action* erroring and cascading through the default success-gate.

## Fix

Mark both Windows jobs' cache steps `continue-on-error: true`. A cache flake then falls through to `vcpkg install` (which rebuilds the tree, backed by the `x-gha` binary cache) and the build + tests run normally. The only cost on the rare flake is a slower run instead of a false red.

Applies to `build-windows-msvc` and `integration-windows-openssl` (they share the same cache pattern).

## Test Evidence

- YAML validates; both cache steps now carry `continue-on-error: true`.
- Behaviour on the happy path (cache hit, no error) is unchanged — `vcpkg install` is still a fast no-op.

## Areas Affected

- `.github/workflows/ci.yml` — the two Windows jobs' cache steps only. No source, no other jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
