### PR TITLE
fix: S12.29 compute Windows atomic counter wrap in uint32_t

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,31 @@
 # Dev Log
 
+## 2026-06-04 — S12.29 Windows atomic counter unsigned wrap (pure refactor)
+
+Closes the High-robustness finding [#530] from the pre-0.1.0 security audit:
+`SolidSyslogWindowsAtomicCounter.c` computed the sequence-id increment on a signed `LONG`
+(`current + 1` and a `(uint32_t)`-cast wrap guard), relying on the guard firing exactly at
+`INT32_MAX` to dodge signed overflow. Rewritten to compute and compare entirely in
+`uint32_t`, casting to `LONG` only at the `InterlockedCompareExchange` boundary — now
+matches the `Std` sibling and no longer depends on guard ordering.
+
+### Decisions
+
+- **Done as a pure refactor, not red/green (David's call).** The overflow path is provably
+  unreachable: `current + 1` is only evaluated when `(uint32_t)current ∈ [0, 0x7FFFFFFE]`,
+  so it never overflows. Old and new code are behaviourally identical for all 2³² inputs, so
+  no failing test is possible — and even UBSan can't fire on a dead path. Dressing it up as a
+  TDD red would have been dishonest.
+- **Boundary characterization test added as the safety net.** `IncrementJustBelowMaxReturnsMax`
+  (`INT32_MAX - 1 → INT32_MAX`) fills the gap next to the existing at-MAX→1 test. Passes on
+  both old and new code; it's a regression guard, not a red.
+
+### Deferred
+
+- **Couldn't exercise the Windows backend locally.** On Linux/WSL (and modern MSVC),
+  `HAVE_STDATOMIC_H` wins, so the `Std` helper compiles and the Windows helper is skipped —
+  the boundary test ran green against `Std` only. CI's Windows lane covers the rest.
+
 ## 2026-06-04 — S12.28 TLS peer-hostname verification surfaced when ServerName is NULL
 
 Closes the High-severity finding from the pre-0.1.0 security audit: both TLS adapters

--- a/Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c
+++ b/Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c
@@ -48,17 +48,17 @@ void WindowsAtomicCounter_Cleanup(struct SolidSyslogAtomicCounter* base)
 static uint32_t WindowsAtomicCounter_Increment(struct SolidSyslogAtomicCounter* base)
 {
     struct SolidSyslogWindowsAtomicCounter* self = WindowsAtomicCounter_SelfFromBase(base);
-    LONG current = InterlockedCompareExchange(&self->Value, 0, 0);
-    LONG next = 0;
+    uint32_t current = (uint32_t) InterlockedCompareExchange(&self->Value, 0, 0);
+    uint32_t next = 0U;
     do
     {
-        next = ((uint32_t) current >= SOLIDSYSLOG_SEQUENCE_ID_MAX) ? 1 : (current + 1);
-        LONG previous = InterlockedCompareExchange(&self->Value, next, current);
+        next = (current >= SOLIDSYSLOG_SEQUENCE_ID_MAX) ? 1U : (current + 1U);
+        uint32_t previous = (uint32_t) InterlockedCompareExchange(&self->Value, (LONG) next, (LONG) current);
         if (previous == current)
         {
             break;
         }
         current = previous;
     } while (1);
-    return (uint32_t) next;
+    return next;
 }

--- a/Tests/SolidSyslogAtomicCounterContractTest.cpp
+++ b/Tests/SolidSyslogAtomicCounterContractTest.cpp
@@ -76,6 +76,18 @@ TEST(AtomicCounterContract, IncrementAfterInitReturnsValuePlusOne)
     TestAtomicCounter_Destroy(counter);
 }
 
+TEST(AtomicCounterContract, IncrementJustBelowMaxReturnsMax)
+{
+    struct SolidSyslogAtomicCounter* counter = TestAtomicCounter_Create();
+
+    /* The step before the wrap must not wrap: INT32_MAX - 1 -> INT32_MAX. */
+    TestAtomicCounter_Init(counter, (uint32_t) INT32_MAX - 1U);
+
+    LONGS_EQUAL(INT32_MAX, TestAtomicCounter_Increment(counter));
+
+    TestAtomicCounter_Destroy(counter);
+}
+
 TEST(AtomicCounterContract, IncrementAtMaxWrapsToOne)
 {
     struct SolidSyslogAtomicCounter* counter = TestAtomicCounter_Create();


### PR DESCRIPTION
## Purpose

Closes #530 — pre-0.1.0 security-audit finding (High, robustness). The Windows atomic
counter computed the sequence-id increment on a signed `LONG`, avoiding signed-overflow UB
only because the wrap guard happens to fire one step early. This removes that reliance.

## Change Description

- `SolidSyslogWindowsAtomicCounter_Increment` now computes and compares entirely in
  `uint32_t`, casting to `LONG` only at the `InterlockedCompareExchange` boundary — matching
  the `Std` sibling (`SolidSyslogStdAtomicCounter.c`). The wrap comparison is purely unsigned.
- Behaviour is unchanged: never returns 0, wraps `INT32_MAX → 1` (RFC 5424 §7.3.1).
- Added boundary characterization test `IncrementJustBelowMaxReturnsMax`
  (`INT32_MAX - 1 → INT32_MAX`) alongside the existing at-MAX→1 test.

## Test Evidence

This is a **pure refactor, not red/green** (agreed with David). The overflow path is
provably unreachable — `current + 1` is only evaluated when `(uint32_t)current ∈
[0, 0x7FFFFFFE]`, so it never overflows. Old and new code are behaviourally identical for
all 2³² inputs, so no failing test is possible (and UBSan can't fire on a dead path). The
new boundary test is a regression guard, green on both old and new code.

Ran the `AtomicCounterContract` group locally on the `debug` preset (gcc container):
`OK (1402 tests, 7 ran, 8 checks, 0 ignored)`. Note: on Linux the `Std` backend compiles,
not the Windows one (`HAVE_STDATOMIC_H` wins), so the Windows path is covered by CI's
Windows lane.

## Areas Affected

- `Platform/Windows/Source/SolidSyslogWindowsAtomicCounter.c`
- `Tests/SolidSyslogAtomicCounterContractTest.cpp`
- `DEVLOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
