### PR TITLE
fix: S12.31 pin mbedTLS minimum TLS version to 1.2

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,28 @@
 # Dev Log
 
+## 2026-06-05 — S12.31 pin mbedTLS minimum TLS version to 1.2
+
+Closes the Medium finding [#532] from the pre-0.1.0 security audit: the mbedTLS adapter
+configured its `ssl_config` with `MBEDTLS_SSL_PRESET_DEFAULT` and never set a minimum
+protocol version, so on a permissive integrator build (mbedTLS 2.x, or 3.x with
+`MBEDTLS_SSL_PROTO_TLS1_0/1_1`) it could negotiate down to TLS 1.0/1.1. The OpenSSL adapter
+already pins TLS 1.2 explicitly (`SSL_CTX_set_min_proto_version`), so the two were not
+equivalent in downgrade resistance. `MbedTlsStream_ApplyTlsPolicy` now calls
+`mbedtls_ssl_conf_min_tls_version(&SslConfig, MBEDTLS_SSL_VERSION_TLS1_2)`.
+
+### Decisions
+
+- **mbedTLS 3.x API only.** The reference image is 3.6.2 and the whole adapter already uses
+  3.x idioms; the deprecated 2.x `mbedtls_ssl_conf_min_version` path was not added. If 2.x
+  parity is ever needed it's a separate, version-guarded change.
+- **Test seam: the setter is `static inline`, so it can't be link-intercepted** like the
+  other `conf_*` doubles — it writes `conf->min_tls_version` directly. Added a
+  `MbedTlsFake_ConfMinTlsVersion(conf)` reader to the fake that exposes the field the
+  production inline call set; the test reads it off the captured `ssl_config` pointer
+  (`MbedTlsFake_LastSslConfigInitArg()`). Red showed `0` (UNKNOWN), green shows `0x0303`.
+- **Docs:** noted the enforced TLS 1.2 floor in `docs/integrating-mbedtls.md` (it's a library
+  default, not integrator-configurable).
+
 ## 2026-06-05 — S12.30 enforce HMAC-SHA256 minimum key length (fail closed)
 
 Closes the Medium finding [#531] from the pre-0.1.0 security audit: both HMAC-SHA256

--- a/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
+++ b/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
@@ -166,6 +166,10 @@ static inline bool MbedTlsStream_ApplySslConfigDefaults(struct SolidSyslogMbedTl
 static inline void MbedTlsStream_ApplyTlsPolicy(struct SolidSyslogMbedTlsStream* self)
 {
     mbedtls_ssl_conf_authmode(&self->SslConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
+    /* Pin the floor at TLS 1.2 rather than inheriting MBEDTLS_SSL_PRESET_DEFAULT,
+     * which can negotiate down to TLS 1.0/1.1 on permissive integrator builds.
+     * Matches the OpenSSL adapter's explicit floor (downgrade-resistance parity). */
+    mbedtls_ssl_conf_min_tls_version(&self->SslConfig, MBEDTLS_SSL_VERSION_TLS1_2);
     mbedtls_ssl_conf_ca_chain(&self->SslConfig, self->Config.CaChain, NULL);
     mbedtls_ssl_conf_rng(&self->SslConfig, mbedtls_ctr_drbg_random, self->Config.Rng);
     if ((self->Config.ClientCertChain != NULL) && (self->Config.ClientKey != NULL))

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
@@ -673,6 +673,16 @@ TEST(SolidSyslogMbedTlsStream, OpenSetsAuthmodeRequired)
     LONGS_EQUAL(MBEDTLS_SSL_VERIFY_REQUIRED, MbedTlsFake_LastSslConfAuthmodeArg());
 }
 
+// Parity with the OpenSSL adapter's explicit TLS 1.2 floor — the mbedTLS default
+// preset can otherwise negotiate down to TLS 1.0/1.1 on permissive builds.
+TEST(SolidSyslogMbedTlsStream, OpenPinsMinimumTlsVersionToTls12)
+
+{
+    SolidSyslogStream_Open(handle, addr);
+
+    LONGS_EQUAL(MBEDTLS_SSL_VERSION_TLS1_2, MbedTlsFake_ConfMinTlsVersion(MbedTlsFake_LastSslConfigInitArg()));
+}
+
 TEST(SolidSyslogMbedTlsStream, OpenWiresCaChainFromConfigAndNullCrl)
 
 {

--- a/Tests/Support/MbedTlsFake.c
+++ b/Tests/Support/MbedTlsFake.c
@@ -483,6 +483,11 @@ int MbedTlsFake_LastSslConfAuthmodeArg(void)
     return lastSslConfAuthmodeArg;
 }
 
+int MbedTlsFake_ConfMinTlsVersion(const mbedtls_ssl_config* conf)
+{
+    return (int) conf->MBEDTLS_PRIVATE(min_tls_version);
+}
+
 int MbedTlsFake_SslConfCaChainCallCount(void)
 {
     return sslConfCaChainCallCount;

--- a/Tests/Support/MbedTlsFake.h
+++ b/Tests/Support/MbedTlsFake.h
@@ -90,6 +90,12 @@ EXTERN_C_BEGIN
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfAuthmodeConfigArg(void);
     int MbedTlsFake_LastSslConfAuthmodeArg(void);
 
+    /* mbedtls_ssl_conf_min_tls_version is a static-inline setter in <mbedtls/ssl.h>
+     * (it writes conf->min_tls_version directly), so it cannot be intercepted at
+     * link time like the other conf_* doubles. This reader exposes the field the
+     * production inline call set, so a test can assert the negotiated floor. */
+    int MbedTlsFake_ConfMinTlsVersion(const struct mbedtls_ssl_config* conf);
+
     /* mbedtls_ssl_conf_ca_chain */
     int MbedTlsFake_SslConfCaChainCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfCaChainConfigArg(void);

--- a/docs/integrating-mbedtls.md
+++ b/docs/integrating-mbedtls.md
@@ -50,6 +50,13 @@ the per-context mbedTLS handles passed through
 The full struct shape lives in
 [`Platform/MbedTls/Interface/SolidSyslogMbedTlsStream.h`](../Platform/MbedTls/Interface/SolidSyslogMbedTlsStream.h).
 
+The adapter pins the **minimum protocol version to TLS 1.2** on its own
+`ssl_config` rather than inheriting `MBEDTLS_SSL_PRESET_DEFAULT` — which, on a
+permissive mbedTLS build (2.x, or 3.x with `MBEDTLS_SSL_PROTO_TLS1_0/1_1`
+enabled), can otherwise negotiate down to TLS 1.0/1.1. This matches the OpenSSL
+reference adapter's explicit floor, so the two are equivalent in downgrade
+resistance; it is not something you configure.
+
 ---
 
 ## Scenario A: you already have Mbed TLS in your image

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -86,8 +86,8 @@ misra-c2012-11.5:Platform/LwipRaw/Source/SolidSyslogLwipRawDnsResolver.c:149
 misra-c2012-11.5:Platform/LwipRaw/Source/SolidSyslogLwipRawDnsResolver.c:211
 misra-c2012-11.5:Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStream.c:143
 misra-c2012-11.5:Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStream.c:151
-misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:294
-misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:306
+misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:298
+misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:310
 misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockDatagram.c:142
 misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:357
 misra-c2012-11.5:Platform/Windows/Source/SolidSyslogWinsockTcpStream.c:377
@@ -199,5 +199,5 @@ misra-c2012-8.9:Core/Source/SolidSyslogFileBlockDevice.c:20
 
 # D.013 — Rule 11.5: void* ↔ unsigned char* at third-party byte-buffer API boundaries
 # See docs/misra-deviations.md#d013
-misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:331
-misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:350
+misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:335
+misra-c2012-11.5:Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c:354


### PR DESCRIPTION
## Purpose

Closes #532 — Medium finding from the pre-0.1.0 security audit (downgrade resistance /
adapter parity). The mbedTLS adapter configured its `ssl_config` with
`MBEDTLS_SSL_PRESET_DEFAULT` and never called `mbedtls_ssl_conf_min_tls_version`, so the
effective floor was whatever the integrator's compiled mbedTLS allowed — on 2.x builds, or
3.x builds with `MBEDTLS_SSL_PROTO_TLS1_0/1_1` enabled, it could negotiate down to TLS
1.0/1.1. The OpenSSL adapter already pins TLS 1.2 (`SSL_CTX_set_min_proto_version`), so the
two were not equivalent in downgrade resistance.

## Change Description

- `MbedTlsStream_ApplyTlsPolicy` now pins the floor explicitly:
  `mbedtls_ssl_conf_min_tls_version(&SslConfig, MBEDTLS_SSL_VERSION_TLS1_2)`, set on the
  library's own `ssl_config` (per the coexistence contract).
- **mbedTLS 3.x API only.** The reference image is 3.6.2 and the adapter already uses 3.x
  idioms throughout; the deprecated 2.x `mbedtls_ssl_conf_min_version` path was deliberately
  not added (a separate, version-guarded change if ever needed).
- Documented the enforced TLS 1.2 floor in `docs/integrating-mbedtls.md` — it's a library
  default, not integrator-configurable.

## Test Evidence

TDD. The setter is a `static inline` in `<mbedtls/ssl.h>` that writes `conf->min_tls_version`
directly, so — unlike the other `conf_*` test doubles — it can't be intercepted at link time.
Added a `MbedTlsFake_ConfMinTlsVersion(conf)` reader to the fake that exposes the field the
production inline call sets. New test `OpenPinsMinimumTlsVersionToTls12` reads it off the
captured `ssl_config` pointer:

- **Red:** field was `0` (`MBEDTLS_SSL_VERSION_UNKNOWN`) — no floor set.
- **Green:** field is `0x0303` (`MBEDTLS_SSL_VERSION_TLS1_2`).

Regression: MbedTlsStream (55), MbedTls HMAC (24), MbedTls AesGcm (28 — all share the
modified fake), full unit suite (1406) — all green. Tree-wide clang-format clean;
`misra_suppressions.txt` line refs renumbered for the four shifted 11.5 sites below the
insertion point.

## Areas Affected

- `Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c` (the floor)
- `Tests/Support/MbedTlsFake.{c,h}` (reader), `Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp`
- `docs/integrating-mbedtls.md`, `misra_suppressions.txt`, `DEVLOG.md`

No public API change. OpenSSL adapter untouched (already correct).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced TLS 1.2 as the minimum supported protocol version for encrypted connections, preventing negotiation of older, less secure versions and strengthening overall security.

* **Documentation**
  * Updated integration guides to document the TLS 1.2 minimum version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->