### PR TITLE
feat: S14.01 SolidSyslogSdValue — escaped streaming SD value sink

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
     "dockerComposeFile": "docker-compose.yml",
     // Pick one service — comment the active line, uncomment the desired one,
     // then "Dev Containers: Rebuild Container". See docs/containers.md.
-    // "service": "gcc",                // host development — BUILD_PRESET=debug
+    "service": "gcc",                // host development — BUILD_PRESET=debug
     // "service": "clang",              // clang variant — BUILD_PRESET=clang-debug
     // "service": "freertos-host",      // FreeRTOS adapter TDD vs fakes — BUILD_PRESET=debug
-    "service": "freertos-target",    // ARM cross + QEMU + GDB — BUILD_PRESET=freertos-cross
+    // "service": "freertos-target",    // ARM cross + QEMU + GDB — BUILD_PRESET=freertos-cross
     // "service": "behave",             // BDD scenarios — no cmake (BUILD_PRESET unset)
     "workspaceFolder": "/workspaces/SolidSyslog",
     "features": {

--- a/Core/Interface/SolidSyslogSdValue.h
+++ b/Core/Interface/SolidSyslogSdValue.h
@@ -3,6 +3,8 @@
 
 #include "ExternC.h"
 
+#include <stdint.h>
+
 EXTERN_C_BEGIN
 
     /* The per-param value sink of the SD authoring API. A value producer is
@@ -16,6 +18,10 @@ EXTERN_C_BEGIN
      * May be called repeatedly; a multi-byte codepoint split across two calls
      * is reassembled. Output is bounded by the message buffer. */
     void SolidSyslogSdValue_String(struct SolidSyslogSdValue * value, const char* source);
+
+    /* Emits the decimal digits of number. Digits are never escapable, so no
+     * escaping is applied. Output is bounded by the message buffer. */
+    void SolidSyslogSdValue_Uint32(struct SolidSyslogSdValue * value, uint32_t number);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogSdValue.h
+++ b/Core/Interface/SolidSyslogSdValue.h
@@ -1,0 +1,22 @@
+#ifndef SOLIDSYSLOGSDVALUE_H
+#define SOLIDSYSLOGSDVALUE_H
+
+#include "ExternC.h"
+
+EXTERN_C_BEGIN
+
+    /* The per-param value sink of the SD authoring API. A value producer is
+     * handed only a SolidSyslogSdValue* — it can stream escaped, UTF-8-safe
+     * content into the message buffer but cannot reach the raw formatter,
+     * open a param, or break SD framing. Stack-transient, no pool (D.002). */
+    struct SolidSyslogSdValue;
+
+    /* Streams source (a NUL-terminated UTF-8 chunk) into the value, escaping
+     * each of '"', '\\', ']' and substituting ill-formed UTF-8 with U+FFFD.
+     * May be called repeatedly; a multi-byte codepoint split across two calls
+     * is reassembled. Output is bounded by the message buffer. */
+    void SolidSyslogSdValue_String(struct SolidSyslogSdValue * value, const char* source);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSDVALUE_H */

--- a/Core/Interface/SolidSyslogSdValue.h
+++ b/Core/Interface/SolidSyslogSdValue.h
@@ -3,6 +3,7 @@
 
 #include "ExternC.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 EXTERN_C_BEGIN
@@ -18,6 +19,17 @@ EXTERN_C_BEGIN
      * May be called repeatedly; a multi-byte codepoint split across two calls
      * is reassembled. Output is bounded by the message buffer. */
     void SolidSyslogSdValue_String(struct SolidSyslogSdValue * value, const char* source);
+
+    /* As _String, but caps the decoded length of the emitted value at
+     * maxDecodedLength bytes — for SD params whose value a receiver parses into
+     * a width-limited field. The decoded length counts what the reader's
+     * un-escaping decoder would extract (an escape pair counts as one byte,
+     * a substituted U+FFFD as three), not the on-wire byte count. */
+    void SolidSyslogSdValue_BoundedString(
+        struct SolidSyslogSdValue * value,
+        const char* source,
+        size_t maxDecodedLength
+    );
 
     /* Emits the decimal digits of number. Digits are never escapable, so no
      * escaping is applied. Output is bounded by the message buffer. */

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
     SolidSyslogStream.c
     SolidSyslogNullStream.c
     SolidSyslogStructuredData.c
+    SolidSyslogSdValue.c
     SolidSyslogTimeQualitySd.c
     SolidSyslogTimeQualitySdStatic.c
     SolidSyslogOriginSd.c

--- a/Core/Source/SolidSyslogSdValue.c
+++ b/Core/Source/SolidSyslogSdValue.c
@@ -13,3 +13,8 @@ void SolidSyslogSdValue_String(struct SolidSyslogSdValue* value, const char* sou
 {
     SolidSyslogFormatter_EscapedString(value->Formatter, source, SIZE_MAX);
 }
+
+void SolidSyslogSdValue_Uint32(struct SolidSyslogSdValue* value, uint32_t number)
+{
+    SolidSyslogFormatter_Uint32(value->Formatter, number);
+}

--- a/Core/Source/SolidSyslogSdValue.c
+++ b/Core/Source/SolidSyslogSdValue.c
@@ -12,6 +12,7 @@ static inline size_t SdValue_ExpectedLength(char lead);
 static inline void SdValue_EmitUnit(struct SolidSyslogSdValue* value, const char* bytes, size_t count);
 static inline void SdValue_Hold(struct SolidSyslogSdValue* value, const char* bytes, size_t count);
 static inline void SdValue_FlushPendingAsReplacement(struct SolidSyslogSdValue* value);
+static inline void SdValue_FlushPendingIfHeld(struct SolidSyslogSdValue* value);
 
 void SolidSyslogSdValue_FromFormatter(struct SolidSyslogSdValue* value, struct SolidSyslogFormatter* formatter)
 {
@@ -137,22 +138,33 @@ static inline void SdValue_Hold(struct SolidSyslogSdValue* value, const char* by
  * without SdValue duplicating the replacement character. */
 static inline void SdValue_FlushPendingAsReplacement(struct SolidSyslogSdValue* value)
 {
-    static const char LONE_CONTINUATION[] = {(char) 0x80, '\0'};
+    static const char LONE_CONTINUATION[] = {'\x80', '\0'};
     SolidSyslogFormatter_EscapedString(value->Formatter, LONE_CONTINUATION, SIZE_MAX);
     value->PendingCount = 0;
 }
 
 void SolidSyslogSdValue_BoundedString(struct SolidSyslogSdValue* value, const char* source, size_t maxDecodedLength)
 {
+    SdValue_FlushPendingIfHeld(value);
     SolidSyslogFormatter_EscapedString(value->Formatter, source, maxDecodedLength);
 }
 
 void SolidSyslogSdValue_Uint32(struct SolidSyslogSdValue* value, uint32_t number)
 {
+    SdValue_FlushPendingIfHeld(value);
     SolidSyslogFormatter_Uint32(value->Formatter, number);
 }
 
 void SolidSyslogSdValue_Close(struct SolidSyslogSdValue* value)
+{
+    SdValue_FlushPendingIfHeld(value);
+}
+
+/* A held incomplete UTF-8 tail is the dangling state of a prior _String call.
+ * Any non-_String write (or close) terminates it with one U+FFFD before its own
+ * output, so the tail is never reordered after, or merged into, that output.
+ * Only consecutive _String calls continue a tail (streaming continuation). */
+static inline void SdValue_FlushPendingIfHeld(struct SolidSyslogSdValue* value)
 {
     if (value->PendingCount > 0U)
     {

--- a/Core/Source/SolidSyslogSdValue.c
+++ b/Core/Source/SolidSyslogSdValue.c
@@ -1,0 +1,15 @@
+#include "SolidSyslogSdValuePrivate.h"
+
+#include <stdint.h>
+
+#include "SolidSyslogFormatter.h"
+
+void SolidSyslogSdValue_FromFormatter(struct SolidSyslogSdValue* value, struct SolidSyslogFormatter* formatter)
+{
+    value->Formatter = formatter;
+}
+
+void SolidSyslogSdValue_String(struct SolidSyslogSdValue* value, const char* source)
+{
+    SolidSyslogFormatter_EscapedString(value->Formatter, source, SIZE_MAX);
+}

--- a/Core/Source/SolidSyslogSdValue.c
+++ b/Core/Source/SolidSyslogSdValue.c
@@ -1,17 +1,145 @@
 #include "SolidSyslogSdValuePrivate.h"
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogUtf8.h"
+
+static size_t SdValue_DrainPending(struct SolidSyslogSdValue* value, const char* source);
+static void SdValue_WriteBody(struct SolidSyslogSdValue* value, const char* source);
+static inline size_t SdValue_ExpectedLength(char lead);
+static inline void SdValue_EmitUnit(struct SolidSyslogSdValue* value, const char* bytes, size_t count);
+static inline void SdValue_Hold(struct SolidSyslogSdValue* value, const char* bytes, size_t count);
+static inline void SdValue_FlushPendingAsReplacement(struct SolidSyslogSdValue* value);
 
 void SolidSyslogSdValue_FromFormatter(struct SolidSyslogSdValue* value, struct SolidSyslogFormatter* formatter)
 {
     value->Formatter = formatter;
+    value->PendingCount = 0;
 }
 
 void SolidSyslogSdValue_String(struct SolidSyslogSdValue* value, const char* source)
 {
-    SolidSyslogFormatter_EscapedString(value->Formatter, source, SIZE_MAX);
+    size_t bodyStart = SdValue_DrainPending(value, source);
+    SdValue_WriteBody(value, &source[bodyStart]);
+}
+
+/* Completes a held trailing sequence from the leading continuation bytes of
+ * source, returning the number of source bytes consumed doing so. A completed
+ * codepoint is emitted; a sequence interrupted by a non-continuation byte is
+ * replaced with one U+FFFD; a sequence still incomplete at end-of-source stays
+ * held for the next call. */
+static size_t SdValue_DrainPending(struct SolidSyslogSdValue* value, const char* source)
+{
+    size_t consumed = 0;
+    if (value->PendingCount > 0U)
+    {
+        size_t expected = SdValue_ExpectedLength(value->Pending[0]);
+        while ((value->PendingCount < expected) && SolidSyslogUtf8_IsContinuationByte(source[consumed]))
+        {
+            value->Pending[value->PendingCount] = source[consumed];
+            value->PendingCount++;
+            consumed++;
+        }
+        if (value->PendingCount == expected)
+        {
+            SdValue_EmitUnit(value, value->Pending, value->PendingCount);
+            value->PendingCount = 0;
+        }
+        else if (source[consumed] != '\0')
+        {
+            SdValue_FlushPendingAsReplacement(value);
+        }
+        else
+        {
+            /* source exhausted mid-sequence — keep the tail for the next call */
+        }
+    }
+    return consumed;
+}
+
+/* Walks source one UTF-8 unit at a time, emitting each complete unit through
+ * the formatter's escaper. A unit whose continuation bytes run out at
+ * end-of-source is held for the next call rather than emitted. */
+static void SdValue_WriteBody(struct SolidSyslogSdValue* value, const char* source)
+{
+    size_t i = 0;
+    while (source[i] != '\0')
+    {
+        size_t expected = SdValue_ExpectedLength(source[i]);
+        size_t avail = 1;
+        while ((avail < expected) && SolidSyslogUtf8_IsContinuationByte(source[i + avail]))
+        {
+            avail++;
+        }
+        if ((avail < expected) && (source[i + avail] == '\0'))
+        {
+            SdValue_Hold(value, &source[i], avail);
+        }
+        else
+        {
+            SdValue_EmitUnit(value, &source[i], avail);
+        }
+        i += avail;
+    }
+}
+
+/* The number of bytes a UTF-8 sequence starting with lead occupies, by its
+ * top-bit structure alone. ASCII, escapable, orphan-continuation and invalid
+ * leads are single-byte units; validity is left to the formatter's escaper. */
+static inline size_t SdValue_ExpectedLength(char lead)
+{
+    size_t length = 1;
+    if (SolidSyslogUtf8_IsTwoByteLead(lead))
+    {
+        length = 2;
+    }
+    else if (SolidSyslogUtf8_IsThreeByteLead(lead))
+    {
+        length = 3;
+    }
+    else if (SolidSyslogUtf8_IsFourByteLead(lead))
+    {
+        length = 4;
+    }
+    else
+    {
+        /* single-byte unit */
+    }
+    return length;
+}
+
+/* Emits one UTF-8 unit through the formatter's escaper — the single source of
+ * truth for escaping ('"', '\\', ']') and per-byte ill-formed substitution. */
+static inline void SdValue_EmitUnit(struct SolidSyslogSdValue* value, const char* bytes, size_t count)
+{
+    char unit[SDVALUE_MAX_CODEPOINT_BYTES + 1U];
+    for (size_t i = 0; i < count; i++)
+    {
+        unit[i] = bytes[i];
+    }
+    unit[count] = '\0';
+    SolidSyslogFormatter_EscapedString(value->Formatter, unit, SIZE_MAX);
+}
+
+static inline void SdValue_Hold(struct SolidSyslogSdValue* value, const char* bytes, size_t count)
+{
+    for (size_t i = 0; i < count; i++)
+    {
+        value->Pending[i] = bytes[i];
+    }
+    value->PendingCount = count;
+}
+
+/* Re-uses the formatter's own ill-formed-byte substitution: a lone
+ * continuation byte decodes to exactly one U+FFFD, so the held tail is replaced
+ * without SdValue duplicating the replacement character. */
+static inline void SdValue_FlushPendingAsReplacement(struct SolidSyslogSdValue* value)
+{
+    static const char LONE_CONTINUATION[] = {(char) 0x80, '\0'};
+    SolidSyslogFormatter_EscapedString(value->Formatter, LONE_CONTINUATION, SIZE_MAX);
+    value->PendingCount = 0;
 }
 
 void SolidSyslogSdValue_BoundedString(struct SolidSyslogSdValue* value, const char* source, size_t maxDecodedLength)
@@ -22,4 +150,12 @@ void SolidSyslogSdValue_BoundedString(struct SolidSyslogSdValue* value, const ch
 void SolidSyslogSdValue_Uint32(struct SolidSyslogSdValue* value, uint32_t number)
 {
     SolidSyslogFormatter_Uint32(value->Formatter, number);
+}
+
+void SolidSyslogSdValue_Close(struct SolidSyslogSdValue* value)
+{
+    if (value->PendingCount > 0U)
+    {
+        SdValue_FlushPendingAsReplacement(value);
+    }
 }

--- a/Core/Source/SolidSyslogSdValue.c
+++ b/Core/Source/SolidSyslogSdValue.c
@@ -14,6 +14,11 @@ void SolidSyslogSdValue_String(struct SolidSyslogSdValue* value, const char* sou
     SolidSyslogFormatter_EscapedString(value->Formatter, source, SIZE_MAX);
 }
 
+void SolidSyslogSdValue_BoundedString(struct SolidSyslogSdValue* value, const char* source, size_t maxDecodedLength)
+{
+    SolidSyslogFormatter_EscapedString(value->Formatter, source, maxDecodedLength);
+}
+
 void SolidSyslogSdValue_Uint32(struct SolidSyslogSdValue* value, uint32_t number)
 {
     SolidSyslogFormatter_Uint32(value->Formatter, number);

--- a/Core/Source/SolidSyslogSdValuePrivate.h
+++ b/Core/Source/SolidSyslogSdValuePrivate.h
@@ -1,0 +1,26 @@
+#ifndef SOLIDSYSLOGSDVALUEPRIVATE_H
+#define SOLIDSYSLOGSDVALUEPRIVATE_H
+
+#include "ExternC.h"
+
+#include "SolidSyslogSdValue.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogFormatter;
+
+    /* Definition lives here (not the public header) so a producer handed a
+     * SolidSyslogSdValue* cannot reach the wrapped formatter. SolidSyslogSdElement
+     * (S14.02) embeds one of these and initialises it via _FromFormatter. */
+    struct SolidSyslogSdValue
+    {
+        struct SolidSyslogFormatter* Formatter;
+    };
+
+    /* Internal constructor — wraps a message-buffer formatter so values stream
+     * straight into it. Stack-transient: the caller owns the storage. */
+    void SolidSyslogSdValue_FromFormatter(struct SolidSyslogSdValue * value, struct SolidSyslogFormatter * formatter);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSDVALUEPRIVATE_H */

--- a/Core/Source/SolidSyslogSdValuePrivate.h
+++ b/Core/Source/SolidSyslogSdValuePrivate.h
@@ -9,17 +9,33 @@ EXTERN_C_BEGIN
 
     struct SolidSyslogFormatter;
 
+    enum
+    {
+        SDVALUE_MAX_CODEPOINT_BYTES = 4
+    };
+
     /* Definition lives here (not the public header) so a producer handed a
      * SolidSyslogSdValue* cannot reach the wrapped formatter. SolidSyslogSdElement
-     * (S14.02) embeds one of these and initialises it via _FromFormatter. */
+     * (S14.02) embeds one of these and initialises it via _FromFormatter.
+     *
+     * Pending holds an incomplete trailing UTF-8 sequence (Option B streaming
+     * state): when a _String chunk ends mid-codepoint the leading bytes wait
+     * here for the next chunk's continuation bytes to complete them. */
     struct SolidSyslogSdValue
     {
         struct SolidSyslogFormatter* Formatter;
+        char Pending[SDVALUE_MAX_CODEPOINT_BYTES];
+        size_t PendingCount;
     };
 
     /* Internal constructor — wraps a message-buffer formatter so values stream
      * straight into it. Stack-transient: the caller owns the storage. */
     void SolidSyslogSdValue_FromFormatter(struct SolidSyslogSdValue * value, struct SolidSyslogFormatter * formatter);
+
+    /* Closes the value: a still-incomplete trailing UTF-8 sequence held in
+     * Pending is flushed as a single U+FFFD. SolidSyslogSdElement (S14.02)
+     * calls this when the param's value ends. */
+    void SolidSyslogSdValue_Close(struct SolidSyslogSdValue * value);
 
 EXTERN_C_END
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,40 @@
 # Dev Log
 
+## 2026-06-05 — S14.01 SolidSyslogSdValue: escaped streaming value sink
+
+First foundation story of E14's safe SD-authoring API. Built `SolidSyslogSdValue` standalone
+(opaque, stack-transient, no pool — deviation D.002), the per-param value sink that makes SD
+param-value escaping un-bypassable. Public header + impl + private header + test, all TDD.
+
+**Value menu:** `_String` (unbounded, buffer-bounded only), `_BoundedString` (decoded-length
+capped), `_Uint32`. Internal `_FromFormatter` constructor (reused by SdElement in S14.02) and
+`_Close`.
+
+### Decisions
+- **Reuse, don't duplicate.** Escaping (`"` `\` `]`) and per-byte maximal-subpart UTF-8 stay the
+  sole responsibility of `SolidSyslogFormatter_EscapedString` — SdValue carries no second decoder.
+  It only adds streaming-continuation bookkeeping using the byte-structure classifiers in
+  `SolidSyslogUtf8.h` (the same ones `Formatter_TrimTruncatedMultiByteTail` uses), never validation.
+- **`maxDecodedLength` is load-bearing, kept.** It bounds the decoded value width for receivers
+  parsing into fixed fields — *not* dropped. Surfaced as the two-method split (David's call):
+  `_String` unbounded + `_BoundedString(maxDecodedLength)`. This corrected an earlier wrong turn
+  where I'd proposed evolving `EscapedString` to drop the decoded cap.
+- **No Formatter change.** Streaming (Option B) is implemented entirely inside SdValue by walking
+  each chunk as UTF-8 units, emitting each complete unit through `EscapedString`, and holding a
+  trailing incomplete unit (≤4 bytes) in the `SdValue` to complete from the next call's leading
+  continuation bytes. A still-incomplete tail at `_Close` → one U+FFFD (emitted by feeding a lone
+  continuation byte through `EscapedString`, so no replacement constant is duplicated). This
+  dissolved the Tier-1 Formatter-refactor question we'd started down.
+
+### Deferred
+- CLAUDE.md public-header table entry for `SolidSyslogSdValue.h` — API is provisional until S14.03
+  confirms it against a real consumer, and S14.08 revises that table wholesale. Land it then.
+
+### Open questions
+- Cross-primitive flush: a held `_String` tail is currently flushed only by the next `_String` or
+  `_Close`, not by an intervening `_Uint32` / `_BoundedString`. Not exercised by any S14.01 AC;
+  revisit if SdElement's usage in S14.02 needs it.
+
 ## 2026-06-05 — S12.33 review and align error-event severity across Core + Platform
 
 S12.27 exposed that the severity ladder had drifted: the library emitted only ERROR / WARNING /

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -30,10 +30,12 @@ capped), `_Uint32`. Internal `_FromFormatter` constructor (reused by SdElement i
 - CLAUDE.md public-header table entry for `SolidSyslogSdValue.h` — API is provisional until S14.03
   confirms it against a real consumer, and S14.08 revises that table wholesale. Land it then.
 
-### Open questions
-- Cross-primitive flush: a held `_String` tail is currently flushed only by the next `_String` or
-  `_Close`, not by an intervening `_Uint32` / `_BoundedString`. Not exercised by any S14.01 AC;
-  revisit if SdElement's usage in S14.02 needs it.
+### Resolved in review
+- Cross-primitive flush (CodeRabbit, PR #550): a held `_String` tail was flushed only by the next
+  `_String` / `_Close`, so an intervening `_Uint32` / `_BoundedString` reordered its output before
+  the U+FFFD. Fixed: every non-`_String` write (and `_Close`) flushes a held tail to one U+FFFD
+  first via a shared `SdValue_FlushPendingIfHeld` guard. Continuation stays a `_String`-only
+  feature (flush, not continue) — uniform and matches the epic's "split across `_String` calls".
 
 ## 2026-06-05 — S12.33 review and align error-event severity across Core + Platform
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(TEST_SOURCES
     SolidSyslogNullStreamTest.cpp
     SolidSyslogNullMutexTest.cpp
     SolidSyslogNullSdTest.cpp
+    SolidSyslogSdValueTest.cpp
     SolidSyslogNullSenderTest.cpp
     SolidSyslogNullStoreTest.cpp
     SolidSyslogNullSecurityPolicyTest.cpp

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -36,3 +36,47 @@ TEST(SolidSyslogSdValue, StringPassesPlainAsciiThrough)
 
     CHECK_VALUE("hello");
 }
+
+TEST(SolidSyslogSdValue, StringEscapesDoubleQuote)
+{
+    writeString("a\"b");
+
+    CHECK_VALUE("a\\\"b");
+}
+
+TEST(SolidSyslogSdValue, StringEscapesBackslash)
+{
+    writeString("a\\b");
+
+    CHECK_VALUE("a\\\\b");
+}
+
+TEST(SolidSyslogSdValue, StringEscapesCloseBracket)
+{
+    writeString("a]b");
+
+    CHECK_VALUE("a\\]b");
+}
+
+TEST(SolidSyslogSdValue, StringEscapesAllThreeSpecialsInOneValue)
+{
+    writeString("\"\\]");
+
+    CHECK_VALUE("\\\"\\\\\\]");
+}
+
+TEST(SolidSyslogSdValue, StringPassesValidUtf8CodepointThrough)
+{
+    /* U+00A9 COPYRIGHT SIGN, a valid two-byte sequence — passes byte-for-byte. */
+    writeString("\xC2\xA9");
+
+    CHECK_VALUE("\xC2\xA9");
+}
+
+TEST(SolidSyslogSdValue, StringSubstitutesIllFormedByteWithReplacementCharacter)
+{
+    /* A lone continuation byte is ill-formed UTF-8 — substituted with U+FFFD. */
+    writeString("\x80");
+
+    CHECK_VALUE("\xEF\xBF\xBD");
+}

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -18,7 +18,7 @@ TEST_GROUP(SolidSyslogSdValue)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
     struct SolidSyslogFormatter* formatter = nullptr;
-    struct SolidSyslogSdValue value;
+    struct SolidSyslogSdValue value{};
 
     void setup() override
     {
@@ -57,7 +57,7 @@ TEST(SolidSyslogSdValue, StringCannotOverflowTheFormatterBuffer)
      * never overflows. A four-byte formatter holds three chars + terminator. */
     SolidSyslogFormatterStorage tinyStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
     struct SolidSyslogFormatter* tiny = SolidSyslogFormatter_Create(tinyStorage, 4);
-    struct SolidSyslogSdValue tinyValue;
+    struct SolidSyslogSdValue tinyValue{};
     SolidSyslogSdValue_FromFormatter(&tinyValue, tiny);
 
     SolidSyslogSdValue_String(&tinyValue, "hello");
@@ -191,6 +191,25 @@ TEST(SolidSyslogSdValue, CloseWithNoHeldTailWritesNothing)
     closeValue();
 
     CHECK_VALUE("hi");
+}
+
+TEST(SolidSyslogSdValue, Uint32FlushesHeldTailBeforeDigits)
+{
+    /* A held incomplete _String tail must resolve to U+FFFD before the digits,
+     * not be silently reordered after them (or dropped). */
+    writeString("\xC2");
+    writeUint32(5);
+
+    CHECK_VALUE("\xEF\xBF\xBD"
+                "5");
+}
+
+TEST(SolidSyslogSdValue, BoundedStringFlushesHeldTailBeforeValue)
+{
+    writeString("\xC2");
+    writeBoundedString("hi", 8);
+
+    CHECK_VALUE("\xEF\xBF\xBDhi");
 }
 
 TEST(SolidSyslogSdValue, BoundedStringPassesValueShorterThanCapThrough)

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -32,6 +32,7 @@ TEST_GROUP(SolidSyslogSdValue)
         SolidSyslogSdValue_BoundedString(&value, source, maxDecodedLength);
     }
     void writeUint32(uint32_t number) { SolidSyslogSdValue_Uint32(&value, number); }
+    void closeValue() { SolidSyslogSdValue_Close(&value); }
 };
 
 // clang-format on
@@ -124,6 +125,72 @@ TEST(SolidSyslogSdValue, ReassemblesTwoByteCodepointSplitAcrossStringCalls)
     writeString("\xA9");
 
     CHECK_VALUE("\xC2\xA9");
+}
+
+TEST(SolidSyslogSdValue, ReassemblesFourByteCodepointSplitAcrossStringCalls)
+{
+    /* U+1F600 GRINNING FACE (F0 9F 98 80) split lead+1 / +2 continuations. */
+    writeString("\xF0\x9F");
+    writeString("\x98\x80");
+
+    CHECK_VALUE("\xF0\x9F\x98\x80");
+}
+
+TEST(SolidSyslogSdValue, ReassemblesFourByteCodepointSplitOneByteAtATime)
+{
+    /* The same codepoint dribbled a byte at a time keeps the partial sequence
+     * held across calls that add no completing byte. */
+    writeString("\xF0");
+    writeString("\x9F");
+    writeString("\x98");
+    writeString("\x80");
+
+    CHECK_VALUE("\xF0\x9F\x98\x80");
+}
+
+TEST(SolidSyslogSdValue, EmitsCompletePrefixAndHoldsTrailingIncompleteSequence)
+{
+    /* Plain text then a dangling lead byte in one chunk: the prefix is emitted
+     * immediately, the lead byte waits for the next chunk to complete it. */
+    writeString("hi\xC2");
+    writeString("\xA9");
+
+    CHECK_VALUE("hi\xC2\xA9");
+}
+
+TEST(SolidSyslogSdValue, SubstitutesInChunkLeadByteInterruptedByAscii)
+{
+    /* A lead byte followed immediately by ASCII within one chunk is ill-formed
+     * and substituted per-byte; the ASCII passes through. */
+    writeString("\xC2Z");
+
+    CHECK_VALUE("\xEF\xBF\xBDZ");
+}
+
+TEST(SolidSyslogSdValue, SubstitutesHeldSequenceInterruptedByNextChunk)
+{
+    /* A held lead byte that the next chunk fails to continue is replaced with a
+     * single U+FFFD, then the interrupting byte is processed normally. */
+    writeString("\xE0");
+    writeString("Z");
+
+    CHECK_VALUE("\xEF\xBF\xBDZ");
+}
+
+TEST(SolidSyslogSdValue, CloseSubstitutesStillIncompleteTailWithReplacementCharacter)
+{
+    writeString("\xC2");
+    closeValue();
+
+    CHECK_VALUE("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogSdValue, CloseWithNoHeldTailWritesNothing)
+{
+    writeString("hi");
+    closeValue();
+
+    CHECK_VALUE("hi");
 }
 
 TEST(SolidSyslogSdValue, BoundedStringPassesValueShorterThanCapThrough)

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -1,0 +1,38 @@
+#include <cstring>
+
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogSdValue.h"
+#include "SolidSyslogSdValuePrivate.h"
+
+enum
+{
+    TEST_BUFFER_SIZE = 64
+};
+
+#define CHECK_VALUE(expected) STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter))
+
+// clang-format off
+TEST_GROUP(SolidSyslogSdValue)
+{
+    SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
+    struct SolidSyslogFormatter* formatter = nullptr;
+    struct SolidSyslogSdValue value;
+
+    void setup() override
+    {
+        formatter = SolidSyslogFormatter_Create(storage, TEST_BUFFER_SIZE);
+        SolidSyslogSdValue_FromFormatter(&value, formatter);
+    }
+
+    void writeString(const char* source) { SolidSyslogSdValue_String(&value, source); }
+};
+
+// clang-format on
+
+TEST(SolidSyslogSdValue, StringPassesPlainAsciiThrough)
+{
+    writeString("hello");
+
+    CHECK_VALUE("hello");
+}

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <stdint.h>
 
 #include "CppUTest/TestHarness.h"
 #include "SolidSyslogFormatter.h"
@@ -26,6 +27,7 @@ TEST_GROUP(SolidSyslogSdValue)
     }
 
     void writeString(const char* source) { SolidSyslogSdValue_String(&value, source); }
+    void writeUint32(uint32_t number) { SolidSyslogSdValue_Uint32(&value, number); }
 };
 
 // clang-format on
@@ -79,4 +81,11 @@ TEST(SolidSyslogSdValue, StringSubstitutesIllFormedByteWithReplacementCharacter)
     writeString("\x80");
 
     CHECK_VALUE("\xEF\xBF\xBD");
+}
+
+TEST(SolidSyslogSdValue, Uint32EmitsDecimalDigits)
+{
+    writeUint32(42);
+
+    CHECK_VALUE("42");
 }

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -36,11 +36,32 @@ TEST_GROUP(SolidSyslogSdValue)
 
 // clang-format on
 
+TEST(SolidSyslogSdValue, StringWithEmptySourceWritesNothing)
+{
+    writeString("");
+
+    CHECK_VALUE("");
+}
+
 TEST(SolidSyslogSdValue, StringPassesPlainAsciiThrough)
 {
     writeString("hello");
 
     CHECK_VALUE("hello");
+}
+
+TEST(SolidSyslogSdValue, StringCannotOverflowTheFormatterBuffer)
+{
+    /* A value longer than the message buffer is truncated at the buffer edge,
+     * never overflows. A four-byte formatter holds three chars + terminator. */
+    SolidSyslogFormatterStorage tinyStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(4)];
+    struct SolidSyslogFormatter* tiny = SolidSyslogFormatter_Create(tinyStorage, 4);
+    struct SolidSyslogSdValue tinyValue;
+    SolidSyslogSdValue_FromFormatter(&tinyValue, tiny);
+
+    SolidSyslogSdValue_String(&tinyValue, "hello");
+
+    STRCMP_EQUAL("hel", SolidSyslogFormatter_AsFormattedBuffer(tiny));
 }
 
 TEST(SolidSyslogSdValue, StringEscapesDoubleQuote)

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -27,6 +27,10 @@ TEST_GROUP(SolidSyslogSdValue)
     }
 
     void writeString(const char* source) { SolidSyslogSdValue_String(&value, source); }
+    void writeBoundedString(const char* source, size_t maxDecodedLength)
+    {
+        SolidSyslogSdValue_BoundedString(&value, source, maxDecodedLength);
+    }
     void writeUint32(uint32_t number) { SolidSyslogSdValue_Uint32(&value, number); }
 };
 
@@ -88,4 +92,28 @@ TEST(SolidSyslogSdValue, Uint32EmitsDecimalDigits)
     writeUint32(42);
 
     CHECK_VALUE("42");
+}
+
+TEST(SolidSyslogSdValue, BoundedStringPassesValueShorterThanCapThrough)
+{
+    writeBoundedString("hi", 8);
+
+    CHECK_VALUE("hi");
+}
+
+TEST(SolidSyslogSdValue, BoundedStringTruncatesAtMaxDecodedLength)
+{
+    writeBoundedString("hello", 3);
+
+    CHECK_VALUE("hel");
+}
+
+TEST(SolidSyslogSdValue, BoundedStringCapCountsEscapePairAsOneDecodedByte)
+{
+    /* The cap bounds the decoded length a receiver un-escapes, not the on-wire
+     * bytes: 'a' (1) + '"' -> \" (1 decoded) reaches the cap of 2, so 'b' is
+     * dropped even though four bytes were written. */
+    writeBoundedString("a\"b", 2);
+
+    CHECK_VALUE("a\\\"");
 }

--- a/Tests/SolidSyslogSdValueTest.cpp
+++ b/Tests/SolidSyslogSdValueTest.cpp
@@ -115,6 +115,17 @@ TEST(SolidSyslogSdValue, Uint32EmitsDecimalDigits)
     CHECK_VALUE("42");
 }
 
+TEST(SolidSyslogSdValue, ReassemblesTwoByteCodepointSplitAcrossStringCalls)
+{
+    /* U+00A9 COPYRIGHT SIGN streamed as its lead byte then its continuation
+     * byte across two _String calls — the value must reassemble the codepoint,
+     * not emit a U+FFFD per orphaned half. */
+    writeString("\xC2");
+    writeString("\xA9");
+
+    CHECK_VALUE("\xC2\xA9");
+}
+
 TEST(SolidSyslogSdValue, BoundedStringPassesValueShorterThanCapThrough)
 {
     writeBoundedString("hi", 8);


### PR DESCRIPTION
Closes #541. First foundation story of E14's safe SD-authoring API.

`SolidSyslogSdValue` is the per-param value sink that makes SD param-value escaping **un-bypassable** — a value producer handed a `SolidSyslogSdValue*` can stream escaped, UTF-8-safe content but cannot reach the raw formatter or break SD framing. Built and tested **standalone** (no consuming SD refactored yet — that starts at S14.03); the API shape is provisional until S14.03 confirms it against a real consumer.

Opaque, stack-transient, no pool (deviation D.002) — like `SolidSyslogFormatter`.

## API
- `SolidSyslogSdValue_String(value, source)` — escaped, UTF-8-safe, unbounded (buffer-bounded only)
- `SolidSyslogSdValue_BoundedString(value, source, maxDecodedLength)` — as `_String`, capped at `maxDecodedLength` **decoded** bytes (for receivers parsing into a width-limited field)
- `SolidSyslogSdValue_Uint32(value, number)` — decimal digits
- internal `_FromFormatter` (reused by `SolidSyslogSdElement` in S14.02) and `_Close`

## Behaviour
- **Escaping**: `"` `\` `]` → `\` + char; all other bytes pass through.
- **UTF-8**: valid 1–4 byte sequences pass byte-for-byte; ill-formed bytes → U+FFFD (per-byte maximal-subpart). Reuses `SolidSyslogFormatter_EscapedString` — **single source of truth, no second decoder**.
- **Streaming continuation (Option B)**: a multi-byte codepoint split across `_String` calls reassembles — each chunk is walked as UTF-8 units, complete units emit immediately, a trailing incomplete unit (≤4 bytes) is held in the `SdValue` and completed from the next call's leading continuation bytes. A still-incomplete tail at `_Close` → a single U+FFFD.
- **Bounded**: output cannot overflow the formatter regardless of input size; excess truncates at the buffer edge.

## Design notes
- **`maxDecodedLength` kept** (not dropped): it bounds the decoded value width a receiver un-escapes into a fixed field — load-bearing, surfaced as the unbounded/bounded method split.
- **`SolidSyslogFormatter` is untouched.** Streaming lives entirely in `SdValue`, using only the byte-structure classifiers in `SolidSyslogUtf8.h` (the same ones `Formatter_TrimTruncatedMultiByteTail` uses) — never validation.

## Verification
- TDD throughout (red → green → commit); 24 `SolidSyslogSdValue` tests
- Full suite green (1444 tests)
- `SolidSyslogSdValue.c` 100% line-covered (68/68 lines, 11/11 functions)
- `clang-format` clean

## Out of scope (later E14 stories)
`SolidSyslogSdElement` framing + name validation (S14.02); SD refactors (S14.03–05); SD vtable flip + formatter privatisation (S14.06/08); CLAUDE.md public-header table entry (deferred to S14.08's wholesale table revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming capabilities for escaped UTF-8 strings and numeric values in syslog structured-data fields, with proper handling of special characters and UTF-8 sequences.

* **Tests**
  * Added comprehensive test suite covering string escaping, UTF-8 handling, and numeric value formatting.

* **Chores**
  * Updated development container configuration to use GCC as the default service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->