### PR TITLE
feat: S14.02 SolidSyslogSdElement — SD framing + name validation

### DIFF
--- a/Core/Interface/SolidSyslogSdElement.h
+++ b/Core/Interface/SolidSyslogSdElement.h
@@ -1,0 +1,21 @@
+#ifndef SOLIDSYSLOGSDELEMENT_H
+#define SOLIDSYSLOGSDELEMENT_H
+
+#include "ExternC.h"
+
+#include <stdint.h>
+
+EXTERN_C_BEGIN
+
+    /* The element writer handed to an SD's Format. Owns SD framing and the
+     * SD-NAME / PARAM-NAME charset so an author cannot desync the framing.
+     * Stack-transient, no pool (D.002). */
+    struct SolidSyslogSdElement;
+
+    /* Opens an SD-ELEMENT: emits "[name" for an IANA name (enterpriseNumber 0)
+     * or "[name@enterpriseNumber" otherwise. */
+    void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement * element, const char* name, uint32_t enterpriseNumber);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSDELEMENT_H */

--- a/Core/Interface/SolidSyslogSdElement.h
+++ b/Core/Interface/SolidSyslogSdElement.h
@@ -11,10 +11,16 @@ EXTERN_C_BEGIN
      * SD-NAME / PARAM-NAME charset so an author cannot desync the framing.
      * Stack-transient, no pool (D.002). */
     struct SolidSyslogSdElement;
+    struct SolidSyslogSdValue;
 
     /* Opens an SD-ELEMENT: emits "[name" for an IANA name (enterpriseNumber 0)
      * or "[name@enterpriseNumber" otherwise. */
     void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement * element, const char* name, uint32_t enterpriseNumber);
+
+    /* Opens an SD-PARAM: emits ' name="' and returns the value sink the caller
+     * streams the param value into. The returned pointer is owned by the
+     * element and stays valid until the next _Param or _End. */
+    struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElement * element, const char* name);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogSdElement.h
+++ b/Core/Interface/SolidSyslogSdElement.h
@@ -22,6 +22,9 @@ EXTERN_C_BEGIN
      * element and stays valid until the next _Param or _End. */
     struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElement * element, const char* name);
 
+    /* Closes the SD-ELEMENT: closes any open param value's quote and emits ']'. */
+    void SolidSyslogSdElement_End(struct SolidSyslogSdElement * element);
+
 EXTERN_C_END
 
 #endif /* SOLIDSYSLOGSDELEMENT_H */

--- a/Core/Source/CMakeLists.txt
+++ b/Core/Source/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     SolidSyslogNullStream.c
     SolidSyslogStructuredData.c
     SolidSyslogSdValue.c
+    SolidSyslogSdElement.c
     SolidSyslogTimeQualitySd.c
     SolidSyslogTimeQualitySdStatic.c
     SolidSyslogOriginSd.c

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -10,6 +10,7 @@ enum
 void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement* element, struct SolidSyslogFormatter* formatter)
 {
     element->Formatter = formatter;
+    element->ValueOpen = false;
 }
 
 void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char* name, uint32_t enterpriseNumber)
@@ -30,12 +31,17 @@ struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElemen
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, '=');
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
     SolidSyslogSdValue_FromFormatter(&element->Value, element->Formatter);
+    element->ValueOpen = true;
     return &element->Value;
 }
 
 void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
 {
-    SolidSyslogSdValue_Close(&element->Value);
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
+    if (element->ValueOpen)
+    {
+        SolidSyslogSdValue_Close(&element->Value);
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
+        element->ValueOpen = false;
+    }
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, ']');
 }

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -1,0 +1,20 @@
+#include "SolidSyslogSdElementPrivate.h"
+
+#include "SolidSyslogFormatter.h"
+
+enum
+{
+    SDELEMENT_NAME_MAX = 32
+};
+
+void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement* element, struct SolidSyslogFormatter* formatter)
+{
+    element->Formatter = formatter;
+}
+
+void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char* name, uint32_t enterpriseNumber)
+{
+    (void) enterpriseNumber;
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '[');
+    SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
+}

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -14,7 +14,11 @@ void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement* element, st
 
 void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char* name, uint32_t enterpriseNumber)
 {
-    (void) enterpriseNumber;
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, '[');
     SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
+    if (enterpriseNumber != 0U)
+    {
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '@');
+        SolidSyslogFormatter_Uint32(element->Formatter, enterpriseNumber);
+    }
 }

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -1,5 +1,7 @@
 #include "SolidSyslogSdElementPrivate.h"
 
+#include <stddef.h>
+
 #include "SolidSyslogFormatter.h"
 
 enum
@@ -8,33 +10,60 @@ enum
 };
 
 static inline void SdElement_CloseOpenValue(struct SolidSyslogSdElement* element);
+static inline struct SolidSyslogSdValue* SdElement_SkipParam(struct SolidSyslogSdElement* element);
 
 void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement* element, struct SolidSyslogFormatter* formatter)
 {
     element->Formatter = formatter;
+    element->DropFormatter = SolidSyslogFormatter_Create(element->DropStorage, 0);
     element->ValueOpen = false;
+    element->Suppressed = false;
 }
 
 void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char* name, uint32_t enterpriseNumber)
 {
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '[');
-    SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
-    if (enterpriseNumber != 0U)
+    element->ValueOpen = false;
+    element->Suppressed = (name == NULL);
+    if (!element->Suppressed)
     {
-        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '@');
-        SolidSyslogFormatter_Uint32(element->Formatter, enterpriseNumber);
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '[');
+        SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
+        if (enterpriseNumber != 0U)
+        {
+            SolidSyslogFormatter_AsciiCharacter(element->Formatter, '@');
+            SolidSyslogFormatter_Uint32(element->Formatter, enterpriseNumber);
+        }
     }
 }
 
 struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElement* element, const char* name)
 {
+    struct SolidSyslogSdValue* sink = NULL;
     SdElement_CloseOpenValue(element);
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, ' ');
-    SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '=');
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
-    SolidSyslogSdValue_FromFormatter(&element->Value, element->Formatter);
-    element->ValueOpen = true;
+    if (element->Suppressed || (name == NULL))
+    {
+        sink = SdElement_SkipParam(element);
+    }
+    else
+    {
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, ' ');
+        SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '=');
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
+        SolidSyslogSdValue_FromFormatter(&element->Value, element->Formatter);
+        element->ValueOpen = true;
+        sink = &element->Value;
+    }
+    return sink;
+}
+
+/* A skipped param (NULL name, or a suppressed element) opens no framing and
+ * hands back a sink over the drop formatter, so the caller's value writes are
+ * absorbed without disturbing the element. ValueOpen stays false — there is no
+ * quote for the next _Param / _End to close. */
+static inline struct SolidSyslogSdValue* SdElement_SkipParam(struct SolidSyslogSdElement* element)
+{
+    SolidSyslogSdValue_FromFormatter(&element->Value, element->DropFormatter);
     return &element->Value;
 }
 
@@ -54,5 +83,8 @@ static inline void SdElement_CloseOpenValue(struct SolidSyslogSdElement* element
 void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
 {
     SdElement_CloseOpenValue(element);
-    SolidSyslogFormatter_AsciiCharacter(element->Formatter, ']');
+    if (!element->Suppressed)
+    {
+        SolidSyslogFormatter_AsciiCharacter(element->Formatter, ']');
+    }
 }

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -32,3 +32,10 @@ struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElemen
     SolidSyslogSdValue_FromFormatter(&element->Value, element->Formatter);
     return &element->Value;
 }
+
+void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
+{
+    SolidSyslogSdValue_Close(&element->Value);
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, ']');
+}

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -22,3 +22,13 @@ void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char
         SolidSyslogFormatter_Uint32(element->Formatter, enterpriseNumber);
     }
 }
+
+struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElement* element, const char* name)
+{
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, ' ');
+    SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '=');
+    SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
+    SolidSyslogSdValue_FromFormatter(&element->Value, element->Formatter);
+    return &element->Value;
+}

--- a/Core/Source/SolidSyslogSdElement.c
+++ b/Core/Source/SolidSyslogSdElement.c
@@ -7,6 +7,8 @@ enum
     SDELEMENT_NAME_MAX = 32
 };
 
+static inline void SdElement_CloseOpenValue(struct SolidSyslogSdElement* element);
+
 void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement* element, struct SolidSyslogFormatter* formatter)
 {
     element->Formatter = formatter;
@@ -26,6 +28,7 @@ void SolidSyslogSdElement_Begin(struct SolidSyslogSdElement* element, const char
 
 struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElement* element, const char* name)
 {
+    SdElement_CloseOpenValue(element);
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, ' ');
     SolidSyslogFormatter_PrintUsAsciiString(element->Formatter, name, SDELEMENT_NAME_MAX);
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, '=');
@@ -35,7 +38,10 @@ struct SolidSyslogSdValue* SolidSyslogSdElement_Param(struct SolidSyslogSdElemen
     return &element->Value;
 }
 
-void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
+/* Closes an open param value: flushes any held UTF-8 tail (one U+FFFD) and
+ * emits the closing quote. Idempotent when no value is open, so both _Param
+ * (before the next param) and _End can call it unconditionally. */
+static inline void SdElement_CloseOpenValue(struct SolidSyslogSdElement* element)
 {
     if (element->ValueOpen)
     {
@@ -43,5 +49,10 @@ void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
         SolidSyslogFormatter_AsciiCharacter(element->Formatter, '"');
         element->ValueOpen = false;
     }
+}
+
+void SolidSyslogSdElement_End(struct SolidSyslogSdElement* element)
+{
+    SdElement_CloseOpenValue(element);
     SolidSyslogFormatter_AsciiCharacter(element->Formatter, ']');
 }

--- a/Core/Source/SolidSyslogSdElementPrivate.h
+++ b/Core/Source/SolidSyslogSdElementPrivate.h
@@ -3,6 +3,8 @@
 
 #include "ExternC.h"
 
+#include <stdbool.h>
+
 #include "SolidSyslogSdElement.h"
 #include "SolidSyslogSdValuePrivate.h"
 
@@ -18,6 +20,7 @@ EXTERN_C_BEGIN
     {
         struct SolidSyslogFormatter* Formatter;
         struct SolidSyslogSdValue Value;
+        bool ValueOpen;
     };
 
     /* Internal constructor — wraps a message-buffer formatter. MessageFormatter

--- a/Core/Source/SolidSyslogSdElementPrivate.h
+++ b/Core/Source/SolidSyslogSdElementPrivate.h
@@ -5,22 +5,29 @@
 
 #include <stdbool.h>
 
+#include "SolidSyslogFormatter.h"
 #include "SolidSyslogSdElement.h"
 #include "SolidSyslogSdValuePrivate.h"
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogFormatter;
-
     /* Definition lives here (not the public header) so an SD author handed a
      * SolidSyslogSdElement* cannot reach the wrapped formatter. The embedded
      * Value is the sink _Param hands back — one per element, re-initialised on
-     * each _Param (only one param value is open at a time). */
+     * each _Param (only one param value is open at a time).
+     *
+     * DropStorage backs a zero-size formatter that safely absorbs the value of
+     * a skipped param (NULL param name, or a NULL-SD-ID-suppressed element):
+     * every write to it is dropped, so a skipped value cannot corrupt framing.
+     * Suppressed marks an element opened with a NULL SD-ID — it emits nothing. */
     struct SolidSyslogSdElement
     {
         struct SolidSyslogFormatter* Formatter;
         struct SolidSyslogSdValue Value;
+        SolidSyslogFormatterStorage DropStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
+        struct SolidSyslogFormatter* DropFormatter;
         bool ValueOpen;
+        bool Suppressed;
     };
 
     /* Internal constructor — wraps a message-buffer formatter. MessageFormatter

--- a/Core/Source/SolidSyslogSdElementPrivate.h
+++ b/Core/Source/SolidSyslogSdElementPrivate.h
@@ -1,0 +1,26 @@
+#ifndef SOLIDSYSLOGSDELEMENTPRIVATE_H
+#define SOLIDSYSLOGSDELEMENTPRIVATE_H
+
+#include "ExternC.h"
+
+#include "SolidSyslogSdElement.h"
+
+EXTERN_C_BEGIN
+
+    struct SolidSyslogFormatter;
+
+    /* Definition lives here (not the public header) so an SD author handed a
+     * SolidSyslogSdElement* cannot reach the wrapped formatter. */
+    struct SolidSyslogSdElement
+    {
+        struct SolidSyslogFormatter* Formatter;
+    };
+
+    /* Internal constructor — wraps a message-buffer formatter. MessageFormatter
+     * (S14.06) builds one of these around the handed formatter and passes it to
+     * each SD's Format. Stack-transient: the caller owns the storage. */
+    void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement * element, struct SolidSyslogFormatter * formatter);
+
+EXTERN_C_END
+
+#endif /* SOLIDSYSLOGSDELEMENTPRIVATE_H */

--- a/Core/Source/SolidSyslogSdElementPrivate.h
+++ b/Core/Source/SolidSyslogSdElementPrivate.h
@@ -24,7 +24,7 @@ EXTERN_C_BEGIN
     {
         struct SolidSyslogFormatter* Formatter;
         struct SolidSyslogSdValue Value;
-        SolidSyslogFormatterStorage DropStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0)];
+        SolidSyslogFormatterStorage DropStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(0U)];
         struct SolidSyslogFormatter* DropFormatter;
         bool ValueOpen;
         bool Suppressed;
@@ -33,7 +33,10 @@ EXTERN_C_BEGIN
     /* Internal constructor — wraps a message-buffer formatter. MessageFormatter
      * (S14.06) builds one of these around the handed formatter and passes it to
      * each SD's Format. Stack-transient: the caller owns the storage. */
-    void SolidSyslogSdElement_FromFormatter(struct SolidSyslogSdElement * element, struct SolidSyslogFormatter * formatter);
+    void SolidSyslogSdElement_FromFormatter(
+        struct SolidSyslogSdElement * element,
+        struct SolidSyslogFormatter * formatter
+    );
 
 EXTERN_C_END
 

--- a/Core/Source/SolidSyslogSdElementPrivate.h
+++ b/Core/Source/SolidSyslogSdElementPrivate.h
@@ -4,16 +4,20 @@
 #include "ExternC.h"
 
 #include "SolidSyslogSdElement.h"
+#include "SolidSyslogSdValuePrivate.h"
 
 EXTERN_C_BEGIN
 
     struct SolidSyslogFormatter;
 
     /* Definition lives here (not the public header) so an SD author handed a
-     * SolidSyslogSdElement* cannot reach the wrapped formatter. */
+     * SolidSyslogSdElement* cannot reach the wrapped formatter. The embedded
+     * Value is the sink _Param hands back — one per element, re-initialised on
+     * each _Param (only one param value is open at a time). */
     struct SolidSyslogSdElement
     {
         struct SolidSyslogFormatter* Formatter;
+        struct SolidSyslogSdValue Value;
     };
 
     /* Internal constructor — wraps a message-buffer formatter. MessageFormatter

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,39 @@
 # Dev Log
 
+## 2026-06-06 — S14.02 SolidSyslogSdElement: SD framing + name validation
+
+Second E14 foundation story. `SolidSyslogSdElement` is the element writer handed to an SD's
+`Format` — it owns the SD grammar and the SD-NAME/PARAM-NAME charset so an author can't
+desync the framing. Built standalone (no SD migrated onto it yet — that's S14.03). Opaque,
+stack-transient, no pool (D.002). Drives the value through the S14.01 `SolidSyslogSdValue`.
+
+**API:** `_Begin(name, enterpriseNumber)` → `[name` (IANA, enterpriseNumber 0) or
+`[name@number`; `_Param(name)` → emits ` name="`, returns the embedded `SdValue*`; `_End` →
+closes any open value quote and emits `]`. Internal `_FromFormatter` (reused by
+MessageFormatter at S14.06).
+
+### Decisions
+- **"Invalid name" = NULL pointer only, for this story** (David's narrowing). RFC charset/
+  length validation is a *caller-supplied-name* concern enforced at `Create` time in the
+  S14.09 wave; in S14.02 every name is a compile-time-valid library constant, and the
+  formatter's PrintUsAscii substitution covers stray non-printables. So the only format-time
+  reaction is **NULL → skip**: a NULL SD-ID suppresses the whole element (zero bytes); a NULL
+  PARAM-NAME skips just that param, element stands.
+- **Skipped-param safe sink.** `_Param` must always return a usable `SdValue*`. For a skipped
+  param it points the embedded value at a per-element **zero-size drop formatter** (writes
+  always drop, buffer never read) — so the caller's value writes are absorbed without
+  corrupting framing. Clean reuse of the formatter's existing capacity guard.
+- **One open value at a time.** `_Param`/`_End` close the previous open value's quote (flush
+  the `SdValue` tail via `_Close`, emit `"`) before their own output — shared
+  `SdElement_CloseOpenValue`, idempotent when nothing is open.
+
+### Verification
+- TDD throughout; 13 `SolidSyslogSdElement` tests; full suite 1457 green.
+- `SolidSyslogSdElement.c` 100% line-covered (43/43, 6/6 fns). `tidy` + `clang-format` clean.
+- MISRA: bare `0` to `FORMATTER_STORAGE_SIZE` mixes signed/unsigned (10.4) — fixed to `0U`
+  (the local cppcheck check caught a real one this time; the 5.7 anon-enum flag is the same
+  false positive as S14.01, CI confirms).
+
 ## 2026-06-05 — S14.01 SolidSyslogSdValue: escaped streaming value sink
 
 First foundation story of E14's safe SD-authoring API. Built `SolidSyslogSdValue` standalone

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_SOURCES
     SolidSyslogNullMutexTest.cpp
     SolidSyslogNullSdTest.cpp
     SolidSyslogSdValueTest.cpp
+    SolidSyslogSdElementTest.cpp
     SolidSyslogNullSenderTest.cpp
     SolidSyslogNullStoreTest.cpp
     SolidSyslogNullSecurityPolicyTest.cpp

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -1,0 +1,37 @@
+#include <cstring>
+#include <stdint.h>
+
+#include "CppUTest/TestHarness.h"
+#include "SolidSyslogFormatter.h"
+#include "SolidSyslogSdElement.h"
+#include "SolidSyslogSdElementPrivate.h"
+
+enum
+{
+    TEST_BUFFER_SIZE = 128
+};
+
+#define CHECK_FRAMED(expected) STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter))
+
+// clang-format off
+TEST_GROUP(SolidSyslogSdElement)
+{
+    SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(TEST_BUFFER_SIZE)];
+    struct SolidSyslogFormatter* formatter = nullptr;
+    struct SolidSyslogSdElement element{};
+
+    void setup() override
+    {
+        formatter = SolidSyslogFormatter_Create(storage, TEST_BUFFER_SIZE);
+        SolidSyslogSdElement_FromFormatter(&element, formatter);
+    }
+};
+
+// clang-format on
+
+TEST(SolidSyslogSdElement, BeginEmitsOpenBracketAndIanaName)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+
+    CHECK_FRAMED("[meta");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -70,3 +70,11 @@ TEST(SolidSyslogSdElement, EndClosesValueQuoteAndElement)
 
     CHECK_FRAMED("[meta tzKnown=\"1\"]");
 }
+
+TEST(SolidSyslogSdElement, EndWithNoParamClosesElementOnly)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[meta]");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -12,7 +12,14 @@ enum
     TEST_BUFFER_SIZE = 128
 };
 
-#define CHECK_FRAMED(expected) STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter))
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+#define CHECK_FRAMED(expected)                                                     \
+    do                                                                             \
+    {                                                                              \
+        STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter)); \
+    } while (0)
+
+// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 // clang-format off
 TEST_GROUP(SolidSyslogSdElement)

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -35,3 +35,10 @@ TEST(SolidSyslogSdElement, BeginEmitsOpenBracketAndIanaName)
 
     CHECK_FRAMED("[meta");
 }
+
+TEST(SolidSyslogSdElement, BeginEmitsNameWithEnterpriseNumber)
+{
+    SolidSyslogSdElement_Begin(&element, "ex", 32473);
+
+    CHECK_FRAMED("[ex@32473");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -88,3 +88,34 @@ TEST(SolidSyslogSdElement, SecondParamClosesThePreviousValueQuote)
 
     CHECK_FRAMED("[timeQuality tzKnown=\"1\" isSynced=\"0\"]");
 }
+
+TEST(SolidSyslogSdElement, BeginWithNullNameSuppressesTheWholeElement)
+{
+    /* A NULL SD-ID can never form a well-formed element, so the whole element
+     * is skipped — params and close emit nothing, writes are absorbed safely. */
+    SolidSyslogSdElement_Begin(&element, nullptr, 0);
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "p"), "v");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("");
+}
+
+TEST(SolidSyslogSdElement, ParamWithNullNameIsSkippedButElementStands)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, nullptr), "v");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[meta]");
+}
+
+TEST(SolidSyslogSdElement, SkippedParamDoesNotDisturbSurroundingParams)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "a"), "1");
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, nullptr), "x");
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "b"), "2");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[meta a=\"1\" b=\"2\"]");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -78,3 +78,13 @@ TEST(SolidSyslogSdElement, EndWithNoParamClosesElementOnly)
 
     CHECK_FRAMED("[meta]");
 }
+
+TEST(SolidSyslogSdElement, SecondParamClosesThePreviousValueQuote)
+{
+    SolidSyslogSdElement_Begin(&element, "timeQuality", 0);
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "tzKnown"), "1");
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "isSynced"), "0");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[timeQuality tzKnown=\"1\" isSynced=\"0\"]");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -60,3 +60,13 @@ TEST(SolidSyslogSdElement, ParamReturnsValueSinkStreamingIntoTheElement)
 
     CHECK_FRAMED("[meta tzKnown=\"1");
 }
+
+TEST(SolidSyslogSdElement, EndClosesValueQuoteAndElement)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    struct SolidSyslogSdValue* value = SolidSyslogSdElement_Param(&element, "tzKnown");
+    SolidSyslogSdValue_String(value, "1");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[meta tzKnown=\"1\"]");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -119,3 +119,14 @@ TEST(SolidSyslogSdElement, SkippedParamDoesNotDisturbSurroundingParams)
 
     CHECK_FRAMED("[meta a=\"1\" b=\"2\"]");
 }
+
+TEST(SolidSyslogSdElement, ParamValueIsEscapedThroughTheValueSink)
+{
+    /* The element owns no escaping path of its own — the value's '"' is escaped
+     * by the reused SolidSyslogSdValue, so framing stays intact. */
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    SolidSyslogSdValue_String(SolidSyslogSdElement_Param(&element, "p"), "a\"b");
+    SolidSyslogSdElement_End(&element);
+
+    CHECK_FRAMED("[meta p=\"a\\\"b\"]");
+}

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -5,6 +5,7 @@
 #include "SolidSyslogFormatter.h"
 #include "SolidSyslogSdElement.h"
 #include "SolidSyslogSdElementPrivate.h"
+#include "SolidSyslogSdValue.h"
 
 enum
 {
@@ -41,4 +42,21 @@ TEST(SolidSyslogSdElement, BeginEmitsNameWithEnterpriseNumber)
     SolidSyslogSdElement_Begin(&element, "ex", 32473);
 
     CHECK_FRAMED("[ex@32473");
+}
+
+TEST(SolidSyslogSdElement, ParamOpensSpaceNameEqualsQuote)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    SolidSyslogSdElement_Param(&element, "tzKnown");
+
+    CHECK_FRAMED("[meta tzKnown=\"");
+}
+
+TEST(SolidSyslogSdElement, ParamReturnsValueSinkStreamingIntoTheElement)
+{
+    SolidSyslogSdElement_Begin(&element, "meta", 0);
+    struct SolidSyslogSdValue* value = SolidSyslogSdElement_Param(&element, "tzKnown");
+    SolidSyslogSdValue_String(value, "1");
+
+    CHECK_FRAMED("[meta tzKnown=\"1");
 }


### PR DESCRIPTION
Closes #542. Second foundation story of E14's safe SD-authoring API, building on S14.01's `SolidSyslogSdValue`.

`SolidSyslogSdElement` is the **element writer** handed to the SD vtable's `Format` — it owns the SD grammar and the SD-NAME / PARAM-NAME charset so an author can never desync the framing. Built and tested **standalone**; no SD is refactored onto it yet (that starts at S14.03). Opaque, stack-transient, no pool (deviation D.002).

## API
- `SolidSyslogSdElement_Begin(element, name, enterpriseNumber)` — emits `[name` for an IANA name (`enterpriseNumber == 0`) or `[name@enterpriseNumber`
- `SolidSyslogSdElement_Param(element, name)` — emits ` name="`, opens the value, returns the embedded `SolidSyslogSdValue*` to stream into
- `SolidSyslogSdElement_End(element)` — closes any open param value's quote and emits `]`
- internal `_FromFormatter` (reused by MessageFormatter at S14.06)

## Behaviour
- `_Begin` → `[meta` (IANA) and `[name@32473` (enterprise).
- `_Param` returns the value sink; a following `_Param` or `_End` closes the previous value's `"` — a sequence of params produces correct framing/spacing (`[timeQuality tzKnown="1" isSynced="0"]`).
- `_End` with no open param still closes the element (`[meta]`).
- Param values are escaped by the **reused `SolidSyslogSdValue`** — no second escaping path in the element.

## Name validation (decision settled this story)
Per the epic, RFC 5424 §6.3.3/§6.3.4 charset/length validation is a **caller-supplied-name** concern enforced at `Create` time (S14.09 wave) — in S14.02 every name is a compile-time-valid library constant, and the formatter's PrintUsAscii substitution covers stray non-printables. So the only format-time reaction is **NULL → skip**:
- **NULL SD-ID** → the whole element is suppressed (emits zero bytes).
- **NULL PARAM-NAME** → that param is skipped; the element stands.

A skipped param still returns a usable `SolidSyslogSdValue*` — pointed at a per-element **zero-size drop formatter** that safely absorbs the caller's value writes without disturbing framing.

## Verification
- TDD throughout (red → green → commit); 13 `SolidSyslogSdElement` tests
- Full suite green (1457 tests)
- `SolidSyslogSdElement.c` 100% line-covered (43/43 lines, 6/6 functions)
- `tidy` and `clang-format` clean locally; MISRA 10.4 (`FORMATTER_STORAGE_SIZE(0)` → `0U`) fixed

## Out of scope (later E14 stories)
SD migrations onto the writer (S14.03 TimeQualitySd, S14.04 MetaSd, S14.05 OriginSd); SD vtable flip `Format(base, element)` (S14.06); caller-supplied-name Create-time validation (S14.09); CLAUDE.md public-header table entry (deferred with `SolidSyslogSdValue` to S14.08's wholesale table revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced syslog message formatting with support for structured data elements, enabling proper parameter encoding with named values, optional enterprise number identification, and RFC5424-compliant quote escaping for parameter content.

* **Tests**
  * Added comprehensive test suite verifying structured data element formatting, parameter handling, and correct output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->