### PR TITLE
refactor: S14.03 migrate TimeQualitySd onto the SD writer

### DIFF
--- a/Core/Source/SolidSyslogTimeQualitySd.c
+++ b/Core/Source/SolidSyslogTimeQualitySd.c
@@ -1,12 +1,12 @@
 #include "SolidSyslogTimeQualitySd.h"
 
 #include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
 
 #include "SolidSyslogError.h"
-#include "SolidSyslogFormatter.h"
 #include "SolidSyslogNullSd.h"
+#include "SolidSyslogSdElementPrivate.h"
+#include "SolidSyslogSdValue.h"
 #include "SolidSyslogStructuredDataDefinition.h"
 #include "SolidSyslogTimeQualitySdErrors.h"
 #include "SolidSyslogTimeQualitySdPrivate.h"
@@ -18,13 +18,6 @@ struct SolidSyslogFormatter;
 static void TimeQualitySd_Format(struct SolidSyslogStructuredData* base, struct SolidSyslogFormatter* formatter);
 
 static inline struct SolidSyslogTimeQualitySd* TimeQualitySd_SelfFromBase(struct SolidSyslogStructuredData* base);
-static inline void TimeQualitySd_FormatBoolParam(
-    struct SolidSyslogFormatter* formatter,
-    const char* name,
-    size_t nameLength,
-    bool value
-);
-static inline void TimeQualitySd_FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value);
 
 void TimeQualitySd_Initialise(struct SolidSyslogStructuredData* base, SolidSyslogTimeQualityFunction getTimeQuality)
 {
@@ -43,47 +36,24 @@ void TimeQualitySd_Cleanup(struct SolidSyslogStructuredData* base)
 
 static void TimeQualitySd_Format(struct SolidSyslogStructuredData* base, struct SolidSyslogFormatter* formatter)
 {
-    static const char sdPrefix[] = "[timeQuality";
-    static const char paramTzKnown[] = " tzKnown";
-    static const char paramIsSynced[] = " isSynced";
     struct SolidSyslogTimeQualitySd* self = TimeQualitySd_SelfFromBase(base);
     struct SolidSyslogTimeQuality q = {0};
+    struct SolidSyslogSdElement element;
 
     self->GetTimeQuality(&q);
 
-    SolidSyslogFormatter_BoundedString(formatter, sdPrefix, sizeof(sdPrefix) - 1U);
-    TimeQualitySd_FormatBoolParam(formatter, paramTzKnown, sizeof(paramTzKnown) - 1U, q.TzKnown);
-    TimeQualitySd_FormatBoolParam(formatter, paramIsSynced, sizeof(paramIsSynced) - 1U, q.IsSynced);
-    TimeQualitySd_FormatSyncAccuracy(formatter, q.SyncAccuracyMicroseconds);
-    SolidSyslogFormatter_AsciiCharacter(formatter, ']');
+    SolidSyslogSdElement_FromFormatter(&element, formatter);
+    SolidSyslogSdElement_Begin(&element, "timeQuality", 0U);
+    SolidSyslogSdValue_Uint32(SolidSyslogSdElement_Param(&element, "tzKnown"), q.TzKnown ? 1U : 0U);
+    SolidSyslogSdValue_Uint32(SolidSyslogSdElement_Param(&element, "isSynced"), q.IsSynced ? 1U : 0U);
+    if (q.SyncAccuracyMicroseconds != SOLIDSYSLOG_SYNC_ACCURACY_OMIT)
+    {
+        SolidSyslogSdValue_Uint32(SolidSyslogSdElement_Param(&element, "syncAccuracy"), q.SyncAccuracyMicroseconds);
+    }
+    SolidSyslogSdElement_End(&element);
 }
 
 static inline struct SolidSyslogTimeQualitySd* TimeQualitySd_SelfFromBase(struct SolidSyslogStructuredData* base)
 {
     return (struct SolidSyslogTimeQualitySd*) base;
-}
-
-static inline void TimeQualitySd_FormatBoolParam(
-    struct SolidSyslogFormatter* formatter,
-    const char* name,
-    size_t nameLength,
-    bool value
-)
-{
-    SolidSyslogFormatter_BoundedString(formatter, name, nameLength);
-    SolidSyslogFormatter_AsciiCharacter(formatter, '=');
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
-    SolidSyslogFormatter_AsciiCharacter(formatter, value ? '1' : '0');
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
-}
-
-static inline void TimeQualitySd_FormatSyncAccuracy(struct SolidSyslogFormatter* formatter, uint32_t value)
-{
-    if (value != SOLIDSYSLOG_SYNC_ACCURACY_OMIT)
-    {
-        static const char paramSyncAccuracy[] = " syncAccuracy=\"";
-        SolidSyslogFormatter_BoundedString(formatter, paramSyncAccuracy, sizeof(paramSyncAccuracy) - 1U);
-        SolidSyslogFormatter_Uint32(formatter, value);
-        SolidSyslogFormatter_AsciiCharacter(formatter, '"');
-    }
 }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,30 @@
 # Dev Log
 
+## 2026-06-06 — S14.03 migrate TimeQualitySd onto the SD writer (walking skeleton)
+
+First real consumer of the E14 SD writer. `TimeQualitySd_Format` now emits via
+`SolidSyslogSdElement` (`_Begin`/`_Param`/`_End`) + `SolidSyslogSdValue` instead of raw
+`SolidSyslogFormatter_*` — proving the writer builds a complete SD element end-to-end through
+the real pipeline. Chosen first because it is struct-fill with **no string callback**, so it
+carries no callback-signature change — the cleanest first cut.
+
+### Decisions
+- **No new value primitive needed.** `tzKnown`/`isSynced` (bool → `'1'`/`'0'`) map onto
+  `SolidSyslogSdValue_Uint32(value ? 1U : 0U)`; `syncAccuracy` onto `_Uint32`. The S14.01 menu
+  already covers TimeQualitySd, so the "additive primitive" the story allowed for wasn't required.
+- **Vtable unchanged** (the flip is S14.06). The SD still receives a `SolidSyslogFormatter*` and
+  wraps it itself via `SolidSyslogSdElement_FromFormatter` — so `TimeQualitySd.c` includes the
+  Core/Source-private `SolidSyslogSdElementPrivate.h` to stack-construct the element.
+- Output **byte-for-byte identical** — existing TimeQualitySd tests stand unchanged (the safety
+  net for this refactor); `TimeQualitySd_Format` now calls **zero** raw `SolidSyslogFormatter_*`.
+
+### Verification
+- Full suite 1457 green; `TimeQualitySd.c` 100% line-covered (22/22, 4/4 fns — leaner, two
+  format helpers dropped). `tidy` + `clang-format` clean.
+- MISRA: the file shrank, so the existing `11.3` downcast suppression for `SelfFromBase` moved
+  63→58 in `misra_suppressions.txt` (a line-move only, applied manually — the renumber tool's
+  other entries are the known leave-for-CI platform/anon-enum ambiguities).
+
 ## 2026-06-06 — S14.02 SolidSyslogSdElement: SD framing + name validation
 
 Second E14 foundation story. `SolidSyslogSdElement` is the element writer handed to an SD's

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -33,7 +33,7 @@ misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:73
 misra-c2012-11.3:Core/Source/SolidSyslogPassthroughBuffer.c:53
 misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:166
 misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:63
-misra-c2012-11.3:Core/Source/SolidSyslogTimeQualitySd.c:63
+misra-c2012-11.3:Core/Source/SolidSyslogTimeQualitySd.c:58
 misra-c2012-11.3:Core/Source/SolidSyslogUdpSender.c:120
 misra-c2012-11.3:Platform/Atomics/Source/SolidSyslogStdAtomicCounter.c:29
 misra-c2012-11.3:Platform/FatFs/Source/SolidSyslogFatFsFile.c:59


### PR DESCRIPTION
Closes #543. Walking-skeleton story of E14 — the first real consumer of the SD writer (`SolidSyslogSdElement` + `SolidSyslogSdValue` from S14.01/S14.02), proving it builds a complete SD element end-to-end through the real message pipeline.

TimeQualitySd is migrated first because it is struct-fill with **no string callback**, so it carries no callback-signature change — the cleanest possible first cut.

## What changes
`TimeQualitySd_Format` now emits via `SolidSyslogSdElement_Begin` / `_Param` / value primitives / `_End` instead of calling raw `SolidSyslogFormatter_*` directly. The two private format helpers (`FormatBoolParam`, `FormatSyncAccuracy`) are dropped.

## Acceptance criteria
- **Output byte-for-byte identical to today** — the existing TimeQualitySd tests stand unchanged (assertions untouched); they are the safety net for this refactor.
- `TimeQualitySd_Format` no longer calls any raw `SolidSyslogFormatter_*` primitive — it emits exclusively through the SD writer.
- `syncAccuracy = OMIT` handling preserved (conditional `_Param`).
- `tzKnown` / `isSynced` map onto `SolidSyslogSdValue_Uint32(value ? 1U : 0U)`; `syncAccuracy` onto `_Uint32`. **No new value primitive needed** — the S14.01 menu already covers TimeQualitySd.
- **Vtable signature unchanged** — the SD still receives a `SolidSyslogFormatter*` and wraps it via `SolidSyslogSdElement_FromFormatter` (so this TU includes the Core/Source-private `SolidSyslogSdElementPrivate.h`).

## Verification
- Full suite green (1457 tests); `SolidSyslogTimeQualitySd.c` 100% line-covered (22/22 lines, 4/4 functions — 30 lines leaner)
- `tidy` and `clang-format` clean; the file shrank, so the existing MISRA `11.3` downcast suppression for `SelfFromBase` moved 63→58 in `misra_suppressions.txt` (line-move only)

## Out of scope
The SD vtable flip `Format(base, element)` (S14.06); MetaSd (S14.04) and OriginSd (S14.05) migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)