### PR TITLE
feat: S14.05 migrate OriginSd onto the SD writer

### DIFF
--- a/Bdd/Targets/Common/BddTargetIps.c
+++ b/Bdd/Targets/Common/BddTargetIps.c
@@ -1,5 +1,5 @@
 #include "BddTargetIps.h"
-#include "SolidSyslogFormatter.h"
+#include "SolidSyslogSdValue.h"
 
 enum
 {
@@ -23,7 +23,8 @@ size_t BddTargetIps_Count(void)
     return sizeof(BDD_TARGET_IPS) / sizeof(BDD_TARGET_IPS[0]);
 }
 
-void BddTargetIps_At(struct SolidSyslogFormatter* formatter, size_t index)
+void BddTargetIps_At(struct SolidSyslogSdValue* value, void* context, size_t index)
 {
-    SolidSyslogFormatter_EscapedString(formatter, BDD_TARGET_IPS[index], BDD_TARGET_IP_MAX);
+    (void) context;
+    SolidSyslogSdValue_BoundedString(value, BDD_TARGET_IPS[index], BDD_TARGET_IP_MAX);
 }

--- a/Bdd/Targets/Common/BddTargetIps.h
+++ b/Bdd/Targets/Common/BddTargetIps.h
@@ -7,10 +7,10 @@
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogFormatter;
+    struct SolidSyslogSdValue;
 
     size_t BddTargetIps_Count(void);
-    void BddTargetIps_At(struct SolidSyslogFormatter * formatter, size_t index);
+    void BddTargetIps_At(struct SolidSyslogSdValue * value, void* context, size_t index);
 
 EXTERN_C_END
 

--- a/Core/Interface/SolidSyslogOriginSd.h
+++ b/Core/Interface/SolidSyslogOriginSd.h
@@ -7,11 +7,11 @@
 
 EXTERN_C_BEGIN
 
-    struct SolidSyslogFormatter;
+    struct SolidSyslogSdValue;
     struct SolidSyslogStructuredData;
 
     typedef size_t (*SolidSyslogOriginIpCountFunction)(void);
-    typedef void (*SolidSyslogOriginIpAtFunction)(struct SolidSyslogFormatter* formatter, size_t index);
+    typedef void (*SolidSyslogOriginIpAtFunction)(struct SolidSyslogSdValue* value, void* context, size_t index);
 
     struct SolidSyslogOriginSdConfig
     {
@@ -20,6 +20,7 @@ EXTERN_C_BEGIN
         const char* EnterpriseId;
         SolidSyslogOriginIpCountFunction GetIpCount;
         SolidSyslogOriginIpAtFunction GetIpAt;
+        void* IpContext;
     };
 
     struct SolidSyslogStructuredData* SolidSyslogOriginSd_Create(const struct SolidSyslogOriginSdConfig* config);

--- a/Core/Source/SolidSyslogOriginSd.c
+++ b/Core/Source/SolidSyslogOriginSd.c
@@ -3,69 +3,57 @@
 #include <stddef.h>
 
 #include "SolidSyslogError.h"
-#include "SolidSyslogFormatter.h"
 #include "SolidSyslogNullSd.h"
 #include "SolidSyslogOriginSdErrors.h"
 #include "SolidSyslogOriginSdPrivate.h"
+#include "SolidSyslogSdElementPrivate.h"
+#include "SolidSyslogSdValue.h"
 #include "SolidSyslogStructuredDataDefinition.h"
 
 const struct SolidSyslogErrorSource OriginSdErrorSource = {"OriginSd"};
 
+struct SolidSyslogFormatter;
+
 static void OriginSd_Format(struct SolidSyslogStructuredData* base, struct SolidSyslogFormatter* formatter);
 
 static inline struct SolidSyslogOriginSd* OriginSd_SelfFromBase(struct SolidSyslogStructuredData* base);
-static inline void OriginSd_PreFormatStaticPrefix(
-    struct SolidSyslogOriginSd* self,
-    const struct SolidSyslogOriginSdConfig* config
-);
-static inline void OriginSd_EmitSoftware(
-    struct SolidSyslogFormatter* f,
-    const struct SolidSyslogOriginSdConfig* config
-);
-static inline void OriginSd_EmitSwVersion(
-    struct SolidSyslogFormatter* f,
-    const struct SolidSyslogOriginSdConfig* config
-);
-static inline void OriginSd_EmitEnterpriseId(
-    struct SolidSyslogFormatter* f,
-    const struct SolidSyslogOriginSdConfig* config
-);
-static inline void OriginSd_EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* self);
-static inline void OriginSd_EmitIp(
-    struct SolidSyslogFormatter* formatter,
-    const struct SolidSyslogOriginSd* self,
-    size_t index
-);
+static inline void OriginSd_EmitSoftware(struct SolidSyslogSdElement* element, const char* software);
+static inline void OriginSd_EmitSwVersion(struct SolidSyslogSdElement* element, const char* swVersion);
+static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogSdElement* element, const char* enterpriseId);
+static inline void OriginSd_EmitIps(struct SolidSyslogSdElement* element, const struct SolidSyslogOriginSd* self);
 
 void OriginSd_Initialise(struct SolidSyslogStructuredData* base, const struct SolidSyslogOriginSdConfig* config)
 {
     struct SolidSyslogOriginSd* self = OriginSd_SelfFromBase(base);
     self->Base.Format = OriginSd_Format;
+    self->Software = config->Software;
+    self->SwVersion = config->SwVersion;
+    self->EnterpriseId = config->EnterpriseId;
     self->GetIpCount = config->GetIpCount;
     self->GetIpAt = config->GetIpAt;
-    OriginSd_PreFormatStaticPrefix(self, config);
+    self->IpContext = config->IpContext;
 }
 
 void OriginSd_Cleanup(struct SolidSyslogStructuredData* base)
 {
     /* Overwrite the abstract base with the shared NullSd vtable so use-after-destroy
-     * is a safe no-op. Derived fields (incl. the pre-formatted static-prefix Formatter
-     * storage) are private to this TU; the next _Initialise rebuilds them. */
+     * is a safe no-op. Derived fields are private to this TU; the next _Initialise
+     * overwrites them. */
     *base = *SolidSyslogNullSd_Get();
 }
 
 static void OriginSd_Format(struct SolidSyslogStructuredData* base, struct SolidSyslogFormatter* formatter)
 {
     struct SolidSyslogOriginSd* self = OriginSd_SelfFromBase(base);
-    struct SolidSyslogFormatter* preformat = SolidSyslogFormatter_FromStorage(self->FormattedStorage);
+    struct SolidSyslogSdElement element;
 
-    SolidSyslogFormatter_BoundedString(
-        formatter,
-        SolidSyslogFormatter_AsFormattedBuffer(preformat),
-        SolidSyslogFormatter_Length(preformat)
-    );
-    OriginSd_EmitIps(formatter, self);
-    SolidSyslogFormatter_AsciiCharacter(formatter, ']');
+    SolidSyslogSdElement_FromFormatter(&element, formatter);
+    SolidSyslogSdElement_Begin(&element, "origin", 0U);
+    OriginSd_EmitSoftware(&element, self->Software);
+    OriginSd_EmitSwVersion(&element, self->SwVersion);
+    OriginSd_EmitEnterpriseId(&element, self->EnterpriseId);
+    OriginSd_EmitIps(&element, self);
+    SolidSyslogSdElement_End(&element);
 }
 
 static inline struct SolidSyslogOriginSd* OriginSd_SelfFromBase(struct SolidSyslogStructuredData* base)
@@ -73,80 +61,50 @@ static inline struct SolidSyslogOriginSd* OriginSd_SelfFromBase(struct SolidSysl
     return (struct SolidSyslogOriginSd*) base;
 }
 
-static inline void OriginSd_PreFormatStaticPrefix(
-    struct SolidSyslogOriginSd* self,
-    const struct SolidSyslogOriginSdConfig* config
-)
+static inline void OriginSd_EmitSoftware(struct SolidSyslogSdElement* element, const char* software)
 {
-    static const char sdPrefix[] = "[origin";
-    struct SolidSyslogFormatter* f = SolidSyslogFormatter_Create(self->FormattedStorage, ORIGIN_FORMATTED_MAX);
-
-    SolidSyslogFormatter_BoundedString(f, sdPrefix, sizeof(sdPrefix) - 1U);
-    OriginSd_EmitSoftware(f, config);
-    OriginSd_EmitSwVersion(f, config);
-    OriginSd_EmitEnterpriseId(f, config);
-    /* closing ']' deferred to OriginSd_Format() so per-message ip params can be spliced in */
-}
-
-static inline void OriginSd_EmitSoftware(struct SolidSyslogFormatter* f, const struct SolidSyslogOriginSdConfig* config)
-{
-    if (config->Software != NULL)
+    if (software != NULL)
     {
-        static const char softwareSd[] = " software=\"";
-        SolidSyslogFormatter_BoundedString(f, softwareSd, sizeof(softwareSd) - 1U);
-        SolidSyslogFormatter_EscapedString(f, config->Software, ORIGIN_SOFTWARE_MAX);
-        SolidSyslogFormatter_AsciiCharacter(f, '"');
+        SolidSyslogSdValue_BoundedString(
+            SolidSyslogSdElement_Param(element, "software"),
+            software,
+            ORIGIN_SOFTWARE_MAX
+        );
     }
 }
 
-static inline void OriginSd_EmitSwVersion(
-    struct SolidSyslogFormatter* f,
-    const struct SolidSyslogOriginSdConfig* config
-)
+static inline void OriginSd_EmitSwVersion(struct SolidSyslogSdElement* element, const char* swVersion)
 {
-    if (config->SwVersion != NULL)
+    if (swVersion != NULL)
     {
-        static const char swVersionSd[] = " swVersion=\"";
-        SolidSyslogFormatter_BoundedString(f, swVersionSd, sizeof(swVersionSd) - 1U);
-        SolidSyslogFormatter_EscapedString(f, config->SwVersion, ORIGIN_SWVERSION_MAX);
-        SolidSyslogFormatter_AsciiCharacter(f, '"');
+        SolidSyslogSdValue_BoundedString(
+            SolidSyslogSdElement_Param(element, "swVersion"),
+            swVersion,
+            ORIGIN_SWVERSION_MAX
+        );
     }
 }
 
-static inline void OriginSd_EmitEnterpriseId(
-    struct SolidSyslogFormatter* f,
-    const struct SolidSyslogOriginSdConfig* config
-)
+static inline void OriginSd_EmitEnterpriseId(struct SolidSyslogSdElement* element, const char* enterpriseId)
 {
-    if (config->EnterpriseId != NULL)
+    if (enterpriseId != NULL)
     {
-        static const char enterpriseIdSd[] = " enterpriseId=\"";
-        SolidSyslogFormatter_BoundedString(f, enterpriseIdSd, sizeof(enterpriseIdSd) - 1U);
-        SolidSyslogFormatter_EscapedString(f, config->EnterpriseId, ORIGIN_ENTERPRISE_ID_MAX);
-        SolidSyslogFormatter_AsciiCharacter(f, '"');
+        SolidSyslogSdValue_BoundedString(
+            SolidSyslogSdElement_Param(element, "enterpriseId"),
+            enterpriseId,
+            ORIGIN_ENTERPRISE_ID_MAX
+        );
     }
 }
 
-static inline void OriginSd_EmitIps(struct SolidSyslogFormatter* formatter, const struct SolidSyslogOriginSd* self)
+static inline void OriginSd_EmitIps(struct SolidSyslogSdElement* element, const struct SolidSyslogOriginSd* self)
 {
     if ((self->GetIpCount != NULL) && (self->GetIpAt != NULL))
     {
         size_t count = self->GetIpCount();
         for (size_t i = 0; i < count; i++)
         {
-            OriginSd_EmitIp(formatter, self, i);
+            self->GetIpAt(SolidSyslogSdElement_Param(element, "ip"), self->IpContext, i);
         }
     }
-}
-
-static inline void OriginSd_EmitIp(
-    struct SolidSyslogFormatter* formatter,
-    const struct SolidSyslogOriginSd* self,
-    size_t index
-)
-{
-    static const char ipSd[] = " ip=\"";
-    SolidSyslogFormatter_BoundedString(formatter, ipSd, sizeof(ipSd) - 1U);
-    self->GetIpAt(formatter, index);
-    SolidSyslogFormatter_AsciiCharacter(formatter, '"');
 }

--- a/Core/Source/SolidSyslogOriginSdPrivate.h
+++ b/Core/Source/SolidSyslogOriginSdPrivate.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 
 #include "SolidSyslogError.h"
-#include "SolidSyslogFormatter.h"
 #include "SolidSyslogOriginSd.h"
 #include "SolidSyslogOriginSdErrors.h"
 #include "SolidSyslogPrival.h"
@@ -15,21 +14,18 @@ enum
     ORIGIN_SOFTWARE_MAX = 48,
     ORIGIN_SWVERSION_MAX = 32,
     ORIGIN_ENTERPRISE_ID_MAX = 64,
-    ORIGIN_IP_MAX = 64,
-    ORIGIN_LITERAL_BYTES =
-        48, /* [origin software="" swVersion="" enterpriseId="" — closing ']' deferred to per-message OriginSd_Format */
-    ORIGIN_CONTENT_MAX = ORIGIN_LITERAL_BYTES + SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SOFTWARE_MAX) +
-                         SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_SWVERSION_MAX) +
-                         SOLIDSYSLOG_ESCAPED_MAX_SIZE(ORIGIN_ENTERPRISE_ID_MAX),
-    ORIGIN_FORMATTED_MAX = ORIGIN_CONTENT_MAX + 1 /* null terminator */
+    ORIGIN_IP_MAX = 64
 };
 
 struct SolidSyslogOriginSd
 {
     struct SolidSyslogStructuredData Base;
+    const char* Software;
+    const char* SwVersion;
+    const char* EnterpriseId;
     SolidSyslogOriginIpCountFunction GetIpCount;
     SolidSyslogOriginIpAtFunction GetIpAt;
-    SolidSyslogFormatterStorage FormattedStorage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(ORIGIN_FORMATTED_MAX)];
+    void* IpContext;
 };
 
 void OriginSd_Initialise(struct SolidSyslogStructuredData* base, const struct SolidSyslogOriginSdConfig* config);

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -14486,3 +14486,37 @@ MISRA rule — different category, doesn't set precedent.
 
 ### Open questions
 - None outstanding.
+
+## 2026-06-06 — S14.05: OriginSd onto the SD writer + #346 scratch removal
+
+### Decisions
+- **OriginSd migrated onto the E14 SD writer**, byte-identical (existing OriginSd tests
+  are the net), same shape as S14.03/S14.04: `SdElement_FromFormatter` +
+  `_Begin("origin",0U)` / `_Param` → `SolidSyslogSdValue_*` / `_End`. Static fields use
+  `SolidSyslogSdValue_BoundedString` with the existing `ORIGIN_*_MAX` decoded caps.
+- **`GetIpAt` signature changed** to `void(struct SolidSyslogSdValue*, void* context,
+  size_t index)` with a paired `OriginSdConfig.IpContext`. It keeps its own typedef name
+  `SolidSyslogOriginIpAtFunction` (not the shared `SolidSyslogSdValueFunction` — it
+  carries the extra `index`). Routing `ip` through the param sink closes the `ip`
+  injection vector; with `language` (S14.04) that completes **#533**. New behaviour
+  (`void* context`) driven RED-first by `FormatPassesIpContextThrough`.
+- **Took the #346 eliminate-the-scratch path.** The static fields emit straight into the
+  element at Format time; the `OriginSd` struct now **borrows** the three config strings
+  directly. `FormattedStorage` and the `ORIGIN_{LITERAL_BYTES,CONTENT_MAX,FORMATTED_MAX}`
+  sizing enums are deleted. No shared SD scratch buffer remains → concurrent-`Log`
+  reentrancy holds by construction. Behaviour change: the config strings are borrowed for
+  the SD's lifetime (were copied at `Create`) — fine for the literal/long-lived config
+  integrators pass.
+- The shared `BddTargetIps_At` moved to `SolidSyslogSdValue_BoundedString`; renamed the
+  now-misnamed `WorstCaseFullyEscapedInputFitsPreFormattedStorage` test.
+- Checks: debug green (1459 tests), OriginSd 38/38, BddTargetIps 2/2, BddTargetTests
+  66/66; clang-format applied; cppcheck-MISRA exit 0 (anchors moved: OriginSd.c 11.3
+  73→61, OriginSdPrivate.h 5.7 14→13). PR #555.
+
+### Deferred
+- SD vtable flip (S14.06), config header fields (S14.07). CLAUDE.md OriginSd
+  header-table row (still describes the removed pre-formatted storage) left for the
+  S14.08 wholesale table revision.
+
+### Open questions
+- None outstanding.

--- a/Tests/Bdd/Targets/BddTargetIpsTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetIpsTest.cpp
@@ -1,5 +1,7 @@
 #include "BddTargetIps.h"
 #include "SolidSyslogFormatter.h"
+#include "SolidSyslogSdValue.h"
+#include "SolidSyslogSdValuePrivate.h"
 #include "CppUTest/TestHarness.h"
 
 enum
@@ -12,10 +14,12 @@ TEST_GROUP(BddTargetIps)
 {
     SolidSyslogFormatterStorage storage[SOLIDSYSLOG_FORMATTER_STORAGE_SIZE(FORMATTER_BUFFER_SIZE)];
     struct SolidSyslogFormatter* formatter = nullptr;
+    struct SolidSyslogSdValue value{};
 
     void setup() override
     {
         formatter = SolidSyslogFormatter_Create(storage, FORMATTER_BUFFER_SIZE);
+        SolidSyslogSdValue_FromFormatter(&value, formatter);
     }
 
     [[nodiscard]] const char* formatted() const
@@ -33,6 +37,7 @@ TEST(BddTargetIps, CountIsOne)
 
 TEST(BddTargetIps, AtZeroEmitsTheConfiguredIp)
 {
-    BddTargetIps_At(formatter, 0);
+    BddTargetIps_At(&value, nullptr, 0);
+    SolidSyslogSdValue_Close(&value);
     STRCMP_EQUAL("192.0.2.1", formatted());
 }

--- a/Tests/SolidSyslogOriginSdTest.cpp
+++ b/Tests/SolidSyslogOriginSdTest.cpp
@@ -9,6 +9,7 @@
 #include "SolidSyslogOriginSd.h"
 #include "SolidSyslogOriginSdErrors.h"
 #include "SolidSyslogPrival.h"
+#include "SolidSyslogSdValue.h"
 #include "SolidSyslogStructuredData.h"
 #include "SolidSyslogTunables.h"
 #include "TestUtils.h"
@@ -21,30 +22,34 @@ class TEST_SolidSyslogOriginSd_FormatIncludesDifferentEnterpriseIdFromConfig_Tes
 class TEST_SolidSyslogOriginSd_FormatIncludesDifferentIpFromCallback_Test;
 class TEST_SolidSyslogOriginSd_FormatIncludesEnterpriseIdFromConfig_Test;
 class TEST_SolidSyslogOriginSd_FormatIncludesOneIpFromCallback_Test;
+class TEST_SolidSyslogOriginSd_FormatPassesIpContextThrough_Test;
 class TEST_SolidSyslogOriginSd_IpContainingSpecialsIsEscaped_Test;
 struct SolidSyslogFormatter;
+struct SolidSyslogSdValue;
 struct SolidSyslogStructuredData;
 
 enum
 {
     /* Worst-case fully-escaped output is 337 bytes — see
-       WorstCaseFullyEscapedInputFitsPreFormattedStorage. Pre-message dispatch
-       widens this further once IP params are spliced in. 512 leaves headroom. */
+       WorstCaseFullyEscapedInputFormatsCorrectly. IP params widen this further
+       once they are appended. 512 leaves headroom. */
     TEST_BUFFER_SIZE = 512,
     MAX_FAKE_IPS = 8
 };
 
 static std::array<const char*, MAX_FAKE_IPS> fakeIps;
 static size_t fakeIpCount;
+static void* fakeIpContext;
 
 static size_t FakeIpCount()
 {
     return fakeIpCount;
 }
 
-static void FakeIpAt(struct SolidSyslogFormatter* f, size_t index)
+static void FakeIpAt(struct SolidSyslogSdValue* value, void* context, size_t index)
 {
-    SolidSyslogFormatter_EscapedString(f, fakeIps.at(index), 64); // ORIGIN_IP_MAX
+    fakeIpContext = context;
+    SolidSyslogSdValue_BoundedString(value, fakeIps.at(index), 64); // ORIGIN_IP_MAX
 }
 
 #define CHECK_ENTERPRISE_ID(expected)                                                           \
@@ -93,6 +98,7 @@ TEST_GROUP(SolidSyslogOriginSd)
         config.Software = "TestSoftware";
         config.SwVersion = "9.8.7";
         fakeIpCount = 0;
+        fakeIpContext = nullptr;
         sd = SolidSyslogOriginSd_Create(&config);
     }
 
@@ -361,7 +367,7 @@ TEST(SolidSyslogOriginSd, EnterpriseIdContainingSpecialsIsEscaped)
     CHECK_ENTERPRISE_ID("a\\\"b\\\\c\\]d");
 }
 
-TEST(SolidSyslogOriginSd, WorstCaseFullyEscapedInputFitsPreFormattedStorage)
+TEST(SolidSyslogOriginSd, WorstCaseFullyEscapedInputFormatsCorrectly)
 {
     const std::string software = repeated(']', 48); /* ORIGIN_SOFTWARE_MAX */
     const std::string swVersion = repeated('"', 32); /* ORIGIN_SWVERSION_MAX */
@@ -412,6 +418,16 @@ TEST(SolidSyslogOriginSd, FormatIncludesMultipleIpsFromCallback)
         "[origin software=\"TestSoftware\" swVersion=\"9.8.7\" ip=\"192.0.2.1\" ip=\"192.0.2.2\" ip=\"10.0.0.1\"]",
         SolidSyslogFormatter_AsFormattedBuffer(formatter)
     );
+}
+
+TEST(SolidSyslogOriginSd, FormatPassesIpContextThrough)
+{
+    int ipContext = 0;
+    config.IpContext = &ipContext;
+    useIps({"192.0.2.1"});
+    resetFormatter();
+    format();
+    POINTERS_EQUAL(&ipContext, fakeIpContext);
 }
 
 TEST(SolidSyslogOriginSd, IpAtMaxLength)

--- a/misra_suppressions.txt
+++ b/misra_suppressions.txt
@@ -29,7 +29,7 @@ misra-c2012-11.3:Core/Source/SolidSyslogCircularBuffer.c:91
 misra-c2012-11.3:Core/Source/SolidSyslogFileBlockDevice.c:106
 misra-c2012-11.3:Core/Source/SolidSyslogFormatter.c:79
 misra-c2012-11.3:Core/Source/SolidSyslogMetaSd.c:64
-misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:73
+misra-c2012-11.3:Core/Source/SolidSyslogOriginSd.c:61
 misra-c2012-11.3:Core/Source/SolidSyslogPassthroughBuffer.c:53
 misra-c2012-11.3:Core/Source/SolidSyslogStreamSender.c:166
 misra-c2012-11.3:Core/Source/SolidSyslogSwitchingSender.c:63
@@ -175,7 +175,7 @@ misra-c2012-5.7:Core/Source/SolidSyslogMessageFormatter.c:19
 misra-c2012-5.7:Core/Source/SolidSyslogCircularBuffer.c:19
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16.c:12
 misra-c2012-5.7:Core/Source/SolidSyslogCrc16Policy.c:10
-misra-c2012-5.7:Core/Source/SolidSyslogOriginSdPrivate.h:14
+misra-c2012-5.7:Core/Source/SolidSyslogOriginSdPrivate.h:13
 misra-c2012-5.7:Platform/FreeRtos/Source/SolidSyslogFreeRtosSysUpTime.c:7
 misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixHostname.c:10
 misra-c2012-5.7:Platform/Posix/Source/SolidSyslogPosixMessageQueueBuffer.c:25


### PR DESCRIPTION
Closes #545. Closes #533. Parent epic: #64.

## What changes

Migrates `OriginSd_Format` onto the E14 SD writer (`SolidSyslogSdElement` +
`SolidSyslogSdValue`), mirroring S14.03/S14.04. Output is **byte-for-byte identical**
to the old raw `SolidSyslogFormatter` framing — the existing OriginSd tests
(software / swVersion / enterpriseId max-length + escape, multi-IP) are the safety net.

- Static fields emit via `_Param` + `SolidSyslogSdValue_BoundedString` (same
  `ORIGIN_*_MAX` decoded caps as the old `_EscapedString`).
- `ip` flows via `_Param` → the `SdValue` handed to the **new-signature** `GetIpAt`.
- `SolidSyslogOriginIpAtFunction` → `void(struct SolidSyslogSdValue*, void* context,
  size_t index)`, with a paired `OriginSdConfig.IpContext` threaded through `Initialise`
  and passed unchanged. Routing `ip` through the param sink makes the library own the
  escaping unconditionally → **closes the `ip` SD-injection vector**. With `language`
  closed in S14.04, **S12.32 (#533) is fully done.**

### #346 — eliminate the scratch path

The static fields are now emitted straight into the element at `Format` time instead of
being pre-formatted into a shared scratch blob at `Create`. The `OriginSd` struct borrows
the three config strings directly; `FormattedStorage` and the
`ORIGIN_{LITERAL_BYTES,CONTENT_MAX,FORMATTED_MAX}` sizing enums are removed. **No shared
SD scratch buffer remains**, so concurrent-`Log` reentrancy holds by construction — the
#346 concern is dissolved, not papered over.

The shared `BddTargetIps_At` moves to `SolidSyslogSdValue_BoundedString`.

## Acceptance criteria

- [x] An `ip` callback emitting `"`, `\`, or `]` is escaped — no break-out
- [x] Static fields remain escaped; output unchanged byte-for-byte
- [x] Preformat scratch blob gone; no shared SD scratch buffer; reentrancy by construction
- [x] `NULL` `GetIpCount` / `GetIpAt` → no `ip` params
- [x] The callback carries `void* context` and the `index`
  (new `FormatPassesIpContextThrough`, RED-first)
- [x] Vtable signature unchanged (`Format(base, formatter)`)

## Behaviour note for reviewers

The `software` / `swVersion` / `enterpriseId` config strings are now borrowed for the
SD's **lifetime** (previously copied into the blob at `Create`). This is the deliberate
#346 trade-off; integrators pass string literals / long-lived config in practice.

## Out of scope

SD vtable flip (S14.06); header fields (S14.07). The CLAUDE.md OriginSd header-table row
(still mentions the pre-formatted storage) is left for the deferred S14.08 wholesale
table revision.

## Checks

Debug green (1459 tests); OriginSd 38/38; BddTargetIps 2/2; BddTargetTests 66/66.
clang-format applied; cppcheck-MISRA exit 0 (suppression anchors moved:
`SolidSyslogOriginSd.c` 11.3 73→61, `SolidSyslogOriginSdPrivate.h` 5.7 14→13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)