### PR TITLE
refactor: S24.18 drop do/while(0) wrapper from test CHECK_* macros

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,10 +549,18 @@ code should follow them; reviewers should call out drift.
 - **`CHECK_*` macros for repeated assertion shapes.** When the same buf+memcmp
   or several-line assertion repeats across tests, wrap it in a macro that
   *names* the intent. The macro must be a macro (not a function) so test
-  failures report the caller's `__FILE__`/`__LINE__`. Wrap with
-  `// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)`
-  and use `do { ... } while (0)` for safe single-statement use. Examples:
-  `CHECK_PRIVAL` in `SolidSyslogTest.cpp`, `CHECK_BLOCK_CONTAINS` in
+  failures report the caller's `__FILE__`/`__LINE__`. A multi-statement body
+  is a plain compound `{ ... }`; a single-statement body is just the bare
+  expression. Do **not** use the `do { ... } while (0)` wrapper: its only job
+  is to stop a multi-statement macro's tail escaping an unbraced `if`/`else`,
+  and `.clang-format`'s `InsertBraces: true` (our MISRA 15.6 enforcement)
+  already braces every conditional body before the macro expands, so the
+  wrapper is dead weight — and `cppcoreguidelines-avoid-do-while` (kept on for
+  the `Tests/` tier) now rejects it. No `NOLINT` is needed: `Tests/.clang-tidy`
+  disables `cppcoreguidelines-macro-usage` tier-wide, so a `CHECK_*` macro
+  needs no per-site suppression. Examples: `CHECK_PRIVAL` (single-statement,
+  bare expression) in `SolidSyslogMessageFormatterTest.cpp`,
+  `CHECK_BLOCK_CONTAINS` (declares a local, so keeps its `{ ... }` block) in
   `SolidSyslogFileBlockDeviceTest.cpp`.
 - **DRY the setup, DRY the asserts, keep the test body small.** Each `TEST(...)`
   body should read as a sentence: arrange → act → assert. If three lines of

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,46 @@
 # Dev Log
 
+## 2026-06-06 — S24.18 drop do/while(0) from test CHECK_* macros
+
+Mechanical tree-wide sweep: removed the `do { ... } while (0)` wrapper (and the
+paired `NOLINTBEGIN/END(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)`
+brackets) from every test assertion/helper macro — 42 files, ~60 macros. The
+wrapper's only purpose is to stop a multi-statement macro's tail escaping an
+unbraced `if`/`else`, and `.clang-format`'s `InsertBraces: true` (our MISRA 15.6
+enforcement) already braces every conditional body before a macro expands, so the
+wrapper was dead weight.
+
+### Decisions
+- **Conversion shape.** Multi-statement bodies → plain compound `{ ... }`
+  (preserves block scope, which matters for macros that declare a local, e.g.
+  `CHECK_BLOCK_CONTAINS`'s `checkBuf`, `CHECK_IS_FALLBACK`'s `for` loop var).
+  Single-statement macros were already bare expressions — untouched.
+- **Re-enabled `cppcoreguidelines-avoid-do-while` in `Tests/.clang-tidy`**
+  (removed it from the tier disable). The check now actively *bans* do/while in
+  test code, so the wrapper can't creep back via a CodeRabbit-style suggestion.
+  `cppcoreguidelines-macro-usage` stays disabled — CppUTest needs macros for
+  caller `__FILE__`/`__LINE__`, so no per-site NOLINT is needed.
+- **Upstream-convention macros left as-is.** `configASSERT` (FreeRTOS) and
+  `LWIP_PLATFORM_DIAG`/`LWIP_PLATFORM_ASSERT` (lwIP) in the fake config headers
+  keep their `do/while(0)` — they are consumed by un-formatted upstream code
+  where InsertBraces gives no protection. Safe under the re-enabled check:
+  `configASSERT` has zero use sites in linted code, and `LWIP_ASSERT` expands
+  only in `Bdd/Targets/FreeRtosLwip/netif/EthernetIf.c` (governed by
+  `Bdd/.clang-tidy`, not `Tests/.clang-tidy`). A definition is not a statement,
+  so the check never fires on the macro body itself.
+- Updated the CLAUDE.md "Test code" design-pattern entry to record the new rule
+  and the InsertBraces rationale; fixed a stale `CHECK_PRIVAL` path reference
+  (now `SolidSyslogMessageFormatterTest.cpp`).
+
+### Verification
+- Builds run via docker compose (`.devcontainer/docker-compose.yml`, gcc image).
+  debug: **1482 tests green**, no behaviour change. `tidy` preset green with
+  `avoid-do-while` enforced (no do/while warnings). `cppcheck` clean rebuild
+  green. clang-format dry-run clean tree-wide. freertos-host debug build green
+  (covers the FreeRtos/Lwip/MbedTls/FatFs/PlusFat test trees).
+- Windows/Winsock and the freertos/lwip clang-tidy lanes are CI's job; the
+  conversions there are identical and mechanical.
+
 ## 2026-06-06 — S14.03 migrate TimeQualitySd onto the SD writer (walking skeleton)
 
 First real consumer of the E14 SD writer. `TimeQualitySd_Format` now emits via

--- a/Tests/.clang-tidy
+++ b/Tests/.clang-tidy
@@ -36,11 +36,18 @@
 #   (FreeRTOSConfig.h, lwipopts.h, …) which the test harness includes:
 #   the upstream symbols must remain macros.
 #
-# -cppcoreguidelines-avoid-do-while
-#   Paired with the macro-usage relaxation above: do { ... } while (0)
-#   is the standard idiom for wrapping a multi-statement macro body so
-#   it remains a single statement at the call site. Without the wrapper,
-#   the macros lose composability inside if/else.
+# cppcoreguidelines-avoid-do-while is intentionally NOT disabled (S24.18).
+#   Multi-statement test assertion/helper macros use a plain compound
+#   `{ ... }` body, not the `do { ... } while (0)` wrapper. The wrapper's
+#   only job — keeping a multi-statement macro a single statement so its
+#   tail cannot escape an unbraced if/else — cannot bite us: `.clang-format`
+#   sets `InsertBraces: true` (our MISRA 15.6 enforcement), so every
+#   conditional body is already brace-delimited before any macro expands.
+#   Leaving the check on keeps the wrapper from creeping back in. The
+#   upstream-convention `do/while(0)` macro *definitions* in the FreeRTOS /
+#   lwIP fake config headers (configASSERT, LWIP_PLATFORM_*) are exempt by
+#   construction: a definition is not a statement, so the check never fires
+#   on it, and those macros are not expanded in any file this config governs.
 #
 # -cppcoreguidelines-pro-type-reinterpret-cast
 #   Test fixtures legitimately reinterpret-cast for two patterns:
@@ -58,5 +65,4 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -google-build-using-namespace,
   -cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-pro-type-reinterpret-cast

--- a/Tests/Bdd/Targets/BddTargetErrorTextTest.cpp
+++ b/Tests/Bdd/Targets/BddTargetErrorTextTest.cpp
@@ -8,14 +8,10 @@
 
 TEST_GROUP(BddTargetErrorText){};
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_CATEGORY_TEXT(category, expectedText)                            \
-    do                                                                         \
     {                                                                          \
         STRCMP_EQUAL((expectedText), BddTargetErrorText_Category((category))); \
-    } while (0)
-
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 TEST(BddTargetErrorText, BadConfigCategoryMapsToText)
 {

--- a/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
+++ b/Tests/FatFs/SolidSyslogFatFsFilePoolTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -27,7 +26,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogFatFsFilePool)

--- a/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogFreeRtosMutexTest.cpp
@@ -17,7 +17,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -25,7 +24,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogFreeRtosMutex)

--- a/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpAddressTest.cpp
@@ -17,7 +17,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -25,7 +24,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPlusTcpAddress)

--- a/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpDatagramTest.cpp
@@ -27,7 +27,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -35,7 +34,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 static const uint16_t TEST_PORT = 514;
 

--- a/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpResolverTest.cpp
@@ -25,7 +25,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -33,7 +32,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 static const char* const TEST_HOST = "10.0.2.2";
 static const char* const TEST_ALTERNATE_HOST = "192.168.1.1";

--- a/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
+++ b/Tests/FreeRtos/SolidSyslogPlusTcpTcpStreamTest.cpp
@@ -26,7 +26,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -34,7 +33,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 static const uint16_t TEST_PORT = 514;
 static const char TEST_MESSAGE[] = "hello";
@@ -120,11 +119,10 @@ TEST_GROUP(SolidSyslogPlusTcpTcpStream)
 // clang-format on
 
 #define CHECK_SOCKET_CLOSED_ONCE()                                                                             \
-    do                                                                                                         \
     {                                                                                                          \
         CALLED_FAKE(FreeRtosSocketsFake_Closesocket, ONCE);                                                    \
         POINTERS_EQUAL(FreeRtosSocketsFake_LastSocketReturned(), FreeRtosSocketsFake_LastClosesocketSocket()); \
-    } while (0)
+    }
 
 TEST(SolidSyslogPlusTcpTcpStream, CreateReturnsNonNullStream)
 

--- a/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawAddressTest.cpp
@@ -16,7 +16,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -24,19 +23,18 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // Asserts the most recent ErrorHandlerFake call matched (severity, source, code).
 // Use after the act-phase of a test that expects exactly one SolidSyslog_Error call.
 #define CHECK_REPORTED(severity, source, expectedCategory, code)                   \
-    do                                                                             \
     {                                                                              \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                  \
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());                  \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());               \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogLwipRawAddress)

--- a/Tests/Lwip/SolidSyslogLwipRawDatagramTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawDatagramTest.cpp
@@ -30,7 +30,6 @@ static const uint16_t TEST_PORT = 514;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -38,19 +37,18 @@ static const uint16_t TEST_PORT = 514;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // Asserts the most recent ErrorHandlerFake call matched (severity, source, code).
 // Use after the act-phase of a test that expects exactly one SolidSyslog_Error call.
 #define CHECK_REPORTED(severity, source, expectedCategory, code)                   \
-    do                                                                             \
     {                                                                              \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                  \
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());                  \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());               \
-    } while (0)
+    }
 
 /* Shared fixture: every Datagram lifecycle test needs the fake reset, a fresh
  * datagram + address handle pair, teardown of both, and the leak invariant

--- a/Tests/Lwip/SolidSyslogLwipRawDnsResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawDnsResolverTest.cpp
@@ -26,7 +26,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -34,18 +33,17 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // Asserts the most recent ErrorHandlerFake call matched (severity, source, code).
 #define CHECK_REPORTED(severity, source, expectedCategory, code)                   \
-    do                                                                             \
     {                                                                              \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                  \
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());                  \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());               \
-    } while (0)
+    }
 
 static const char* const TEST_HOST = "syslog-ng";
 static const uint16_t TEST_PORT = 514;

--- a/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawResolverTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -30,19 +29,18 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // Asserts the most recent ErrorHandlerFake call matched (severity, source, code).
 // Use after the act-phase of a test that expects exactly one SolidSyslog_Error call.
 #define CHECK_REPORTED(severity, source, expectedCategory, code)                   \
-    do                                                                             \
     {                                                                              \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                  \
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());                  \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());               \
-    } while (0)
+    }
 
 static const char* const TEST_HOST = "127.0.0.1";
 static const uint16_t TEST_PORT = 514;

--- a/Tests/Lwip/SolidSyslogLwipRawTcpStreamTest.cpp
+++ b/Tests/Lwip/SolidSyslogLwipRawTcpStreamTest.cpp
@@ -32,10 +32,8 @@ using namespace CososoTesting;
 
 static const uint16_t TEST_PORT = 514;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -43,18 +41,17 @@ static const uint16_t TEST_PORT = 514;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // Asserts the most recent ErrorHandlerFake call matched (severity, source, code).
 #define CHECK_REPORTED(severity, source, expectedCategory, code)                   \
-    do                                                                             \
     {                                                                              \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                  \
         POINTERS_EQUAL(&(source), ErrorHandlerFake_LastSource());                  \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());               \
-    } while (0)
+    }
 
 // Asserts the lwIP API call recorded the pcb the wrapper got back from
 // tcp_new — proves the wrapper forwarded the right handle. `getter` is
@@ -62,8 +59,6 @@ static const uint16_t TEST_PORT = 514;
 // clang-format off
 #define CHECK_FORWARDED_PCB(getter) POINTERS_EQUAL(LwipTcpFake_LastTcpNewReturned(), getter())
 // clang-format on
-
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 
 namespace
 {

--- a/Tests/MbedTls/SolidSyslogMbedTlsAesGcmPolicyTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsAesGcmPolicyTest.cpp
@@ -63,26 +63,21 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
     return true;
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_REPORTED_ERROR(severity, expectedCategory, code)                          \
-    do                                                                                  \
     {                                                                                   \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                     \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                       \
         POINTERS_EQUAL(&MbedTlsAesGcmPolicyErrorSource, ErrorHandlerFake_LastSource()); \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());      \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());                    \
-    } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 #define CHECK_IS_NULL_FALLBACK(handle) POINTERS_EQUAL(SolidSyslogNullSecurityPolicy_Get(), (handle))
 
 /* One macro per direction so each fallible mbedTLS GCM call's failure path reads
  * as a one-line test: seal/open must fail closed and report once. Used only
  * inside the Seal fixture (they reference its seal()/open() helpers). */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_SEAL_REPORTS_ENCRYPT_FAILURE_AT(step)     \
-    do                                                  \
     {                                                   \
         ErrorHandlerFake_Install(nullptr);              \
         MbedTlsFake_SetGcmStepFails(step);              \
@@ -92,10 +87,9 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
             SOLIDSYSLOG_CAT_SECURITYPOLICY_SEAL_FAILED, \
             MBEDTLSAESGCMPOLICY_ERROR_ENCRYPT_FAILED    \
         );                                              \
-    } while (0)
+    }
 
 #define CHECK_OPEN_REPORTS_DECRYPT_FAILURE_AT(step)     \
-    do                                                  \
     {                                                   \
         ErrorHandlerFake_Install(nullptr);              \
         MbedTlsFake_SetGcmStepFails(step);              \
@@ -105,9 +99,7 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
             SOLIDSYSLOG_CAT_SECURITYPOLICY_OPEN_FAILED, \
             MBEDTLSAESGCMPOLICY_ERROR_DECRYPT_FAILED    \
         );                                              \
-    } while (0)
-
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 // clang-format off
 TEST_BASE(MbedTlsAesGcmPolicyTestBase)

--- a/Tests/MbedTls/SolidSyslogMbedTlsHmacSha256PolicyTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsHmacSha256PolicyTest.cpp
@@ -64,17 +64,14 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
 }
 
 /* Asserts exactly one error of (severity, code) was reported from this policy's source. */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_REPORTED_ERROR(severity, expectedCategory, code)                              \
-    do                                                                                      \
     {                                                                                       \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                         \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                           \
         POINTERS_EQUAL(&MbedTlsHmacSha256PolicyErrorSource, ErrorHandlerFake_LastSource()); \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());          \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());                        \
-    } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 #define CHECK_IS_NULL_FALLBACK(handle) POINTERS_EQUAL(SolidSyslogNullSecurityPolicy_Get(), (handle))
 

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamPoolTest.cpp
@@ -21,7 +21,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -29,7 +28,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogMbedTlsStreamPool)

--- a/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
+++ b/Tests/MbedTls/SolidSyslogMbedTlsStreamTest.cpp
@@ -26,7 +26,6 @@ extern "C"
 using namespace CososoTesting;
 
 #define CHECK_OPEN_UNWOUND_WITH_SEVERITY(transport, expectedSeverity, expectedCategory, expectedCode) \
-    do                                                                                                \
     {                                                                                                 \
         LONGS_EQUAL(1, StreamFake_CloseCallCount(transport));                                         \
         LONGS_EQUAL(1, MbedTlsFake_SslFreeCallCount());                                               \
@@ -36,7 +35,7 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());                    \
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastDetail());                          \
         LONGS_EQUAL((expectedSeverity), ErrorHandlerFake_LastSeverity());                             \
-    } while (0)
+    }
 
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCategory, expectedCode) \
     CHECK_OPEN_UNWOUND_WITH_SEVERITY(transport, SOLIDSYSLOG_SEVERITY_ERROR, expectedCategory, expectedCode)

--- a/Tests/PlusFat/SolidSyslogPlusFatFilePoolTest.cpp
+++ b/Tests/PlusFat/SolidSyslogPlusFatFilePoolTest.cpp
@@ -19,7 +19,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -27,7 +26,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPlusFatFilePool)

--- a/Tests/SolidSyslogCircularBufferTest.cpp
+++ b/Tests/SolidSyslogCircularBufferTest.cpp
@@ -24,17 +24,15 @@ using namespace CososoTesting;
 // Asserts the last record read equals `expected` bytes of length `size`.
 // Depends on `readData` and `readSize` from CircularBufferFixture being in scope.
 #define CHECK_LAST_READ_RECORD(expected, size)      \
-    do                                              \
     {                                               \
         LONGS_EQUAL((size), readSize);              \
         MEMCMP_EQUAL((expected), readData, (size)); \
-    } while (0)
+    }
 
 // Asserts buf is a non-null handle that is not one of the slots in pool.
 // Used to pin the pool-exhaustion Fallback contract: every legitimate
 // _Create returns either a pool slot or the Fallback singleton, never NULL.
 #define CHECK_IS_FALLBACK(buf, pool)                                                 \
-    do                                                                               \
     {                                                                                \
         CHECK_TEXT((buf) != nullptr, "Fallback handle was nullptr");                 \
         for (auto* slot : (pool))                                                    \
@@ -42,7 +40,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)"); \
             CHECK_TEXT((buf) != slot, "Fallback handle collided with a pool slot");  \
         }                                                                            \
-    } while (0)
+    }
 
 enum
 {

--- a/Tests/SolidSyslogFileBlockDeviceTest.cpp
+++ b/Tests/SolidSyslogFileBlockDeviceTest.cpp
@@ -27,12 +27,11 @@ static const char* const TEST_PATH_PREFIX = "/tmp/blockdev_";
  * tests read as "block N at offset O contains 'foo'" rather than buf+memcmp boilerplate.
  * Macro (not function) so test failures report the caller's __FILE__/__LINE__. */
 #define CHECK_BLOCK_CONTAINS(blockIndex, offset, expected, length)                                   \
-    do                                                                                               \
     {                                                                                                \
         char checkBuf[(length) + 1] = {};                                                            \
         CHECK_TRUE(SolidSyslogBlockDevice_Read(device, (blockIndex), (offset), checkBuf, (length))); \
         MEMCMP_EQUAL((expected), checkBuf, (length));                                                \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogFileBlockDevice)

--- a/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
+++ b/Tests/SolidSyslogGetAddrInfoResolverTest.cpp
@@ -129,7 +129,6 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
 }
 
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -137,7 +136,7 @@ TEST(SolidSyslogGetAddrInfoResolver, FreesAddrInfoOnSuccess)
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogGetAddrInfoResolverPool)

--- a/Tests/SolidSyslogOpenSslAesGcmPolicyTest.cpp
+++ b/Tests/SolidSyslogOpenSslAesGcmPolicyTest.cpp
@@ -59,26 +59,21 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
     return true;
 }
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_REPORTED_ERROR(severity, expectedCategory, code)                          \
-    do                                                                                  \
     {                                                                                   \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                     \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                       \
         POINTERS_EQUAL(&OpenSslAesGcmPolicyErrorSource, ErrorHandlerFake_LastSource()); \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());      \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());                    \
-    } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 #define CHECK_IS_NULL_FALLBACK(handle) POINTERS_EQUAL(SolidSyslogNullSecurityPolicy_Get(), (handle))
 
 /* One macro per direction so each EVP step's failure path reads as a one-line
  * test: seal/open must fail closed and report once. Used only inside the Seal
  * fixture (they reference its seal()/open() helpers). */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_SEAL_REPORTS_ENCRYPT_FAILURE_AT(step)     \
-    do                                                  \
     {                                                   \
         ErrorHandlerFake_Install(nullptr);              \
         OpenSslFake_SetGcmStepFails(step);              \
@@ -88,10 +83,9 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
             SOLIDSYSLOG_CAT_SECURITYPOLICY_SEAL_FAILED, \
             OPENSSLAESGCMPOLICY_ERROR_ENCRYPT_FAILED    \
         );                                              \
-    } while (0)
+    }
 
 #define CHECK_OPEN_REPORTS_DECRYPT_FAILURE_AT(step)     \
-    do                                                  \
     {                                                   \
         ErrorHandlerFake_Install(nullptr);              \
         OpenSslFake_SetGcmStepFails(step);              \
@@ -101,9 +95,7 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
             SOLIDSYSLOG_CAT_SECURITYPOLICY_OPEN_FAILED, \
             OPENSSLAESGCMPOLICY_ERROR_DECRYPT_FAILED    \
         );                                              \
-    } while (0)
-
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 // clang-format off
 TEST_BASE(OpenSslAesGcmPolicyTestBase)

--- a/Tests/SolidSyslogOpenSslHmacSha256PolicyTest.cpp
+++ b/Tests/SolidSyslogOpenSslHmacSha256PolicyTest.cpp
@@ -64,17 +64,14 @@ static bool TestGetKey(void* context, uint8_t* keyOut, size_t capacity, size_t* 
 }
 
 /* Asserts exactly one error of (severity, code) was reported from this policy's source. */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_REPORTED_ERROR(severity, expectedCategory, code)                              \
-    do                                                                                      \
     {                                                                                       \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                         \
         LONGS_EQUAL((severity), ErrorHandlerFake_LastSeverity());                           \
         POINTERS_EQUAL(&OpenSslHmacSha256PolicyErrorSource, ErrorHandlerFake_LastSource()); \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());          \
         UNSIGNED_LONGS_EQUAL((code), ErrorHandlerFake_LastDetail());                        \
-    } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 #define CHECK_IS_NULL_FALLBACK(handle) POINTERS_EQUAL(SolidSyslogNullSecurityPolicy_Get(), (handle))
 

--- a/Tests/SolidSyslogPoolTest.cpp
+++ b/Tests/SolidSyslogPoolTest.cpp
@@ -17,7 +17,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -25,7 +24,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPool)

--- a/Tests/SolidSyslogPosixAddressTest.cpp
+++ b/Tests/SolidSyslogPosixAddressTest.cpp
@@ -18,7 +18,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -26,7 +25,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixAddress)

--- a/Tests/SolidSyslogPosixDatagramTest.cpp
+++ b/Tests/SolidSyslogPosixDatagramTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 #include <sys/socket.h>
 
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -30,7 +29,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 static const char* const TEST_MESSAGE     = "hello";

--- a/Tests/SolidSyslogPosixFileTest.cpp
+++ b/Tests/SolidSyslogPosixFileTest.cpp
@@ -18,7 +18,6 @@ using namespace CososoTesting;
 static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
 
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -26,7 +25,7 @@ static const char* const TEST_PATH = "/tmp/test_posix_file.dat";
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixFile)

--- a/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
+++ b/Tests/SolidSyslogPosixMessageQueueBufferTest.cpp
@@ -202,7 +202,6 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
 }
 
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -210,7 +209,7 @@ TEST(SolidSyslogPosixMessageQueueBuffer, ServiceSendsMessageWrittenViaLog)
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMessageQueueBufferPool)

--- a/Tests/SolidSyslogPosixMutexTest.cpp
+++ b/Tests/SolidSyslogPosixMutexTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -23,7 +22,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixMutex)

--- a/Tests/SolidSyslogPosixTcpStreamTest.cpp
+++ b/Tests/SolidSyslogPosixTcpStreamTest.cpp
@@ -99,11 +99,10 @@ TEST_GROUP(SolidSyslogPosixTcpStream)
 // clang-format on
 
 #define CHECK_SOCKET_CLOSED_ONCE()                                     \
-    do                                                                 \
     {                                                                  \
         CALLED_FAKE(SocketFake_Close, ONCE);                           \
         LONGS_EQUAL(SocketFake_SocketFd(), SocketFake_LastClosedFd()); \
-    } while (0)
+    }
 
 TEST(SolidSyslogPosixTcpStream, CreateDestroyWorksWithoutCrashing)
 {
@@ -565,7 +564,6 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
 }
 
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -573,7 +571,7 @@ TEST(SolidSyslogPosixTcpStream, ReadReturnsNegativeOneOnErrorAndClosesSocket)
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogPosixTcpStreamPool)

--- a/Tests/SolidSyslogSdElementTest.cpp
+++ b/Tests/SolidSyslogSdElementTest.cpp
@@ -12,14 +12,10 @@ enum
     TEST_BUFFER_SIZE = 128
 };
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_FRAMED(expected)                                                     \
-    do                                                                             \
     {                                                                              \
         STRCMP_EQUAL(expected, SolidSyslogFormatter_AsFormattedBuffer(formatter)); \
-    } while (0)
-
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogSdElement)

--- a/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogStdAtomicCounterPoolTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -23,7 +22,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogStdAtomicCounterPool)

--- a/Tests/SolidSyslogStreamSenderTest.cpp
+++ b/Tests/SolidSyslogStreamSenderTest.cpp
@@ -739,14 +739,13 @@ TEST(SolidSyslogStreamSenderPool, FillingPoolThenOverflowReturnsDistinctFallback
 
 /* Macro (not function) so test failures report the caller's __FILE__/__LINE__. */
 #define CHECK_STREAMSENDER_BAD_SETUP_ERROR(expectedCategory, expectedCode)           \
-    do                                                                               \
     {                                                                                \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                  \
         LONGS_EQUAL(SOLIDSYSLOG_SEVERITY_CRITICAL, ErrorHandlerFake_LastSeverity()); \
         POINTERS_EQUAL(&StreamSenderErrorSource, ErrorHandlerFake_LastSource());     \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());   \
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastDetail());         \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogStreamSenderBadSetup)

--- a/Tests/SolidSyslogTlsStreamPoolTest.cpp
+++ b/Tests/SolidSyslogTlsStreamPoolTest.cpp
@@ -29,7 +29,6 @@ void NoOpSleep(int milliseconds)
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -37,7 +36,7 @@ void NoOpSleep(int milliseconds)
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogTlsStreamPool)

--- a/Tests/SolidSyslogTlsStreamTest.cpp
+++ b/Tests/SolidSyslogTlsStreamTest.cpp
@@ -23,7 +23,6 @@
 using namespace CososoTesting;
 
 #define CHECK_OPEN_UNWOUND_WITH_SEVERITY(transport, expectedSeverity, expectedCategory, expectedCode) \
-    do                                                                                                \
     {                                                                                                 \
         LONGS_EQUAL(1, StreamFake_CloseCallCount(transport));                                         \
         CALLED_FAKE(ErrorHandlerFake_Handle, ONCE);                                                   \
@@ -31,7 +30,7 @@ using namespace CososoTesting;
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory());                    \
         UNSIGNED_LONGS_EQUAL((expectedCode), ErrorHandlerFake_LastDetail());                          \
         LONGS_EQUAL((expectedSeverity), ErrorHandlerFake_LastSeverity());                             \
-    } while (0)
+    }
 
 #define CHECK_OPEN_UNWOUND_WITH_ERROR(transport, expectedCategory, expectedCode) \
     CHECK_OPEN_UNWOUND_WITH_SEVERITY(transport, SOLIDSYSLOG_SEVERITY_ERROR, expectedCategory, expectedCode)
@@ -196,31 +195,26 @@ TEST_GROUP(SolidSyslogTlsStream)
 // clang-format on
 
 #define CHECK_BIO_READ_RETRY_SIGNALLED()            \
-    do                                              \
     {                                               \
         CALLED_FAKE(OpenSslFake_BioSetFlags, ONCE); \
-    } while (0)
+    }
 #define CHECK_BIO_READ_RETRY_NOT_SIGNALLED()         \
-    do                                               \
     {                                                \
         CALLED_FAKE(OpenSslFake_BioSetFlags, NEVER); \
-    } while (0)
+    }
 #define CHECK_BIO_RETRY_FLAGS_CLEARED()               \
-    do                                                \
     {                                                 \
         CALLED_FAKE(OpenSslFake_BioClearFlags, ONCE); \
-    } while (0)
+    }
 #define CHECK_SSL_SESSION_CLOSED()               \
-    do                                           \
     {                                            \
         CALLED_FAKE(OpenSslFake_Shutdown, ONCE); \
         CALLED_FAKE(OpenSslFake_Free, ONCE);     \
-    } while (0)
+    }
 #define CHECK_TRANSPORT_CLOSED_ONCE()                      \
-    do                                                     \
     {                                                      \
         CALLED_FAKE_ON(StreamFake_Close, transport, ONCE); \
-    } while (0)
+    }
 
 TEST(SolidSyslogTlsStream, CreateSucceeds)
 {

--- a/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
+++ b/Tests/SolidSyslogWindowsAtomicCounterPoolTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -23,7 +22,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsAtomicCounterPool)

--- a/Tests/SolidSyslogWindowsFileTest.cpp
+++ b/Tests/SolidSyslogWindowsFileTest.cpp
@@ -21,7 +21,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -29,7 +28,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 

--- a/Tests/SolidSyslogWindowsMutexTest.cpp
+++ b/Tests/SolidSyslogWindowsMutexTest.cpp
@@ -15,7 +15,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -23,7 +22,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogWindowsMutex)

--- a/Tests/SolidSyslogWinsockAddressTest.cpp
+++ b/Tests/SolidSyslogWinsockAddressTest.cpp
@@ -17,7 +17,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -25,7 +24,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 TEST_GROUP(SolidSyslogWinsockAddress)

--- a/Tests/SolidSyslogWinsockDatagramTest.cpp
+++ b/Tests/SolidSyslogWinsockDatagramTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -30,7 +29,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 static const char* const TEST_MESSAGE     = "hello";

--- a/Tests/SolidSyslogWinsockResolverTest.cpp
+++ b/Tests/SolidSyslogWinsockResolverTest.cpp
@@ -21,7 +21,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -29,7 +28,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 // clang-format off
 static const char* const TEST_HOST           = "127.0.0.1";

--- a/Tests/SolidSyslogWinsockTcpStreamTest.cpp
+++ b/Tests/SolidSyslogWinsockTcpStreamTest.cpp
@@ -22,7 +22,6 @@ using namespace CososoTesting;
 
 // Asserts handle is non-null and not one of the slots in pool.
 #define CHECK_IS_FALLBACK(handle, pool)                                                \
-    do                                                                                 \
     {                                                                                  \
         CHECK_TEXT((handle) != nullptr, "Fallback handle was nullptr");                \
         for (auto* slot : (pool))                                                      \
@@ -30,7 +29,7 @@ using namespace CososoTesting;
             CHECK_TEXT(slot != nullptr, "pool slot was nullptr (FillPool failed?)");   \
             CHECK_TEXT((handle) != slot, "Fallback handle collided with a pool slot"); \
         }                                                                              \
-    } while (0)
+    }
 
 namespace
 {
@@ -117,11 +116,10 @@ TEST_GROUP(SolidSyslogWinsockTcpStream)
 // clang-format on
 
 #define CHECK_SOCKET_CLOSED_ONCE()                                   \
-    do                                                               \
     {                                                                \
         CALLED_FAKE(WinsockFake_Close, ONCE);                        \
         CHECK(WinsockFake_SocketFd() == WinsockFake_LastClosedFd()); \
-    } while (0)
+    }
 
 TEST(SolidSyslogWinsockTcpStream, CreateDestroyWorksWithoutCrashing)
 {

--- a/Tests/Support/TestUtils.h
+++ b/Tests/Support/TestUtils.h
@@ -40,14 +40,11 @@ enum
  * (source, category, detail) triple. Prefer the portable Category — it survives
  * a backend swap — over the per-class Detail code when a portable reaction is
  * the thing under test. Use at a site that includes "ErrorHandlerFake.h". */
-// NOLINTBEGIN(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
 #define CHECK_ERROR_EVENT(expectedSource, expectedCategory, expectedDetail)        \
-    do                                                                             \
     {                                                                              \
         POINTERS_EQUAL((expectedSource), ErrorHandlerFake_LastSource());           \
         UNSIGNED_LONGS_EQUAL((expectedCategory), ErrorHandlerFake_LastCategory()); \
         LONGS_EQUAL((expectedDetail), ErrorHandlerFake_LastDetail());              \
-    } while (0)
-// NOLINTEND(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)
+    }
 
 #endif /* TESTUTILS_H */


### PR DESCRIPTION
## Purpose

Closes #552.

CodeRabbit flagged `CHECK_FRAMED` on #551 for not using the house
`do { … } while (0)` + `NOLINT(...avoid-do-while)` "safe-test-macro" form. On
review, that safety is unreachable here: `.clang-format` sets `InsertBraces: true`
(our MISRA 15.6 enforcement), so every conditional body is already brace-delimited
before any macro expands — the wrapper's tail can never escape an `if`/`else`. The
`do/while(0)` is dead weight, and it *introduces* an `avoid-do-while` violation we
then silence with `NOLINT`. This removes the idiom tree-wide and turns the lint
check back on so it can't return.

## Change Description

- Removed `do { … } while (0)` from every test assertion/helper macro (42 files,
  ~60 macros), plus the paired
  `NOLINTBEGIN/END(cppcoreguidelines-macro-usage,cppcoreguidelines-avoid-do-while)`
  brackets (8 files had them).
- Multi-statement bodies → plain compound `{ … }` (block scope kept, which matters
  for macros declaring a local — e.g. `CHECK_BLOCK_CONTAINS`'s `checkBuf`,
  `CHECK_IS_FALLBACK`'s `for` var). Single-statement macros were already bare
  expressions and are untouched.
- **Re-enabled `cppcoreguidelines-avoid-do-while` in `Tests/.clang-tidy`** so the
  wrapper can't creep back. `cppcoreguidelines-macro-usage` stays disabled
  (CppUTest needs macros for caller `__FILE__`/`__LINE__`), so no per-site NOLINT
  is required.
- Left the upstream-convention `configASSERT` (FreeRTOS) and
  `LWIP_PLATFORM_DIAG`/`LWIP_PLATFORM_ASSERT` (lwIP) macros in the fake config
  headers as `do/while(0)` — they're consumed by un-formatted upstream code where
  InsertBraces gives no cover. Safe under the re-enabled check: `configASSERT` has
  zero use sites in linted code; `LWIP_ASSERT` expands only in
  `Bdd/Targets/FreeRtosLwip/netif/EthernetIf.c` (under `Bdd/.clang-tidy`).
- Updated the CLAUDE.md "Test code" convention + DEVLOG; fixed a stale
  `CHECK_PRIVAL` path reference.

## Test Evidence

Builds via docker compose (`.devcontainer/docker-compose.yml`):

- `debug`: **1482 tests pass**, no behaviour change (same assertions/counts).
- `tidy` (Posix/OpenSsl) with `avoid-do-while` now enforced: green, no do/while
  warnings.
- `cppcheck` clean rebuild: green.
- `clang-format` dry-run: clean tree-wide.
- `freertos-host` debug build: green (covers FreeRtos/Lwip/MbedTls/FatFs/PlusFat
  test trees).

Windows/Winsock and the freertos/lwip clang-tidy lanes are CI's job; the
conversions there are identical and mechanical.

## Areas Affected

- `Tests/**` (assertion/helper macros), `Tests/.clang-tidy`
- `CLAUDE.md`, `DEVLOG.md`
- No production code (`Core/`, `Platform/`) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test assertion macro structures across the test suite by removing unnecessary control-flow wrappers and replacing them with standard compound blocks.
  * Updated test code style guidelines and linter configuration to enforce the new macro patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->