### PR TITLE
feat: S30.02 consumer-friendly CMake umbrellas + dogfood BDD targets

### DIFF
--- a/Bdd/Targets/FreeRtos/CMakeLists.txt
+++ b/Bdd/Targets/FreeRtos/CMakeLists.txt
@@ -266,25 +266,9 @@ add_executable(SolidSyslogBddTarget
     Startup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Common/CmsdkUart.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Common/Syscalls.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusFat/Source/SolidSyslogPlusFatFile.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusFat/Source/SolidSyslogPlusFatFileStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpAddress.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpAddressStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpDatagram.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpDatagramStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutexStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpResolver.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpResolverStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosSysUpTime.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpTcpStream.c
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source/SolidSyslogPlusTcpTcpStreamStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsStreamStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsHmacSha256Policy.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsHmacSha256PolicyStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsAesGcmPolicy.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsAesGcmPolicyStatic.c
+    # SolidSyslog platform adapters arrive via the SolidSyslog::{PlusTcp,FreeRtos,
+    # MbedTls,PlusFat} pack umbrellas linked below (S30.02 dogfood) — their
+    # target_sources(INTERFACE) compile here against this target's config.
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/BddTargetErrorText.c
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/BddTargetFreeRtosPipeline.c
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/BddTargetCustomSd.c
@@ -317,13 +301,8 @@ target_include_directories(SolidSyslogBddTarget PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Common                # CmsdkUart.h
     ${CMAKE_SOURCE_DIR}/Core/Interface                # SolidSyslog*.h
     ${CMAKE_SOURCE_DIR}/Core/Source                   # internal headers consumed by adapters
-    ${CMAKE_SOURCE_DIR}/Platform/PlusFat/Interface    # SolidSyslogPlusFatFile.h
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Interface   # SolidSyslogFreeRtos{Mutex,SysUpTime}.h
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source      # SolidSyslogFreeRtosMutexPrivate.h
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Interface    # SolidSyslogFreeRtos{Address,Datagram,Resolver,TcpStream}.h
-    ${CMAKE_SOURCE_DIR}/Platform/PlusTcp/Source       # SolidSyslogPlusTcpAddressPrivate.h
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Interface    # SolidSyslogMbedTlsStream.h
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source       # SolidSyslogMbedTlsStreamPrivate.h
+    # Platform/{PlusFat,FreeRtos,PlusTcp,MbedTls}/{Interface,Source} include dirs
+    # now arrive transitively from the SolidSyslog::* pack umbrellas linked below.
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common            # BddTargetInteractive.h
     ${BAKED_PEMS_DIR}                                 # BddBaked*.h (xxd -i output)
     ${FREERTOS_KERNEL_PATH}/include
@@ -352,6 +331,10 @@ set_source_files_properties(
 
 target_link_libraries(SolidSyslogBddTarget PRIVATE
     ${PROJECT_NAME}                                   # libSolidSyslog.a (cross-compiled)
+    SolidSyslog::PlusTcp                              # Address/Datagram/Resolver/TcpStream adapters (sources)
+    SolidSyslog::FreeRtos                             # Mutex + SysUpTime adapters (sources)
+    SolidSyslog::MbedTls                              # TLS Stream + HMAC/AES-GCM policy adapters (sources)
+    SolidSyslog::PlusFat                              # Plus-FAT file adapter (sources)
     mbedtls mbedx509 mbedcrypto                       # mbedTLS upstream (subproject, cross-compiled)
 )
 

--- a/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
+++ b/Bdd/Targets/FreeRtosLwip/CMakeLists.txt
@@ -225,29 +225,12 @@ add_executable(SolidSyslogBddTargetLwip
     ${FREERTOS_COMMON_DIR}/CmsdkUart.c
     ${FREERTOS_COMMON_DIR}/Syscalls.c
     netif/EthernetIf.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawAddress.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawAddressStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDnsResolver.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDnsResolverStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDatagram.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawDatagramStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStream.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawTcpStreamStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source/SolidSyslogLwipRawMarshal.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutex.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosMutexStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source/SolidSyslogFreeRtosSysUpTime.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsStream.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsStreamStatic.c
-    # At-rest store: FatFs file adapter + the mbedTLS HMAC / AES-GCM security
-    # policies (Crc16Policy lives in Core, already linked). diskio.c is the
-    # shared semihosting media driver (Bdd/Targets/Common, 8 MiB FAT16).
-    ${CMAKE_SOURCE_DIR}/Platform/FatFs/Source/SolidSyslogFatFsFile.c
-    ${CMAKE_SOURCE_DIR}/Platform/FatFs/Source/SolidSyslogFatFsFileStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsHmacSha256Policy.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsHmacSha256PolicyStatic.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsAesGcmPolicy.c
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source/SolidSyslogMbedTlsAesGcmPolicyStatic.c
+    # SolidSyslog platform adapters arrive via the SolidSyslog::* pack umbrellas
+    # linked below (S30.02 dogfood): LwipRawDnsResolver (the opt-in DNS component
+    # — pulls the LwipRaw umbrella's Address/Datagram/TcpStream/numeric-Resolver/
+    # Marshal too; the unused numeric resolver dead-strips), FreeRtos (Mutex +
+    # SysUpTime), MbedTls (TLS Stream + HMAC/AES-GCM policies), FatFs (file
+    # adapter). diskio.c is the shared semihosting media driver (8 MiB FAT16).
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/diskio.c
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/SemihostingDisk.c
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common/BddTargetErrorText.c
@@ -282,13 +265,8 @@ target_include_directories(SolidSyslogBddTargetLwip PRIVATE
     ${FREERTOS_COMMON_DIR}                            # CmsdkUart.h
     ${CMAKE_SOURCE_DIR}/Core/Interface                # SolidSyslog*.h
     ${CMAKE_SOURCE_DIR}/Core/Source                   # internal headers consumed by adapters
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Interface    # SolidSyslogLwipRaw{Address,DnsResolver,Datagram,TcpStream,Marshal}.h
-    ${CMAKE_SOURCE_DIR}/Platform/LwipRaw/Source        # SolidSyslogLwipRaw*Private.h
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Interface   # SolidSyslogFreeRtos{Mutex,SysUpTime}.h
-    ${CMAKE_SOURCE_DIR}/Platform/FreeRtos/Source      # SolidSyslogFreeRtosMutexPrivate.h
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Interface    # SolidSyslogMbedTlsStream.h, *Policy.h
-    ${CMAKE_SOURCE_DIR}/Platform/MbedTls/Source       # SolidSyslogMbedTlsStreamPrivate.h
-    ${CMAKE_SOURCE_DIR}/Platform/FatFs/Interface      # SolidSyslogFatFsFile.h
+    # Platform/{LwipRaw,FreeRtos,MbedTls,FatFs}/{Interface,Source} include dirs
+    # now arrive transitively from the SolidSyslog::* pack umbrellas linked below.
     ${FATFS_STAGE_DIR}                                # ff.h, diskio.h + integrator ffconf.h colocated
     ${BAKED_PEMS_DIR}                                 # BddBaked*.h (xxd -i output)
     ${CMAKE_SOURCE_DIR}/Bdd/Targets/Common            # BddTargetInteractive.h, BddTargetSwitchConfig.h, …
@@ -300,6 +278,10 @@ target_include_directories(SolidSyslogBddTargetLwip PRIVATE
 
 target_link_libraries(SolidSyslogBddTargetLwip PRIVATE
     ${PROJECT_NAME}                                   # libSolidSyslog.a (cross-compiled)
+    SolidSyslog::LwipRawDnsResolver                   # DNS resolver (opt-in, needs LWIP_DNS=1) + LwipRaw umbrella
+    SolidSyslog::FreeRtos                             # Mutex + SysUpTime adapters (sources)
+    SolidSyslog::MbedTls                              # TLS Stream + HMAC/AES-GCM policy adapters (sources)
+    SolidSyslog::FatFs                                # FatFs file adapter (sources)
     mbedtls mbedx509 mbedcrypto                       # mbedTLS upstream (subproject, cross-compiled)
 )
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,49 @@
 # Dev Log
 
+## 2026-06-10 — S30.02 consumer-friendly CMake umbrellas + dogfood
+
+E30's CI-risk story. Made the six Pattern-B platform packs consumable in one line
+and proved it by routing the FreeRTOS BDD targets through them the way a customer
+would.
+
+### Decisions
+- **Packs carry their own sources.** Each pack (`FreeRtos`, `PlusTcp`, `LwipRaw`,
+  `MbedTls`, `FatFs`, `PlusFat`) now does `target_sources(<pack> INTERFACE …)`, so
+  linking it compiles the adapter `.c` into the consumer's target against the
+  consumer's config header. Discovered every pack's sources also need
+  `Core/Source` (the internal `SolidSyslogPoolAllocator.h`; MbedTls also
+  `SolidSyslogMacros.h`), so each pack exports `Interface` + `Source` +
+  `Core/Source` and links `SolidSyslogTunables` (Core/Interface). Nobody linked
+  these `INTERFACE` targets before, so the change is inert until consumers switch.
+- **`SolidSyslog::<Pack>` aliases.** Namespaced ALIAS per pack for the consumer
+  API.
+- **Umbrella vs component.** Umbrella = adapters that compile in *any* valid
+  config. The lwIP DNS resolver needs `LWIP_DNS=1`, so it's kept OUT of the
+  `LwipRaw` umbrella and shipped as opt-in `SolidSyslog::LwipRawDnsResolver`
+  (links the umbrella). Confirmed with David: MbedTls umbrella = Stream + both
+  at-rest policies (not split); tests stay hand-listed (they compile deliberate
+  per-adapter subsets — dogfood = BDD targets only).
+- **Dogfood = the two cross BDD targets.** FreeRtos (Plus-TCP) links
+  `SolidSyslog::{PlusTcp,FreeRtos,MbedTls,PlusFat}`; FreeRtosLwip links
+  `SolidSyslog::{LwipRawDnsResolver,FreeRtos,MbedTls,FatFs}`. Removed ~75 lines of
+  hand-listed `Platform/*/Source/*.c` + Platform include dirs.
+
+### Verification (local)
+- `freertos-cross` (Plus-TCP) and `freertos-cross-lwip` ARM ELFs both build + link
+  via the umbrellas.
+- Behaviour-neutral: same sources, same per-target config/defines. The lwIP target
+  now also *compiles* the umbrella's numeric resolver, but it's unreferenced and
+  `arm-none-eabi-nm` confirms it's **absent from the linked ELF** (dead-stripped
+  under `-Wl,--gc-sections`).
+- `freertos-host` TDD suite configures + passes (pack CMake executes cleanly on a
+  host compiler; tests unaffected).
+- Updated `getting-started.md` Path A to document the now-available umbrellas
+  (replacing the "lands in S30.02" placeholder).
+
+### Deferred
+- Manifest generation from CMake (S30.03 #569).
+- Fine-grained per-adapter component targets beyond the DnsResolver split.
+
 ## 2026-06-10 — S30.01 getting-started doc + integration manifest
 
 First story of E30 (#566, frictionless integration). Docs-only, authored against

--- a/Platform/FatFs/CMakeLists.txt
+++ b/Platform/FatFs/CMakeLists.txt
@@ -10,16 +10,28 @@
 # Tests/FatFs/*Test, downstream integrator apps) recompiles the adapter
 # sources with its own ffconf.h on the include path. Mirrors the
 # Platform/FreeRtos/ pack — see project_header_configured_platforms memory.
+#
+# The pack CARRIES its sources via target_sources(INTERFACE) (S30.02): a
+# consumer that links SolidSyslog::FatFs compiles the adapter into its own
+# target, seeing its own ffconf.h — no per-file listing. The consumer still
+# points at its own FatFs tree and supplies its own diskio.c.
 
 add_library(SolidSyslogFatFs INTERFACE)
 
-# No adapter sources at S08.05 slice 1 — first content
-# (SolidSyslogFatFsFile.c) lands at slice 2. The INTERFACE target exists
-# so the directory and CMake wiring are in place from the plumbing slice.
+target_sources(SolidSyslogFatFs INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogFatFsFile.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogFatFsFileStatic.c
+)
 
 target_include_directories(SolidSyslogFatFs INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogFatFsFilePrivate.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h
 )
+
+target_link_libraries(SolidSyslogFatFs INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::FatFs ALIAS SolidSyslogFatFs)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/Platform/FreeRtos/CMakeLists.txt
+++ b/Platform/FreeRtos/CMakeLists.txt
@@ -13,16 +13,31 @@
 # Posix / Windows / OpenSSL keep the existing PRIVATE-into-${PROJECT_NAME}
 # pattern; their ABIs are OS-level, not header-configured. Don't retrofit
 # INTERFACE across the tree.
+#
+# The pack CARRIES its sources via target_sources(INTERFACE) (S30.02): a
+# consumer that links SolidSyslog::FreeRtos compiles the kernel-primitive
+# adapters into its own target, seeing its own FreeRTOSConfig.h — no per-file
+# listing. The consumer still points at its own FreeRTOS-Kernel tree.
 
 add_library(SolidSyslogFreeRtos INTERFACE)
 
-# No adapter sources at S08.01 — first content (SolidSyslogFreeRtosMutex.c)
-# lands at S08.04. The INTERFACE target exists so the directory and CMake
-# wiring are in place from day one.
+# Kernel primitives, independent of the chosen networking backend: the
+# static-allocation Mutex and the kernel-tick SysUpTime source.
+target_sources(SolidSyslogFreeRtos INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogFreeRtosMutex.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogFreeRtosMutexStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogFreeRtosSysUpTime.c
+)
 
 target_include_directories(SolidSyslogFreeRtos INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogFreeRtosMutexPrivate.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h
 )
+
+target_link_libraries(SolidSyslogFreeRtos INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::FreeRtos ALIAS SolidSyslogFreeRtos)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/Platform/LwipRaw/CMakeLists.txt
+++ b/Platform/LwipRaw/CMakeLists.txt
@@ -15,12 +15,57 @@
 # primitives in Source/. Any host primitive needed (e.g. a wait primitive for DNS in
 # the future S28.07 sibling) is abstracted behind a SolidSyslog* vtable, mirroring
 # how SolidSyslogMutex abstracts locking. See E28 (#439) Architecture boundary.
+#
+# The pack CARRIES its umbrella sources via target_sources(INTERFACE) (S30.02):
+# a consumer that links SolidSyslog::LwipRaw compiles the adapter .c files into
+# its own target, seeing its own lwipopts.h — no per-file listing. The pack
+# exports the SolidSyslog-side include dirs its sources need (its own
+# Interface/Source, Core/Interface via SolidSyslogTunables, and Core/Source for
+# the internal pool-allocator helper); the consumer still points at its own lwIP
+# tree (lwip/*.h are consumer-located).
 
 add_library(SolidSyslogLwipRaw INTERFACE)
 
+# Umbrella = the adapters that compile in ANY valid lwIP config: Address,
+# Datagram, TcpStream, the NUMERIC Resolver, and the Marshal hop. The DNS
+# resolver is config-gated (needs LWIP_DNS=1) and is kept OUT of the umbrella —
+# see the SolidSyslogLwipRawDnsResolver component below.
+target_sources(SolidSyslogLwipRaw INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawAddress.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawAddressStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawDatagram.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawDatagramStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawTcpStream.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawTcpStreamStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawResolver.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawResolverStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawMarshal.c
+)
+
 target_include_directories(SolidSyslogLwipRaw INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogLwipRaw*Private.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h
 )
+
+target_link_libraries(SolidSyslogLwipRaw INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::LwipRaw ALIAS SolidSyslogLwipRaw)
+
+# Opt-in DNS resolver component — REQUIRES LWIP_DNS=1 in the consumer's
+# lwipopts.h. Kept out of the umbrella so a numeric-only build never has to
+# enable DNS. Links the umbrella, so a consumer that wants DNS links just this
+# one target and gets Address/Datagram/TcpStream/Marshal too.
+add_library(SolidSyslogLwipRawDnsResolver INTERFACE)
+
+target_sources(SolidSyslogLwipRawDnsResolver INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawDnsResolver.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogLwipRawDnsResolverStatic.c
+)
+
+target_link_libraries(SolidSyslogLwipRawDnsResolver INTERFACE SolidSyslogLwipRaw)
+
+add_library(SolidSyslog::LwipRawDnsResolver ALIAS SolidSyslogLwipRawDnsResolver)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/Platform/MbedTls/CMakeLists.txt
+++ b/Platform/MbedTls/CMakeLists.txt
@@ -11,17 +11,36 @@
 # sources from Source/ with its own mbedtls_config.h on the include path.
 # Mirrors Platform/FreeRtos/ and Platform/FatFs/ — see
 # project_header_configured_platforms memory.
+#
+# The pack CARRIES its umbrella sources via target_sources(INTERFACE) (S30.02):
+# a consumer that links SolidSyslog::MbedTls compiles the adapter .c files into
+# its own target, seeing its own mbedtls_config.h — no per-file listing. The
+# consumer still points at its own mbedTLS tree (mbedtls/*.h are consumer-located)
+# and sets MBEDTLS_USER_CONFIG_FILE on its target.
 
 add_library(SolidSyslogMbedTls INTERFACE)
 
-# No adapter sources at S08.07 slice 1 — first content
-# (SolidSyslogMbedTlsStream.h plus the three-TU split) lands in the
-# slice-1 green step. The INTERFACE target exists so the directory and
-# CMake wiring are in place from the plumbing slice.
+# Umbrella = all mbedTLS adapters (they all compile against the consumer's
+# mbedtls_config.h): the TLS Stream plus the two at-rest SecurityPolicies.
+# Unused TUs dead-strip at link time (-Wl,--gc-sections).
+target_sources(SolidSyslogMbedTls INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsStream.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsStreamStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsHmacSha256Policy.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsHmacSha256PolicyStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsAesGcmPolicy.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogMbedTlsAesGcmPolicyStatic.c
+)
 
 target_include_directories(SolidSyslogMbedTls INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogMbedTls*Private.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h, SolidSyslogMacros.h
 )
+
+target_link_libraries(SolidSyslogMbedTls INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::MbedTls ALIAS SolidSyslogMbedTls)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/Platform/PlusFat/CMakeLists.txt
+++ b/Platform/PlusFat/CMakeLists.txt
@@ -12,12 +12,28 @@
 # sources with its own FreeRTOSFATConfig.h on the include path. Mirrors the
 # Platform/FatFs/ and Platform/FreeRtos/ packs — see
 # project_header_configured_platforms memory.
+#
+# The pack CARRIES its sources via target_sources(INTERFACE) (S30.02): a
+# consumer that links SolidSyslog::PlusFat compiles the adapter into its own
+# target, seeing its own FreeRTOSFATConfig.h — no per-file listing. The consumer
+# still points at its own FreeRTOS-Plus-FAT tree and supplies its FF_Disk_t driver.
 
 add_library(SolidSyslogPlusFat INTERFACE)
 
+target_sources(SolidSyslogPlusFat INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusFatFile.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusFatFileStatic.c
+)
+
 target_include_directories(SolidSyslogPlusFat INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogPlusFatFilePrivate.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h
 )
+
+target_link_libraries(SolidSyslogPlusFat INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::PlusFat ALIAS SolidSyslogPlusFat)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/Platform/PlusTcp/CMakeLists.txt
+++ b/Platform/PlusTcp/CMakeLists.txt
@@ -11,12 +11,36 @@
 # sources with its own config on the include path. Mirrors Platform/FreeRtos/
 # (kernel primitives — Mutex, SysUpTime) and Platform/MbedTls/ — see
 # project_header_configured_platforms memory.
+#
+# The pack CARRIES its umbrella sources via target_sources(INTERFACE) (S30.02):
+# a consumer that links SolidSyslog::PlusTcp compiles the adapter .c files into
+# its own target, seeing its own FreeRTOSConfig.h / FreeRTOSIPConfig.h — no
+# per-file listing. The consumer still points at its own FreeRTOS-Plus-TCP tree.
 
 add_library(SolidSyslogPlusTcp INTERFACE)
 
+# Umbrella = all four FreeRTOS-Plus-TCP networking adapters (no config-gated
+# optional): Address, Datagram, Resolver, TcpStream.
+target_sources(SolidSyslogPlusTcp INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpAddress.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpAddressStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpDatagram.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpDatagramStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpResolver.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpResolverStatic.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpTcpStream.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source/SolidSyslogPlusTcpTcpStreamStatic.c
+)
+
 target_include_directories(SolidSyslogPlusTcp INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/Source          # SolidSyslogPlusTcp*Private.h
+    ${CMAKE_SOURCE_DIR}/Core/Source             # SolidSyslogPoolAllocator.h
 )
+
+target_link_libraries(SolidSyslogPlusTcp INTERFACE SolidSyslogTunables)
+
+add_library(SolidSyslog::PlusTcp ALIAS SolidSyslogPlusTcp)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Interface/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,12 +106,8 @@ later epic, but the seams exist today.)
 
 ## Path A — CMake consumer
 
-> The frictionless one-line-per-platform form (`SolidSyslog::LwipRaw` +
-> `SolidSyslog::MbedTls` umbrella targets) lands in S30.02. Until then, the
-> current consumer path is the maintainer/CI mechanism described here.
-
-Selection today is auto-detect plus environment variables pointing at your
-upstream trees:
+Selection is auto-detect plus environment variables pointing at your upstream
+trees:
 
 - Host roles (POSIX / Winsock / OpenSSL / C11 atomics) are **auto-detected**
   (`find_package(OpenSSL)`, `check_symbol_exists`, an `_Atomic` compile probe)
@@ -121,11 +117,30 @@ upstream trees:
 - The FreeRTOS networking backend is chosen with
   `-DSOLIDSYSLOG_FREERTOS_NET=PLUSTCP|LWIP|BOTH`.
 
-The header-configured packs (`FreeRtos`, `PlusTcp`, `LwipRaw`, `MbedTls`,
-`FatFs`, `PlusFat`) are `INTERFACE` libraries that export include dirs; today the
-consuming target still hand-lists `Platform/<X>/Source/*.c`. See the worked
-target wiring in [`Bdd/Targets/FreeRtos/`](../Bdd/Targets/FreeRtos/) for a
-complete example, and the platform-specific guides:
+The header-configured packs ship as **namespaced umbrella targets** — link one
+per platform and the adapter sources compile into *your* target against *your*
+config header, with the SolidSyslog-side include dirs carried automatically (you
+still point at your own upstream trees):
+
+```cmake
+target_link_libraries(my_app PRIVATE
+    SolidSyslog::LwipRaw      # Address + Datagram + TcpStream + numeric Resolver + Marshal
+    SolidSyslog::MbedTls      # TLS Stream + HMAC / AES-GCM at-rest policies
+    SolidSyslog::FreeRtos     # Mutex + SysUpTime
+    SolidSyslog::FatFs)       # FatFs file adapter
+```
+
+Available umbrellas: `SolidSyslog::FreeRtos`, `SolidSyslog::PlusTcp`,
+`SolidSyslog::LwipRaw`, `SolidSyslog::MbedTls`, `SolidSyslog::FatFs`,
+`SolidSyslog::PlusFat`. The lwIP **DNS** resolver is config-gated (needs
+`LWIP_DNS=1`), so it sits outside the umbrella as an opt-in component —
+`SolidSyslog::LwipRawDnsResolver` (linking it also pulls the `LwipRaw` umbrella).
+A numeric-only lwIP build links `SolidSyslog::LwipRaw` and never enables DNS.
+
+See the worked target wiring in
+[`Bdd/Targets/FreeRtos/`](../Bdd/Targets/FreeRtos/) and
+[`Bdd/Targets/FreeRtosLwip/`](../Bdd/Targets/FreeRtosLwip/) (both consume the
+umbrellas), and the platform-specific guides:
 
 - [Integrating with lwIP (Raw API)](integrating-lwip.md)
 - [Integrating with Mbed TLS](integrating-mbedtls.md)


### PR DESCRIPTION
## Purpose

E30 (#566), the **CI-guardrail** story. Make CMake consumers link **one umbrella
per platform** instead of hand-listing `.c` files, keep the upstream-config-gated
lwIP DNS resolver opt-in, and prove the consumer path in CI by **dogfooding** the
FreeRTOS BDD targets onto the packs.

Closes #568

## Change Description

**Packs carry their sources (commit 1, inert).** Each Pattern-B pack
(`FreeRtos`, `PlusTcp`, `LwipRaw`, `MbedTls`, `FatFs`, `PlusFat`) now carries its
adapter sources via `target_sources(<pack> INTERFACE …)`, so linking the pack
compiles the adapter `.c` into the consumer's target against the consumer's
config header. Each pack exports its `Interface` + `Source` include dirs plus
`Core/Source` (the adapters consume the internal `SolidSyslogPoolAllocator.h`;
MbedTls also `SolidSyslogMacros.h`), links `SolidSyslogTunables`, and gains a
`SolidSyslog::<Pack>` ALIAS.

- **Umbrella** = adapters that compile in *any* valid config.
- **lwIP DNS resolver is opt-in:** kept OUT of the `LwipRaw` umbrella (needs
  `LWIP_DNS=1`); shipped as `SolidSyslog::LwipRawDnsResolver`, which links the
  umbrella. A numeric-only lwIP build links `SolidSyslog::LwipRaw` and never
  enables DNS.
- **MbedTls umbrella = Stream + both at-rest policies** (HMAC-SHA256, AES-GCM) —
  confirmed not to split (epic defers fine-grained components).

Nobody linked these `INTERFACE` targets before, so commit 1 is inert on its own.

**Dogfood the BDD targets (commit 2).** Both FreeRTOS BDD targets stop
hand-listing `Platform/*/Source/*.c` (and the matching Platform include dirs) and
link the umbrellas the way a customer would:

- FreeRtos (Plus-TCP) → `SolidSyslog::{PlusTcp,FreeRtos,MbedTls,PlusFat}`
- FreeRtosLwip → `SolidSyslog::{LwipRawDnsResolver,FreeRtos,MbedTls,FatFs}`

**Docs (commit 3).** `getting-started.md` Path A now documents the umbrellas
(replacing the S30.01 "lands in S30.02" placeholder); DEVLOG updated.

## Test Evidence

Behaviour-neutral build refactor (CMake-only; no `.c`/`.h` changed, so no
format/tidy/cppcheck surface). Verified locally in the `freertos-target` and
`freertos-host` containers:

- `freertos-cross` (Plus-TCP) ARM ELF — **builds + links** via the umbrellas.
- `freertos-cross-lwip` ARM ELF — **builds + links**; the DnsResolver component
  pulls the umbrella; the umbrella's numeric resolver compiles but is
  **dead-stripped** (`arm-none-eabi-nm` confirms `SolidSyslogLwipRawResolver_Create`
  is absent from the linked ELF, DnsResolver present) — so the ELF is identical in
  behaviour.
- `freertos-host` debug TDD suite — **configures + tests pass** (pack CMake now
  executes on a host compiler; tests unaffected, they keep hand-listing subsets).

The full QEMU BDD lanes (`bdd-freertos-qemu-plustcp`, `bdd-freertos-qemu-lwip`)
and cross-build lanes run in CI; the ELFs are behaviourally identical so they are
expected green.

## Areas Affected

`Platform/{FreeRtos,PlusTcp,LwipRaw,MbedTls,FatFs,PlusFat}/CMakeLists.txt`,
`Bdd/Targets/FreeRtos/CMakeLists.txt`, `Bdd/Targets/FreeRtosLwip/CMakeLists.txt`,
`docs/getting-started.md`, `DEVLOG.md`. No Core/Platform source, no public header,
no test source changed. New public CMake surface: the `SolidSyslog::*` umbrella +
`SolidSyslog::LwipRawDnsResolver` targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored build system to introduce namespaced CMake umbrella targets (`SolidSyslog::*`) that consolidate platform adapter management, reducing boilerplate in consumer configurations.
  * Reorganized lwIP DNS resolver as an opt-in target component.

* **Documentation**
  * Updated getting-started guide with details on the new umbrella targets and their configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->