### PR TITLE
ci: park release-please until 0.1.0 beta baseline

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,18 @@
 name: Release Please
 
+# Parked: manual-trigger only until the first 0.1.0 beta baseline.
+#
+# With no prior release and a 0.0.0 manifest, release-please tries to build one
+# initial release PR from all of main's history; that changelog overflows
+# GitHub's PR-body limit and the run fails on every push. Rather than baseline
+# on this (personal) repo only to redo it after the business-org migration, the
+# push trigger is disabled. Re-enable it (restore `on: push: branches: [main]`)
+# at beta time, once .release-please-manifest.json is seeded to 0.1.0 and a
+# curated v0.1.0 release/tag exists, so release-please manages 0.1.x onward
+# incrementally. Until then it can still be exercised by hand via the Actions
+# tab (workflow_dispatch).
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## What

Switch the **Release Please** workflow to `workflow_dispatch`-only so it stops failing on every push to `main`.

## Why

With no prior release and a `0.0.0` manifest, release-please tries to build a single initial release PR from all of `main`'s history (~351 commits). That changelog overflows GitHub's ~64 KB PR-body limit, and the run then errors trying to spill the body to a `release-please--branches--main--release-notes` branch that doesn't exist:

```
##[error]release-please failed: Failed to find file: release-notes.md
```

It's been red on every main push for many runs. It is **not** in the branch-protection required checks, so this is non-blocking noise (red X + failure emails), not a merge gate.

Baselining release-please now would only be redone after the pending migration to the business GitHub org, so parking the push trigger is the lowest-effort fix.

## Re-enabling (at beta time)

Restore `on: push: branches: [main]`, after:
1. `.release-please-manifest.json` seeded to `0.1.0`, and
2. a curated `v0.1.0` release/tag exists,

so release-please manages `0.1.x` onward incrementally. Until then it can still be run by hand from the Actions tab (`workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to require manual trigger instead of automatically triggering on pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->