### PR TITLE
ci: make repro-mtls-flake.ps1 oracle cleanup not throw on clean start

### DIFF
--- a/scripts/repro-mtls-flake.ps1
+++ b/scripts/repro-mtls-flake.ps1
@@ -81,7 +81,7 @@ $stressJobs = @()
 $otel = $null
 try {
     Write-Host "Starting otelcol-contrib oracle..." -ForegroundColor Cyan
-    taskkill /F /IM otelcol-contrib.exe 2>$null | Out-Null
+    Get-Process otelcol-contrib -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
     $otel = Start-Process -FilePath $otelBin -ArgumentList "--config=$otelConfig" `
         -RedirectStandardOutput (Join-Path $outDir 'otelcol.out') `
         -RedirectStandardError  (Join-Path $outDir 'otelcol.err') `
@@ -124,5 +124,5 @@ try {
 }
 finally {
     if ($stressJobs) { $stressJobs | Remove-Job -Force -ErrorAction SilentlyContinue }
-    taskkill /F /IM otelcol-contrib.exe 2>$null | Out-Null
+    Get-Process otelcol-contrib -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
Follow-up to #576.

## Problem

The repro script cleared stale oracles with `taskkill /F /IM otelcol-contrib.exe 2>$null`. Under `$ErrorActionPreference='Stop'` (and PowerShell 5.1's handling of native-command stderr), the "process not found" message taskkill emits when nothing is running becomes a **terminating error**. On a clean box — no leftover otelcol — the *startup* cleanup throws before the oracle is ever started, which surfaced as "not finding the oracle". (It only appeared to work when a stale otelcol happened to be present, so taskkill succeeded.)

## Fix

Replace both `taskkill` calls with a PowerShell-native, non-throwing kill:

```powershell
Get-Process otelcol-contrib -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
```

## Verification

On a native Windows box: **60/60 `@mtls` iterations pass under `-Stress`**, confirming the stderr-drain fix from #576 holds under sustained CPU load (no `0 of 1` stalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced process termination reliability in the mTLS flake reproduction utility during startup and shutdown sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->