### PR TITLE
chore: remove restate-what comments across code and tests

### DIFF
--- a/Bdd/Targets/Common/BddTargetFreeRtosPipeline.c
+++ b/Bdd/Targets/Common/BddTargetFreeRtosPipeline.c
@@ -180,8 +180,6 @@ static void GetAppName(struct SolidSyslogHeaderField* field, void* context);
 static void GetTimeQuality(struct SolidSyslogTimeQuality* timeQuality);
 static void ErrorHandlerEx(void* context, const struct SolidSyslogErrorEvent* event);
 
-/* ---- console glue ---------------------------------------------------------- */
-
 static uint32_t MmioRead32(uintptr_t address)
 {
     // NOLINTNEXTLINE(performance-no-int-to-ptr) -- mapping the CMSDK UART MMIO address into a 32-bit volatile pointer.
@@ -218,8 +216,6 @@ void BddTargetFreeRtosPipeline_SetConfig(const struct BddTargetFreeRtosPipelineC
 {
     g_config = config;
 }
-
-/* ---- SolidSyslog config callbacks ------------------------------------------ */
 
 static void GetAppName(struct SolidSyslogHeaderField* field, void* context)
 {
@@ -268,8 +264,6 @@ static void ErrorHandlerEx(void* context, const struct SolidSyslogErrorEvent* ev
         message
     );
 }
-
-/* ---- interactive `set` handler --------------------------------------------- */
 
 static bool OnSet(const char* name, const char* value)
 {
@@ -484,8 +478,6 @@ static bool TryParseUInt(const char* value, unsigned long* out)
     return true;
 }
 
-/* ---- store + security policy lifecycle ------------------------------------- */
-
 /* DEMO KEY ONLY. A real integrator supplies key material from a secure element,
  * a KDF, or encrypted NVM via their own SolidSyslogKeyFunction — never a
  * hard-coded constant. This exists so the BDD scenario can exercise the mbedTLS
@@ -661,8 +653,6 @@ static void OnThresholdCrossed(void* context)
     (void) printf("[THRESHOLD-CROSSED]\r\n");
 }
 
-/* ---- teardown -------------------------------------------------------------- */
-
 /* Full teardown of every shared resource. Two entry points — `quit` (falls
  * through after BddTargetInteractive_Run returns) and `set shutdown 1` — both
  * route through here. The platform UnmountStore hook fires regardless so the
@@ -724,8 +714,6 @@ void BddTargetFreeRtosPipeline_Exit(int status)
     {
     }
 }
-
-/* ---- tasks ----------------------------------------------------------------- */
 
 void BddTargetFreeRtosPipeline_InteractiveTask(void* argument)
 {

--- a/Bdd/features/environment.py
+++ b/Bdd/features/environment.py
@@ -225,7 +225,6 @@ def _dump_target_log(process, attr, channel, prefix):
 
 
 def after_scenario(context, scenario):
-    # Clean up any long-lived interactive process
     if hasattr(context, "interactive_process"):
         process = context.interactive_process
         if process.poll() is None:

--- a/Bdd/features/steps/syslog_steps.py
+++ b/Bdd/features/steps/syslog_steps.py
@@ -1039,7 +1039,6 @@ def step_check_msg(context, msg):
 @then("the syslog oracle receives {count:d} message")
 @then("the syslog oracle receives {count:d} messages")
 def step_check_message_count(context, count):
-    # For interactive processes, refresh the line count
     if hasattr(context, "interactive_process"):
         wait_for_messages(context, count)
     assert context.message_count == count, (
@@ -1277,7 +1276,6 @@ def step_check_contiguous_sequence_ids(context):
             f"No sequenceId in structured data: {sd}"
         )
         ids.append(int(match.group(1)))
-    # Check that IDs form a contiguous ascending sequence
     for i in range(1, len(ids)):
         assert ids[i] == ids[i - 1] + 1, (
             f"Non-contiguous sequenceIds: {ids[i - 1]} followed by {ids[i]}"

--- a/Core/Source/SolidSyslogBlockStore.c
+++ b/Core/Source/SolidSyslogBlockStore.c
@@ -105,10 +105,6 @@ static void BlockStore_ResumeFromExistingBlock(struct SolidSyslogBlockStore* sel
     }
 }
 
-/* ------------------------------------------------------------------
- * BlockStore_Write
- * ----------------------------------------------------------------*/
-
 static bool BlockStore_StoreRecord(struct SolidSyslogBlockStore* self, const void* data, size_t size);
 
 static bool BlockStore_Write(struct SolidSyslogStore* base, const void* data, size_t size)
@@ -145,10 +141,6 @@ static bool BlockStore_StoreRecord(struct SolidSyslogBlockStore* self, const voi
     return written;
 }
 
-/* ------------------------------------------------------------------
- * BlockStore_HasUnsent / BlockStore_IsHalted / BlockStore_GetTotalBytes / BlockStore_GetUsedBytes
- * ----------------------------------------------------------------*/
-
 static bool BlockStore_HasUnsent(struct SolidSyslogStore* base)
 {
     return BlockSequence_HasUnsent(BlockStore_SelfFromBase(base)->BlockSequence);
@@ -177,10 +169,6 @@ static bool BlockStore_IsTransient(struct SolidSyslogStore* base)
     (void) base;
     return false;
 }
-
-/* ------------------------------------------------------------------
- * BlockStore_ReadNextUnsent
- * ----------------------------------------------------------------*/
 
 static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* self, void* data, size_t maxSize, size_t* bytesRead);
 
@@ -217,10 +205,6 @@ static bool BlockStore_ReadCurrent(struct SolidSyslogBlockStore* self, void* dat
         bytesRead
     );
 }
-
-/* ------------------------------------------------------------------
- * BlockStore_MarkSent
- * ----------------------------------------------------------------*/
 
 static void BlockStore_MarkSent(struct SolidSyslogStore* base)
 {

--- a/Core/Source/SolidSyslogCircularBuffer.c
+++ b/Core/Source/SolidSyslogCircularBuffer.c
@@ -109,7 +109,6 @@ static inline void CircularBuffer_ConsumeWrapMarker(struct SolidSyslogCircularBu
 
 static inline size_t CircularBuffer_PeekRecordSize(const struct SolidSyslogCircularBuffer* self)
 {
-    /* Little-endian read of the 2-byte length header out of the uint8_t ring. */
     return ((size_t) self->Ring[self->Head]) | (((size_t) self->Ring[self->Head + 1U]) << 8U);
 }
 
@@ -185,7 +184,6 @@ static inline void CircularBuffer_WrapTail(struct SolidSyslogCircularBuffer* sel
 
 static inline void CircularBuffer_StoreRecord(struct SolidSyslogCircularBuffer* self, const void* data, size_t size)
 {
-    /* Little-endian write of the 2-byte length header into the uint8_t ring. */
     self->Ring[self->Tail] = (uint8_t) (size & 0xFFU);
     self->Ring[self->Tail + 1U] = (uint8_t) ((size >> 8U) & 0xFFU);
     (void) memcpy(&self->Ring[self->Tail + HEADER_BYTES], data, size);

--- a/Core/Source/SolidSyslogFileBlockDevice.c
+++ b/Core/Source/SolidSyslogFileBlockDevice.c
@@ -115,10 +115,6 @@ static inline void FileBlockDevice_CloseIfOpen(struct OpenHandle* handle)
     }
 }
 
-/* ------------------------------------------------------------------
- * FileBlockDevice_Acquire
- * ----------------------------------------------------------------*/
-
 static bool FileBlockDevice_EnsureHandleOpenOnBlock(
     struct OpenHandle* handle,
     const struct SolidSyslogFileBlockDevice* self,
@@ -220,10 +216,6 @@ static inline const char* FileBlockDevice_FormatBlockFilename(
     return SolidSyslogFormatter_AsFormattedBuffer(formatter);
 }
 
-/* ------------------------------------------------------------------
- * FileBlockDevice_Dispose
- * ----------------------------------------------------------------*/
-
 static inline void FileBlockDevice_CloseIfHoldingBlock(struct OpenHandle* handle, size_t blockIndex);
 
 static bool FileBlockDevice_Dispose(struct SolidSyslogBlockDevice* base, size_t blockIndex)
@@ -253,10 +245,6 @@ static inline void FileBlockDevice_CloseIfHoldingBlock(struct OpenHandle* handle
     }
 }
 
-/* ------------------------------------------------------------------
- * FileBlockDevice_Exists
- * ----------------------------------------------------------------*/
-
 static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* base, size_t blockIndex)
 {
     bool exists = false;
@@ -271,10 +259,6 @@ static bool FileBlockDevice_Exists(struct SolidSyslogBlockDevice* base, size_t b
 
     return exists;
 }
-
-/* ------------------------------------------------------------------
- * FileBlockDevice_Read / FileBlockDevice_Append / FileBlockDevice_WriteAt / FileBlockDevice_Size
- * ----------------------------------------------------------------*/
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) -- vtable signature: blockIndex / offset are positional, distinct semantics
 static bool FileBlockDevice_Read(

--- a/Tests/FileFake.c
+++ b/Tests/FileFake.c
@@ -135,10 +135,6 @@ static const struct SolidSyslogFile POISONED_VTABLE = {
     FileFake_DestroyedDelete,
 };
 
-/* ------------------------------------------------------------------
- * Create / Destroy
- * ----------------------------------------------------------------*/
-
 struct SolidSyslogFile* FileFake_Create(struct FileFakeStorage* storage)
 {
     struct FileFake* fake = (struct FileFake*) storage;
@@ -163,10 +159,6 @@ void FileFake_Destroy(void)
      * in Open detects ownership leaks across instances. */
     memset(filesystem, 0, sizeof(filesystem));
 }
-
-/* ------------------------------------------------------------------
- * Fail injection
- * ----------------------------------------------------------------*/
 
 void FileFake_FailNextOpen(struct SolidSyslogFile* file)
 {
@@ -208,10 +200,6 @@ void FileFake_FailNextDelete(struct SolidSyslogFile* file)
     AsFake(file)->failNextDelete = true;
 }
 
-/* ------------------------------------------------------------------
- * Inspection
- * ----------------------------------------------------------------*/
-
 const void* FileFake_FileContent(void)
 {
     return HasActiveFile(lastCreated) ? lastCreated->active->content : NULL;
@@ -226,10 +214,6 @@ static inline bool HasActiveFile(const struct FileFake* fake)
 {
     return FoundEntry(fake->active);
 }
-
-/* ------------------------------------------------------------------
- * Open
- * ----------------------------------------------------------------*/
 
 static bool FileFake_Open(struct SolidSyslogFile* self, const char* path)
 {
@@ -351,10 +335,6 @@ static inline void InitialiseEntry(struct FileEntry* entry, const char* path)
     SafeString_Copy(entry->path, FILEFAKE_MAX_PATH, path);
 }
 
-/* ------------------------------------------------------------------
- * Close
- * ----------------------------------------------------------------*/
-
 static void FileFake_Close(struct SolidSyslogFile* self)
 {
     struct FileFake* fake = AsFake(self);
@@ -380,19 +360,11 @@ static inline bool IsFileClosed(const struct FileFake* fake)
     return !fake->open;
 }
 
-/* ------------------------------------------------------------------
- * IsOpen
- * ----------------------------------------------------------------*/
-
 static bool FileFake_IsOpen(struct SolidSyslogFile* self)
 {
     struct FileFake* fake = AsFake(self);
     return fake->open;
 }
-
-/* ------------------------------------------------------------------
- * Read
- * ----------------------------------------------------------------*/
 
 static bool FileFake_Read(struct SolidSyslogFile* self, void* buf, size_t count)
 {
@@ -429,10 +401,6 @@ static inline void AdvancePosition(struct FileFake* fake, size_t count)
 {
     fake->position += count;
 }
-
-/* ------------------------------------------------------------------
- * Write
- * ----------------------------------------------------------------*/
 
 static bool FileFake_Write(struct SolidSyslogFile* self, const void* buf, size_t count)
 {
@@ -473,10 +441,6 @@ static inline void ExtendFileSize(struct FileFake* fake)
         fake->active->fileSize = fake->position;
     }
 }
-
-/* ------------------------------------------------------------------
- * SeekTo / Size / Truncate / Exists
- * ----------------------------------------------------------------*/
 
 static void FileFake_SeekTo(struct SolidSyslogFile* self, size_t offset)
 {

--- a/Tests/FileFakeTest.cpp
+++ b/Tests/FileFakeTest.cpp
@@ -263,10 +263,6 @@ TEST(FileFake, DeleteReturnsFalseForUnknownFile)
     CHECK_FALSE(SolidSyslogFile_Delete(api, "nonexistent.dat"));
 }
 
-/* ------------------------------------------------------------------
- * Two independent instances
- * ----------------------------------------------------------------*/
-
 TEST(FileFake, TwoInstancesShareFilesystem)
 {
     SolidSyslogFile_Open(api, "shared.dat");
@@ -302,10 +298,6 @@ TEST(FileFake, OpenWhileAnotherInstanceHoldsPathOpenAsserts)
     api = FileFake_Create(&storage);
 }
 
-/* ------------------------------------------------------------------
- * Operations on closed file
- * ----------------------------------------------------------------*/
-
 TEST(FileFake, CloseWithNoFileOpenThrows)
 {
     CHECK_THROWS(std::runtime_error, SolidSyslogFile_Close(api));
@@ -336,10 +328,6 @@ TEST(FileFake, TruncateWithNoFileOpenThrows)
 {
     CHECK_THROWS(std::runtime_error, SolidSyslogFile_Truncate(api));
 }
-
-/* ------------------------------------------------------------------
- * Operations after Destroy
- * ----------------------------------------------------------------*/
 
 // clang-format off
 TEST_GROUP(FileFakeAfterDestroy)
@@ -411,10 +399,6 @@ TEST(FileFakeAfterDestroy, DeleteThrows)
     CHECK_THROWS(std::runtime_error, SolidSyslogFile_Delete(api, "test.dat"));
 }
 
-/* ------------------------------------------------------------------
- * Stale handle after delete
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP(FileFakeStaleHandle)
 {
@@ -439,12 +423,10 @@ TEST_GROUP(FileFakeStaleHandle)
 
 TEST(FileFakeStaleHandle, ReadFailsOnStaleHandleAfterDeleteAndSlotReuse)
 {
-    /* handleA opens file "old.dat" and writes data */
     SolidSyslogFile_Open(handleA, "old.dat");
     const char data[] = "original";
     SolidSyslogFile_Write(handleA, data, sizeof(data));
 
-    /* Delete the file via handleB */
     SolidSyslogFile_Delete(handleB, "old.dat");
 
     /* Create a new file that could reuse the freed slot */

--- a/Tests/SolidSyslogBlockStorePosixTest.cpp
+++ b/Tests/SolidSyslogBlockStorePosixTest.cpp
@@ -127,11 +127,9 @@ TEST(SolidSyslogBlockStorePosix, DiscardOldestWhenReadIsPartwayThroughOldestBloc
     std::memset(msgC, 'C', sizeof(msgC));
     std::memset(msgD, 'D', sizeof(msgD));
 
-    /* Fill block 00 with two records */
     SolidSyslogStore_Write(store, msgA, sizeof(msgA));
     SolidSyslogStore_Write(store, msgB, sizeof(msgB));
 
-    /* Fill block 01 with two records */
     SolidSyslogStore_Write(store, msgC, sizeof(msgC));
     SolidSyslogStore_Write(store, msgD, sizeof(msgD));
 

--- a/Tests/SolidSyslogBlockStoreTest.cpp
+++ b/Tests/SolidSyslogBlockStoreTest.cpp
@@ -109,10 +109,6 @@ TEST_BASE(BlockDeviceTestBase)
 
 // clang-format on
 
-/* ------------------------------------------------------------------
- * Basic operations
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStore, BlockDeviceTestBase)
 {
@@ -326,10 +322,6 @@ TEST(SolidSyslogBlockStore, FiveWritesDrainAllInOrder)
     CHECK_FALSE(SolidSyslogStore_HasUnsent(store));
 }
 
-/* ------------------------------------------------------------------
- * Resume from existing block
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreResume, BlockDeviceTestBase)
 {
@@ -444,10 +436,6 @@ TEST(SolidSyslogBlockStoreResume, CanWriteNewMessagesAfterResume)
     MEMCMP_EQUAL("new", buf, strlen("new"));
 }
 
-/* ------------------------------------------------------------------
- * Destroy
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreDestroy, BlockDeviceTestBase)
 {
@@ -471,10 +459,6 @@ TEST(SolidSyslogBlockStoreDestroy, DoubleDestroyDoesNotCrash)
     SolidSyslogBlockStore_Destroy(store);
     SolidSyslogBlockStore_Destroy(store);
 }
-
-/* ------------------------------------------------------------------
- * Config validation
- * ----------------------------------------------------------------*/
 
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreConfig, BlockDeviceTestBase)
@@ -626,10 +610,6 @@ TEST(SolidSyslogBlockStoreConfig, OversizedSecurityPolicyLeavesNoIntegrityGap)
     MEMCMP_EQUAL(body, static_cast<const uint8_t*>(FileFake_FileContent()) + RECORD_HEADER, bodyLen);
 }
 
-/* ------------------------------------------------------------------
- * Error paths
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreErrors, BlockDeviceTestBase)
 {
@@ -703,10 +683,6 @@ TEST(SolidSyslogBlockStoreErrors, MarkSentDoesNotAdvanceWhenWriteFails)
 
     CHECK_TRUE(SolidSyslogStore_HasUnsent(store));
 }
-
-/* ------------------------------------------------------------------
- * Block rotation
- * ----------------------------------------------------------------*/
 
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreRotation, BlockDeviceTestBase)
@@ -1390,10 +1366,6 @@ TEST(SolidSyslogBlockStoreRotation, DiscardRetriesAfterTransientDisposeFailure)
     CHECK_FALSE(SolidSyslogFile_Exists(file, "/tmp/test_store00.log"));
 }
 
-/* ------------------------------------------------------------------
- * Integrity (SecurityPolicy integration)
- * ----------------------------------------------------------------*/
-
 enum
 {
     CONTENT_REGION_MAX = 2 + 2 + SOLIDSYSLOG_MAX_MESSAGE_SIZE /* magic + length + body */
@@ -1489,11 +1461,9 @@ TEST(SolidSyslogBlockStoreIntegrity, SealRecordReceivesContentRegionAndHeaderSpl
     /* magic|length is the cleartext header; message is the body */
     LONGS_EQUAL(HEADER_SIZE, sealHeaderLength);
 
-    /* verify magic bytes */
     BYTES_EQUAL(0xA5, sealContentData[0]);
     BYTES_EQUAL(0x5A, sealContentData[1]);
 
-    /* verify body is included */
     MEMCMP_EQUAL(TEST_DATA, sealContentData + HEADER_SIZE, TEST_DATA_LEN);
 }
 
@@ -1525,17 +1495,11 @@ TEST(SolidSyslogBlockStoreIntegrity, OpenRecordReceivesContentRegionAndHeaderSpl
     /* magic|length is the cleartext header; message is the body */
     LONGS_EQUAL(HEADER_SIZE, openHeaderLength);
 
-    /* verify magic bytes */
     BYTES_EQUAL(0xA5, openContentData[0]);
     BYTES_EQUAL(0x5A, openContentData[1]);
 
-    /* verify body is included */
     MEMCMP_EQUAL(TEST_DATA, openContentData + HEADER_SIZE, TEST_DATA_LEN);
 }
-
-/* ------------------------------------------------------------------
- * Corruption detection
- * ----------------------------------------------------------------*/
 
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreCorruption, BlockDeviceTestBase)
@@ -1685,10 +1649,6 @@ TEST(SolidSyslogBlockStoreCorruption, InvalidLengthReadReturnsFalse)
     CHECK_FALSE(SolidSyslogStore_ReadNextUnsent(store, buf, sizeof(buf), &bytesRead));
 }
 
-/* ------------------------------------------------------------------
- * Corruption recovery
- * ----------------------------------------------------------------*/
-
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreCorruptionRecovery, BlockDeviceTestBase)
 {
@@ -1782,10 +1742,6 @@ TEST(SolidSyslogBlockStoreCorruptionRecovery, CorruptWriteBlockRotatesOnNextWrit
     CHECK_TRUE(SolidSyslogStore_Write(store, newMsg, sizeof(newMsg)));
     CHECK_TRUE(SolidSyslogFile_Exists(file, "/tmp/test_store01.log"));
 }
-
-/* ------------------------------------------------------------------
- * Capacity getters
- * ----------------------------------------------------------------*/
 
 // clang-format off
 TEST_GROUP_BASE(SolidSyslogBlockStoreCapacity, BlockDeviceTestBase)
@@ -1918,10 +1874,6 @@ TEST(SolidSyslogBlockStoreCapacity, GetUsedBytesIsStickyAtTotalAfterSizeFailure)
     /* Sticky: GetUsedBytes returns total even though the active blocks have slack. */
     LONGS_EQUAL(SolidSyslogStore_GetTotalBytes(store), SolidSyslogStore_GetUsedBytes(store));
 }
-
-/* ------------------------------------------------------------------
- * Capacity threshold alert (S05.09)
- * ----------------------------------------------------------------*/
 
 static int CountThresholdCrossingsCallCount;
 static size_t thresholdReturnValue;

--- a/Tests/Support/FatFsFakes/Interface/FatFsFake.h
+++ b/Tests/Support/FatFsFakes/Interface/FatFsFake.h
@@ -8,46 +8,37 @@ EXTERN_C_BEGIN
 
     void FatFsFake_Reset(void);
 
-    /* f_open */
     void FatFsFake_SetOpenResult(FRESULT result);
     int FatFsFake_OpenCallCount(void);
     const char* FatFsFake_LastOpenPath(void);
     unsigned char FatFsFake_LastOpenMode(void);
 
-    /* f_close */
     int FatFsFake_CloseCallCount(void);
 
-    /* f_lseek */
     int FatFsFake_LseekCallCount(void);
     unsigned long FatFsFake_LastLseekOffset(void);
 
-    /* f_truncate */
     int FatFsFake_TruncateCallCount(void);
 
-    /* f_read */
     void FatFsFake_SetReadResult(FRESULT result);
     void FatFsFake_SetReadBytesReturned(unsigned int bytes);
     void FatFsFake_SetReadSource(const void* bytes, unsigned int count);
     int FatFsFake_ReadCallCount(void);
     unsigned int FatFsFake_LastReadCount(void);
 
-    /* f_write */
     void FatFsFake_SetWriteResult(FRESULT result);
     void FatFsFake_SetWriteBytesReturned(unsigned int bytes);
     int FatFsFake_WriteCallCount(void);
     const void* FatFsFake_LastWriteBytes(void);
     unsigned int FatFsFake_LastWriteCount(void);
 
-    /* f_sync */
     void FatFsFake_SetSyncResult(FRESULT result);
     int FatFsFake_SyncCallCount(void);
 
-    /* f_stat */
     void FatFsFake_SetStatResult(FRESULT result);
     int FatFsFake_StatCallCount(void);
     const char* FatFsFake_LastStatPath(void);
 
-    /* f_unlink */
     void FatFsFake_SetUnlinkResult(FRESULT result);
     int FatFsFake_UnlinkCallCount(void);
     const char* FatFsFake_LastUnlinkPath(void);

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosArpFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosArpFake.h
@@ -13,14 +13,11 @@ EXTERN_C_BEGIN
 
     void FreeRtosArpFake_Reset(void);
 
-    /* xIsIPInARPCache configuration */
     void FreeRtosArpFake_SetCacheHit(bool hit);
 
-    /* xIsIPInARPCache accessors */
     unsigned FreeRtosArpFake_IsIpInArpCacheCallCount(void);
     uint32_t FreeRtosArpFake_LastIsIpInArpCacheArg(void);
 
-    /* FreeRTOS_OutputARPRequest accessors */
     unsigned FreeRtosArpFake_OutputArpRequestCallCount(void);
     uint32_t FreeRtosArpFake_LastOutputArpRequestArg(void);
 

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosDnsFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosDnsFake.h
@@ -10,15 +10,12 @@ EXTERN_C_BEGIN
 
     void FreeRtosDnsFake_Reset(void);
 
-    /* getaddrinfo configuration */
     void FreeRtosDnsFake_SetGetAddrInfoFails(bool fails);
 
-    /* getaddrinfo accessors */
     unsigned FreeRtosDnsFake_GetAddrInfoCallCount(void);
     const char* FreeRtosDnsFake_LastGetAddrInfoHostname(void);
     BaseType_t FreeRtosDnsFake_LastGetAddrInfoSocktype(void);
 
-    /* freeaddrinfo accessors */
     unsigned FreeRtosDnsFake_FreeAddrInfoCallCount(void);
 
 EXTERN_C_END

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosSemaphoreFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosSemaphoreFake.h
@@ -8,16 +8,12 @@ EXTERN_C_BEGIN
 
     void FreeRtosSemaphoreFake_Reset(void);
 
-    /* xSemaphoreCreateMutexStatic accessors */
     unsigned FreeRtosSemaphoreFake_CreateMutexStaticCallCount(void);
 
-    /* xSemaphoreTake accessors */
     unsigned FreeRtosSemaphoreFake_SemaphoreTakeCallCount(void);
 
-    /* xSemaphoreGive accessors */
     unsigned FreeRtosSemaphoreFake_SemaphoreGiveCallCount(void);
 
-    /* vSemaphoreDelete accessors */
     unsigned FreeRtosSemaphoreFake_SemaphoreDeleteCallCount(void);
 
 EXTERN_C_END

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosSocketsFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosSocketsFake.h
@@ -14,31 +14,24 @@ EXTERN_C_BEGIN
 
     void FreeRtosSocketsFake_Reset(void);
 
-    /* socket configuration */
     void FreeRtosSocketsFake_SetSocketFails(bool fails);
 
-    /* sendto configuration */
     void FreeRtosSocketsFake_SetSendtoFails(bool fails);
 
-    /* connect configuration */
     void FreeRtosSocketsFake_SetConnectFails(bool fails);
 
-    /* send configuration */
     void FreeRtosSocketsFake_SetSendFails(bool fails); /* returns -pdFREERTOS_ERRNO_ENOTCONN */
     void FreeRtosSocketsFake_SetSendReturn(BaseType_t value); /* explicit return for short-write scenarios */
 
-    /* recv configuration */
     void FreeRtosSocketsFake_SetRecvFails(bool fails); /* returns -pdFREERTOS_ERRNO_ENOTCONN */
     void FreeRtosSocketsFake_SetRecvReturn(BaseType_t value); /* explicit return; 0 models a zero-timeout would-block */
 
-    /* socket accessors */
     unsigned FreeRtosSocketsFake_SocketCallCount(void);
     BaseType_t FreeRtosSocketsFake_LastSocketDomain(void);
     BaseType_t FreeRtosSocketsFake_LastSocketType(void);
     BaseType_t FreeRtosSocketsFake_LastSocketProtocol(void);
     Socket_t FreeRtosSocketsFake_LastSocketReturned(void);
 
-    /* sendto accessors */
     unsigned FreeRtosSocketsFake_SendtoCallCount(void);
     Socket_t FreeRtosSocketsFake_LastSendtoSocket(void);
     const void* FreeRtosSocketsFake_LastSendtoBuffer(void);
@@ -47,7 +40,6 @@ EXTERN_C_BEGIN
     const struct freertos_sockaddr* FreeRtosSocketsFake_LastSendtoDestination(void);
     socklen_t FreeRtosSocketsFake_LastSendtoDestinationLength(void);
 
-    /* connect accessors */
     unsigned FreeRtosSocketsFake_ConnectCallCount(void);
     Socket_t FreeRtosSocketsFake_LastConnectSocket(void);
     const struct freertos_sockaddr* FreeRtosSocketsFake_LastConnectAddress(void);
@@ -60,21 +52,18 @@ EXTERN_C_BEGIN
     TickType_t FreeRtosSocketsFake_SndTimeoAtConnect(void);
     TickType_t FreeRtosSocketsFake_RcvTimeoAtConnect(void);
 
-    /* send accessors */
     unsigned FreeRtosSocketsFake_SendCallCount(void);
     Socket_t FreeRtosSocketsFake_LastSendSocket(void);
     const void* FreeRtosSocketsFake_LastSendBuffer(void);
     size_t FreeRtosSocketsFake_LastSendLength(void);
     BaseType_t FreeRtosSocketsFake_LastSendFlags(void);
 
-    /* recv accessors */
     unsigned FreeRtosSocketsFake_RecvCallCount(void);
     Socket_t FreeRtosSocketsFake_LastRecvSocket(void);
     void* FreeRtosSocketsFake_LastRecvBuffer(void);
     size_t FreeRtosSocketsFake_LastRecvLength(void);
     BaseType_t FreeRtosSocketsFake_LastRecvFlags(void);
 
-    /* setsockopt accessors */
     TickType_t FreeRtosSocketsFake_LastSndTimeoSet(void);
     TickType_t FreeRtosSocketsFake_LastRcvTimeoSet(void);
     unsigned FreeRtosSocketsFake_RcvTimeoSetCallCount(void);
@@ -83,7 +72,6 @@ EXTERN_C_BEGIN
     int32_t FreeRtosSocketsFake_LastSetsockoptOptionName(void);
     size_t FreeRtosSocketsFake_LastSetsockoptOptionLength(void);
 
-    /* closesocket accessors */
     unsigned FreeRtosSocketsFake_ClosesocketCallCount(void);
     Socket_t FreeRtosSocketsFake_LastClosesocketSocket(void);
 

--- a/Tests/Support/FreeRtosFakes/Interface/FreeRtosTaskFake.h
+++ b/Tests/Support/FreeRtosFakes/Interface/FreeRtosTaskFake.h
@@ -8,11 +8,9 @@ EXTERN_C_BEGIN
 
     void FreeRtosTaskFake_Reset(void);
 
-    /* vTaskDelay accessors */
     unsigned FreeRtosTaskFake_VTaskDelayCallCount(void);
     TickType_t FreeRtosTaskFake_LastVTaskDelayTicks(void);
 
-    /* xTaskGetTickCount stub */
     void FreeRtosTaskFake_SetTickCount(TickType_t ticks);
 
 EXTERN_C_END

--- a/Tests/Support/LwipFakes/Interface/LwipPbufFake.h
+++ b/Tests/Support/LwipFakes/Interface/LwipPbufFake.h
@@ -12,17 +12,14 @@ EXTERN_C_BEGIN
 
     void LwipPbufFake_Reset(void);
 
-    /* pbuf_alloc configuration */
     void LwipPbufFake_SetPbufAllocFails(bool fails);
 
-    /* pbuf_alloc spy */
     unsigned LwipPbufFake_PbufAllocCallCount(void);
     pbuf_layer LwipPbufFake_LastAllocLayer(void);
     uint16_t LwipPbufFake_LastAllocLength(void);
     pbuf_type LwipPbufFake_LastAllocType(void);
     struct pbuf* LwipPbufFake_LastAllocReturned(void);
 
-    /* pbuf_free spy */
     unsigned LwipPbufFake_PbufFreeCallCount(void);
 
     /* Allocated-but-not-yet-freed pbuf count. Successful pbuf_alloc bumps it;

--- a/Tests/Support/LwipFakes/Interface/LwipTcpFake.h
+++ b/Tests/Support/LwipFakes/Interface/LwipTcpFake.h
@@ -30,7 +30,6 @@ EXTERN_C_BEGIN
     unsigned LwipTcpFake_TcpSentCallCount(void);
     tcp_sent_fn LwipTcpFake_LastSentFn(void);
 
-
     /* Immediate err returned by tcp_connect itself. Default ERR_OK. */
     void LwipTcpFake_SetTcpConnectError(int8_t err);
 

--- a/Tests/Support/LwipFakes/Interface/LwipTcpFake.h
+++ b/Tests/Support/LwipFakes/Interface/LwipTcpFake.h
@@ -13,10 +13,8 @@ EXTERN_C_BEGIN
 
     void LwipTcpFake_Reset(void);
 
-    /* tcp_new configuration */
     void LwipTcpFake_SetTcpNewFails(bool fails);
 
-    /* tcp_new spy */
     unsigned LwipTcpFake_TcpNewCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastTcpNewReturned(void);
 
@@ -32,7 +30,6 @@ EXTERN_C_BEGIN
     unsigned LwipTcpFake_TcpSentCallCount(void);
     tcp_sent_fn LwipTcpFake_LastSentFn(void);
 
-    /* tcp_connect configuration */
 
     /* Immediate err returned by tcp_connect itself. Default ERR_OK. */
     void LwipTcpFake_SetTcpConnectError(int8_t err);
@@ -45,38 +42,30 @@ EXTERN_C_BEGIN
     /* The err passed to the connected_cb when it fires. Default ERR_OK. */
     void LwipTcpFake_SetConnectCallbackResult(int8_t err);
 
-    /* tcp_connect spy */
     unsigned LwipTcpFake_TcpConnectCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastConnectPcb(void);
     const ip_addr_t* LwipTcpFake_LastConnectIpaddr(void);
     uint16_t LwipTcpFake_LastConnectPort(void);
     tcp_connected_fn LwipTcpFake_LastConnectedFn(void);
 
-    /* tcp_close configuration */
     void LwipTcpFake_SetTcpCloseError(int8_t err);
 
-    /* tcp_close spy */
     unsigned LwipTcpFake_TcpCloseCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastClosePcb(void);
 
-    /* tcp_abort spy */
     unsigned LwipTcpFake_TcpAbortCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastAbortPcb(void);
 
-    /* tcp_write configuration */
     void LwipTcpFake_SetTcpWriteError(int8_t err);
 
-    /* tcp_write spy */
     unsigned LwipTcpFake_TcpWriteCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastWritePcb(void);
     const void* LwipTcpFake_LastWriteDataptr(void);
     uint16_t LwipTcpFake_LastWriteLength(void);
     uint8_t LwipTcpFake_LastWriteApiFlags(void);
 
-    /* tcp_output configuration */
     void LwipTcpFake_SetTcpOutputError(int8_t err);
 
-    /* tcp_output spy */
     unsigned LwipTcpFake_TcpOutputCallCount(void);
     struct tcp_pcb* LwipTcpFake_LastOutputPcb(void);
 

--- a/Tests/Support/LwipFakes/Interface/LwipUdpFake.h
+++ b/Tests/Support/LwipFakes/Interface/LwipUdpFake.h
@@ -15,21 +15,16 @@ EXTERN_C_BEGIN
 
     void LwipUdpFake_Reset(void);
 
-    /* udp_new configuration */
     void LwipUdpFake_SetUdpNewFails(bool fails);
 
-    /* udp_new spy */
     unsigned LwipUdpFake_UdpNewCallCount(void);
     struct udp_pcb* LwipUdpFake_LastUdpNewReturned(void);
 
-    /* udp_remove spy */
     unsigned LwipUdpFake_UdpRemoveCallCount(void);
     struct udp_pcb* LwipUdpFake_LastUdpRemovePcb(void);
 
-    /* udp_sendto configuration */
     void LwipUdpFake_SetUdpSendtoError(int8_t err);
 
-    /* udp_sendto spy */
     unsigned LwipUdpFake_UdpSendtoCallCount(void);
     struct udp_pcb* LwipUdpFake_LastSendtoPcb(void);
     struct pbuf* LwipUdpFake_LastSendtoPbuf(void);

--- a/Tests/Support/MbedTlsFake.h
+++ b/Tests/Support/MbedTlsFake.h
@@ -19,11 +19,9 @@ EXTERN_C_BEGIN
      * Call from TEST_GROUP::setup() so each test starts from a clean slate. */
     void MbedTlsFake_Reset(void);
 
-    /* mbedtls_ssl_config_init */
     int MbedTlsFake_SslConfigInitCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfigInitArg(void);
 
-    /* mbedtls_ssl_config_defaults */
     int MbedTlsFake_SslConfigDefaultsCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfigDefaultsConfigArg(void);
     int MbedTlsFake_LastSslConfigDefaultsEndpoint(void);
@@ -31,17 +29,14 @@ EXTERN_C_BEGIN
     int MbedTlsFake_LastSslConfigDefaultsPreset(void);
     void MbedTlsFake_SetSslConfigDefaultsReturn(int value);
 
-    /* mbedtls_ssl_init */
     int MbedTlsFake_SslInitCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslInitArg(void);
 
-    /* mbedtls_ssl_setup */
     int MbedTlsFake_SslSetupCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslSetupContextArg(void);
     const struct mbedtls_ssl_config* MbedTlsFake_LastSslSetupConfigArg(void);
     void MbedTlsFake_SetSslSetupReturn(int value);
 
-    /* mbedtls_ssl_set_bio */
     int MbedTlsFake_SslSetBioCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslSetBioContextArg(void);
     void* MbedTlsFake_LastSslSetBioPBioArg(void);
@@ -49,7 +44,6 @@ EXTERN_C_BEGIN
     int (*MbedTlsFake_LastSslSetBioRecvCallback(void))(void*, unsigned char*, size_t);
     int (*MbedTlsFake_LastSslSetBioRecvTimeoutCallback(void))(void*, unsigned char*, size_t, uint32_t);
 
-    /* mbedtls_ssl_handshake */
     int MbedTlsFake_SslHandshakeCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslHandshakeArg(void);
     void MbedTlsFake_SetSslHandshakeReturn(int value);
@@ -59,33 +53,27 @@ EXTERN_C_BEGIN
      * at MBEDTLSFAKE_MAX_HANDSHAKE_RETURNS (silently truncated). */
     void MbedTlsFake_SetSslHandshakeReturnSequence(const int* values, int count);
 
-    /* mbedtls_ssl_write */
     int MbedTlsFake_SslWriteCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslWriteContextArg(void);
     const unsigned char* MbedTlsFake_LastSslWriteBufArg(void);
     size_t MbedTlsFake_LastSslWriteLenArg(void);
     void MbedTlsFake_SetSslWriteReturn(int value);
 
-    /* mbedtls_ssl_read */
     int MbedTlsFake_SslReadCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslReadContextArg(void);
     unsigned char* MbedTlsFake_LastSslReadBufArg(void);
     size_t MbedTlsFake_LastSslReadLenArg(void);
     void MbedTlsFake_SetSslReadReturn(int value);
 
-    /* mbedtls_ssl_close_notify */
     int MbedTlsFake_SslCloseNotifyCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslCloseNotifyArg(void);
 
-    /* mbedtls_ssl_free */
     int MbedTlsFake_SslFreeCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslFreeArg(void);
 
-    /* mbedtls_ssl_config_free */
     int MbedTlsFake_SslConfigFreeCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfigFreeArg(void);
 
-    /* mbedtls_ssl_conf_authmode */
     int MbedTlsFake_SslConfAuthmodeCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfAuthmodeConfigArg(void);
     int MbedTlsFake_LastSslConfAuthmodeArg(void);
@@ -96,19 +84,16 @@ EXTERN_C_BEGIN
      * production inline call set, so a test can assert the negotiated floor. */
     int MbedTlsFake_ConfMinTlsVersion(const struct mbedtls_ssl_config* conf);
 
-    /* mbedtls_ssl_conf_ca_chain */
     int MbedTlsFake_SslConfCaChainCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfCaChainConfigArg(void);
     struct mbedtls_x509_crt* MbedTlsFake_LastSslConfCaChainArg(void);
     struct mbedtls_x509_crl* MbedTlsFake_LastSslConfCaChainCrlArg(void);
 
-    /* mbedtls_ssl_conf_rng */
     int MbedTlsFake_SslConfRngCallCount(void);
     struct mbedtls_ssl_config* MbedTlsFake_LastSslConfRngConfigArg(void);
     int (*MbedTlsFake_LastSslConfRngFuncArg(void))(void*, unsigned char*, size_t);
     void* MbedTlsFake_LastSslConfRngContextArg(void);
 
-    /* mbedtls_ssl_set_hostname */
     int MbedTlsFake_SslSetHostnameCallCount(void);
     struct mbedtls_ssl_context* MbedTlsFake_LastSslSetHostnameContextArg(void);
     const char* MbedTlsFake_LastSslSetHostnameNameArg(void);
@@ -120,7 +105,6 @@ EXTERN_C_BEGIN
     struct mbedtls_x509_crt* MbedTlsFake_LastSslConfOwnCertCertArg(void);
     struct mbedtls_pk_context* MbedTlsFake_LastSslConfOwnCertKeyArg(void);
 
-    /* mbedtls_md_info_from_type / mbedtls_md_hmac */
     int MbedTlsFake_MdHmacCallCount(void);
     int MbedTlsFake_LastMdInfoType(void);
     const uint8_t* MbedTlsFake_LastMdHmacKey(void);
@@ -140,7 +124,6 @@ EXTERN_C_BEGIN
         uint8_t* tagOut
     );
 
-    /* mbedtls_platform_zeroize */
     int MbedTlsFake_PlatformZeroizeCallCount(void);
     const void* MbedTlsFake_LastPlatformZeroizeBuf(void);
     size_t MbedTlsFake_LastPlatformZeroizeLen(void);

--- a/Tests/Support/MqFake.h
+++ b/Tests/Support/MqFake.h
@@ -13,7 +13,6 @@ EXTERN_C_BEGIN
     /* open configuration — one-shot, consumed by the next mq_open call */
     void MqFake_FailNextOpen(int errnoValue);
 
-    /* open accessors */
     int MqFake_OpenCallCount(void);
     const char* MqFake_LastOpenName(void);
     int MqFake_LastOpenOflag(void);
@@ -24,7 +23,6 @@ EXTERN_C_BEGIN
     /* send configuration — one-shot, consumed by the next mq_send call */
     void MqFake_FailNextSend(int errnoValue);
 
-    /* send accessors */
     int MqFake_SendCallCount(void);
     mqd_t MqFake_LastSendMqd(void);
     const char* MqFake_LastSendBufAsString(void);
@@ -33,16 +31,13 @@ EXTERN_C_BEGIN
     /* receive configuration — one-shot, consumed by the next mq_receive call */
     void MqFake_FailNextReceive(int errnoValue);
 
-    /* receive accessors */
     int MqFake_ReceiveCallCount(void);
     mqd_t MqFake_LastReceiveMqd(void);
     size_t MqFake_LastReceiveMaxLen(void);
 
-    /* close accessors */
     int MqFake_CloseCallCount(void);
     mqd_t MqFake_LastClosedMqd(void);
 
-    /* unlink accessors */
     int MqFake_UnlinkCallCount(void);
     const char* MqFake_LastUnlinkName(void);
 

--- a/Tests/Support/OpenSslFake.h
+++ b/Tests/Support/OpenSslFake.h
@@ -18,7 +18,6 @@ EXTERN_C_BEGIN
 
     void OpenSslFake_Reset(void);
 
-    /* Failure-mode switches */
     void OpenSslFake_SetConnectFails(bool fails);
     void OpenSslFake_SetWriteFails(bool fails);
     void OpenSslFake_SetSet1HostFails(bool fails);
@@ -43,21 +42,17 @@ EXTERN_C_BEGIN
     void OpenSslFake_SetGetErrorReturn(int err);
     int OpenSslFake_GetErrorCallCount(void);
 
-    /* BIO retry-flag spies */
     int OpenSslFake_BioSetFlagsCallCount(void);
     int OpenSslFake_LastBioSetFlags(void);
     int OpenSslFake_BioClearFlagsCallCount(void);
 
-    /* SSL_CTX_new */
     int OpenSslFake_CtxNewCallCount(void);
     const struct ssl_method_st* OpenSslFake_LastCtxNewMethodArg(void);
     struct ssl_ctx_st* OpenSslFake_LastCtxReturned(void);
 
-    /* SSL_CTX_load_verify_locations */
     struct ssl_ctx_st* OpenSslFake_LastLoadVerifyLocationsCtxArg(void);
     const char* OpenSslFake_LastCaBundlePath(void);
 
-    /* SSL_CTX_set_verify */
     struct ssl_ctx_st* OpenSslFake_LastSetVerifyCtxArg(void);
     int OpenSslFake_LastVerifyMode(void);
 
@@ -65,47 +60,38 @@ EXTERN_C_BEGIN
     struct ssl_ctx_st* OpenSslFake_LastSslCtxCtrlCtxArg(void);
     long OpenSslFake_LastMinProtoVersion(void);
 
-    /* SSL_CTX_set_cipher_list */
     int OpenSslFake_SetCipherListCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastSetCipherListCtxArg(void);
     const char* OpenSslFake_LastCipherList(void);
 
-    /* SSL_new */
     int OpenSslFake_SslNewCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastSslNewCtxArg(void);
     struct ssl_st* OpenSslFake_LastSslReturned(void);
 
-    /* BIO_meth_new */
     struct bio_method_st* OpenSslFake_LastBioMethReturned(void);
 
-    /* BIO_meth_free */
     int OpenSslFake_BioMethFreeCallCount(void);
     struct bio_method_st* OpenSslFake_LastBioMethFreeArg(void);
 
-    /* BIO_meth_set_read */
     struct bio_method_st* OpenSslFake_LastBioMethSetReadMethodArg(void);
     int (*OpenSslFake_LastBioReadCallback(void))(struct bio_st*, char*, int);
     long (*OpenSslFake_LastBioCtrlCallback(void))(struct bio_st*, int, long, void*);
     int (*OpenSslFake_LastBioCreateCallback(void))(struct bio_st*);
     int OpenSslFake_LastSetInitArg(void);
 
-    /* BIO_meth_set_write */
     struct bio_method_st* OpenSslFake_LastBioMethSetWriteMethodArg(void);
     int (*OpenSslFake_LastBioWriteCallback(void))(struct bio_st*, const char*, int);
 
-    /* BIO_new */
     int OpenSslFake_BioNewCallCount(void);
     const struct bio_method_st* OpenSslFake_LastBioNewMethodArg(void);
     struct bio_st* OpenSslFake_LastBioReturned(void);
 
-    /* BIO_set_data */
     struct bio_st* OpenSslFake_LastSetDataBioArg(void);
     void* OpenSslFake_LastSetDataArg(void);
 
     /* BIO_get_data (arg capture for BIO-callback introspection) */
     struct bio_st* OpenSslFake_LastGetDataBioArg(void);
 
-    /* SSL_set_bio */
     int OpenSslFake_SetBioCallCount(void);
     struct ssl_st* OpenSslFake_LastSetBioSslArg(void);
     struct bio_st* OpenSslFake_LastSetBioReadBioArg(void);
@@ -115,52 +101,42 @@ EXTERN_C_BEGIN
     struct ssl_st* OpenSslFake_LastSslCtrlSslArg(void);
     const char* OpenSslFake_LastSniHostname(void);
 
-    /* SSL_set1_host */
     struct ssl_st* OpenSslFake_LastSet1HostSslArg(void);
     const char* OpenSslFake_LastSet1Host(void);
 
-    /* SSL_connect */
     int OpenSslFake_ConnectCallCount(void);
     struct ssl_st* OpenSslFake_LastConnectSslArg(void);
 
-    /* SSL_write */
     int OpenSslFake_WriteCallCount(void);
     struct ssl_st* OpenSslFake_LastWriteSslArg(void);
     const void* OpenSslFake_LastWriteBuf(void);
     int OpenSslFake_LastWriteSize(void);
 
-    /* SSL_read */
     int OpenSslFake_SslReadCallCount(void);
     struct ssl_st* OpenSslFake_LastSslReadSslArg(void);
     void* OpenSslFake_LastSslReadBuf(void);
     int OpenSslFake_LastSslReadSize(void);
 
-    /* SSL_shutdown */
     int OpenSslFake_ShutdownCallCount(void);
     struct ssl_st* OpenSslFake_LastShutdownSslArg(void);
 
-    /* SSL_free */
     int OpenSslFake_FreeCallCount(void);
     struct ssl_st* OpenSslFake_LastFreeSslArg(void);
 
-    /* SSL_CTX_free */
     int OpenSslFake_CtxFreeCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastCtxFreeCtxArg(void);
 
-    /* SSL_CTX_use_certificate_chain_file */
     int OpenSslFake_UseCertChainFileCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastUseCertChainFileCtxArg(void);
     const char* OpenSslFake_LastClientCertChainPath(void);
     void OpenSslFake_SetUseCertChainFileFails(bool fails);
 
-    /* SSL_CTX_use_PrivateKey_file */
     int OpenSslFake_UsePrivateKeyFileCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastUsePrivateKeyFileCtxArg(void);
     const char* OpenSslFake_LastClientKeyPath(void);
     int OpenSslFake_LastClientKeyFileType(void);
     void OpenSslFake_SetUsePrivateKeyFileFails(bool fails);
 
-    /* SSL_CTX_check_private_key */
     int OpenSslFake_CheckPrivateKeyCallCount(void);
     struct ssl_ctx_st* OpenSslFake_LastCheckPrivateKeyCtxArg(void);
     void OpenSslFake_SetCheckPrivateKeyFails(bool fails);
@@ -186,7 +162,6 @@ EXTERN_C_BEGIN
         uint8_t* tagOut
     );
 
-    /* OPENSSL_cleanse */
     int OpenSslFake_CleanseCallCount(void);
     const void* OpenSslFake_LastCleanseBuf(void);
     size_t OpenSslFake_LastCleanseLen(void);

--- a/Tests/Support/PlusFatFakes/Interface/PlusFatFake.h
+++ b/Tests/Support/PlusFatFakes/Interface/PlusFatFake.h
@@ -7,49 +7,39 @@ EXTERN_C_BEGIN
 
     void PlusFatFake_Reset(void);
 
-    /* ff_fopen */
     void PlusFatFake_SetOpenFailsForMode(const char* mode);
     void PlusFatFake_SetOpenAlwaysFails(void);
     int PlusFatFake_OpenCallCount(void);
     const char* PlusFatFake_OpenModeAt(int index);
     const char* PlusFatFake_LastOpenPath(void);
 
-    /* ff_fclose */
     int PlusFatFake_CloseCallCount(void);
 
-    /* ff_fread */
     void PlusFatFake_SetReadSource(const void* bytes, unsigned long count);
     int PlusFatFake_ReadCallCount(void);
     unsigned long PlusFatFake_LastReadSize(void);
     unsigned long PlusFatFake_LastReadItems(void);
 
-    /* ff_fwrite */
     void PlusFatFake_SetWriteIncomplete(void);
     int PlusFatFake_WriteCallCount(void);
     const void* PlusFatFake_LastWriteBytes(void);
     unsigned long PlusFatFake_LastWriteItems(void);
 
-    /* FF_FlushCache */
     void PlusFatFake_SetFlushCacheFails(void);
     int PlusFatFake_FlushCacheCallCount(void);
 
-    /* ff_fseek */
     int PlusFatFake_SeekCallCount(void);
     long PlusFatFake_LastSeekOffset(void);
     int PlusFatFake_LastSeekWhence(void);
 
-    /* ff_filelength */
     void PlusFatFake_SetFileLength(unsigned long length);
 
-    /* ff_seteof */
     int PlusFatFake_SeteofCallCount(void);
 
-    /* ff_stat */
     void PlusFatFake_SetStatFails(void);
     int PlusFatFake_StatCallCount(void);
     const char* PlusFatFake_LastStatPath(void);
 
-    /* ff_remove */
     void PlusFatFake_SetRemoveFails(void);
     int PlusFatFake_RemoveCallCount(void);
     const char* PlusFatFake_LastRemovePath(void);

--- a/Tests/Support/SocketFake.h
+++ b/Tests/Support/SocketFake.h
@@ -12,11 +12,9 @@ EXTERN_C_BEGIN
 
     void SocketFake_Reset(void);
 
-    /* sendto configuration */
     void SocketFake_SetSendtoFails(bool fails);
     void SocketFake_FailNextSendtoWithErrno(int errnoValue);
 
-    /* sendto accessors */
     int SocketFake_SendtoCallCount(void);
     const void* SocketFake_LastBuf(void);
     const char* SocketFake_LastBufAsString(void);
@@ -28,41 +26,34 @@ EXTERN_C_BEGIN
     socklen_t SocketFake_LastAddrLen(void);
     int SocketFake_LastSendtoFd(void);
 
-    /* socket configuration */
     void SocketFake_SetSocketFails(bool fails);
 
-    /* socket accessors */
     int SocketFake_SocketCallCount(void);
     int SocketFake_SocketFd(void);
     int SocketFake_SocketDomain(void);
     int SocketFake_SocketType(void);
 
-    /* send configuration */
     void SocketFake_SetSendFails(bool fails);
     void SocketFake_FailSendOnCall(int callNumber);
     void SocketFake_SetSendReturn(ssize_t value);
     void SocketFake_FailNextSendWithErrno(int errnoValue);
 
-    /* send accessors */
     int SocketFake_SendCallCount(void);
     const char* SocketFake_SendBufAsString(int callIndex);
     size_t SocketFake_SendLen(int callIndex);
     int SocketFake_LastSendFd(void);
     int SocketFake_SendFlags(int callIndex);
 
-    /* connect configuration */
     void SocketFake_SetConnectFails(bool fails);
     /* When set, connect returns -1 with errno == errnoValue (e.g. EINPROGRESS so
        the non-blocking-connect path can be exercised). One-shot. */
     void SocketFake_SetConnectFailsWithErrno(int errnoValue);
 
-    /* connect accessors */
     int SocketFake_ConnectCallCount(void);
     int SocketFake_LastConnectFd(void);
     int SocketFake_LastConnectPort(void);
     const char* SocketFake_LastConnectAddrAsString(void);
 
-    /* setsockopt accessors */
     int SocketFake_SetSockOptCallCount(void);
     int SocketFake_LastSetSockOptLevel(void);
     int SocketFake_LastSetSockOptOptname(void);
@@ -80,16 +71,13 @@ EXTERN_C_BEGIN
     void SocketFake_SetSoError(int err);
     void SocketFake_SetSoErrorLookupFails(bool fails);
 
-    /* getsockopt accessors */
     int SocketFake_GetSockOptCallCount(void);
     int SocketFake_LastGetSockOptLevel(void);
     int SocketFake_LastGetSockOptOptname(void);
 
-    /* fcntl configuration */
     void SocketFake_SetFcntlSetFlFails(bool fails);
     void SocketFake_SetFcntlGetFlReturn(int flags);
 
-    /* fcntl accessors */
     int SocketFake_FcntlCallCount(void);
     int SocketFake_LastFcntlCmd(void);
     int SocketFake_LastFcntlSetFlags(void);
@@ -111,35 +99,28 @@ EXTERN_C_BEGIN
     void SocketFake_SetSelectError(bool hasError);
     void SocketFake_SetSelectReturn(int value);
 
-    /* select accessors */
     int SocketFake_SelectCallCount(void);
     long SocketFake_LastSelectTimeoutSec(void);
     long SocketFake_LastSelectTimeoutUsec(void);
 
-    /* close accessors */
     int SocketFake_CloseCallCount(void);
     int SocketFake_LastClosedFd(void);
 
-    /* recv configuration */
     void SocketFake_SetRecvReturn(ssize_t value);
     void SocketFake_FailNextRecvWithErrno(int errnoValue);
 
-    /* recv accessors */
     int SocketFake_RecvCallCount(void);
     int SocketFake_LastRecvFd(void);
     const void* SocketFake_LastRecvBuf(void);
     size_t SocketFake_LastRecvLen(void);
     int SocketFake_LastRecvFlags(void);
 
-    /* getaddrinfo configuration */
     void SocketFake_SetGetAddrInfoFails(bool fails);
 
-    /* getaddrinfo accessors */
     int SocketFake_GetAddrInfoCallCount(void);
     const char* SocketFake_LastGetAddrInfoHostname(void);
     int SocketFake_LastGetAddrInfoSocktype(void);
 
-    /* freeaddrinfo accessors */
     int SocketFake_FreeAddrInfoCallCount(void);
 
 EXTERN_C_END

--- a/Tests/Support/WinsockFake.h
+++ b/Tests/Support/WinsockFake.h
@@ -11,20 +11,16 @@ EXTERN_C_BEGIN
 
     void WinsockFake_Reset(void);
 
-    /* socket configuration */
     void WinsockFake_SetSocketFails(bool fails);
 
-    /* socket accessors */
     int WinsockFake_SocketCallCount(void);
     SOCKET WinsockFake_SocketFd(void);
     int WinsockFake_SocketDomain(void);
     int WinsockFake_SocketType(void);
 
-    /* sendto configuration */
     void WinsockFake_SetSendtoFails(bool fails);
     void WinsockFake_FailNextSendtoWithLastError(int wsaError);
 
-    /* sendto accessors */
     int WinsockFake_SendtoCallCount(void);
     const char* WinsockFake_LastBufAsString(void);
     size_t WinsockFake_LastLen(void);
@@ -35,43 +31,36 @@ EXTERN_C_BEGIN
     int WinsockFake_LastAddrLen(void);
     SOCKET WinsockFake_LastSendtoFd(void);
 
-    /* connect configuration */
     void WinsockFake_SetConnectFails(bool fails);
     /* When set, connect returns SOCKET_ERROR with WSAGetLastError == wsaError
        (e.g. WSAEWOULDBLOCK so the non-blocking-connect path can be exercised). */
     void WinsockFake_SetConnectFailsWithLastError(int wsaError);
 
-    /* connect accessors */
     int WinsockFake_ConnectCallCount(void);
     SOCKET WinsockFake_LastConnectFd(void);
     int WinsockFake_LastConnectPort(void);
     const char* WinsockFake_LastConnectAddrAsString(void);
 
-    /* send configuration */
     void WinsockFake_SetSendFails(bool fails);
     void WinsockFake_SetSendReturn(int value);
 
-    /* send accessors */
     int WinsockFake_SendCallCount(void);
     const char* WinsockFake_SendBufAsString(int callIndex);
     size_t WinsockFake_SendLen(int callIndex);
     int WinsockFake_SendFlags(int callIndex);
     SOCKET WinsockFake_LastSendFd(void);
 
-    /* recv configuration */
     void WinsockFake_SetRecvReturn(int value);
     /* When set, the next recv returns SOCKET_ERROR with WSAGetLastError == wsaError
        (e.g. WSAEWOULDBLOCK for the non-blocking would-block path). One-shot. */
     void WinsockFake_FailNextRecvWithLastError(int wsaError);
 
-    /* recv accessors */
     int WinsockFake_RecvCallCount(void);
     SOCKET WinsockFake_LastRecvFd(void);
     const void* WinsockFake_LastRecvBuf(void);
     size_t WinsockFake_LastRecvLen(void);
     int WinsockFake_LastRecvFlags(void);
 
-    /* setsockopt accessors */
     int WinsockFake_SetSockOptCallCount(void);
     int WinsockFake_LastSetSockOptLevel(void);
     int WinsockFake_LastSetSockOptOptname(void);
@@ -81,7 +70,6 @@ EXTERN_C_BEGIN
        sizeof(int)); other shapes are ignored. Returns 0 if no match. */
     int WinsockFake_LastSetSockOptValue(int level, int optname);
 
-    /* getsockopt configuration */
     void WinsockFake_SetIpMtu(int mtu);
     void WinsockFake_SetIpMtuLookupFails(bool fails);
     /* SOL_SOCKET / SO_ERROR — read by the non-blocking-connect completion
@@ -89,30 +77,23 @@ EXTERN_C_BEGIN
     void WinsockFake_SetSoError(int err);
     void WinsockFake_SetSoErrorLookupFails(bool fails);
 
-    /* getsockopt accessors */
     int WinsockFake_GetSockOptCallCount(void);
     int WinsockFake_LastGetSockOptLevel(void);
     int WinsockFake_LastGetSockOptOptname(void);
 
-    /* closesocket accessors */
     int WinsockFake_CloseCallCount(void);
     SOCKET WinsockFake_LastClosedFd(void);
 
-    /* getaddrinfo configuration */
     void WinsockFake_SetGetAddrInfoFails(bool fails);
 
-    /* getaddrinfo accessors */
     int WinsockFake_GetAddrInfoCallCount(void);
     const char* WinsockFake_LastGetAddrInfoHostname(void);
     int WinsockFake_LastGetAddrInfoSocktype(void);
 
-    /* freeaddrinfo accessors */
     int WinsockFake_FreeAddrInfoCallCount(void);
 
-    /* ioctlsocket configuration */
     void WinsockFake_SetIoctlSocketFails(bool fails);
 
-    /* ioctlsocket accessors */
     int WinsockFake_IoctlSocketCallCount(void);
     SOCKET WinsockFake_LastIoctlSocketFd(void);
     long WinsockFake_LastIoctlSocketCmd(void);
@@ -134,7 +115,6 @@ EXTERN_C_BEGIN
     void WinsockFake_SetSelectError(bool hasError);
     void WinsockFake_SetSelectReturn(int value);
 
-    /* select accessors */
     int WinsockFake_SelectCallCount(void);
     long WinsockFake_LastSelectTimeoutSec(void);
     long WinsockFake_LastSelectTimeoutUsec(void);


### PR DESCRIPTION
Comment hygiene pass: remove comments that merely restate what the code does, per the Clean Code "say why, not what" principle. **Pure deletions — no code/behaviour change** (25 files, ~300 lines removed).

## What was removed
- **Core/Source** — 8 function-divider banners (`/* ---- BlockStore_Write ---- */`) + 2 "Little-endian read/write" restatements.
- **Tests root** — section-divider banners (BlockStoreTest, FileFake, FileFakeTest, OpenSslFakeTest) + inline restatements ("verify magic bytes", "Fill block 00 with two records", "handleA opens file …").
- **Tests/Support fake headers** — 148 `/* <symbol> configuration|accessors|spy */` banners that only repeat the `Fake_Set*`/`*CallCount` names beneath them. The `.c` fakes keep theirs (there the banners map abbreviated statics back to the faked symbol).
- **BDD** — 6 section banners in `BddTargetFreeRtosPipeline.c` + 3 Python restatements.

## What was deliberately kept
RFC/MISRA/standard refs, `cppcheck-suppress`/`NOLINT`/IWYU justifications, third-party API gotchas (lwIP/OpenSSL/Winsock quirks), ownership/contract/threshold docs, deliberately-empty-branch markers, Given/When/Then test specs, seam explanations (poisoned-vtable, injection-via-UT_PTR_SET), header banners carrying extra info (e.g. getsockopt's modelled options, MqFake one-shot semantics, mbedTLS `conf_own_cert` mTLS note, OpenSSL SNI path), the magic-`sleep()` purpose comments, and test-intent notes ("Covered by teardown", "Doesn't crash; nothing to assert").

## Verification
- clang-format reflow applied (one double-blank collapse in `LwipTcpFake.h`).
- Local MISRA cppcheck was inconclusive only because the base dev container lacks the FreeRTOS/lwIP/mbedTLS third-party headers (cppcheck can't fully parse those `Platform/*/Source/` trees) — an environment gap, not a regression. No comment-only change can introduce a MISRA finding, and none of the modified files touch `Platform/`. CI's `analyze-cppcheck` (full toolchain) is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal section comments and documentation headers throughout the codebase to streamline code organization and reduce visual clutter.
  * Consolidated test support interface declarations by removing redundant grouping comments.

*Note: No functional changes, features, or bug fixes included in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->